### PR TITLE
✨ GH-1 Streamline first-run permission setup

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Dev10x",
-  "description": "v0.68.0.dev0 — 67 skills for structured commits, PR lifecycle, branch hygiene, ticket management, task tracking, code review, scoping, and QA automation in Claude Code.",
+  "description": "v0.68.0.dev0 — 68 skills for structured commits, PR lifecycle, branch hygiene, ticket management, task tracking, code review, scoping, and QA automation in Claude Code.",
   "version": "0.68.0.dev0",
   "author": {
     "name": "Janusz Skonieczny",

--- a/.claude/rules/INDEX.md
+++ b/.claude/rules/INDEX.md
@@ -80,7 +80,7 @@ Always apply `references/review-checks-common.md`.
 | `skill-invocation.md` | Skill() syntax, named parameters, delegation | `reviewer-skill.md` (items 8g, 9a) | Mandatory for skill reviews |
 | `task-orchestration.md` | Orchestration patterns, auto-advance, batched decisions | All skills (via `## Orchestration` section) | Referenced, not auto-loaded |
 | `code-sharing-patterns.md` | MCP imports, PEP 723 inlining, cross-context code | Review agents (false positive prevention) | Referenced, not auto-loaded |
-| `permission-architecture.md` | Permission → hook execution order, hook-enabled rules | `permission-auditor` agent, `upgrade-cleanup` skill | Referenced, not auto-loaded |
+| `permission-architecture.md` | Permission → hook execution order, hook-enabled rules | `permission-auditor` agent, `plugin-maintenance` skill (and the `upgrade-cleanup` entry point) | Referenced, not auto-loaded |
 | `execution-modes.md` | Structural modes, per-step mode mappings, mode precedence | `work-on` skill, `playbook` skill | Referenced, not auto-loaded |
 | `friction-levels.md` | Friction levels, gate behavior, playbook integration | `work-on` skill, `verify-acc-dod` skill | Referenced, not auto-loaded |
 | `model-tiers.md` | Model assignments, tier framework, per-project overrides | `model-selection.md` rule, playbook system | Referenced, not auto-loaded |

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ review comment) is concise enough to evaluate in seconds.
 | **DB** | [`db`](skills/db/SKILL.md), [`db-psql`](skills/db-psql/SKILL.md) | Safe database query planning and execution |
 | **Tooling** | [`py-uv`](skills/py-uv/SKILL.md), [`slack`](skills/slack/SKILL.md), [`slack-review-request`](skills/slack-review-request/SKILL.md), [`slack-setup`](skills/slack-setup/SKILL.md), [`ask`](skills/ask/SKILL.md) | Python packaging, Slack notifications, interactive prompts |
 | **Meta** | [`skill-create`](skills/skill-create/SKILL.md), [`skill-audit`](skills/skill-audit/SKILL.md), [`skill-index`](skills/skill-index/SKILL.md), [`audit-report`](skills/audit-report/SKILL.md), [`playbook`](skills/playbook/SKILL.md), [`skill-reinforcement`](skills/skill-reinforcement/SKILL.md), [`onboarding`](skills/onboarding/SKILL.md) | Create, audit, discover, and learn skills |
-| **Maintenance** | [`memory-maintenance`](skills/memory-maintenance/SKILL.md), [`upgrade-cleanup`](skills/upgrade-cleanup/SKILL.md), [`playbook-maintenance`](skills/playbook-maintenance/SKILL.md), [`context-audit`](skills/context-audit/SKILL.md) | Memory, permission, playbook, and context hygiene |
+| **Maintenance** | [`memory-maintenance`](skills/memory-maintenance/SKILL.md), [`plugin-maintenance`](skills/plugin-maintenance/SKILL.md), [`upgrade-cleanup`](skills/upgrade-cleanup/SKILL.md), [`playbook-maintenance`](skills/playbook-maintenance/SKILL.md), [`context-audit`](skills/context-audit/SKILL.md) | Memory, permission, playbook, and context hygiene |
 
 All skills use the `Dev10x:` prefix — type `/Dev10x:git-commit` in the Claude
 Code CLI to run it. Run `/Dev10x:skill-index` for the full reference.

--- a/references/permission-architecture.md
+++ b/references/permission-architecture.md
@@ -65,7 +65,7 @@ When adding a new SkillRedirectValidator entry:
 |------|------------|
 | `permission-auditor` agent | Must classify hook-enabled rules as `HOOK_ENABLED`, not `DEAD_RULE` |
 | `clean-project-files.py` | Must detect and skip hook-enabled rules during cleanup |
-| `upgrade-cleanup` skill | Must not strip hook-enabled rules from project settings |
+| `plugin-maintenance` skill (invoked directly or via `upgrade-cleanup`) | Must not strip hook-enabled rules from project settings |
 
 ## References
 

--- a/skills/onboarding/references/tour-guide.md
+++ b/skills/onboarding/references/tour-guide.md
@@ -73,6 +73,36 @@ Options:
 
 If user chooses setup: `Skill(skill="Dev10x:git-alias-setup")`
 
+### 2.2b Permission Setup
+
+**Skip if:** Base Dev10x permissions are already present in
+`~/.claude/settings.json` (look for entries like
+`Bash(/tmp/Dev10x/bin/mktmp.sh:*)` and any
+`Bash(~/.claude/plugins/cache/**/skills/git-commit/scripts/...)`
+patterns).
+
+```
+Dev10x ships with a curated set of allow rules so common skills
+run without per-invocation approval prompts. The bootstrap pass
+ensures those rules are present in your user settings.
+```
+
+**REQUIRED: Call `AskUserQuestion`** (do NOT use plain text).
+Options:
+- Set up permissions now (Recommended) — runs the fast bootstrap
+- Skip — I'll run `/Dev10x:upgrade-cleanup` later
+
+If user chooses setup:
+`Skill(skill="Dev10x:plugin-maintenance", args="bootstrap")`
+
+The bootstrap pass runs only the steps a new user needs:
+migrate any leftover legacy config files, ensure base
+permissions, and confirm script coverage. It skips the heavier
+post-upgrade steps (path version bumps, generalization, full
+permission audit, project-settings dedup) — those remain
+available via `/Dev10x:upgrade-cleanup` whenever the user wants
+the comprehensive sweep.
+
 ### 2.3 PR Pipeline Demo
 
 ```

--- a/skills/plugin-maintenance/SKILL.md
+++ b/skills/plugin-maintenance/SKILL.md
@@ -1,0 +1,369 @@
+---
+name: Dev10x:plugin-maintenance
+description: >
+  Maintain Dev10x plugin configuration — ensure base permissions,
+  migrate config files, generalize session-specific allow rules,
+  enumerate MCP tool globs, refresh script coverage, merge worktree
+  permissions, audit permissions for friction, and clean redundant
+  rules from project settings. Two modes: `bootstrap` (fast subset
+  for first-time setup) and `full` (complete cleanup, default).
+  TRIGGER when: bootstrapping a new install, after `claude plugin
+  update`, when permission prompts appear unexpectedly, or when
+  `Dev10x:onboarding` / `Dev10x:upgrade-cleanup` orchestrates
+  maintenance.
+  DO NOT TRIGGER when: permissions are already working and no
+  upgrade or bootstrap is in progress.
+user-invocable: true
+invocation-name: Dev10x:plugin-maintenance
+allowed-tools:
+  - Bash(${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/scripts/:*)
+  - mcp__plugin_Dev10x_cli__update_paths
+  - Agent(Dev10x:permission-auditor)
+  - AskUserQuestion
+  - TaskCreate
+  - TaskUpdate
+---
+
+# Dev10x:plugin-maintenance
+
+Single source for Dev10x plugin maintenance. Used directly, or
+orchestrated by `Dev10x:onboarding` (bootstrap mode) and
+`Dev10x:upgrade-cleanup` (full mode).
+
+**Announce:** "Using plugin-maintenance to keep Dev10x permission
+settings and config files in shape."
+
+## Modes
+
+| Mode | Steps | When to use |
+|------|-------|-------------|
+| `bootstrap` | 2, 3, 5 | First-time setup; eliminate prompts on the demoed skill set without doing a full sweep |
+| `full` (default) | 1–8 | Post-upgrade; suspected permission friction; long-term maintenance |
+
+`bootstrap` is intentionally fast and idempotent: ensure base
+permissions, migrate any leftover legacy config files, and confirm
+script coverage. It skips destructive cleanup (generalize, clean
+project files) and the heavier `permission-auditor` sweep.
+
+## Argument Parsing
+
+Read the args string passed to the skill:
+
+- empty / unset → mode = `full`
+- starts with `bootstrap` → mode = `bootstrap`
+- starts with `full` → mode = `full`
+- anything else → mode = `full`, log a note that the arg was
+  unrecognized
+
+## Orchestration
+
+This skill follows `references/task-orchestration.md` patterns.
+**Auto-advance:** complete each step, immediately start the next.
+Run dry-run before applying — no pause between steps.
+
+**REQUIRED: Create tasks before ANY work.** The task list depends
+on the mode. Execute these `TaskCreate` calls at startup:
+
+**Bootstrap mode:**
+
+1. `TaskCreate(subject="Migrate config files", activeForm="Migrating configs")`
+2. `TaskCreate(subject="Ensure base permissions", activeForm="Ensuring base perms")`
+3. `TaskCreate(subject="Ensure script coverage", activeForm="Verifying script rules")`
+
+**Full mode:**
+
+1. `TaskCreate(subject="Update version paths", activeForm="Updating paths")`
+2. `TaskCreate(subject="Migrate config files", activeForm="Migrating configs")`
+3. `TaskCreate(subject="Ensure base permissions", activeForm="Ensuring base perms")`
+4. `TaskCreate(subject="Generalize session-specific permissions", activeForm="Generalizing perms")`
+5. `TaskCreate(subject="Enumerate MCP tool globs", activeForm="Enumerating MCP globs")`
+6. `TaskCreate(subject="Ensure script coverage", activeForm="Verifying script rules")`
+7. `TaskCreate(subject="Merge worktree permissions", activeForm="Merging worktree perms")`
+8. `TaskCreate(subject="Audit permissions for friction", activeForm="Auditing permissions")`
+9. `TaskCreate(subject="Clean project files", activeForm="Cleaning project files")`
+
+Set sequential dependencies. Mark each step `in_progress` when
+starting and `completed` when done. Steps that produce no
+changes (dry-run shows no diff) should still be marked
+`completed` with a note in the description.
+
+## First-Time Setup
+
+Initialize userspace config with your project roots:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/scripts/update-paths.py --init
+```
+
+Then edit `~/.claude/skills/Dev10x:upgrade-cleanup/projects.yaml`
+to add your project roots. (The userspace config path keeps the
+`upgrade-cleanup` directory name for backward compatibility — the
+on-disk location does not change with the rename.)
+
+## Workflow
+
+The numbered headings below match the **full** mode task list.
+In `bootstrap` mode, run only the steps marked **[bootstrap]**.
+
+### 1. Update version paths *(full only)*
+
+Bump versioned plugin paths in every settings file to the current
+plugin version.
+
+1. Dry run:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/scripts/update-paths.py --dry-run
+```
+
+For large updates prefer `--summary`:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/scripts/update-paths.py --dry-run --summary
+```
+
+2. Apply:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/scripts/update-paths.py
+```
+
+### 2. Migrate config files **[bootstrap]**
+
+Move config files from deprecated locations to canonical Dev10x
+paths. Files are moved (not copied) so old paths stop working
+immediately.
+
+| Old path | New path |
+|----------|----------|
+| `~/.claude/memory/slack-config.yaml` | `~/.claude/memory/Dev10x/slack-config.yaml` |
+| `~/.claude/memory/slack-config-code-review-requests.yaml` | `~/.claude/memory/Dev10x/slack-config-code-review-requests.yaml` |
+| `~/.claude/memory/github-reviewers-config.yaml` | `~/.claude/memory/Dev10x/github-reviewers-config.yaml` |
+| `~/.claude/memory/databases.yaml` | `~/.claude/memory/Dev10x/databases.yaml` |
+
+For each file:
+1. Check if source exists (skip if not — user may not use it)
+2. Check destination exists (skip + warn if both present)
+3. Ensure `~/.claude/memory/Dev10x/` exists
+4. `mv` source to destination
+5. Report what moved
+
+### 3. Ensure base permissions **[bootstrap]**
+
+Add missing base permissions (gh CLI, /tmp/Dev10x paths, git ops,
+MCP tools, Dev10x config file RWE access) to all settings files.
+The base set is defined in
+`${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/projects.yaml`
+under `base_permissions:`.
+
+**Enumeration requirement:** All script paths and MCP tool names
+MUST be listed individually in `base_permissions`. Glob wildcards
+(e.g., `Bash(~/.claude/plugins/cache/**:*)` or
+`mcp__plugin_Dev10x_*`) cause permission friction — Claude Code
+cannot pre-approve glob patterns for Bash or MCP tools, so each
+invocation triggers a manual approval prompt. When adding new
+scripts or MCP tools to the plugin, enumerate them explicitly in
+`projects.yaml` following the existing per-script and per-tool
+entries.
+
+1. Dry run:
+
+```
+mcp__plugin_Dev10x_cli__update_paths(ensure_base=true, dry_run=true)
+```
+
+2. Apply:
+
+```
+mcp__plugin_Dev10x_cli__update_paths(ensure_base=true)
+```
+
+### 4. Generalize session-specific permissions *(full only)*
+
+Replace permission rules containing session-specific arguments
+(ticket IDs, PR numbers, temp file hashes) with generalized
+wildcard patterns that work across future sessions.
+
+1. Dry run:
+
+```
+mcp__plugin_Dev10x_cli__update_paths(generalize=true, dry_run=true)
+```
+
+2. Apply:
+
+```
+mcp__plugin_Dev10x_cli__update_paths(generalize=true)
+```
+
+**What gets generalized:**
+- `detect-tracker.sh PAY-123` → `detect-tracker.sh *`
+- `gh-pr-detect.sh 42` → `gh-pr-detect.sh *`
+- `gh-issue-get.sh 15` → `gh-issue-get.sh *`
+- `generate-commit-list.sh 42` → `generate-commit-list.sh *`
+- `/tmp/Dev10x/git/msg.AbCdEf.txt` → `/tmp/Dev10x/git/**`
+
+### 5. Enumerate MCP tool globs *(full only)*
+
+Claude Code does not expand `mcp__plugin_Dev10x_*` globs in allow
+rules — glob-shaped MCP rules match nothing. This step discovers
+Dev10x MCP tools and replaces any matching wildcard with the
+enumerated tool list.
+
+> **Note:** With `ensure_base` already auto-expanding stale MCP
+> wildcards in step 3 (since v0.66.0), this step is usually a
+> no-op. Run it to catch wildcards introduced by external edits.
+
+1. Dry run:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/scripts/enumerate-mcp.py --dry-run
+```
+
+2. Apply:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/scripts/enumerate-mcp.py
+```
+
+### 6. Ensure script coverage **[bootstrap]**
+
+Verify that all callable scripts in the current plugin version
+have individual allow rules in each settings file. New plugin
+versions may add scripts that are not yet enumerated.
+
+1. Dry run:
+
+```
+mcp__plugin_Dev10x_cli__update_paths(ensure_scripts=true, dry_run=true)
+```
+
+2. Add missing rules:
+
+```
+mcp__plugin_Dev10x_cli__update_paths(ensure_scripts=true)
+```
+
+**What gets scanned:**
+- `bin/*.sh` — helper scripts
+- `hooks/scripts/*.py`, `hooks/scripts/*.sh` — hook implementations
+- `skills/*/scripts/*.py`, `skills/*/scripts/*.sh` — skill scripts
+
+### 7. Merge worktree permissions *(full only)*
+
+Worktrees accumulate allow rules during sessions that the main
+project never sees. This script collects stable permissions from
+all worktrees and merges them back.
+
+1. Dry run:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/scripts/merge-worktree-permissions.py --dry-run
+```
+
+2. Apply:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/scripts/merge-worktree-permissions.py
+```
+
+Session-specific noise is filtered out automatically; only
+stable, reusable permissions are merged.
+
+### 8. Audit permissions for friction *(full only)*
+
+Dispatch the `permission-auditor` agent to perform a comprehensive
+7-phase security and friction audit. The agent analyzes:
+
+- Overly broad allow rules that should be narrowed
+- Script-call permissions that should use skills instead
+- Missing deny rules for destructive operations
+- Dead rules blocked by hooks
+- Hardcoded paths in instruction files
+
+**Invoke:**
+
+```
+Agent(subagent_type="Dev10x:permission-auditor",
+    description="Audit permission settings",
+    prompt="Audit all Claude Code permission settings for security
+    gaps, overly broad rules, and friction-causing patterns.
+    Pay special attention to allow rules that permit direct script
+    calls when equivalent skills exist — these cause friction and
+    should be replaced with Skill() invocations or blocked.")
+```
+
+The agent produces a severity-categorized report with specific
+fix proposals. Review and apply selectively.
+
+### 9. Clean project files *(full only)*
+
+Strip redundant rules from project `settings.local.json` files
+that are now covered by global `~/.claude/settings.json`. Also
+flags rules containing leaked secrets.
+
+1. Dry run:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/scripts/clean-project-files.py --dry-run
+```
+
+For large cleanups prefer `--summary`:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/scripts/clean-project-files.py --dry-run --summary
+```
+
+2. Apply:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/scripts/clean-project-files.py
+```
+
+**What gets cleaned:**
+- Exact duplicates of global rules
+- Rules covered by global wildcard patterns
+- Old plugin version paths (any version older than current)
+- Env-prefixed session noise (`GIT_SEQUENCE_EDITOR=*`, …)
+- Shell control flow fragments (`do`, `done`, `fi`, …)
+- Double-slash path typos (`Read(//work/...)`)
+
+**Leaked secret detection:** Rules containing plaintext
+credentials are flagged with warnings so users can rotate them.
+
+## Configuration
+
+The script looks for `projects.yaml` in two locations (first wins):
+1. `~/.claude/skills/Dev10x:upgrade-cleanup/projects.yaml` (userspace)
+2. `${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/projects.yaml` (plugin default)
+
+The userspace location is preserved across the rename so existing
+users do not need to migrate config files.
+
+## Options
+
+### update_paths MCP tool
+
+| Parameter | Purpose |
+|-----------|---------|
+| `dry_run` | Preview changes without writing |
+| `version` | Target a specific version instead of latest |
+| `init` | Copy plugin default config to userspace for customization |
+| `ensure_base` | Add missing base permissions from projects.yaml |
+| `generalize` | Replace session-specific args with wildcard patterns |
+| `ensure_scripts` | Verify all plugin scripts have allow rules; add missing |
+
+### update-paths.py CLI
+
+| Flag | Purpose |
+|------|---------|
+| `--dry-run` | Preview what would change without writing |
+| `--summary` | One line per changed file |
+| `--quiet` | Suppress per-file details and headers |
+| `--version VER` | Target a specific version |
+| `--restore` | Restore settings from most recent backups |
+
+### merge-worktree-permissions.py / clean-project-files.py
+
+Both accept `--dry-run` (and `--summary` for clean-project-files).
+See the script `--help` output for the full list.

--- a/skills/upgrade-cleanup/SKILL.md
+++ b/skills/upgrade-cleanup/SKILL.md
@@ -1,363 +1,63 @@
 ---
 name: Dev10x:upgrade-cleanup
 description: >
-  Post-upgrade cleanup — update plugin version paths, ensure base
-  permissions, migrate config files from deprecated locations to
-  canonical Dev10x paths, merge worktree rules, generalize
-  session-specific args, audit for friction-causing patterns via
-  the permission-auditor agent, and clean redundant rules from
+  Post-upgrade cleanup entry point — delegates to
+  `Dev10x:plugin-maintenance` in `full` mode. Updates plugin
+  version paths, ensures base permissions, migrates config files,
+  generalizes session-specific args, enumerates MCP tool globs,
+  refreshes script coverage, merges worktree rules, audits for
+  friction-causing patterns, and cleans redundant rules from
   project settings files.
   TRIGGER when: plugin version changes, permission prompts keep
   appearing, config files are at old locations, or user asks to
   fix permission friction.
-  DO NOT TRIGGER when: permissions are working correctly, or user
-  is asking about non-permission configuration.
+  DO NOT TRIGGER when: permissions are working correctly, or
+  you only need a fast bootstrap subset (use
+  `Dev10x:plugin-maintenance bootstrap` instead).
 user-invocable: true
 invocation-name: Dev10x:upgrade-cleanup
 allowed-tools:
-  - Bash(${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/scripts/:*)
-  - mcp__plugin_Dev10x_cli__update_paths
-  - Agent(Dev10x:permission-auditor)
+  - Skill
 ---
 
-# Upgrade Cleanup
+# Dev10x:upgrade-cleanup
 
-**Announce:** "Using upgrade-cleanup to maintain Claude Code
-permission settings and migrate config files across all projects."
+Top-level entry point for post-upgrade maintenance. The
+implementation lives in `Dev10x:plugin-maintenance`; this skill
+is a thin orchestrator that runs the **full** maintenance pass.
 
-## Orchestration
+## Why a separate skill
 
-This skill follows `references/task-orchestration.md` patterns.
+`Dev10x:upgrade-cleanup` and `Dev10x:onboarding` share the same
+underlying maintenance logic but call it with different intent:
 
-**Auto-advance:** Complete each step, immediately start the next.
-Run dry-run first, then apply — no pause between steps.
+| Caller | Mode | Focus |
+|--------|------|-------|
+| `Dev10x:onboarding` | `bootstrap` | Eliminate friction on the demoed skill set out of the box |
+| `Dev10x:upgrade-cleanup` (this skill) | `full` | Comprehensive post-upgrade hygiene |
+| Direct invocation of `Dev10x:plugin-maintenance` | either | Manual control |
 
-**REQUIRED: Create tasks before ANY work.** Execute these
-`TaskCreate` calls at startup:
+Keeping `upgrade-cleanup` as a named entry point preserves the
+discoverability users expect after running `claude plugin update`,
+without forcing them to remember the underlying skill name.
 
-1. `TaskCreate(subject="Update version paths", activeForm="Updating paths")`
-2. `TaskCreate(subject="Migrate config files", activeForm="Migrating configs")`
-3. `TaskCreate(subject="Ensure base permissions", activeForm="Ensuring base perms")`
-4. `TaskCreate(subject="Generalize session-specific permissions", activeForm="Generalizing perms")`
-4b. `TaskCreate(subject="Enumerate MCP tool globs", activeForm="Enumerating MCP globs")`
-5. `TaskCreate(subject="Ensure script coverage", activeForm="Verifying script rules")`
-6. `TaskCreate(subject="Merge worktree permissions", activeForm="Merging worktree perms")`
-7. `TaskCreate(subject="Audit permissions for friction", activeForm="Auditing permissions")`
-8. `TaskCreate(subject="Clean project files", activeForm="Cleaning project files")`
+## Execution
 
-Set sequential dependencies. Mark each step `in_progress` when
-starting and `completed` when done. Steps that produce no
-changes (dry-run shows no diff) should still be marked
-`completed` with a note in the description.
-
-## When to Use
-
-- After installing a new Dev10x plugin version
-- When `Bash()` allow rules fail because paths reference an old version
-- After `claude plugin update`
-- When worktree sessions accumulate useful permissions the main project lacks
-- When permissions contain session-specific args (ticket IDs, PR numbers) that should be generalized for future sessions
-- When you suspect allow rules cause friction by permitting script calls that should use skills instead
-
-## First-Time Setup
-
-Initialize userspace config with your project roots:
-
-```bash
-${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/scripts/update-paths.py --init
-```
-
-Then edit `~/.claude/skills/Dev10x:upgrade-cleanup/projects.yaml`
-to add your project roots.
-
-## Workflow
-
-### 1. Update version paths
-
-1. Dry run first to preview changes:
-
-```bash
-${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/scripts/update-paths.py --dry-run
-```
-
-For large updates (many settings files), prefer `--summary` to
-get one line per changed file instead of full per-file detail:
-
-```bash
-${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/scripts/update-paths.py --dry-run --summary
-```
-
-2. Apply updates:
-
-```bash
-${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/scripts/update-paths.py
-```
-
-### 2. Migrate config files
-
-Move config files from deprecated locations to canonical Dev10x
-paths. Files are moved (not copied) so old paths stop working
-immediately.
-
-**Migrations:**
-
-| Old path | New path |
-|----------|----------|
-| `~/.claude/memory/slack-config.yaml` | `~/.claude/memory/Dev10x/slack-config.yaml` |
-| `~/.claude/memory/slack-config-code-review-requests.yaml` | `~/.claude/memory/Dev10x/slack-config-code-review-requests.yaml` |
-| `~/.claude/memory/github-reviewers-config.yaml` | `~/.claude/memory/Dev10x/github-reviewers-config.yaml` |
-| `~/.claude/memory/databases.yaml` | `~/.claude/memory/Dev10x/databases.yaml` |
-
-For each file:
-1. Check if source exists
-2. Check if destination already exists (skip if so, warn user)
-3. Ensure `~/.claude/memory/Dev10x/` directory exists
-4. `mv` source to destination
-5. Report what was moved
-
-Skip files that don't exist at the old path (user may not use
-that feature). Warn if a file exists at both old and new paths.
-
-### 3. Ensure base permissions
-
-Add missing base permissions (gh CLI, /tmp/claude paths, git ops, MCP
-tools, Dev10x config file RWE access) to all settings files. The base
-set is defined in `projects.yaml` under `base_permissions:`.
-
-**Enumeration requirement:** All script paths and MCP tool names
-MUST be listed individually in `base_permissions`. Glob wildcards
-(e.g., `Bash(~/.claude/plugins/cache/**:*)` or
-`mcp__plugin_Dev10x_*`) cause permission friction — Claude Code
-cannot pre-approve glob patterns for Bash or MCP tools, so each
-invocation triggers a manual approval prompt. When adding new
-scripts or MCP tools to the plugin, enumerate them explicitly in
-`projects.yaml` following the existing per-script and per-tool
-entries.
-
-1. Dry run:
+Delegate to the maintenance skill in `full` mode:
 
 ```
-mcp__plugin_Dev10x_cli__update_paths(ensure_base=true, dry_run=true)
+Skill(skill="Dev10x:plugin-maintenance", args="full")
 ```
 
-2. Apply:
-
-```
-mcp__plugin_Dev10x_cli__update_paths(ensure_base=true)
-```
-
-### 4. Generalize session-specific permissions
-
-Replace permission rules containing session-specific arguments (ticket
-IDs, PR numbers, temp file hashes) with generalized wildcard patterns
-that work across future sessions.
-
-1. Dry run to preview generalizations:
-
-```
-mcp__plugin_Dev10x_cli__update_paths(generalize=true, dry_run=true)
-```
-
-2. Apply generalizations:
-
-```
-mcp__plugin_Dev10x_cli__update_paths(generalize=true)
-```
-
-**What gets generalized:**
-- `detect-tracker.sh PAY-123` → `detect-tracker.sh *` (ticket IDs)
-- `gh-pr-detect.sh 42` → `gh-pr-detect.sh *` (PR numbers)
-- `gh-issue-get.sh 15` → `gh-issue-get.sh *` (issue numbers)
-- `generate-commit-list.sh 42` → `generate-commit-list.sh *` (PR args)
-- `/tmp/Dev10x/git/msg.AbCdEf.txt` → `/tmp/Dev10x/git/**` (temp hashes)
-
-### 4b. Enumerate MCP tool globs
-
-Claude Code does not expand `mcp__plugin_Dev10x_*` globs in allow
-rules — glob-shaped MCP rules match nothing, so every MCP call
-triggers a manual approval prompt. This step discovers Dev10x MCP
-tools from the plugin's own server registrations and replaces any
-matching wildcard in a settings file with the enumerated tool list.
-
-> **Note:** With `ensure_base` already auto-expanding stale MCP
-> wildcards in step 3 (since v0.66.0), this step is usually a
-> no-op. Run it to catch wildcards introduced by other tooling
-> or external edits.
-
-1. Dry run to preview expansions:
-
-```bash
-${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/scripts/enumerate-mcp.py --dry-run
-```
-
-2. Apply expansions:
-
-```bash
-${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/scripts/enumerate-mcp.py
-```
-
-**What gets expanded:**
-- `mcp__plugin_Dev10x_*` → every tool registered by the Dev10x
-  cli and db MCP servers (deduplicated against existing rules)
-- `mcp__plugin_Dev10x_cli_*` → every tool registered by the Dev10x
-  cli server only
-
-The catalog is auto-discovered by parsing `@server.tool()`
-decorators in `src/dev10x/mcp/server_cli.py` and `server_db.py`,
-so the expansion is always accurate for the plugin version you
-have checked out.
-
-### 5. Ensure script coverage
-
-Verify that all callable scripts in the current plugin version have
-individual allow rules in each settings file. New plugin versions may
-add scripts that are not yet enumerated.
-
-1. Dry run to preview missing rules:
-
-```
-mcp__plugin_Dev10x_cli__update_paths(ensure_scripts=true, dry_run=true)
-```
-
-2. Add missing script rules:
-
-```
-mcp__plugin_Dev10x_cli__update_paths(ensure_scripts=true)
-```
-
-**What gets scanned:**
-- `bin/*.sh` — helper scripts
-- `hooks/scripts/*.py`, `hooks/scripts/*.sh` — hook implementations
-- `skills/*/scripts/*.py`, `skills/*/scripts/*.sh` — skill scripts
-
-### 6. Merge worktree permissions
-
-Worktrees accumulate allow rules during sessions that the main project
-never sees. This script collects stable permissions from all worktrees
-and merges them back.
-
-1. Dry run to preview:
-
-```bash
-${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/scripts/merge-worktree-permissions.py --dry-run
-```
-
-2. Apply merge:
-
-```bash
-${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/scripts/merge-worktree-permissions.py
-```
-
-Session-specific noise (temp file hashes, inline conditionals, ticket-
-specific script args) is filtered out automatically. Only stable,
-reusable permissions are merged.
-
-### 7. Audit permissions for friction
-
-Dispatch the `permission-auditor` agent to perform a comprehensive
-7-phase security and friction audit. The agent analyzes:
-
-- Overly broad allow rules that should be narrowed
-- Script-call permissions that should use skills instead
-- Missing deny rules for destructive operations
-- Dead rules blocked by hooks
-- Hardcoded paths in instruction files
-
-**Invoke:** Launch the `permission-auditor` agent via:
-
-```
-Agent(subagent_type="Dev10x:permission-auditor",
-    description="Audit permission settings",
-    prompt="Audit all Claude Code permission settings for security
-    gaps, overly broad rules, and friction-causing patterns.
-    Pay special attention to allow rules that permit direct script
-    calls when equivalent skills exist — these cause friction and
-    should be replaced with Skill() invocations or blocked.")
-```
-
-The agent produces a severity-categorized report with specific fix
-proposals. Review and apply selectively.
-
-### 8. Clean project files
-
-Strip redundant rules from project `settings.local.json` files that are
-now covered by global `~/.claude/settings.json`. Also flags rules
-containing leaked secrets (env vars with plaintext credential values).
-
-1. Dry run to preview:
-
-```bash
-${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/scripts/clean-project-files.py --dry-run
-```
-
-For large cleanups, prefer `--summary` to get one line per
-changed file instead of full per-file detail. (Files with
-flagged secrets always show full output regardless of mode.)
-
-```bash
-${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/scripts/clean-project-files.py --dry-run --summary
-```
-
-2. Apply cleanup:
-
-```bash
-${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/scripts/clean-project-files.py
-```
-
-**What gets cleaned:**
-- Exact duplicates of global rules
-- Rules covered by global wildcard patterns (MCP families, plugin path wildcards)
-- Old plugin version paths (any version older than current)
-- Env-prefixed session noise (`GIT_SEQUENCE_EDITOR=*`, `DATABASE_URL=*`, etc.)
-- Shell control flow fragments (`do`, `done`, `fi`, `for`, `while`, etc.)
-- Double-slash path typos (`Read(//work/...)`)
-
-**Leaked secret detection:** Rules containing plaintext credentials
-(e.g., `LINEAR_KEY=lin_api_...`) are flagged with warnings so users
-know they were persisted in settings files and can rotate them.
+The maintenance skill creates its own task list and runs
+steps 1–9 sequentially (update paths → migrate configs →
+ensure base perms → generalize → enumerate MCP → script
+coverage → worktree merge → permission audit → clean project
+files).
 
 ## Configuration
 
-The script looks for `projects.yaml` in two locations (first wins):
-1. `~/.claude/skills/Dev10x:upgrade-cleanup/projects.yaml` (userspace)
-2. `${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/projects.yaml` (plugin default)
-
-The userspace config is user-specific and not tracked in git.
-The plugin default ships with empty roots as a template.
-
-## Options
-
-### update_paths MCP tool
-
-| Parameter | Purpose |
-|-----------|---------|
-| `dry_run` | Preview changes without writing |
-| `version` | Target a specific version instead of latest |
-| `init` | Copy plugin default config to userspace for customization |
-| `ensure_base` | Add missing base permissions from projects.yaml |
-| `generalize` | Replace session-specific args with wildcard patterns |
-| `ensure_scripts` | Verify all plugin scripts have allow rules; add missing |
-
-### update-paths.py CLI
-
-| Flag | Purpose |
-|------|---------|
-| `--dry-run` | Preview what would change without writing |
-| `--summary` | One line per changed file (count) — concise output |
-| `--quiet` | Suppress per-file details and headers |
-| `--version VER` | Target a specific version instead of latest |
-| `--restore` | Restore settings from most recent backups |
-
-### merge-worktree-permissions.py
-
-| Flag | Purpose |
-|------|---------|
-| `--dry-run` | Preview what would be merged without writing |
-
-### clean-project-files.py
-
-| Flag | Purpose |
-|------|---------|
-| `--dry-run` | Preview what would be cleaned without writing |
-| `--summary` | One line per changed file (count) — concise output |
-| `--verbose` | Print every affected rule (verbose) |
+See `Dev10x:plugin-maintenance` for `projects.yaml` location
+and base-permission semantics. The userspace config path
+(`~/.claude/skills/Dev10x:upgrade-cleanup/projects.yaml`) is
+unchanged for backward compatibility.


### PR DESCRIPTION
**When** a new user runs `/Dev10x:onboarding` for the first time, **the new user wants** the recommended permission baseline applied automatically, **so the user can** start running Dev10x skills like git-commit, gh-pr-create, and mktmp without hitting manual approval prompts that contradict the tour's "no friction" promise.

---

- ✨ GH-1 Streamline first-run permission setup
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/1

---