### PR TITLE
♻️ GH-993 Guard request-review against approved PR pings

### DIFF
--- a/references/review-guidelines.md
+++ b/references/review-guidelines.md
@@ -4,6 +4,44 @@ Review **workflow** rules — how to conduct reviews, manage threads,
 write summaries, and interact with authors. For **what to check**
 in code, see the domain-specific agent specs in `.claude/agents/`.
 
+## Approval State Guard (GH-993)
+
+Before requesting review (or re-review) on a PR, the
+`Dev10x:request-review` skill family **must** check the PR's
+current review state to avoid pinging reviewers on already-approved
+PRs.
+
+**Decision rule:**
+
+1. Fetch state via `gh pr view N --json reviewDecision,reviews,headRefOid`
+   (or the equivalent MCP tool).
+2. If `reviewDecision == "APPROVED"` AND the latest review's
+   `commit.oid` matches `headRefOid` → PR is approved on the
+   current HEAD. **Short-circuit** the request and offer
+   `Dev10x:gh-pr-merge` instead via `AskUserQuestion`.
+3. If `reviewDecision == "APPROVED"` but newer commits have
+   invalidated the approval (review SHA != HEAD SHA) →
+   proceed with re-request, but **filter out** any reviewer whose
+   most recent review on the current HEAD is already `APPROVED`.
+4. Otherwise (`CHANGES_REQUESTED`, `REVIEW_REQUIRED`, or `null`) →
+   proceed normally.
+
+**Bypass:** Callers may pass `bypass_approval_check: true` (or a
+`--force` flag) to skip the guard. This is intended for explicit
+internal flows — e.g., `Dev10x:gh-pr-monitor` Phase 3 re-request
+after fixups, where the caller has already validated state. Do
+not bypass for direct user invocations.
+
+**Why?** Re-pings on approved PRs create reviewer fatigue and
+churn — the supervisor's next action is merge, not another review
+cycle. The guard turns a mid-flow noise event into an explicit
+choice between merge and force-request.
+
+The guard applies to:
+- `Dev10x:request-review` (orchestrator) — Step 1.5 precheck
+- `Dev10x:gh-pr-request-review` — Pre-flight Approval State Check
+- `Dev10x:slack-review-request` — Step 0 precheck
+
 ## Review Workflow
 
 1. Check existing review comments (mcp__github__get_pull_request_review_comments)

--- a/skills/gh-pr-request-review/SKILL.md
+++ b/skills/gh-pr-request-review/SKILL.md
@@ -62,6 +62,39 @@ projects:
 - `default_action: ask` prompts the user for unconfigured projects;
   `skip` silently skips them
 
+### Pre-flight: Approval State Check (GH-993)
+
+Before requesting review, verify the PR is not already approved
+on its current HEAD. Spamming reviewers with redundant requests
+on already-approved PRs is the failure mode this guard prevents.
+
+1. Fetch review state:
+   ```bash
+   gh pr view {pr_number} --repo {repo} \
+     --json reviewDecision,reviews,headRefOid
+   ```
+2. **If `reviewDecision == "APPROVED"`** and the latest review's
+   `commit.oid` matches `headRefOid`: the PR is approved on the
+   current HEAD. **REQUIRED: Call `AskUserQuestion`** (do NOT use
+   plain text) with options:
+   - **Skip — already approved (Recommended)** — short-circuit;
+     suggest `Dev10x:gh-pr-merge` instead
+   - **Force request anyway** — proceed (e.g., need additional
+     reviewers beyond the existing approver)
+   - **Cancel** — do nothing
+3. **If `reviewDecision == "APPROVED"`** but newer commits invalidate
+   the approval (latest review `commit.oid` != `headRefOid`): proceed
+   to the re-request flow but **filter out** any reviewer whose latest
+   review on the current HEAD is `APPROVED`. Build the per-reviewer
+   filter from `reviews[]` grouped by `author.login`, taking each
+   author's most recent review.
+4. **Otherwise** (`CHANGES_REQUESTED` or `null`): proceed normally.
+
+Skip this precheck when invoked with `--force` flag or when the
+caller passes `bypass_approval_check: true` (e.g., from
+`Dev10x:gh-pr-monitor` Phase 3 after fixup commits where the monitor
+has already validated the state transition).
+
 ### Pre-flight: Draft State Check (GH-851 F7)
 
 Before requesting review, verify the PR is not in draft state.

--- a/skills/request-review/SKILL.md
+++ b/skills/request-review/SKILL.md
@@ -43,6 +43,38 @@ Pass `$ARG` as the skill argument (PR URL, bare number, or empty).
 
 If detection fails, report the error and stop.
 
+### Step 1.5: Approval state precheck (GH-993)
+
+Before pinging reviewers, check whether the PR is already
+approved on its current HEAD:
+
+```bash
+gh pr view {PR_NUMBER} --repo {REPO} \
+  --json reviewDecision,reviews,headRefOid
+```
+
+Decision logic:
+
+- `reviewDecision == "APPROVED"` and the latest review's
+  `commit.oid` matches `headRefOid` → PR is approved on the
+  current HEAD. **REQUIRED: Call `AskUserQuestion`** (do NOT
+  use plain text):
+  - **Skip — merge instead (Recommended)** — short-circuit
+    review request and offer to invoke `Dev10x:gh-pr-merge`
+  - **Force request anyway** — proceed to Step 2 with all
+    reviewers (e.g., user wants additional eyes)
+  - **Cancel** — do nothing
+- `reviewDecision == "APPROVED"` but newer commits have landed
+  since the latest approval → approval is stale; proceed
+  normally to Step 2 (re-review needed)
+- `reviewDecision == "CHANGES_REQUESTED"` or `null` → proceed
+  normally to Step 2
+
+Skip this precheck when invoked with `--force` or when the
+caller is `Dev10x:gh-pr-monitor` Phase 3 with explicit
+`bypass_approval_check: true` (re-review request after fixups
+where the monitor has already validated state).
+
 ### Step 2: Assign GitHub reviewers
 
 Delegate to the GitHub reviewer assignment skill:

--- a/skills/slack-review-request/SKILL.md
+++ b/skills/slack-review-request/SKILL.md
@@ -62,6 +62,29 @@ Mentions are resolved against `~/.claude/memory/Dev10x/slack-config.yaml`
 
 ## Flow
 
+### Step 0: Approval state precheck (GH-993)
+
+Before posting a Slack ping, verify the PR is not already approved
+on its current HEAD. Re-pinging reviewers on an approved PR is
+noise — the human supervisor's next action is merge, not another
+review pass.
+
+1. Fetch review state:
+   ```bash
+   gh pr view {pr_number} --repo {repo} \
+     --json reviewDecision,reviews,headRefOid
+   ```
+2. **If `reviewDecision == "APPROVED"`** and the latest review's
+   `commit.oid` matches `headRefOid`: skip the Slack notification.
+   Report "Slack notification skipped — PR already approved on
+   current HEAD" and stop.
+3. **Otherwise**: proceed to Step 1.
+
+Skip this precheck when invoked with `--force` flag or when the
+caller passes `bypass_approval_check: true` (e.g., re-review
+notifications composed by `Dev10x:gh-pr-monitor` Phase 2.7 after
+fixups, where the caller has already validated state).
+
 ### Step 1: Prepare
 
 Resolve project config and format the Slack message:


### PR DESCRIPTION
**When** I run `Dev10x:request-review` on a PR, **I want to** detect that the PR is already approved on its current HEAD before pinging reviewers, **so I can** avoid sending redundant review requests and Slack pings that create reviewer fatigue and workflow churn.

---

- ♻️ GH-993 Guard request-review against approved PR pings
Fixes: https://github.com/Dev10x-Guru/dev10x-claude2/issues/993

---