### PR TITLE
✨ GH-5 Detect raw CLI in skill docs to prevent MCP/Skill bypass

### DIFF
--- a/.claude/agents/reviewer-skill.md
+++ b/.claude/agents/reviewer-skill.md
@@ -107,6 +107,22 @@ Files matching: `skills/**`
     Exemptions follow the same rule as 14: orchestration hubs may
     exceed the budget with a one-line justification.
 
+15. **CLI-friction scanner** (GH-5) — run
+    `bin/check-skill-cli-friction.py <changed-skill-files>` and flag any
+    output as CRITICAL. Common findings the scanner detects:
+    - Raw `gh pr|issue|api|repo` in bash fences → must use
+      `mcp__plugin_Dev10x_cli__*` tools
+    - Raw `git commit|push|rebase|checkout -b` → must delegate to the
+      matching `Skill(Dev10x:git-*)` / `Skill(Dev10x:ticket-branch)`
+      wrapper
+    - Raw `pytest` invocation → must use `Skill(Dev10x:py-test)`
+    - `--no-verify` anywhere → CLAUDE.md global rule, no exemption
+    Skills that *implement* a wrapper are exempt automatically (see
+    `SKILL_EXEMPTIONS` in `src/dev10x/skills/audit/cli_friction.py`).
+    For one-off legitimate cases, suggest the inline marker
+    `# cli-friction: allow <rule-id> — reason` rather than adding a
+    skill-wide exemption.
+
 ## Output Format
 
 Apply to ALL `skills/**` files in the diff, including same-PR additions.

--- a/.github/workflows/skill-cli-friction.yml
+++ b/.github/workflows/skill-cli-friction.yml
@@ -1,0 +1,84 @@
+name: Skill CLI Friction
+
+on:
+  pull_request:
+    branches: [develop]
+    paths:
+      - "skills/**/SKILL.md"
+      - "skills/**/instructions.md"
+      - "skills/**/references/**/*.md"
+      - "skills/**/references/**/*.yaml"
+      - "skills/**/references/**/*.yml"
+      - "src/dev10x/skills/audit/cli_friction.py"
+      - "tests/skills/audit/test_cli_friction.py"
+      - "bin/check-skill-cli-friction.py"
+      - ".github/workflows/skill-cli-friction.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scanner-tests:
+    name: Scanner unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Run scanner unit tests
+        run: |
+          uv run --extra dev pytest tests/skills/audit/test_cli_friction.py \
+            -v --tb=short -o 'addopts='
+
+  changed-files:
+    name: Scan changed skill docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Collect changed skill docs
+        id: changed
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+          # Diff PR head against the merge base with the target branch so
+          # we only scan files this PR actually changed.
+          BASE_SHA="$(git merge-base "origin/${BASE_REF}" HEAD)"
+          git diff --name-only --diff-filter=AM "${BASE_SHA}" HEAD \
+            | grep -E '^skills/[^/]+/.*\.(md|yaml|yml)$' \
+            | grep -v '/scripts/' \
+            | grep -v '/evals/' \
+            > /tmp/changed-skill-docs.txt || true
+          echo "count=$(wc -l < /tmp/changed-skill-docs.txt)" >> "$GITHUB_OUTPUT"
+          if [ -s /tmp/changed-skill-docs.txt ]; then
+            echo "Changed skill docs:"
+            cat /tmp/changed-skill-docs.txt
+          else
+            echo "No skill docs changed in this PR."
+          fi
+
+      - name: Scan changed files
+        if: steps.changed.outputs.count != '0'
+        run: |
+          set -euo pipefail
+          xargs -a /tmp/changed-skill-docs.txt \
+            uv run --extra dev bin/check-skill-cli-friction.py

--- a/bin/check-skill-cli-friction.py
+++ b/bin/check-skill-cli-friction.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# ///
+"""Scan skill docs for raw CLI usage that should route through MCP/Skill wrappers.
+
+Usage:
+    bin/check-skill-cli-friction.py [--all] [PATH ...]
+
+Modes:
+    No paths given      → read newline-separated paths from stdin
+    Paths given         → scan those files
+    ``--all``           → scan every skill doc under ``skills/``
+
+Exits with status 1 if any violation is found.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from dev10x.skills.audit import cli_friction  # noqa: E402
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        help="Files to scan (default: read from stdin)",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Scan every skill doc under skills/",
+    )
+    return parser.parse_args(argv)
+
+
+def _resolve_paths(args: argparse.Namespace) -> list[Path]:
+    if args.all:
+        return cli_friction.find_target_files(REPO_ROOT / "skills")
+    if args.paths:
+        return list(args.paths)
+    if sys.stdin.isatty():
+        return []
+    return [Path(line.strip()) for line in sys.stdin if line.strip()]
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    paths = _resolve_paths(args)
+    # Filter to files the scanner targets — silently drop unrelated paths
+    # (e.g., a PR that touches both ``skills/`` and ``src/``).
+    target_paths = [
+        p for p in paths if p.is_file() and cli_friction._skill_dir_name(p) is not None
+    ]
+    if not target_paths:
+        print("No skill docs to scan.", file=sys.stderr)
+        return 0
+
+    violations = cli_friction.scan_paths(target_paths)
+    if not violations:
+        print(f"OK — scanned {len(target_paths)} file(s), no CLI-friction violations.")
+        return 0
+
+    print(
+        f"Found {len(violations)} CLI-friction violation(s) "
+        f"across {len({v.path for v in violations})} file(s):\n",
+        file=sys.stderr,
+    )
+    for v in violations:
+        print(v.format(), file=sys.stderr)
+        print(file=sys.stderr)
+
+    print(
+        "Suppress an intentional case with an inline marker on the offending line:\n"
+        "    `# cli-friction: allow <rule-id> — reason`\n",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/dev10x/skills/audit/cli_friction.py
+++ b/src/dev10x/skills/audit/cli_friction.py
@@ -1,0 +1,362 @@
+"""Detect raw CLI commands in skill docs that should route through MCP/Skill wrappers.
+
+Background: skill docs (`SKILL.md`, `instructions.md`, `references/*.md`,
+`references/*.yaml`) sometimes embed example commands like ``gh pr view``,
+``git commit``, or ``pytest`` directly. Two failure modes follow:
+
+1. **Permission friction** — every raw ``gh``/``git``/``pytest`` invocation
+   needs a matching ``Bash(...:*)`` allow rule in front matter, otherwise
+   users hit an approval prompt on every run.
+2. **Guardrail bypass** — the agent reads the example and runs the raw
+   command instead of the project's ``Skill(...)`` wrapper, skipping
+   gitmoji/JTBD/CI-monitor/coverage gates that the wrapper enforces.
+
+This module scans skill docs and reports each raw CLI usage with the
+suggested replacement. Only fenced code blocks tagged ``bash``, ``sh``,
+or ``shell`` are scanned — prose tables that *describe* what to avoid
+are left alone.
+
+Skills whose job is to *implement* the underlying operation (e.g.,
+``git-commit`` implements ``git commit``) are exempt via :data:`SKILL_EXEMPTIONS`.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# ── Skills allowed to embed raw operations (they ARE the wrapper) ──────
+GIT_IMPLEMENTERS = frozenset(
+    {
+        "git",
+        "git-alias-setup",
+        "git-commit",
+        "git-commit-split",
+        "git-fixup",
+        "git-groom",
+        "git-promote",
+        "git-worktree",
+        "ticket-branch",
+    }
+)
+GH_IMPLEMENTERS = frozenset(
+    {
+        "gh-context",
+        "gh-pr-bookmark",
+        "gh-pr-create",
+        "gh-pr-doctor",
+        "gh-pr-fixup",
+        "gh-pr-merge",
+        "gh-pr-monitor",
+        "gh-pr-request-review",
+        "gh-pr-respond",
+        "gh-pr-review",
+        "gh-pr-triage",
+        "request-review",
+    }
+)
+# Skills whose docs intentionally embed raw CLI as the *thing being warned
+# against* — e.g., `skill-reinforcement` quotes the bad command back to the
+# agent so it learns to avoid it.
+META_DOC_SKILLS = frozenset({"skill-reinforcement"})
+PYTEST_IMPLEMENTERS = frozenset({"py-test", "py-test-flaky"})
+
+# Skills exempt from each rule family. Maps rule_id → set of skill dir names.
+SKILL_EXEMPTIONS: dict[str, frozenset[str]] = {
+    "raw-gh-pr": GH_IMPLEMENTERS | META_DOC_SKILLS,
+    "raw-gh-issue": GH_IMPLEMENTERS | META_DOC_SKILLS | frozenset({"ticket-create", "park"}),
+    "raw-gh-api": GH_IMPLEMENTERS | META_DOC_SKILLS,
+    "raw-gh-repo": GH_IMPLEMENTERS | META_DOC_SKILLS,
+    "raw-git-commit": GIT_IMPLEMENTERS | META_DOC_SKILLS,
+    "raw-git-push": GIT_IMPLEMENTERS | META_DOC_SKILLS,
+    "raw-git-rebase": GIT_IMPLEMENTERS | META_DOC_SKILLS,
+    "raw-git-branch": GIT_IMPLEMENTERS | META_DOC_SKILLS,
+    "raw-pytest": PYTEST_IMPLEMENTERS | META_DOC_SKILLS | frozenset({"gh-pr-create"}),
+    "no-verify": frozenset(),
+}
+
+
+@dataclass(frozen=True)
+class Rule:
+    """A single CLI-friction detection rule."""
+
+    rule_id: str
+    pattern: re.Pattern[str]
+    message: str
+    suggestion: str
+
+
+# Patterns target the START of a shell command. Anchors: start-of-line,
+# whitespace, common shell separators (``;``/``|``/``&``), backtick, or
+# ``$(`` (command substitution). Plain ``(`` is excluded so prose like
+# "(not raw pytest)" does not match.
+_CMD_START = r"(?:^|[\s;&|`]|\$\()"
+
+RULES: tuple[Rule, ...] = (
+    Rule(
+        rule_id="raw-gh-pr",
+        pattern=re.compile(
+            _CMD_START + r"gh\s+pr\s+(?:view|list|checks|ready|comment|create|edit|merge|diff)\b"
+        ),
+        message="Raw `gh pr ...` command in skill doc",
+        suggestion=(
+            "Use `mcp__plugin_Dev10x_cli__pr_detect` / `pr_comments` / "
+            "`verify_pr_state` / `Skill(Dev10x:gh-pr-*)` instead"
+        ),
+    ),
+    Rule(
+        rule_id="raw-gh-issue",
+        pattern=re.compile(_CMD_START + r"gh\s+issue\s+(?:view|list|create|comment|edit|close)\b"),
+        message="Raw `gh issue ...` command in skill doc",
+        suggestion=(
+            "Use `mcp__plugin_Dev10x_cli__issue_get` / `issue_comments` / `issue_create` instead"
+        ),
+    ),
+    Rule(
+        rule_id="raw-gh-api",
+        pattern=re.compile(_CMD_START + r"gh\s+api\b"),
+        message="Raw `gh api` command in skill doc",
+        suggestion=(
+            "Use the matching `mcp__plugin_Dev10x_cli__*` tool when one exists "
+            "(pr_comments, pr_comment_reply, issue_get, request_review, ...)"
+        ),
+    ),
+    Rule(
+        rule_id="raw-gh-repo",
+        pattern=re.compile(_CMD_START + r"gh\s+repo\s+view\b"),
+        message="Raw `gh repo view` command in skill doc",
+        suggestion="Use `mcp__plugin_Dev10x_cli__pr_detect` (returns repo) or `detect_base_branch`",
+    ),
+    Rule(
+        rule_id="raw-git-commit",
+        # Match `git commit` but NOT `git commit -F <file>` inside our own
+        # commit-message pattern (still flag — the wrapper still applies).
+        pattern=re.compile(_CMD_START + r"git\s+commit\b"),
+        message="Raw `git commit` command in skill doc",
+        suggestion="Use `Skill(Dev10x:git-commit)` (or `Skill(Dev10x:git-fixup)` for fixups)",
+    ),
+    Rule(
+        rule_id="raw-git-push",
+        pattern=re.compile(_CMD_START + r"git\s+push\b"),
+        message="Raw `git push` command in skill doc",
+        suggestion="Use `Skill(Dev10x:git)` — enforces protected-branch checks",
+    ),
+    Rule(
+        rule_id="raw-git-rebase",
+        pattern=re.compile(_CMD_START + r"git\s+rebase\b"),
+        message="Raw `git rebase` command in skill doc",
+        suggestion="Use `Skill(Dev10x:git-groom)` for history rewrites, `Skill(Dev10x:git)` for unattended rebases",
+    ),
+    Rule(
+        rule_id="raw-git-branch",
+        pattern=re.compile(_CMD_START + r"git\s+checkout\s+-b\b"),
+        message="Raw `git checkout -b` command in skill doc",
+        suggestion="Use `Skill(Dev10x:ticket-branch)` (enforces username/TICKET-ID/slug naming)",
+    ),
+    Rule(
+        rule_id="raw-pytest",
+        pattern=re.compile(
+            _CMD_START + r"(?:uv\s+run\s+(?:--[\w=-]+\s+)*)?(?:python\s+-m\s+)?pytest\b"
+        ),
+        message="Raw `pytest` invocation in skill doc",
+        suggestion="Use `Skill(Dev10x:py-test)` — enforces coverage gate",
+    ),
+    Rule(
+        rule_id="no-verify",
+        pattern=re.compile(r"--no-verify\b"),
+        message="`--no-verify` skips pre-commit hooks (CLAUDE.md global rule)",
+        suggestion="Fix the underlying hook failure instead of bypassing it",
+    ),
+)
+
+# Per-line opt-out marker. Place ``# cli-friction: allow <rule-id> — reason``
+# at the end of the offending line to silence the scanner.
+_INLINE_ALLOW = re.compile(r"(?:#|<!--)\s*cli-friction:\s*allow\s+(?P<rule>[\w,-]+)")
+_FENCE_OPEN = re.compile(r"^\s*```(?P<lang>\w*)")
+_FENCE_CLOSE = re.compile(r"^\s*```\s*$")
+# Only fences explicitly tagged as a shell language are scanned. Untagged
+# fences (``` ... ```) frequently hold output/example transcripts where
+# the agent should NOT mistake the content for executable instructions.
+_SCANNED_LANGS = frozenset({"bash", "sh", "shell", "console"})
+
+# YAML block scalar opener — ``key: |`` or ``key: >`` (with optional
+# chomping/indent indicators) starts an indented prose block.
+_YAML_BLOCK_OPEN = re.compile(r":\s*[|>][+-]?\d*\s*$")
+
+
+@dataclass(frozen=True)
+class Violation:
+    """A single rule hit in a skill file."""
+
+    path: Path
+    line_no: int
+    line: str
+    rule: Rule
+
+    def format(self) -> str:
+        return (
+            f"{self.path}:{self.line_no}: [{self.rule.rule_id}] "
+            f"{self.rule.message}\n"
+            f"    | {self.line.rstrip()}\n"
+            f"    → {self.rule.suggestion}"
+        )
+
+
+@dataclass
+class _ScanState:
+    in_fence: bool = False
+    fence_lang: str = ""
+    in_frontmatter: bool = False
+    # YAML block scalar tracking — when active, ``yaml_block_indent`` is the
+    # column at which the block's prose starts; lines indented further than
+    # that are skipped. ``None`` means no active block.
+    yaml_block_indent: int | None = None
+    allowed_rules: set[str] = field(default_factory=set)
+
+
+def _skill_dir_name(path: Path) -> str | None:
+    """Return the skill directory name for a path under skills/<name>/, else None."""
+    parts = path.parts
+    try:
+        idx = parts.index("skills")
+    except ValueError:
+        return None
+    if idx + 1 >= len(parts):
+        return None
+    return parts[idx + 1]
+
+
+def _is_exempt(rule: Rule, skill_name: str | None) -> bool:
+    if skill_name is None:
+        return False
+    exempt = SKILL_EXEMPTIONS.get(rule.rule_id, frozenset())
+    return skill_name in exempt
+
+
+def _should_scan_line(line: str, state: _ScanState, path: Path) -> bool:
+    """Decide whether to scan a single line for rule violations."""
+    stripped = line.strip()
+
+    # Track YAML front matter (skip it).
+    if stripped == "---":
+        if state.in_frontmatter:
+            state.in_frontmatter = False
+            return False
+        # Front matter only opens at the very first non-empty line of the file;
+        # we approximate by toggling on the first ``---``.
+        if not state.in_fence:
+            state.in_frontmatter = not state.in_frontmatter
+            return False
+
+    if state.in_frontmatter:
+        return False
+
+    # Track fenced code blocks.
+    open_m = _FENCE_OPEN.match(line)
+    if open_m and not state.in_fence:
+        state.in_fence = True
+        state.fence_lang = open_m.group("lang").lower()
+        return False
+    if _FENCE_CLOSE.match(line) and state.in_fence:
+        state.in_fence = False
+        state.fence_lang = ""
+        return False
+
+    # Markdown files: scan only inside fences explicitly tagged as a shell
+    # language. Untagged fences usually hold output transcripts, not commands.
+    if path.suffix == ".md":
+        if not state.in_fence:
+            return False
+        return state.fence_lang in _SCANNED_LANGS
+
+    # YAML files (e.g., playbook.yaml): skip indented prose inside block
+    # scalars (``prompt: >`` / ``check: |``); scan everything else so command
+    # values like ``check: gh pr checks`` are still flagged.
+    if path.suffix in {".yaml", ".yml"}:
+        if state.yaml_block_indent is not None:
+            indent = len(line) - len(line.lstrip())
+            if line.strip() == "" or indent >= state.yaml_block_indent:
+                # Still inside the block scalar — skip.
+                if _YAML_BLOCK_OPEN.search(line):
+                    state.yaml_block_indent = indent + 2
+                return False
+            # De-dented past the scalar; resume scanning.
+            state.yaml_block_indent = None
+        if _YAML_BLOCK_OPEN.search(line):
+            state.yaml_block_indent = len(line) - len(line.lstrip()) + 2
+            # The opener line itself has no value — nothing to scan.
+            return False
+        return True
+    return True
+
+
+def scan_file(path: Path) -> list[Violation]:
+    """Return all rule violations in a single skill doc."""
+    if not path.is_file():
+        return []
+
+    skill_name = _skill_dir_name(path)
+    content = path.read_text()
+    state = _ScanState()
+    violations: list[Violation] = []
+
+    for line_no, line in enumerate(content.splitlines(), start=1):
+        if not _should_scan_line(line, state, path):
+            continue
+
+        # Per-line opt-out — comma-separated list of rule IDs.
+        allow_match = _INLINE_ALLOW.search(line)
+        allowed_here: set[str] = set()
+        if allow_match:
+            allowed_here = {r.strip() for r in allow_match.group("rule").split(",")}
+
+        for rule in RULES:
+            if rule.rule_id in allowed_here:
+                continue
+            if _is_exempt(rule, skill_name):
+                continue
+            if rule.pattern.search(line):
+                violations.append(Violation(path=path, line_no=line_no, line=line, rule=rule))
+
+    return violations
+
+
+def scan_paths(paths: list[Path]) -> list[Violation]:
+    """Scan many files and return aggregated violations."""
+    violations: list[Violation] = []
+    for path in paths:
+        violations.extend(scan_file(path))
+    return violations
+
+
+_TARGET_SUFFIXES = frozenset({".md", ".yaml", ".yml"})
+_TARGET_NAMES = frozenset({"SKILL.md", "instructions.md", "playbook.yaml"})
+
+
+def find_target_files(root: Path) -> list[Path]:
+    """Return doc files under ``skills/`` that the scanner targets.
+
+    Only files that ship instructions to agents — ``SKILL.md``, ``instructions.md``,
+    and any ``.md``/``.yaml`` under a skill's ``references/`` directory — are
+    in scope. Implementation files under ``scripts/`` are intentionally
+    excluded; they ARE the wrapper.
+    """
+    if not root.is_dir():
+        return []
+
+    results: list[Path] = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        if path.suffix not in _TARGET_SUFFIXES:
+            continue
+        # Skip eval criteria files — they describe what to test, not what to do.
+        if path.parent.name == "evals":
+            continue
+        # Skip script directories.
+        if "scripts" in path.parts:
+            continue
+        if path.name in _TARGET_NAMES or "references" in path.parts:
+            results.append(path)
+    return results

--- a/tests/skills/audit/test_cli_friction.py
+++ b/tests/skills/audit/test_cli_friction.py
@@ -1,0 +1,241 @@
+"""Tests for the CLI-friction scanner (GH-5)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dev10x.skills.audit import cli_friction as mod
+
+
+def _write(path: Path, body: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+    return path
+
+
+@pytest.fixture
+def skill_root(tmp_path: Path) -> Path:
+    """A throwaway ``skills/`` root for fixture files."""
+    root = tmp_path / "skills"
+    root.mkdir()
+    return root
+
+
+class TestRulesMatchRawCommands:
+    """Each rule fires on the canonical raw-command form."""
+
+    @pytest.mark.parametrize(
+        ("rule_id", "line"),
+        [
+            ("raw-gh-pr", "gh pr view 42 --json title"),
+            ("raw-gh-pr", "$ gh pr list --state open"),
+            ("raw-gh-issue", "gh issue create --title foo"),
+            ("raw-gh-api", "gh api repos/owner/repo/pulls/42/comments"),
+            ("raw-gh-repo", "gh repo view --json nameWithOwner"),
+            ("raw-git-commit", "git commit -m 'msg'"),
+            ("raw-git-push", "git push --force-with-lease origin foo"),
+            ("raw-git-rebase", "git rebase -i develop"),
+            ("raw-git-branch", "git checkout -b user/PROJ-1/slug"),
+            ("raw-pytest", "pytest src/"),
+            ("raw-pytest", "uv run pytest --cov"),
+            ("raw-pytest", "python -m pytest"),
+            ("no-verify", "git commit --no-verify -m 'rebase'"),
+        ],
+    )
+    def test_rule_fires_for_canonical_command(
+        self, skill_root: Path, rule_id: str, line: str
+    ) -> None:
+        skill = _write(
+            skill_root / "demo" / "SKILL.md",
+            "# Demo\n\n```bash\n" + line + "\n```\n",
+        )
+        violations = mod.scan_file(skill)
+        rule_ids = {v.rule.rule_id for v in violations}
+        assert rule_id in rule_ids
+
+
+class TestRulesIgnoreProse:
+    """Rule patterns ignore lines outside fenced bash blocks in Markdown."""
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "We previously used `gh pr view` — now use the MCP tool.",
+            "| Run tests | `Skill(test)` | `pytest`, `uv run pytest` |",
+            "Avoid running `git commit` directly.",
+            "Never use `gh api` from inside a skill body.",
+        ],
+    )
+    def test_prose_mentions_are_ignored(self, skill_root: Path, line: str) -> None:
+        skill = _write(skill_root / "demo" / "SKILL.md", "# Demo\n\n" + line + "\n")
+        assert mod.scan_file(skill) == []
+
+    def test_non_bash_fence_is_ignored(self, skill_root: Path) -> None:
+        skill = _write(
+            skill_root / "demo" / "SKILL.md",
+            "# Demo\n\n```python\nsubprocess.run(['gh', 'pr', 'view'])\n```\n",
+        )
+        assert mod.scan_file(skill) == []
+
+    def test_frontmatter_is_ignored(self, skill_root: Path) -> None:
+        skill = _write(
+            skill_root / "demo" / "SKILL.md",
+            "---\nname: Dev10x:demo\nallowed-tools:\n  - Bash(git commit:*)\n---\n",
+        )
+        assert mod.scan_file(skill) == []
+
+
+class TestSkillExemptions:
+    """Skills that implement the underlying op are exempt from their rules."""
+
+    @pytest.mark.parametrize(
+        ("skill_name", "rule_id", "line"),
+        [
+            ("git-commit", "raw-git-commit", "git commit -m 'msg'"),
+            ("git-groom", "raw-git-rebase", "git rebase -i develop"),
+            ("git", "raw-git-push", "git push --force-with-lease"),
+            ("ticket-branch", "raw-git-branch", "git checkout -b user/X/slug"),
+            ("gh-pr-respond", "raw-gh-api", "gh api repos/o/r/pulls/comments"),
+            ("py-test", "raw-pytest", "pytest --cov"),
+        ],
+    )
+    def test_implementer_skill_is_exempt(
+        self, skill_root: Path, skill_name: str, rule_id: str, line: str
+    ) -> None:
+        skill = _write(
+            skill_root / skill_name / "SKILL.md",
+            "# X\n\n```bash\n" + line + "\n```\n",
+        )
+        rule_ids = {v.rule.rule_id for v in mod.scan_file(skill)}
+        assert rule_id not in rule_ids
+
+    def test_no_verify_has_no_exemptions(self, skill_root: Path) -> None:
+        skill = _write(
+            skill_root / "git-commit" / "SKILL.md",
+            "# X\n\n```bash\ngit commit --no-verify -m foo\n```\n",
+        )
+        rule_ids = {v.rule.rule_id for v in mod.scan_file(skill)}
+        assert "no-verify" in rule_ids
+
+
+class TestInlineAllow:
+    """Per-line opt-out marker silences specific rules on that line."""
+
+    def test_inline_allow_silences_named_rule(self, skill_root: Path) -> None:
+        skill = _write(
+            skill_root / "demo" / "SKILL.md",
+            (
+                "# X\n\n"
+                "```bash\n"
+                "git commit -m foo  # cli-friction: allow raw-git-commit — example only\n"
+                "```\n"
+            ),
+        )
+        assert mod.scan_file(skill) == []
+
+    def test_inline_allow_does_not_silence_other_rules(self, skill_root: Path) -> None:
+        skill = _write(
+            skill_root / "demo" / "SKILL.md",
+            (
+                "# X\n\n"
+                "```bash\n"
+                "git commit --no-verify  # cli-friction: allow raw-git-commit\n"
+                "```\n"
+            ),
+        )
+        rule_ids = {v.rule.rule_id for v in mod.scan_file(skill)}
+        assert rule_ids == {"no-verify"}
+
+
+class TestYamlScanning:
+    """Playbook YAML files are scanned regardless of fence context."""
+
+    def test_yaml_prompt_with_raw_command_is_flagged(self, skill_root: Path) -> None:
+        playbook = _write(
+            skill_root / "demo" / "references" / "playbook.yaml",
+            "defaults:\n  feature:\n    steps:\n"
+            "      - prompt: Run pytest with coverage. Fix failures.\n",
+        )
+        rule_ids = {v.rule.rule_id for v in mod.scan_file(playbook)}
+        assert "raw-pytest" in rule_ids
+
+    def test_yaml_block_scalar_prose_is_ignored(self, skill_root: Path) -> None:
+        playbook = _write(
+            skill_root / "demo" / "references" / "playbook.yaml",
+            (
+                "defaults:\n"
+                "  bugfix:\n"
+                "    checks:\n"
+                "      - prompt: >\n"
+                "          Were tests delegated to the test skill (not raw\n"
+                "          pytest/uv run pytest)? Were commits via\n"
+                "          Dev10x:git-commit (not raw git commit)?\n"
+                "      - check: gh pr checks {pr_number}\n"
+            ),
+        )
+        violations = mod.scan_file(playbook)
+        # The block-scalar prose should not fire any rule, but the literal
+        # ``check: gh pr checks`` value should still be flagged.
+        rule_ids = [v.rule.rule_id for v in violations]
+        assert rule_ids == ["raw-gh-pr"]
+        assert violations[0].line_no == 8
+
+
+class TestFindTargetFiles:
+    """``find_target_files`` walks a skills root and returns doc files."""
+
+    def test_returns_skill_md_and_instructions_md(self, skill_root: Path) -> None:
+        _write(skill_root / "a" / "SKILL.md", "")
+        _write(skill_root / "a" / "instructions.md", "")
+        _write(skill_root / "a" / "references" / "playbook.yaml", "")
+        _write(skill_root / "a" / "references" / "guide.md", "")
+        files = {p.name for p in mod.find_target_files(skill_root)}
+        assert files == {"SKILL.md", "instructions.md", "playbook.yaml", "guide.md"}
+
+    def test_excludes_scripts_and_evals(self, skill_root: Path) -> None:
+        _write(skill_root / "a" / "scripts" / "run.sh", "")
+        _write(skill_root / "a" / "evals" / "evals.json", "")
+        _write(skill_root / "a" / "SKILL.md", "")
+        files = mod.find_target_files(skill_root)
+        assert [p.name for p in files] == ["SKILL.md"]
+
+    def test_returns_empty_for_missing_root(self, tmp_path: Path) -> None:
+        assert mod.find_target_files(tmp_path / "nonexistent") == []
+
+
+class TestScanPaths:
+    """``scan_paths`` aggregates violations across files."""
+
+    def test_aggregates_across_files(self, skill_root: Path) -> None:
+        a = _write(
+            skill_root / "demo-a" / "SKILL.md",
+            "# A\n\n```bash\ngit commit -m foo\n```\n",
+        )
+        b = _write(
+            skill_root / "demo-b" / "SKILL.md",
+            "# B\n\n```bash\npytest src/\n```\n",
+        )
+        violations = mod.scan_paths([a, b])
+        assert len(violations) == 2
+        assert {v.rule.rule_id for v in violations} == {"raw-git-commit", "raw-pytest"}
+
+    def test_skips_missing_paths(self, skill_root: Path) -> None:
+        assert mod.scan_paths([skill_root / "missing.md"]) == []
+
+
+class TestViolationFormat:
+    """``Violation.format`` produces a reviewer-friendly message."""
+
+    def test_includes_path_line_rule_and_suggestion(self, skill_root: Path) -> None:
+        skill = _write(
+            skill_root / "demo" / "SKILL.md",
+            "# X\n\n```bash\ngit commit -m foo\n```\n",
+        )
+        v = mod.scan_file(skill)[0]
+        formatted = v.format()
+        assert str(skill) in formatted
+        assert "[raw-git-commit]" in formatted
+        assert "git commit -m foo" in formatted
+        assert "Skill(Dev10x:git-commit)" in formatted


### PR DESCRIPTION
**When** a skill doc embeds a raw `gh`, `git`, or `pytest` command in a bash fence, **I want to** flag it on every PR **so the agent can** route through MCP tools or `Skill()` wrappers instead of silently bypassing the gitmoji/JTBD/coverage guardrails those wrappers enforce.

## What this PR adds

- `src/dev10x/skills/audit/cli_friction.py` — scanner with 10 rules (`raw-gh-pr|issue|api|repo`, `raw-git-commit|push|rebase|branch`, `raw-pytest`, `no-verify`), skill-level exemptions for skills that *implement* a wrapper, and an inline `# cli-friction: allow <rule-id> — reason` opt-out marker
- `tests/skills/audit/test_cli_friction.py` — 36 tests (rule firing, prose-ignore, fence/frontmatter/YAML-block-scalar handling, exemptions, aggregation) at 94 % coverage
- `bin/check-skill-cli-friction.py` — CLI entry point; takes paths via args, stdin, or `--all`
- `.github/workflows/skill-cli-friction.yml` — runs the unit tests and scans only the skill docs changed against `merge-base origin/develop HEAD`
- `.claude/agents/reviewer-skill.md` item 15 — Claude PR review now flags scanner output as CRITICAL with the suggested wrapper inline

## Why these rules

The rules mirror the `work-on` Skill Routing Enforcement table: every action that has a project wrapper is detected if used raw. Skills that implement a wrapper (`git-commit`, `gh-pr-respond`, `py-test`, …) are exempt automatically; the meta-doc skill `skill-reinforcement` is exempt too because its job is to quote the bad command back to the agent.

## Real-codebase impact

Running the scanner across `skills/` reports 47 violations across 13 skills — all consistent with the audit checklist already posted on issue #5. Those fixes are deliberately out of scope for this PR; they will land per the suggested order (D → A → C → B → E) on the issue thread.

---

- ✨ GH-5 Detect raw CLI in skill docs to prevent MCP/Skill bypass
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/5

---