### PR TITLE
🐛 GH-998 Lock down skill-audit findings (U1, U2, U5b, U7)

### DIFF
--- a/skills/gh-pr-create/instructions.md
+++ b/skills/gh-pr-create/instructions.md
@@ -291,10 +291,25 @@ ${CLAUDE_PLUGIN_ROOT}/skills/gh-pr-create/scripts/pre-pr-checks.sh
 Automatically skips if no Python files changed. Runs ruff, formatting,
 mypy, and pytest. Exits on first failure.
 
-**If any check fails:**
-- Stop the workflow
-- Display the error output
-- Suggest fix commands
+**STOP on failure (REQUIRED):**
+
+If `pre-pr-checks.sh` exits non-zero, or
+`mcp__plugin_Dev10x_cli__pre_pr_checks` returns
+`{"error": "..."}` or any non-success structure:
+
+1. STOP the PR creation workflow immediately
+2. Display the error output to the user
+3. Suggest fix commands or delegate to the appropriate skill
+   (`Skill(test)` for pytest failures, project lint runner for
+   ruff/black, etc.)
+
+Do NOT attempt to debug by running `uv run mypy`, `.venv/bin/mypy`,
+`ruff check`, `black --check`, or any other lint/test tool directly
+in the main session. The check failure is the signal to halt — not
+to investigate. The agent must hand control back to the user (or to
+a test/lint skill) instead of looping on raw tool invocations. This
+applies whether the failure was reported by the script path or the
+MCP tool path.
 
 ### Step 6: Push and Create Draft PR
 

--- a/skills/slack-review-request/SKILL.md
+++ b/skills/slack-review-request/SKILL.md
@@ -87,7 +87,13 @@ fixups, where the caller has already validated state).
 
 ### Step 1: Prepare
 
-Resolve project config and format the Slack message:
+**REQUIRED:** Run the `prepare` subcommand to resolve project config
+and format the Slack message. Do NOT inline `yq` reads of
+`slack-config.yaml`, manual mention resolution, or hand-built message
+strings — the script handles user-group → `<!subteam^ID>` resolution,
+user → `<@SLACK_ID>` resolution, JTBD extraction from the PR body,
+and channel lookup in one call. Inlining bypasses these and produces
+malformed mentions.
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/skills/slack-review-request/scripts/slack-review-request.py \

--- a/skills/ticket-create/SKILL.md
+++ b/skills/ticket-create/SKILL.md
@@ -51,6 +51,14 @@ Determine which tracker to use. Priority:
 3. **Repo default** — if no prefix, check autolinks to determine project's
    primary tracker. GitHub Issues if no autolinks exist.
 
+**Fast-fail rule:** Make ONE attempt at the `detect_tracker` MCP call.
+If the tool is unavailable, returns an error, or `ToolSearch` does not
+surface it on the first lookup, fall through to step 3 (repo default)
+immediately. Do NOT retry `ToolSearch` for Linear, JIRA, or
+`detect_tracker` MCP names. Repeated retries block the skill for
+many minutes and produce no new information — the absence of a tool
+on the first lookup means it is not registered in this session.
+
 | Tracker | Required | Creation method |
 |---------|----------|----------------|
 | GitHub | `gh` CLI | `gh issue create` |
@@ -160,42 +168,39 @@ Select appropriate labels based on the context:
 
 ### Step 5: Create the Ticket
 
-**REQUIRED:** Delegate ticket creation to a background haiku agent.
-This prevents raw API responses (full issue JSON, project lookups)
-from consuming main session context. The agent returns only the
-ticket ID and URL.
+**REQUIRED: Dispatch a background haiku agent to create the ticket.**
+Execute this `Agent` call (do NOT inline ticket creation in the main
+session). This prevents raw API responses (full issue JSON, project
+lookups) from consuming main session context — the agent returns only
+the ticket ID and URL.
 
-**Dispatch:**
+1. `Agent(subagent_type="general-purpose", model="haiku", description="Create {tracker} ticket: {short_title}", prompt="<see template below>", run_in_background=true)`
+
+The agent prompt template (substitute placeholders before dispatching):
 
 ```
-Agent(
-    subagent_type="general-purpose",
-    model="haiku",
-    description="Create {tracker} ticket: {short_title}",
-    prompt="""
-    Create a ticket with the following details:
+Create a ticket with the following details:
 
-    Tracker: {tracker_type}
-    Title: {title}
-    Description: {description}
-    Labels: {labels}
-    {tracker-specific config: team UUID, project UUID, repo}
+Tracker: {tracker_type}
+Title: {title}
+Description: {description}
+Labels: {labels}
+{tracker-specific config: team UUID, project UUID, repo}
 
-    {include the tracker-specific instructions below}
+{include the tracker-specific instructions below}
 
-    Return ONLY:
-    - Tracker: {GitHub Issues | Linear | JIRA}
-    - ID: {ticket ID}
-    - URL: {ticket URL}
-    Do NOT return full API response bodies.
-    """,
-    run_in_background=true
-)
+Return ONLY:
+- Tracker: {GitHub Issues | Linear | JIRA}
+- ID: {ticket ID}
+- URL: {ticket URL}
+Do NOT return full API response bodies.
 ```
 
 The main session waits for the agent result and passes it to
 Step 6. The tracker-specific instructions below describe what
-the agent executes — include the relevant section in its prompt.
+the agent executes — include the relevant section in the agent's
+prompt (the fenced blocks under each tracker are reference material
+for the dispatched agent, not instructions for the main session).
 
 **Nested invocation:** When invoked from a background agent
 (e.g., from `project-scope`'s Phase 3 agent), skip the


### PR DESCRIPTION
**When** invoking a Dev10x skill nested under another orchestrator, **the developer wants** the skill's mandatory `TaskCreate` and `Agent()` calls to execute reliably, **so the user can** trust that orchestration steps documented in SKILL.md actually run instead of being silently skipped because a fenced code block downgraded them to advisory examples.

---

- 🐛 GH-998 Halt PR creation when pre-PR checks fail
- 🐛 GH-998 Enforce ticket-create haiku dispatch and tracker fast-fail
- 🐛 GH-998 Enforce slack-review-request prepare script use
Fixes: https://github.com/Dev10x-Guru/dev10x-claude2/issues/998

---