### PR TITLE
✨ GH-11 Eliminate per-invocation permission prompts in 18 skills

### DIFF
--- a/skills/audit-report/SKILL.md
+++ b/skills/audit-report/SKILL.md
@@ -14,6 +14,7 @@ allowed-tools:
   - Bash(/tmp/Dev10x/bin/mktmp.sh:*)
   - Skill(Dev10x:ticket-create)
   - Bash(ls ~/.claude/plugins/cache/:*)
+  - Bash(gh issue create:*)
 ---
 
 # Audit Report — File Findings Upstream

--- a/skills/context-audit/SKILL.md
+++ b/skills/context-audit/SKILL.md
@@ -19,6 +19,7 @@ allowed-tools:
   - TaskCreate
   - TaskUpdate
   - Edit
+  - Bash(pytest:*)
 ---
 
 # Dev10x:context-audit — Context Window Optimizer

--- a/skills/fanout-parallel/SKILL.md
+++ b/skills/fanout-parallel/SKILL.md
@@ -22,6 +22,7 @@ allowed-tools:
   - Skill(skill="Dev10x:session-wrap-up")
   - Write(~/.claude/Dev10x/**)
   - mcp__plugin_Dev10x_cli__*
+  - Bash(gh pr view:*)
 ---
 
 # Dev10x:fanout-parallel — Experimental Parallel Fanout

--- a/skills/gh-context/SKILL.md
+++ b/skills/gh-context/SKILL.md
@@ -13,6 +13,9 @@ allowed-tools:
   - mcp__plugin_Dev10x_cli__*
   - Bash(${CLAUDE_PLUGIN_ROOT}/skills/gh-context/scripts/:*)
   - Bash(/tmp/Dev10x/bin/mktmp.sh:*)
+  - Bash(gh pr view:*)
+  - Bash(gh repo view:*)
+  - Bash(gh api:*)
 ---
 
 # Dev10x:gh-context — GitHub CLI helpers

--- a/skills/gh-pr-doctor/SKILL.md
+++ b/skills/gh-pr-doctor/SKILL.md
@@ -16,6 +16,7 @@ allowed-tools:
   - Bash(${CLAUDE_PLUGIN_ROOT}/skills/gh-pr-doctor/scripts/:*)
   - mcp__plugin_Dev10x_cli__unresolved_threads
   - AskUserQuestion
+  - Bash(gh issue create:*)
 ---
 
 # Dev10x:gh-pr-doctor

--- a/skills/gh-pr-fixup/SKILL.md
+++ b/skills/gh-pr-fixup/SKILL.md
@@ -12,6 +12,10 @@ invocation-name: Dev10x:gh-pr-fixup
 allowed-tools:
   - mcp__plugin_Dev10x_cli__pr_comment_reply
   - mcp__plugin_Dev10x_cli__pr_comments
+  - Bash(gh pr comment:*)
+  - Bash(gh api:*)
+  - Bash(pytest:*)
+  - mcp__plugin_Dev10x_cli__push_safe
 ---
 
 # Implement Fix for PR Review Comment

--- a/skills/gh-pr-request-review/SKILL.md
+++ b/skills/gh-pr-request-review/SKILL.md
@@ -9,8 +9,13 @@ user-invocable: true
 invocation-name: Dev10x:gh-pr-request-review
 allowed-tools:
   - mcp__plugin_Dev10x_cli__request_review
+  - mcp__plugin_Dev10x_cli__pr_detect
   - Bash(gh repo view:*)
+  - Bash(gh pr view:*)
+  - Bash(gh pr ready:*)
+  - Bash(gh api:*)
   - Bash(yq:*)
+  - Bash(jq:*)
   - AskUserQuestion
 ---
 

--- a/skills/gh-pr-triage/SKILL.md
+++ b/skills/gh-pr-triage/SKILL.md
@@ -13,6 +13,7 @@ invocation-name: Dev10x:gh-pr-triage
 allowed-tools:
   - mcp__plugin_Dev10x_cli__pr_comment_reply
   - mcp__plugin_Dev10x_cli__pr_comments
+  - Bash(gh api:*)
 ---
 
 # Triage PR Review Comment

--- a/skills/git-fixup/SKILL.md
+++ b/skills/git-fixup/SKILL.md
@@ -13,6 +13,9 @@ invocation-name: Dev10x:git-fixup
 allowed-tools:
   - Bash(/tmp/Dev10x/bin/mktmp.sh:*)
   - Write(/tmp/Dev10x/git/**)
+  - Bash(gh repo view:*)
+  - Bash(gh api:*)
+  - mcp__plugin_Dev10x_cli__push_safe
 ---
 
 # Create Fixup Commit

--- a/skills/park-discover/SKILL.md
+++ b/skills/park-discover/SKILL.md
@@ -9,6 +9,11 @@ description: >
   deferred items.
 user-invocable: true
 invocation-name: Dev10x:park-discover
+allowed-tools:
+  - Bash(gh pr view:*)
+  - Bash(gh pr list:*)
+  - Bash(jq:*)
+  - mcp__claude_ai_Slack__slack_search_public_and_private
 ---
 
 # Dev10x:park-discover — Gather Deferred Items

--- a/skills/park/SKILL.md
+++ b/skills/park/SKILL.md
@@ -10,6 +10,13 @@ description: >
   Dev10x:park-remind).
 user-invocable: true
 invocation-name: Dev10x:park
+allowed-tools:
+  - Bash(gh pr view:*)
+  - Bash(gh pr list:*)
+  - Bash(gh pr comment:*)
+  - Bash(gh api:*)
+  - mcp__plugin_Dev10x_cli__pr_comments
+  - AskUserQuestion
 ---
 
 # Dev10x:park — Smart Deferral Router

--- a/skills/project-audit/SKILL.md
+++ b/skills/project-audit/SKILL.md
@@ -27,6 +27,7 @@ allowed-tools:
   - Skill(Dev10x:project-scope)
   - Skill(Dev10x:adr)
   - Skill(Dev10x:ticket-create)
+  - mcp__plugin_Dev10x_cli__detect_tracker
 ---
 
 # Dev10x:project-audit — Comprehensive Architecture Audit

--- a/skills/project-scope/SKILL.md
+++ b/skills/project-scope/SKILL.md
@@ -26,6 +26,10 @@ allowed-tools:
   - Bash(gh api repos/:*)
   - Bash(/tmp/Dev10x/bin/mktmp.sh:*)
   - Skill(Dev10x:ticket-create)
+  - Bash(gh issue view:*)
+  - Bash(gh issue edit:*)
+  - Bash(gh api:*)
+  - mcp__plugin_Dev10x_cli__detect_tracker
 ---
 
 # Project Scope - Multi-Ticket Project Creation

--- a/skills/request-review/SKILL.md
+++ b/skills/request-review/SKILL.md
@@ -14,6 +14,8 @@ allowed-tools:
   - Bash(${CLAUDE_PLUGIN_ROOT}/skills/gh-context/scripts/:*)
   - Skill(Dev10x:gh-pr-request-review)
   - Skill(Dev10x:slack-review-request)
+  - Bash(gh pr view:*)
+  - Bash(gh pr comment:*)
 ---
 
 ## Orchestration

--- a/skills/session-wrap-up/SKILL.md
+++ b/skills/session-wrap-up/SKILL.md
@@ -9,6 +9,8 @@ description: >
   list, or starting new work (use Dev10x:work-on).
 user-invocable: true
 invocation-name: Dev10x:session-wrap-up
+allowed-tools:
+  - Bash(gh pr list:*)
 ---
 
 # Dev10x:session-wrap-up — Session End Orchestrator

--- a/skills/slack-review-request/SKILL.md
+++ b/skills/slack-review-request/SKILL.md
@@ -11,6 +11,7 @@ user-invocable: true
 invocation-name: Dev10x:slack-review-request
 allowed-tools:
   - Bash(${CLAUDE_PLUGIN_ROOT}/skills/slack-review-request/scripts/:*)
+  - Bash(gh pr view:*)
 ---
 
 # Slack Review Request

--- a/skills/ticket-create/SKILL.md
+++ b/skills/ticket-create/SKILL.md
@@ -21,6 +21,7 @@ allowed-tools:
   - mcp__claude_ai_Linear__list_projects
   - Bash(secret-tool lookup:*)
   - Bash(curl:*atlassian.net*)
+  - mcp__plugin_Dev10x_cli__detect_tracker
 ---
 
 # Create Issue Tracker Ticket

--- a/skills/ticket-jtbd/SKILL.md
+++ b/skills/ticket-jtbd/SKILL.md
@@ -24,6 +24,8 @@ allowed-tools:
   - mcp__claude_ai_Linear__update_issue
   - Bash(secret-tool lookup:*)
   - Bash(curl:*atlassian.net*)
+  - Bash(gh issue comment:*)
+  - mcp__plugin_Dev10x_cli__detect_tracker
 ---
 
 # Write JTBD Story to Target


### PR DESCRIPTION
**When** invoking a Dev10x skill that calls external `gh`, `git`, or `pytest` commands, **the agent wants** every external invocation to be pre-declared in the skill's `allowed-tools:` front matter, **so the user can** run the skill without granting per-invocation Bash permissions on every step.

---

- ✨ GH-11 Eliminate per-invocation permission prompts in 18 skills
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/11

---