### PR TITLE
♻️ GH-12 Eliminate raw gh CLI in PR-skill bodies

### DIFF
--- a/skills/gh-pr-request-review/SKILL.md
+++ b/skills/gh-pr-request-review/SKILL.md
@@ -10,10 +10,10 @@ invocation-name: Dev10x:gh-pr-request-review
 allowed-tools:
   - mcp__plugin_Dev10x_cli__request_review
   - mcp__plugin_Dev10x_cli__pr_detect
-  - Bash(gh repo view:*)
   - Bash(gh pr view:*)
   - Bash(gh pr ready:*)
-  - Bash(gh api:*)
+  - Bash(gh api orgs/:*)
+  - Bash(git remote get-url:*)
   - Bash(yq:*)
   - Bash(jq:*)
   - AskUserQuestion
@@ -73,7 +73,8 @@ Before requesting review, verify the PR is not already approved
 on its current HEAD. Spamming reviewers with redundant requests
 on already-approved PRs is the failure mode this guard prevents.
 
-1. Fetch review state:
+1. Fetch review state (no MCP wrapper exists for review-decision
+   data — `gh pr view` is the supported call site):
    ```bash
    gh pr view {pr_number} --repo {repo} \
      --json reviewDecision,reviews,headRefOid
@@ -106,14 +107,21 @@ Before requesting review, verify the PR is not in draft state.
 GitHub silently accepts review requests on draft PRs but does
 NOT notify the requested reviewers — the request is lost.
 
-1. Check draft state via MCP: `mcp__plugin_Dev10x_cli__pr_detect`
-   or `gh pr view --json isDraft --jq .isDraft`
-2. If `isDraft == true`: run `gh pr ready` first, then proceed
-3. If `isDraft == false`: proceed to reviewer resolution
+1. Confirm PR identity via
+   `mcp__plugin_Dev10x_cli__pr_detect(arg="<pr_number_or_url>")`
+   to resolve `pr_number` and `repo`, then fetch the draft flag
+   (no MCP wrapper exists for `isDraft`):
+   ```bash
+   gh pr view {pr_number} --repo {repo} --json isDraft -q .isDraft
+   ```
+2. If draft: run `gh pr ready` first, then proceed
+3. If not draft: proceed to reviewer resolution
 
 ### Resolution workflow
 
-1. Detect the current repo: `gh repo view --json name --jq .name`
+1. Detect the current repo: parse `git remote get-url origin`
+   (or call `mcp__plugin_Dev10x_cli__pr_detect` and use its
+   returned `repo` field — last path segment is the repo name)
 2. Read and parse the config file using `yq`:
    `yq '.projects["REPO_NAME"]' ~/.claude/memory/Dev10x/github-reviewers-config.yaml`
 3. Look up the repo name in `projects`:

--- a/skills/gh-pr-respond/SKILL.md
+++ b/skills/gh-pr-respond/SKILL.md
@@ -12,7 +12,12 @@ invocation-name: Dev10x:gh-pr-respond
 allowed-tools:
   - AskUserQuestion
   - mcp__plugin_Dev10x_cli__pr_comment_reply
-  - Bash(gh:*)
+  - mcp__plugin_Dev10x_cli__pr_comments
+  - mcp__plugin_Dev10x_cli__pr_detect
+  - Bash(gh pr ready:*)
+  - Bash(gh api graphql:*)
+  - Bash(gh api repos/:*)
+  - Bash(jq:*)
   - Skill(Dev10x:gh-pr-triage)
   - Skill(Dev10x:gh-pr-fixup)
   - Skill(Dev10x:git-groom)

--- a/skills/gh-pr-respond/instructions.md
+++ b/skills/gh-pr-respond/instructions.md
@@ -172,10 +172,10 @@ detection. If unavailable, warn and stop — do NOT silently fall
 back to `git -C` (GH-759 F1). The `git -C` fallback cascades
 across nested skills, breaking allow-rule matching.
 
-1. Extract the PR branch name:
-   ```bash
-   gh pr view {pr_number} --repo {owner}/{repo} --json headRefName -q .headRefName
-   ```
+1. Extract the PR branch name via
+   `mcp__plugin_Dev10x_cli__pr_detect(arg="<pr_number>")` —
+   returns `head_ref` (the branch name) along with `repo` and
+   `state`. No raw `gh pr view` call is needed.
 2. Check if the branch is checked out in the current worktree:
    ```bash
    git symbolic-ref --short HEAD
@@ -311,12 +311,11 @@ See `references/github_api.md` § Hiding (Minimizing) Comments.
 
 ### Step 2: Check for remaining comments
 
-After processing the single comment, check for other unaddressed root comments:
-
-```bash
-gh api repos/{owner}/{repo}/pulls/{pr_number}/comments \
-  | jq '[.[] | select(.in_reply_to_id == null)]'
-```
+After processing the single comment, check for other unaddressed
+root comments via
+`mcp__plugin_Dev10x_cli__pr_comments(action="list", pr_number=<N>)`
+and filter the returned list to entries whose `in_reply_to_id`
+is null.
 
 ### Step 3: Offer to continue
 
@@ -346,14 +345,13 @@ This blocks execution until the user decides how to proceed. Options:
 
 ### Step 1: Collect unaddressed comments
 
-**For a PR URL or number:**
-```bash
-gh api repos/{owner}/{repo}/pulls/{pr_number}/comments \
-  | jq '[.[] | select(.in_reply_to_id == null)]'
-```
+**For a PR URL or number:** call
+`mcp__plugin_Dev10x_cli__pr_comments(action="list", pr_number=<N>)`
+and keep entries whose `in_reply_to_id` is null.
 
 **For a review URL** (`#pullrequestreview-{review_id}`):
-Filter to only comments from that review (match `pull_request_review_id`).
+filter the same MCP result to comments whose
+`pull_request_review_id` matches the review ID.
 
 **Always check the review body for findings**, even when inline
 comments exist. CI hygiene reviews from `claude[bot]` commonly
@@ -682,15 +680,19 @@ external approval.
 
 ## Tools
 
-Use `gh api` for PR comment operations:
+Prefer MCP tools for PR comment operations; reach for `gh api`
+only for endpoints that have no MCP wrapper (review listings,
+GraphQL mutations).
 
-| Operation | Command |
+| Operation | Tool |
 |---|---|
-| List comments | `gh api repos/{owner}/{repo}/pulls/{N}/comments` |
-| Filter root only | `\| jq '[.[] \| select(.in_reply_to_id == null)]'` |
-| Fetch one comment | `gh api repos/{owner}/{repo}/pulls/comments/{id}` |
+| List comments | `mcp__plugin_Dev10x_cli__pr_comments(action="list", pr_number=N)` |
+| Fetch one comment | `mcp__plugin_Dev10x_cli__pr_comments(action="get", comment_id=ID)` |
 | Reply to thread | `mcp__plugin_Dev10x_cli__pr_comment_reply(pr_number=N, comment_id=ID, body="...")` |
+| Filter root-only | Filter MCP result on `in_reply_to_id == null` |
 | Resolve thread | See `references/github_api.md` GraphQL section |
+| List reviews | `gh api repos/{owner}/{repo}/pulls/{N}/reviews` (no MCP) |
+| Minimize comment | `gh api graphql` minimizeComment (no MCP) |
 
 ---
 

--- a/skills/gh-pr-respond/references/playbook.yaml
+++ b/skills/gh-pr-respond/references/playbook.yaml
@@ -143,11 +143,13 @@ defaults:
           Auto-advance when green.
       - subject: Merge PR
         type: detailed
+        skills: [Dev10x:gh-pr-merge]
         prompt: >
-          When CI passes and no new review comments exist, merge
-          via `gh pr merge --squash --delete-branch`. In solo-
-          maintainer mode, merge automatically. Otherwise, stop
-          and report ready-to-merge status.
+          When CI passes and no new review comments exist,
+          delegate to Dev10x:gh-pr-merge — never run raw
+          `gh pr merge`. In solo-maintainer mode the skill
+          merges automatically; otherwise it stops and reports
+          ready-to-merge status.
         condition: ci-green-no-comments
 
 overrides: []

--- a/skills/project-audit/SKILL.md
+++ b/skills/project-audit/SKILL.md
@@ -21,7 +21,6 @@ allowed-tools:
   - Read
   - Write(docs/memos/**)
   - Bash(gh pr list:*)
-  - Bash(gh api repos/:*)
   - TaskCreate
   - TaskUpdate
   - Skill(Dev10x:project-scope)

--- a/skills/session-wrap-up/SKILL.md
+++ b/skills/session-wrap-up/SKILL.md
@@ -10,7 +10,7 @@ description: >
 user-invocable: true
 invocation-name: Dev10x:session-wrap-up
 allowed-tools:
-  - Bash(gh pr list:*)
+  - mcp__plugin_Dev10x_cli__pr_detect
 ---
 
 # Dev10x:session-wrap-up — Session End Orchestrator
@@ -68,10 +68,12 @@ session (lines starting with `+` that contain TODO or FIXME).
 
 ### 1d. Open PRs
 
-```bash
-gh pr list --head "$(git branch --show-current)" --state open \
-  --json number,title,url --limit 5
-```
+Call `mcp__plugin_Dev10x_cli__pr_detect(arg="")` (no arg) — the
+tool auto-detects the PR for the current branch and returns
+`pr_number`, `repo`, `pr_url`, and `branch`. Treat an `error`
+response (no PR for branch) as "no open PR" rather than a
+failure. No raw `gh` invocation or branch-name subshell is
+needed.
 
 ### 1e. Project TODO file
 


### PR DESCRIPTION
**When** invoking Dev10x skills that interact with GitHub PRs, **the developer wants** the skill bodies to call `mcp__plugin_Dev10x_cli__*` tools instead of raw `gh` CLI, **so the skill operator can** run shipping workflows without per-invocation `Bash(gh …)` permission prompts breaking the flow.

---

- ♻️ GH-12 Eliminate raw gh CLI in PR-skill bodies
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/12

---