### PR TITLE
♻️ GH-14 Route raw git CLI in skill bodies through wrappers

### DIFF
--- a/skills/fanout/instructions.md
+++ b/skills/fanout/instructions.md
@@ -321,11 +321,10 @@ Work-on executes the pr-continuation play:
 
 **Fixup race condition guard (GH-724):** Before creating any
 fixup commit for a PR that is also being monitored in Phase 4,
-verify the PR is still open:
-```bash
-gh pr view N --json state -q '.state'
-```
-If the result is not `OPEN`, the PR was merged by the monitor
+verify the PR is still open via
+`mcp__plugin_Dev10x_cli__pr_detect(arg="<pr-number>")` and check
+the returned `state` field. If the result is not `OPEN`, the PR
+was merged by the monitor
 while you were preparing the fix. Do NOT push the fixup commit
 to the dead branch — create a follow-up branch from develop
 and open a new PR instead.
@@ -384,11 +383,17 @@ GH-555).
 After merging any item, check if downstream items in the
 same sequential chain are affected:
 
-1. `git fetch origin develop`
-2. For each active branch in the chain:
-   `git rebase origin/develop`
-3. If rebase conflicts → resolve, commit, force-push
-4. If rebase succeeds → continue processing
+1. Fetch the base via `mcp__plugin_Dev10x_cli__detect_base_branch`
+   to determine the merge target.
+2. For each active branch in the chain, delegate the rebase to
+   `Skill(Dev10x:git-groom)` — it rebases onto the resolved base
+   and force-pushes through `Skill(Dev10x:git)` (protected-branch
+   safety). Never invoke `git rebase origin/<base>` directly from
+   this skill — see Skill Routing Enforcement in
+   `skills/work-on/instructions.md`.
+3. If rebase conflicts → resolve, commit, then re-invoke
+   `Skill(Dev10x:git-groom)` to complete the force-push.
+4. If rebase succeeds → continue processing.
 
 ### Merge Mode (GH-688)
 

--- a/skills/gh-pr-monitor/instructions.md
+++ b/skills/gh-pr-monitor/instructions.md
@@ -319,27 +319,23 @@ For each CI fix:
 
 When `gh pr view` reports `mergeable: CONFLICTING`:
 
-1. Fetch latest base branch:
-   ```bash
-   gh pr view {pr_number} --repo {repo} --json baseRefName -q '.baseRefName'
-   git fetch origin {base_branch}
-   ```
+1. Resolve the base branch via `mcp__plugin_Dev10x_cli__pr_detect`
+   (returns `baseRefName`).
 
-2. Rebase onto the base branch:
-   ```bash
-   git rebase origin/{base_branch}
-   ```
+2. Delegate the rebase + force-push to `Skill(Dev10x:git-groom)` —
+   it fetches the base, rebases, and runs the protected-branch
+   safety checks before force-pushing. Do NOT call `git rebase` or
+   `git push --force-with-lease` directly from this skill: routing
+   through the wrapper preserves the autosquash, gitmoji, and
+   protected-branch guardrails (see Skill Routing Enforcement in
+   `skills/work-on/instructions.md`).
 
-3. If rebase succeeds, force-push:
-   ```bash
-   git push --force-with-lease origin {branch}
-   ```
-
-4. If rebase has conflicts that cannot be auto-resolved, stop the
+3. If `Dev10x:git-groom` reports unresolved conflicts, stop the
    monitor and report the conflicting files to the user.
 
-5. After force-push, wait 30 seconds for GitHub to re-compute
-   mergeability and re-run CI, then restart the Phase 1 loop.
+4. After the wrapper completes the force-push, wait 30 seconds for
+   GitHub to re-compute mergeability and re-run CI, then restart the
+   Phase 1 loop.
 
 ### Post-CI Comment Re-check (REQUIRED)
 

--- a/skills/gh-pr-monitor/references/ci-failure-patterns.md
+++ b/skills/gh-pr-monitor/references/ci-failure-patterns.md
@@ -141,22 +141,20 @@ ${CLAUDE_PLUGIN_ROOT}/skills/gh-pr-monitor/scripts/detect-fixup-commits.sh \
 
 **Fix:**
 1. Get the base branch from the PR
-2. Run autosquash rebase to squash fixups into targets:
-   ```bash
-   git autosquash-{base}
-   ```
-3. Force-push the cleaned history:
-   ```bash
-   git push --force-with-lease origin {branch}
-   ```
-4. Wait 60 seconds for GitHub to register new check suites
-5. Resume the Phase 1 CI monitoring loop
+2. Delegate squash + force-push to `Skill(Dev10x:git-groom)` — it
+   runs the autosquash rebase and pushes through `Skill(Dev10x:git)`,
+   which enforces protected-branch checks. Do NOT call
+   `git autosquash-{base}` or `git push --force-with-lease` directly
+   from this skill (that bypasses the wrapper guardrails — see
+   Skill Routing Enforcement in `skills/work-on/instructions.md`).
+3. Wait 60 seconds for GitHub to register new check suites
+4. Resume the Phase 1 CI monitoring loop
 
-**Note:** The `git autosquash-{base}` alias runs a non-interactive
-rebase with `--autosquash` that matches `fixup!` commit prefixes
-to their target commits and squashes them automatically. After the
-force-push, all previous CI results are invalidated — the agent
-must re-monitor from scratch.
+**Note:** `Dev10x:git-groom` invokes the `git autosquash-{base}`
+alias under the hood — a non-interactive rebase with `--autosquash`
+that matches `fixup!` commit prefixes to their target commits and
+squashes them automatically. After the force-push, all previous CI
+results are invalidated — the agent must re-monitor from scratch.
 
 ## Coverage Failures
 

--- a/skills/git-promote/references/pr-workflow.md
+++ b/skills/git-promote/references/pr-workflow.md
@@ -14,7 +14,12 @@ The workflow automatically:
 
 ## Fish Function Reference
 
-Original fish function for reference:
+Original fish function for reference. The raw `git push` and
+`gh pr create` calls below are historical — modern invocations
+must route through `Skill(Dev10x:git)` (push) and
+`Skill(Dev10x:gh-pr-create)` (PR creation) per the Skill Routing
+Enforcement table in `skills/work-on/instructions.md`. See the
+"Bash Equivalent" section below for the wrapper-based form.
 
 ```fish
 function gpr-develop
@@ -46,39 +51,26 @@ function gpr-develop
 end
 ```
 
-## Bash Equivalent
+## Wrapper-Based Equivalent
 
-For the commit-to-linear-ticket workflow, simplified version:
+For the commit-to-linear-ticket workflow, route all side-effecting
+operations through skill wrappers. Pseudo-flow (each numbered step
+maps to one wrapper invocation, not a raw command):
 
-```bash
-#!/bin/bash
+1. Extract metadata in-process: read the latest commit message and
+   parse the ticket ID from `git symbolic-ref --short HEAD`.
+2. Push the branch via `Skill(Dev10x:git)` — it enforces protected
+   branch rules and `--set-upstream` semantics. Do NOT invoke
+   `git push --set-upstream origin <branch>` directly here.
+3. Create the draft PR via `Skill(Dev10x:gh-pr-create)` with title,
+   body referencing the Linear issue, and `--unattended` if running
+   without supervision. The skill handles `gh pr create`,
+   checklist-comment posting, and the final `gh pr view --web`
+   handoff via `mcp__plugin_Dev10x_cli__create_pr`.
 
-# Extract information
-TITLE=$(git log -1 --format=%s)
-ISSUE=$(git branch --show-current | rev | cut -d"/" -f2 | rev)
-BRANCH_NAME=$(git symbolic-ref --short HEAD)
-
-# Display information
-echo "Linear issue: $ISSUE"
-echo "Title: $TITLE"
-echo "For: $BRANCH_NAME -> develop"
-
-# Push branch
-git push --set-upstream origin "$BRANCH_NAME"
-
-# Create draft PR
-gh pr create --draft \
-  --title "$TITLE" \
-  --body "Fixes: https://linear.app/example/issue/$ISSUE"
-
-# Post checklist comment if template exists
-if [ -f .github/checklist.md ]; then
-  gh pr comment --body "$(sed -e "s/ISSUE-NO/$ISSUE/" .github/checklist.md)"
-fi
-
-# Open PR in browser
-gh pr view --web
-```
+Routing through these skills preserves gitmoji/JTBD validation,
+protected-branch checks, and the JTBD-driven PR body — all of which
+raw `git push` + `gh pr create` skip.
 
 ## Key Differences
 

--- a/skills/ticket-branch/SKILL.md
+++ b/skills/ticket-branch/SKILL.md
@@ -197,7 +197,13 @@ Worktree (e.g., in `/work/example/.worktrees/app-pos-7`):
 
 ### Step 6: Create the Branch
 
-Create and checkout the new branch:
+This skill IS the project wrapper for branch creation — the raw
+`git checkout -b` calls below are the implementation, not user-facing
+guidance. Other skills MUST delegate to `Skill(Dev10x:ticket-branch)`
+rather than embedding `git checkout -b` directly (see Skill Routing
+Enforcement in `skills/work-on/instructions.md`). The cli-friction
+scanner exempts this skill via the `GIT_IMPLEMENTERS` allowlist in
+`src/dev10x/skills/audit/cli_friction.py`.
 
 ```bash
 git checkout -b username/TICKET-ID/slug


### PR DESCRIPTION
**When** documenting git operations in skill bodies, **the Dev10x maintainer wants to** route raw `git push`, `git rebase`, and `git checkout -b` examples through `Skill(Dev10x:git*)` wrappers, **so the agent can** preserve gitmoji, JTBD, and force-push guardrails instead of bypassing them through copy-paste of raw commands.

---

- ♻️ GH-14 Route raw git CLI in skill bodies through wrappers
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/14

---