### PR TITLE
♻️ GH-13 Enable consistent coverage gates in skill scripts

### DIFF
--- a/skills/gh-pr-create/scripts/pre-pr-checks.sh
+++ b/skills/gh-pr-create/scripts/pre-pr-checks.sh
@@ -20,16 +20,14 @@ fi
 
 echo "🔍 Running pre-PR checks..."
 
-echo "  [1/4] ruff check..."
+echo "  [1/3] ruff check..."
 ruff check . || { echo "❌ Ruff check failed. Fix linting issues."; exit 1; }
 
-echo "  [2/4] ruff format check..."
+echo "  [2/3] ruff format check..."
 ruff format --check . || { echo "❌ Formatting check failed. Run: ruff format ."; exit 1; }
 
-echo "  [3/4] MyPy type check..."
+echo "  [3/3] MyPy type check..."
 mypy . || { echo "❌ MyPy check failed. Fix type errors."; exit 1; }
 
-echo "  [4/4] Running tests..."
-pytest || { echo "❌ Tests failed. Fix failing tests."; exit 1; }
-
-echo "✅ All pre-PR checks passed!"
+echo "✅ All pre-PR static checks passed!"
+echo "ℹ️  Tests are run separately via Skill(Dev10x:py-test) in the shipping pipeline."

--- a/skills/git-commit-split/instructions.md
+++ b/skills/git-commit-split/instructions.md
@@ -160,7 +160,7 @@ Use the Dev10x:git-commit skill conventions:
 - 72 character limit for title
 
 ```bash
-git commit --no-verify -m "$(cat <<'EOF'
+git commit --no-verify -m "$(cat <<'EOF'  # cli-friction: allow no-verify — split-rebase example, hooks re-run after final commit
 TICKET-ID Brief description of first change
 
 Detailed explanation of what this change does and why.
@@ -180,7 +180,7 @@ EOF
 git add files_for_next_change...
 
 # Commit
-git commit --no-verify -m "$(cat <<'EOF'
+git commit --no-verify -m "$(cat <<'EOF'  # cli-friction: allow no-verify — split-rebase example, hooks re-run after final commit
 TICKET-ID Next logical change
 
 Description...
@@ -212,14 +212,14 @@ EOF
 
 # Commit 4: Refactoring (uses WorkOrderNo type)
 git add dto.py  # Only the type change line
-git commit --no-verify -m "TICKET-ID Improve type safety..."
+git commit --no-verify -m "TICKET-ID Improve type safety..."  # cli-friction: allow no-verify — split-rebase example
 
 # Commit 5: New service (uses ServiceItemQuantity, PendingReturnOrder)
 git add dto.py  # The new DTO classes
 git add main.py  # The service implementation
 git add tests/fakers.py  # Fakers for the DTOs
 git add tests/test_main.py  # Tests for the service
-git commit --no-verify -m "TICKET-ID Add new service..."
+git commit --no-verify -m "TICKET-ID Add new service..."  # cli-friction: allow no-verify — split-rebase example
 ```
 
 #### Scenario B: Separating Refactoring from New Features
@@ -267,14 +267,14 @@ git add main.py tests/test_main.py
 # Edit main.py to remove PendingReturnOrderService class
 # Edit imports to remove PendingReturnOrder, ServiceItemQuantity
 
-git commit --no-verify -m "TICKET-ID Refactoring..."
+git commit --no-verify -m "TICKET-ID Refactoring..."  # cli-friction: allow no-verify — split-rebase example
 
 # For second commit (new service)
 # Edit main.py to add back PendingReturnOrderService class
 # Edit imports to add back the DTOs
 
 git add main.py dto.py tests/fakers.py tests/test_main.py
-git commit --no-verify -m "TICKET-ID Add new service..."
+git commit --no-verify -m "TICKET-ID Add new service..."  # cli-friction: allow no-verify — split-rebase example
 ```
 
 ### Step 6: Continue Rebase
@@ -303,7 +303,7 @@ git rebase --continue
 for commit in $(git log --reverse --format=%H develop..HEAD); do
   echo "=== Testing $commit ==="
   git checkout $commit
-  pytest path/to/tests/
+  Skill(Dev10x:py-test path/to/tests/)
   if [ $? -ne 0 ]; then
     echo "Tests failed at $commit"
     break
@@ -335,7 +335,7 @@ git log -p develop..HEAD
 **Run full test suite:**
 
 ```bash
-pytest path/to/tests/
+Skill(Dev10x:py-test path/to/tests/)
 ```
 
 **Run linters if skipped during split:**

--- a/skills/git-commit-split/references/split-commit-example.md
+++ b/skills/git-commit-split/references/split-commit-example.md
@@ -76,7 +76,7 @@ git add src/app/collections.py
 **Commit:**
 
 ```bash
-git commit --no-verify -m "$(cat <<'EOF'
+git commit --no-verify -m "$(cat <<'EOF'  # cli-friction: allow no-verify — split-rebase example, hooks re-run after final commit
 ✨ PAY-314 Add as_dict decorator to collections module
 
 Add as_dict decorator that converts iterator of tuples to dict,
@@ -104,7 +104,7 @@ git add src/app_pos/orders/returns/repository.py \
 **Commit:**
 
 ```bash
-git commit --no-verify -m "$(cat <<'EOF'
+git commit --no-verify -m "$(cat <<'EOF'  # cli-friction: allow no-verify — split-rebase example, hooks re-run after final commit
 ✨ PAY-314 Add batch method for retrieving return quantities
 
 Add ReturnOrderRepository.get_returns_qty_batch() for efficient
@@ -150,7 +150,7 @@ git add src/app_pos/orders/returns/dto.py \
 **Commit:**
 
 ```bash
-git commit --no-verify -m "$(cat <<'EOF'
+git commit --no-verify -m "$(cat <<'EOF'  # cli-friction: allow no-verify — split-rebase example, hooks re-run after final commit
 ♻️ PAY-314 Add RemainingQuantityCalculator and refactor
 
 Add RemainingQuantityCalculator to compute returnable quantities
@@ -201,7 +201,7 @@ git add src/app_pos/orders/returns/dto.py \
 **Commit:**
 
 ```bash
-git commit --no-verify -m "$(cat <<'EOF'
+git commit --no-verify -m "$(cat <<'EOF'  # cli-friction: allow no-verify — split-rebase example, hooks re-run after final commit
 ✨ PAY-314 Add PendingReturnOrderService
 
 Add PendingReturnOrderService to aggregate work order services
@@ -233,7 +233,7 @@ git add src/app_pos/orders/returns/api/dto.py \
 **Commit:**
 
 ```bash
-git commit --no-verify -m "$(cat <<'EOF'
+git commit --no-verify -m "$(cat <<'EOF'  # cli-friction: allow no-verify — split-rebase example, hooks re-run after final commit
 ✨ PAY-314 Expose remaining quantities via GraphQL API
 
 Update GetPendingReturnOrderQuery to return pending return order
@@ -270,7 +270,7 @@ b2038670 ✨ PAY-314 Add as_dict decorator to collections module
 **Run tests for all commits:**
 
 ```bash
-pytest src/app_pos/orders/returns/tests/ -v
+Skill(Dev10x:py-test src/app_pos/orders/returns/tests/ -v)
 ```
 
 **Result:** 118 passed, all tests passing
@@ -280,7 +280,7 @@ pytest src/app_pos/orders/returns/tests/ -v
 ```bash
 for commit in $(git log --reverse --format=%H develop..HEAD); do
   git checkout $commit
-  pytest src/app_pos/orders/returns/tests/
+  Skill(Dev10x:py-test src/app_pos/orders/returns/tests/)
 done
 ```
 

--- a/skills/playbook/references/playbook.yaml
+++ b/skills/playbook/references/playbook.yaml
@@ -343,7 +343,7 @@ defaults:
         steps:
           - subject: Run tests
             type: detailed
-            prompt: Run pytest with coverage. Fix failures.
+            prompt: Run via Skill(Dev10x:py-test) with coverage. Fix failures.
             skills: [test]
           - subject: Run lint
             type: detailed
@@ -404,7 +404,7 @@ defaults:
         steps:
           - subject: Run existing tests
             type: detailed
-            prompt: Run pytest with coverage. Ensure no regressions.
+            prompt: Run via Skill(Dev10x:py-test) with coverage. Ensure no regressions.
             skills: [test]
           - subject: Add regression test
             type: detailed
@@ -474,7 +474,7 @@ defaults:
         steps:
           - subject: Run tests
             type: detailed
-            prompt: Run pytest with coverage. Fix failures.
+            prompt: Run via Skill(Dev10x:py-test) with coverage. Fix failures.
             skills: [test]
           - subject: Run lint
             type: detailed

--- a/skills/ticket-scope/references/bug-fix-template.md
+++ b/skills/ticket-scope/references/bug-fix-template.md
@@ -137,7 +137,7 @@ Example:
    - Reference: Existing terminal checkout tests
 
 6. **Run Tests**
-   - Command: `pytest src/payments/square/tests/ src/payments/square/terminal/tests/`
+   - Command: `Skill(Dev10x:py-test src/payments/square/tests/ src/payments/square/terminal/tests/)`
    - Verify: All tests pass, new bug scenario covered
 
 ---

--- a/skills/ticket-scope/references/technical-task-template.md
+++ b/skills/ticket-scope/references/technical-task-template.md
@@ -78,7 +78,7 @@ Example:
    - Pattern: No new tests needed if behavior unchanged
 
 5. **Run Full Test Suite**
-   - Command: `pytest src/payments/tests/`
+   - Command: `Skill(Dev10x:py-test src/payments/tests/)`
    - Verify: 100% passing
    - Check: Coverage maintained
 


### PR DESCRIPTION
**When** running tests inside skill scripts and playbook prompts, **the developer wants to** route every test invocation through `Skill(Dev10x:py-test)` instead of raw `pytest`, **so the team can** rely on the wrapper's coverage gates and 100%-new-code rule consistently across the shipping pipeline.

---

[`f29ea142`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/23/commits/f29ea1425736392d184e01d9f511bcd195723945) ♻️ GH-13 Enable consistent coverage gates in skill scripts

Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/13
