### PR TITLE
✨ GH-19 Auto-detect Slack state to skip redundant prompts

### DIFF
--- a/skills/slack-setup/SKILL.md
+++ b/skills/slack-setup/SKILL.md
@@ -3,7 +3,10 @@ name: Dev10x:slack-setup
 description: >
   Guide the user through setting up their Slack integration —
   create a Slack app, configure scopes, store the token in the
-  system keyring, and generate slack-config.yaml.
+  system keyring, and generate slack-config.yaml. Auto-detects
+  existing tokens, validates them via auth.test, and derives
+  config from the API and git so prompts only fire when state
+  cannot be discovered.
   TRIGGER when: setting up Slack integration for the first time, or
   reconfiguring Slack credentials.
   DO NOT TRIGGER when: Slack already configured and working, or
@@ -14,143 +17,253 @@ allowed-tools:
   - AskUserQuestion
   - Bash(secret-tool:*)
   - Bash(security:*)
+  - Bash(curl:*slack.com/api/auth.test*)
+  - Bash(curl:*slack.com/api/users.lookupByEmail*)
+  - Bash(pgrep:*)
+  - Bash(command:*)
+  - Bash(git config user.email:*)
 ---
 
 # Dev10x:slack-setup — Slack Integration Setup
 
 **Announce:** "Using Dev10x:slack-setup to configure Slack integration."
 
+## Arguments
+
+The skill accepts a single optional argument:
+
+```
+/Dev10x:slack-setup [xoxb-...]
+```
+
+When a token is passed, skip Step 2 entirely (no token-source
+prompt) and go directly to validation in Step 1c.
+
 ## Orchestration
 
 **REQUIRED: Create tasks before ANY work.** Execute at startup:
 
-1. `TaskCreate(subject="Detect current Slack state", activeForm="Detecting state")`
-2. `TaskCreate(subject="Guide Slack App creation", activeForm="Creating app")`
+1. `TaskCreate(subject="Detect and validate Slack state", activeForm="Detecting state")`
+2. `TaskCreate(subject="Acquire bot token (if missing)", activeForm="Acquiring token")`
 3. `TaskCreate(subject="Store token in keyring", activeForm="Storing token")`
 4. `TaskCreate(subject="Generate slack-config.yaml", activeForm="Generating config")`
-5. `TaskCreate(subject="Verify setup", activeForm="Verifying")`
 
-## Step 1: Detect Current State
+Verification is folded into Step 1 — `auth.test` is the test.
+A separate "Verify setup" task is created only when the user
+opts into a test message in Step 4.
 
-Check what's already configured:
+## Step 1: Detect and Validate Current State
 
-1. Check if `~/.claude/memory/Dev10x/slack-config.yaml` exists
-2. Try retrieving a token from the system keyring:
-   - Linux: `secret-tool lookup service slack key bot_token`
-   - macOS: `security find-generic-password -s slack -a bot_token -w`
-3. Check if `SLACK_TOKEN` environment variable is set
+The goal of this step is to short-circuit setup whenever the
+existing state is already valid. Prompts MUST NOT fire while
+state is still discoverable from the environment.
 
-**If token found and config exists** → report current state and
-offer to reconfigure or exit.
+### 1a. Locate a candidate token
 
-**If partially configured** → resume from the missing step.
+Probe sources in priority order — stop at the first hit:
 
-**If nothing configured** → proceed to Step 2.
+1. **Argument** — token passed to the skill (`xoxb-...`)
+2. **Keyring** — `secret-tool lookup service slack key bot_token`
+   (Linux) or `security find-generic-password -s slack -a bot_token -w`
+   (macOS)
+3. **Environment** — `SLACK_TOKEN` env var
 
-## Step 2: Guide Slack App Creation
+Record where the token came from (`source: arg|keyring|env`) so
+later steps know whether to persist it.
+
+### 1b. Read existing config (if any)
+
+Check for `~/.claude/memory/Dev10x/slack-config.yaml`. If present,
+load it — fields already filled there are reused, not re-prompted.
+
+### 1c. Validate via auth.test
+
+If a token was located in 1a, call Slack `auth.test`:
+
+```
+curl -sS -X POST https://slack.com/api/auth.test \
+  -H "Authorization: Bearer <TOKEN>"
+```
+
+Parse the JSON response:
+
+| `ok` | Action |
+|------|--------|
+| `true` | Persist `bot_username` ← `user`, `bot_user_id` ← `user_id`, `team_id` ← `team_id` into the in-memory config. Skip Step 2. Proceed to Step 3 only if the token still needs to be stored (`source: arg|env`); skip Step 3 when `source: keyring`. |
+| `false` | Read the `error` field. Treat `invalid_auth` / `token_revoked` / `account_inactive` as unrecoverable for this token — discard it and fall through to Step 2 with a diagnostic line ("token validation failed: <error>"). |
+
+When **no token is found** in 1a, fall through to Step 2.
+
+### 1d. Final state report
+
+Before any prompts fire, summarize what is already configured:
+
+```
+Token: found (keyring) — auth.test ok
+Bot:   <user> (<user_id>) in team <team_id>
+Config: present at ~/.claude/memory/Dev10x/slack-config.yaml
+Result: setup already complete — nothing to do
+```
+
+If the report covers all required fields (`bot_username`,
+`self_user_id`, `user_groups`, token reachable), exit with that
+message. **No `AskUserQuestion` fires in this branch.**
+
+## Step 2: Acquire Bot Token (only when missing or invalid)
+
+Skip this step entirely when Step 1c reported `ok: true`.
+
+When the user passed a token via arguments and `auth.test`
+rejected it, report the diagnostic and fall through here.
+
+### 2a. Token source
 
 **REQUIRED: Call `AskUserQuestion`** (do NOT use plain text).
 Options:
-- Create a new Slack Bot (Recommended)
-- Use an existing bot token
-- Use a user token (xoxp-)
+- **Use existing token (Recommended)** — paste a token you already have
+- **Create a new Slack Bot** — guided app creation
+- **Use a user token (xoxp-)** — works but acts as the user
 
-### New Bot Flow
+Skip this prompt when a token argument was passed (the source is
+already "existing token"; only validation in Step 1c failed).
 
-Walk the user through creating a Slack App:
+### 2b. Existing token flow
 
-1. Direct them to https://api.slack.com/apps → "Create New App"
-2. Choose "From scratch"
-3. Name the app (suggest: "Claude AI" or "Dev10x Bot")
-4. Select the workspace
+Point the user at [`references/token-discovery.md`](references/token-discovery.md)
+when they ask "where is my token?". Re-run Step 1c after the
+user pastes a token; reject anything that fails `auth.test`.
 
-### Required OAuth Scopes
+### 2c. New bot flow
 
-Guide the user to add these **Bot Token Scopes** under
-OAuth & Permissions:
-
-| Scope | Used by |
-|-------|---------|
-| `chat:write` | Posting messages |
-| `files:write` | Uploading screenshots/evidence |
-| `reactions:write` | Adding emoji reactions |
-| `conversations:join` | Auto-joining channels when posting |
-| `users:read` | Resolving user mentions |
-
-Optional scopes for DM reminders:
-| Scope | Used by |
-|-------|---------|
-| `im:write` | Sending DM reminders to yourself |
-
-After adding scopes, guide them to:
-1. Install the app to the workspace
-2. Copy the **Bot User OAuth Token** (starts with `xoxb-`)
-
-### Existing Token Flow
-
-Ask the user to paste their token. Validate format:
-- `xoxb-` → bot token (recommended)
-- `xoxp-` → user token (works but limited)
-- Anything else → invalid, ask again
+See [`references/new-bot-creation.md`](references/new-bot-creation.md)
+for the full workspace-setup guide (app creation, required and
+optional OAuth scopes, install + token copy steps). Walk the user
+through it, then loop back to Step 1c with the pasted token to
+validate before storing.
 
 ## Step 3: Store Token in System Keyring
 
-**REQUIRED: Call `AskUserQuestion`** (do NOT use plain text).
-Options:
-- System keyring (Recommended) — secure, persists across sessions
-- Environment variable — must set each session
-- Skip storage — manual setup later
+Skip when `source: keyring` (already stored).
 
-### Keyring Storage
+### 3a. Auto-detect the keyring backend
 
-Detect the platform and store:
+Run platform detection silently — do NOT prompt yet.
 
 **Linux:**
+
 ```
-secret-tool store --label="Slack Bot Token" service slack key bot_token
+command -v secret-tool >/dev/null 2>&1 && \
+  pgrep -f 'gnome-keyring-daemon|kwalletd' >/dev/null 2>&1
 ```
-Then paste the token when prompted.
+
+If both succeed → the keyring backend is available. Default to
+keyring storage **without** an `AskUserQuestion`.
 
 **macOS:**
+
 ```
-security add-generic-password -s slack -a bot_token -w "<token>"
+command -v security >/dev/null 2>&1
 ```
 
-### Env Var Storage
+If it succeeds → default to Keychain storage **without** an
+`AskUserQuestion`.
 
-Tell the user to add to their shell profile:
+Store the token:
+
+| Platform | Command |
+|----------|---------|
+| Linux | `secret-tool store --label="Slack Bot Token" service slack key bot_token` (token piped in) |
+| macOS | `security add-generic-password -s slack -a bot_token -w "<token>"` |
+
+### 3b. Fallback prompt
+
+Only when 3a fails to detect a working keyring backend:
+
+**REQUIRED: Call `AskUserQuestion`** (do NOT use plain text).
+Options:
+- **Environment variable (Recommended)** — add `export SLACK_TOKEN=...` to shell profile
+- **Skip storage** — manual setup later
+
+Provide the export line for the env-var option:
+
 ```
 export SLACK_TOKEN="xoxb-your-token-here"
 ```
 
 ## Step 4: Generate slack-config.yaml
 
-Create `~/.claude/memory/Dev10x/slack-config.yaml` with:
+Generate `~/.claude/memory/Dev10x/slack-config.yaml`. Each field
+is **derived first**, prompted only on derivation failure.
+
+### 4a. Derive fields
+
+| Field | Derivation | Fallback |
+|-------|-----------|----------|
+| `bot_username` | `auth.test.user` (already in memory from Step 1c) | Prompt only if absent |
+| `bot_user_id` | `auth.test.user_id` | Prompt only if absent |
+| `team_id` | `auth.test.team_id` | Prompt only if absent |
+| `self_user_id` | `users.lookupByEmail?email=$(git config user.email)` against the same token | See 4b |
+| `user_groups` | `{}` (empty default — managed in `Dev10x:slack` later) | None — never prompts |
+
+`users.lookupByEmail` call:
+
+```
+curl -sS -G \
+  --data-urlencode "email=$(git config user.email)" \
+  -H "Authorization: Bearer <TOKEN>" \
+  https://slack.com/api/users.lookupByEmail
+```
+
+On `ok: true`, take `user.id`. On `ok: false` with
+`users_not_found`, `missing_scope`, or unset git email, fall to 4b.
+
+### 4b. Prompt only on derivation failure
+
+Only when at least one required field could not be derived,
+issue a single batched `AskUserQuestion` listing the fields to
+collect (e.g., `self_user_id` because the git email did not match
+a workspace member). Never prompt for fields that were derived
+successfully.
+
+When all fields are derived (the common case), write the file
+without any prompt:
 
 ```yaml
-self_user_id: ""  # Your Slack user ID (for DM reminders)
+self_user_id: "U0123456789"
 bot_username: "Claude AI"
+bot_user_id: "U9876543210"
+team_id: "T01234567"
 user_groups: {}
 ```
 
-**REQUIRED: Call `AskUserQuestion`** to gather:
-- Their Slack user ID (guide: click profile → "..." → "Copy member ID")
-- Preferred bot display name
-- Any user group mentions to configure (e.g., `@team-leads` → `<!subteam^S123>`)
+## Step 5: Verify (Folded Into Step 1c)
 
-## Step 5: Verify Setup
+`auth.test` is the verification. The skill marks setup verified
+on `ok: true` from Step 1c — no separate verification prompt
+fires by default.
 
-Test the configuration:
+### Opt-in test message
 
-1. Attempt to resolve the token (keyring or env)
-2. If token found, offer to send a test message:
+Only when the user explicitly asked for a verification message
+(e.g., passed `--test` or asked "send a test message" inline)
+should the skill fire:
 
 **REQUIRED: Call `AskUserQuestion`** (do NOT use plain text).
 Options:
-- Send test message to a channel
-- Send test DM to myself
-- Skip verification
+- **Send test DM to myself (Recommended)** — uses derived `self_user_id`
+- **Send test message to a channel** — prompts for channel ID
+- **Skip** — accept the auth.test result
 
-Use `Dev10x:slack` skill to send the test message.
+Delegate the actual send to `Dev10x:slack`.
 
-Report success or failure with actionable guidance.
+## Net Effect
+
+| Scenario | Prompts before this change | Prompts after |
+|----------|---------------------------|--------------|
+| Token already in keyring, valid | 3–5 | 0 |
+| User pastes existing token | 3–5 | 1 (token paste) |
+| User passes token as argument | 3–5 | 0 |
+| New Slack Bot creation | 3–5 | ~2 (app guidance + token paste) |
+
+All other prompts fire only on detection failure — never as a
+default.

--- a/skills/slack-setup/evals/evals.json
+++ b/skills/slack-setup/evals/evals.json
@@ -4,68 +4,133 @@
     {
       "id": "state_detection",
       "name": "Current State Detection",
-      "description": "Correctly detects existing Slack config, keyring tokens, and env vars before proceeding"
+      "description": "Locates existing tokens (arg, keyring, env) and config before prompting"
     },
     {
-      "id": "decision_gates",
-      "name": "Decision Gate Enforcement",
-      "description": "Uses AskUserQuestion for all 4 decision gates (token type, storage method, config details, verification)"
+      "id": "auth_validation",
+      "name": "auth.test Validation",
+      "description": "Calls auth.test on any located token and short-circuits setup when ok:true; falls through on invalid_auth/token_revoked"
     },
     {
-      "id": "platform_detection",
-      "name": "Cross-Platform Support",
-      "description": "Detects OS and provides correct keyring commands for Linux (secret-tool) and macOS (security)"
+      "id": "keyring_auto_detect",
+      "name": "Keyring Auto-Detection",
+      "description": "Detects running keyring backend (secret-tool + gnome-keyring-daemon/kwalletd on Linux, security on macOS) and defaults to keyring without prompting"
     },
     {
-      "id": "config_generation",
-      "name": "Config File Generation",
-      "description": "Generates valid slack-config.yaml with correct structure (self_user_id, bot_username, user_groups)"
+      "id": "field_derivation",
+      "name": "Config Field Derivation",
+      "description": "Derives bot_username/bot_user_id/team_id from auth.test, self_user_id from users.lookupByEmail, defaults user_groups to {} — only prompts on derivation failure"
+    },
+    {
+      "id": "minimal_prompts",
+      "name": "Prompt Minimization",
+      "description": "Prompts only fire when discovery genuinely fails; pre-configured users see zero AskUserQuestion calls"
     }
   ],
   "evals": [
     {
       "id": 1,
-      "name": "fresh-setup",
+      "name": "preconfigured-token-keyring",
       "prompt": "/Dev10x:slack-setup",
-      "description": "Fresh setup with no existing config or token. Tests full happy-path workflow.",
+      "description": "Token already in keyring, daemon running, config absent. Should auto-validate, derive fields, write config — zero AskUserQuestion calls.",
       "assertions": [
         {
           "check": "tool_called",
-          "tool": "AskUserQuestion",
-          "assertion": "gate1_token_type",
-          "signal": "AskUserQuestion is called for token type selection"
+          "tool": "Bash",
+          "assertion": "calls_auth_test",
+          "signal": "curl POST to slack.com/api/auth.test fires after locating the token"
         },
         {
-          "check": "tool_called",
+          "check": "tool_not_called",
           "tool": "AskUserQuestion",
-          "assertion": "gate2_storage_method",
-          "signal": "AskUserQuestion is called for storage method selection"
+          "assertion": "no_prompts_in_happy_path",
+          "signal": "Zero AskUserQuestion calls when keyring token is valid and fields are derivable"
         },
         {
-          "check": "tool_called",
-          "tool": "AskUserQuestion",
-          "assertion": "gate3_config_details",
-          "signal": "AskUserQuestion is called for config details (user ID, bot name)"
-        },
-        {
-          "check": "tool_called",
-          "tool": "AskUserQuestion",
-          "assertion": "gate4_verification",
-          "signal": "AskUserQuestion is called for verification method selection"
+          "check": "output_contains",
+          "value": "auth.test ok",
+          "assertion": "reports_validation_result",
+          "signal": "Final state report mentions successful auth.test result"
         }
       ]
     },
     {
       "id": 2,
-      "name": "partial-setup-token-exists",
+      "name": "token-via-argument",
+      "prompt": "/Dev10x:slack-setup xoxb-test-token",
+      "description": "Token passed as argument. Should validate via auth.test and skip the token-source prompt.",
+      "assertions": [
+        {
+          "check": "tool_called",
+          "tool": "Bash",
+          "assertion": "validates_arg_token",
+          "signal": "auth.test fires against the argument token"
+        },
+        {
+          "check": "tool_not_called",
+          "tool": "AskUserQuestion",
+          "assertion": "skips_token_source_gate",
+          "signal": "No 'token source' AskUserQuestion when token is passed as arg"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "name": "fresh-setup-no-token",
       "prompt": "/Dev10x:slack-setup",
-      "description": "Token already in keyring but no config file. Should skip token setup steps.",
+      "description": "No token in keyring, env, or args. Should prompt for token source — but not for storage method when keyring daemon is running.",
+      "assertions": [
+        {
+          "check": "tool_called",
+          "tool": "AskUserQuestion",
+          "assertion": "prompts_token_source",
+          "signal": "AskUserQuestion fires for token source (existing/new/user)"
+        },
+        {
+          "check": "tool_called",
+          "tool": "Bash",
+          "assertion": "detects_keyring_backend",
+          "signal": "command -v secret-tool / pgrep keyring-daemon runs to auto-detect storage"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "name": "invalid-token-fallthrough",
+      "prompt": "/Dev10x:slack-setup",
+      "description": "Stale token in keyring returns invalid_auth. Should discard token, report diagnostic, fall through to Step 2.",
       "assertions": [
         {
           "check": "output_contains",
-          "value": "token found",
-          "assertion": "detects_existing_token",
-          "signal": "Agent detects and reports existing token in keyring"
+          "value": "invalid_auth",
+          "assertion": "reports_validation_failure",
+          "signal": "Diagnostic line reports the auth.test error code"
+        },
+        {
+          "check": "tool_called",
+          "tool": "AskUserQuestion",
+          "assertion": "prompts_for_replacement",
+          "signal": "Step 2 token-source prompt fires after invalid token is discarded"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "name": "self-user-id-derivation",
+      "prompt": "/Dev10x:slack-setup",
+      "description": "After auth.test ok, derives self_user_id via users.lookupByEmail using git user.email — without prompting.",
+      "assertions": [
+        {
+          "check": "tool_called",
+          "tool": "Bash",
+          "assertion": "calls_lookup_by_email",
+          "signal": "curl to users.lookupByEmail fires with git config user.email value"
+        },
+        {
+          "check": "tool_not_called",
+          "tool": "AskUserQuestion",
+          "assertion": "no_self_user_id_prompt",
+          "signal": "self_user_id is not prompted when lookup succeeds"
         }
       ]
     }

--- a/skills/slack-setup/references/new-bot-creation.md
+++ b/skills/slack-setup/references/new-bot-creation.md
@@ -1,0 +1,39 @@
+# New Slack Bot Creation Guide
+
+Use this reference when the user chose "Create a new Slack Bot"
+in Step 2a of `Dev10x:slack-setup`.
+
+## App Creation
+
+1. Direct the user to https://api.slack.com/apps → "Create New App"
+2. Choose "From scratch"
+3. Name the app (suggest: "Claude AI" or "Dev10x Bot")
+4. Select the workspace
+
+## Required Bot Token Scopes
+
+Add under **OAuth & Permissions → Bot Token Scopes**:
+
+| Scope | Used by |
+|-------|---------|
+| `chat:write` | Posting messages |
+| `files:write` | Uploading screenshots/evidence |
+| `reactions:write` | Adding emoji reactions |
+| `conversations:join` | Auto-joining channels when posting |
+| `users:read` | Resolving user mentions |
+| `users:read.email` | Deriving `self_user_id` from git email |
+
+## Optional Scopes
+
+| Scope | Used by |
+|-------|---------|
+| `im:write` | Sending DM reminders to yourself |
+
+## Install and Copy Token
+
+1. Install the app to the workspace
+2. Copy the **Bot User OAuth Token** (starts with `xoxb-`)
+3. Paste it back to the skill
+
+After paste, the skill loops back through Step 1c (`auth.test`)
+to validate before storing.

--- a/skills/slack-setup/references/token-discovery.md
+++ b/skills/slack-setup/references/token-discovery.md
@@ -1,0 +1,66 @@
+# Where to Find an Existing Slack Bot Token
+
+Use this reference when a user reports they "already have a token"
+but cannot locate it.
+
+## Slack App Console
+
+The canonical source for any token.
+
+1. Open https://api.slack.com/apps
+2. Sign in to the workspace that owns the app
+3. Pick the app (e.g., "Claude AI", "Dev10x Bot")
+4. Sidebar → **OAuth & Permissions**
+5. Copy the **Bot User OAuth Token** (`xoxb-...`)
+
+If the workspace owner installed the app under a different account,
+the user must ask that owner — Slack only exposes the token to app
+collaborators.
+
+## Password Manager / Vault
+
+Search terms that commonly surface stored Slack tokens:
+
+- `slack`
+- `xoxb`
+- `bot token`
+- workspace name (e.g., `acme-eng`)
+
+1Password, Bitwarden, KeePass, Vaultwarden all index secret bodies,
+so even if the entry title is generic, the `xoxb-` prefix matches.
+
+## OS Keychain (already-stored token)
+
+If the user previously ran `Dev10x:slack-setup` on this machine,
+the token is in the system keyring. The skill detects this in
+Step 1 — no manual lookup needed.
+
+Manual lookup commands (debug only):
+
+| Platform | Command |
+|----------|---------|
+| Linux | `secret-tool lookup service slack key bot_token` |
+| macOS | `security find-generic-password -s slack -a bot_token -w` |
+
+## Environment Variable
+
+Some users export the token in their shell profile:
+
+```
+export SLACK_TOKEN="xoxb-..."
+```
+
+Check `~/.zshrc`, `~/.bashrc`, `~/.config/fish/config.fish`, or any
+file the user sources at login.
+
+## Token Format Validation
+
+| Prefix | Type | Notes |
+|--------|------|-------|
+| `xoxb-` | Bot User OAuth Token | Recommended for this skill |
+| `xoxp-` | User OAuth Token | Works but acts as the user, not a bot |
+| `xoxe.xoxb-` | Refresh-rotated bot token | Newer Slack apps; treat as `xoxb-` |
+| anything else | Invalid | Reject and ask again |
+
+A valid `auth.test` response confirms the token regardless of
+prefix. The skill always calls `auth.test` before persisting.


### PR DESCRIPTION
**When** setting up Slack integration with an existing bot token already stored in the system keyring, **the developer wants** the `Dev10x:slack-setup` skill to auto-detect and validate the token via `auth.test` and derive remaining config from the API and git, **so the developer can** complete setup with zero prompts instead of answering 3–5 redundant questions about state already discoverable from the environment.

---

- ✨ GH-19 Auto-detect Slack state to skip redundant prompts
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/19

---