### PR TITLE
♻️ GH-26 Enforce skill contract gaps from skill-audit findings

### DIFF
--- a/.claude/rules/mcp-tools.md
+++ b/.claude/rules/mcp-tools.md
@@ -77,6 +77,8 @@ supporting each tool:
 | `next_worktree_name` | `cli` | PR #126 | v0.25.0+ |
 | `setup_aliases` | `cli` | PR #288 | v0.30.0+ |
 | `mktmp` | `cli` | PR #160 | v0.26.0+ |
+| `audit_hook_log_path` | `cli` | GH-29 | v0.69.0+ |
+| `audit_hook_recent` | `cli` | GH-29 | v0.69.0+ |
 | `query` | `db` | PR #126 | v0.25.0+ |
 
 When adding a new tool, update this table and note any dependencies on

--- a/skills/fanout-parallel/SKILL.md
+++ b/skills/fanout-parallel/SKILL.md
@@ -271,6 +271,31 @@ Present findings via `AskUserQuestion`:
 - File issue — Create GH issue documenting findings
 - Done — Keep findings in this session only
 
+## Child `claude -p` Gotchas
+
+These are non-obvious behaviors of the child subprocess that
+skill authors must know when constructing prompts and budgets.
+
+### `--bare` strips OAuth credentials (GH-30)
+
+Do **NOT** pass `--bare` to a child `claude -p` invocation. The
+flag strips OAuth credentials needed by the child to talk to the
+API, causing immediate authentication failure on the first tool
+call. This is not documented anywhere in the Claude Code CLI
+help text and burned a smoke-test iteration in the GH-4 PoC.
+
+```bash
+# ❌ WRONG — child fails with auth error
+claude -p --bare --max-budget-usd 1.50 "..."
+
+# ✅ CORRECT — child inherits parent's OAuth
+claude -p --max-budget-usd 1.50 "..."
+```
+
+If a child needs to run without parent-context inheritance, find
+an isolation flag that does not strip credentials. As of
+2026-04, no such flag exists — children always inherit OAuth.
+
 ## Known Limitations
 
 - **This is experimental.** Results may vary across Claude Code

--- a/skills/fanout-parallel/SKILL.md
+++ b/skills/fanout-parallel/SKILL.md
@@ -321,6 +321,35 @@ parent dispatches multiple children in the same session, whether
 they share a warm plugin cache (and pay the 79K tokens once vs
 N times) is open. Measure before assuming amortization.
 
+### Parent hooks fire inside the child (GH-32)
+
+When the parent dispatches a child `claude -p`, the parent's
+PreToolUse hooks (e.g., `validate-bash`) are inherited and
+**DO fire on the child's tool calls**. Confirmed via the GH-4
+PoC turn 73 hook-probe. This is desirable — the child is
+guarded by the same safety rails as the parent — but it has
+two surprising consequences skill authors must plan for:
+
+1. **Hook-blocked patterns inside child prompts** — if the
+   parent prompt contains a string that *matches* a hook block
+   pattern (e.g., the prompt text describes a blocked Bash
+   idiom for documentation purposes), the parent's own hook
+   can fire on the parent Bash invocation that wraps the child
+   `claude -p` call. The block is on the *parent* command line,
+   not on anything the child actually executed. Workaround:
+   pass the child prompt via `--prompt-file` instead of inline.
+
+2. **Hook config drift** — children inherit *parent* hooks at
+   dispatch time. If the child triggers a new session that
+   reloads hook config (e.g., via SessionStart), the effective
+   hook set may differ from the parent's. Treat the child as
+   running under the parent's hooks unless explicitly proven
+   otherwise.
+
+When writing a fanout child prompt, assume parent hook coverage
+(use the same MCP tools, avoid the same blocked idioms) and
+keep prompt strings free of literal blocked patterns.
+
 ## Known Limitations
 
 - **This is experimental.** Results may vary across Claude Code

--- a/skills/fanout-parallel/SKILL.md
+++ b/skills/fanout-parallel/SKILL.md
@@ -296,6 +296,31 @@ If a child needs to run without parent-context inheritance, find
 an isolation flag that does not strip credentials. As of
 2026-04, no such flag exists — children always inherit OAuth.
 
+### Cold-load cost floor (~$0.20–0.50 per child) (GH-31)
+
+Each child `claude -p` subprocess that loads the Dev10x plugin
+cold incurs **~79K cache-creation tokens** before doing useful
+work. Live measurements during the GH-4 PoC observed roughly
+**$0.20 on Sonnet** and **$0.50 on the unspecified default
+model** per child, and a `--max-budget-usd 0.10` invocation
+failed with `error_max_budget_usd` before any output.
+
+**Recommended budget floor:** `--max-budget-usd 1.50` (sufficient
+for meaningful child work after the cold-load tax).
+
+```bash
+# ❌ Too low — fails with error_max_budget_usd before any output
+claude -p --max-budget-usd 0.10 "..."
+
+# ✅ Empirically sufficient
+claude -p --max-budget-usd 1.50 "..."
+```
+
+**Warm-cache reuse across siblings:** Not yet confirmed. If a
+parent dispatches multiple children in the same session, whether
+they share a warm plugin cache (and pay the 79K tokens once vs
+N times) is open. Measure before assuming amortization.
+
 ## Known Limitations
 
 - **This is experimental.** Results may vary across Claude Code

--- a/skills/gh-pr-create/scripts/pre-pr-checks.sh
+++ b/skills/gh-pr-create/scripts/pre-pr-checks.sh
@@ -27,7 +27,10 @@ echo "  [2/3] ruff format check..."
 ruff format --check . || { echo "❌ Formatting check failed. Run: ruff format ."; exit 1; }
 
 echo "  [3/3] MyPy type check..."
-mypy . || { echo "❌ MyPy check failed. Fix type errors."; exit 1; }
+# Match the [tool.mypy] mypy_path = "src" config in pyproject.toml.
+# Running `mypy .` tripped on hyphenated test directories (e.g.
+# tests/skills/gh-pr-monitor) which are not valid package names.
+mypy src || { echo "❌ MyPy check failed. Fix type errors."; exit 1; }
 
 echo "✅ All pre-PR static checks passed!"
 echo "ℹ️  Tests are run separately via Skill(Dev10x:py-test) in the shipping pipeline."

--- a/skills/skill-audit/scripts/analyze-actions.py
+++ b/skills/skill-audit/scripts/analyze-actions.py
@@ -5,8 +5,10 @@
 # ///
 import sys
 from pathlib import Path
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
 from dev10x.skills.audit.analyze_actions import *  # noqa: F401, F403
 from dev10x.skills.audit.analyze_actions import main
+
 if __name__ == "__main__":
     main()

--- a/skills/skill-audit/scripts/analyze-permissions.py
+++ b/skills/skill-audit/scripts/analyze-permissions.py
@@ -5,8 +5,10 @@
 # ///
 import sys
 from pathlib import Path
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
 from dev10x.skills.audit.analyze_permissions import *  # noqa: F401, F403
 from dev10x.skills.audit.analyze_permissions import main
+
 if __name__ == "__main__":
     main()

--- a/skills/skill-audit/scripts/extract-session.py
+++ b/skills/skill-audit/scripts/extract-session.py
@@ -5,8 +5,10 @@
 # ///
 import sys
 from pathlib import Path
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
 from dev10x.skills.audit.extract_session import *  # noqa: F401, F403
 from dev10x.skills.audit.extract_session import main
+
 if __name__ == "__main__":
     main()

--- a/skills/ticket-scope/SKILL.md
+++ b/skills/ticket-scope/SKILL.md
@@ -39,6 +39,17 @@ The full workflow — ticket fetch, context gathering, research
 loop, story point sizing, AC generation, comment writeback —
 lives in [`instructions.md`](instructions.md).
 
-When this skill is invoked, Read `instructions.md` now and
-follow it end-to-end. `TaskCreate` calls and `AskUserQuestion`
-gates documented there are REQUIRED.
+**REQUIRED before ANY other tool call:** Read
+[`instructions.md`](instructions.md) end-to-end. The
+orchestration contract (TaskCreate calls, phase ordering,
+AskUserQuestion gates, mandatory delegations like
+`Skill(Dev10x:jtbd)` and template selection) lives there —
+not in this SKILL.md. Skipping the read causes downstream
+phase bypasses (GH-26, GH-27, GH-28).
+
+**Self-check after the read:** Confirm you can name the
+six TaskCreate subjects, the Phase 4b skill delegation,
+and the Phase 5.1 templates before fetching the ticket.
+If you cannot, re-read the file. Do NOT proceed to
+`mcp__plugin_Dev10x_cli__issue_get` (or any other tool)
+until the read is complete.

--- a/skills/ticket-scope/instructions.md
+++ b/skills/ticket-scope/instructions.md
@@ -145,11 +145,26 @@ Order steps by dependencies:
 
 After estimating complexity, draft a Job Story for the ticket using the JTBD framework. This captures the business "why" early — before implementation begins — and will later be used in the PR description and release notes.
 
-**Invoke the `Dev10x:jtbd` base skill in attended mode:**
+**REQUIRED: Call `Skill(Dev10x:jtbd)` in attended mode** (do NOT
+draft the Job Story inline as prose inside the scope document).
+Inline drafting bypasses jtbd's own context-gathering and
+approval gate and breaks reusable orchestration (GH-27).
 
-1. Pass the ticket context already gathered in Phase 1 (ticket details, parent ticket, related tickets) via the `context` parameter to avoid redundant API calls
-2. The `Dev10x:jtbd` skill handles: situation identification, drafting, and user approval
-3. Include the approved Job Story in the scoping document under a `## Job Story` section (right after the title)
+1. Pass the ticket context already gathered in Phase 1 (ticket
+   details, parent ticket, related tickets) via the `context`
+   parameter to avoid redundant API calls
+2. The `Dev10x:jtbd` skill handles: situation identification,
+   drafting, and user approval
+3. Include the approved Job Story (the string returned by the
+   skill) in the scoping document under a `## Job Story` section
+   right after the title
+
+**Anti-pattern (GH-27):** Writing a Job Story sentence directly
+into the scope document Write call without a preceding
+`Skill(Dev10x:jtbd)` invocation. Even when the resulting story
+reads correctly, the skipped delegation is a compliance
+violation — the jtbd skill's own attended-mode approval gate
+must fire.
 
 **Do NOT update the Linear ticket description at this point** — the story is saved in the scoping document and will be applied to the PR later via `Dev10x:ticket-jtbd` or `Dev10x:gh-pr-create`.
 

--- a/skills/ticket-scope/instructions.md
+++ b/skills/ticket-scope/instructions.md
@@ -172,10 +172,31 @@ must fire.
 
 #### 5.1 Select Template
 
-Based on task type:
+**REQUIRED: Read one of the three templates and use its
+section structure.** Do NOT hand-craft the scope document
+without consulting a template — different sessions produce
+different shapes, breaking downstream consumers (PR creation,
+project audit) that expect template-stable section names
+(GH-28).
+
+Pick by task type and `Read` the corresponding file before
+writing the scope document:
+
 - Business Feature → `references/business-feature-template.md`
 - Technical Task → `references/technical-task-template.md`
 - Bug Fix → `references/bug-fix-template.md`
+
+**Verification:** Before the Phase 5.2 Write call that creates
+the scope document, confirm the section headings match the
+template's headings exactly (Job Story, Objective, Technical
+Approach, Architecture, …). If a heading is missing or
+renamed, you skipped the template — go back and read it.
+
+**Anti-pattern (GH-28):** Writing
+`/tmp/Dev10x/ticket-scope/<ID>-scope.md` with custom section
+names ("Findings", "Approach Notes", etc.) instead of the
+template's section names. Even when the content is correct,
+the diverged structure breaks audits and PR generation.
 
 #### 5.2 Complete All Sections
 

--- a/skills/ticket-scope/instructions.md
+++ b/skills/ticket-scope/instructions.md
@@ -44,6 +44,18 @@ Options:
 - Approve (Recommended) — Save document and optionally update Linear
 - Revise — I have corrections to the scope
 - More research needed — Need to explore additional areas
+- Run PoC — Validate unverified architectural claims via a live
+  proof-of-concept before approving (e.g., `claude -p` subprocesses,
+  small scripts, or codebase probes that confirm a claim the scope
+  depends on)
+
+**When to surface "Run PoC":** Whenever the scope contains claims
+the agent could not verify by reading the codebase alone (e.g.,
+"approach X loads the plugin in a child session", "tool Y
+propagates env vars to subprocesses"). Listing the option
+short-circuits the manual escalation pattern observed in audit
+session 1d53f6ec — the user otherwise has to invent the PoC step
+themselves under "More research needed" (GH-33).
 
 ## Prerequisites
 

--- a/skills/ticket-scope/tool-calls/ask-scope-approval.md
+++ b/skills/ticket-scope/tool-calls/ask-scope-approval.md
@@ -10,7 +10,9 @@ AskUserQuestion(questions=[{
         {label: "Revise",
          description: "I have corrections to the scope"},
         {label: "More research needed",
-         description: "Need to explore additional areas"}
+         description: "Need to explore additional areas"},
+        {label: "Run PoC",
+         description: "Validate unverified architectural claims via a live proof-of-concept before approving"}
     ],
     multiSelect: false
 }])

--- a/src/dev10x/domain/result.py
+++ b/src/dev10x/domain/result.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Generic, TypeVar
-
-T = TypeVar("T")
+from typing import Any
 
 
 @dataclass(frozen=True)
-class SuccessResult(Generic[T]):
+class SuccessResult[T]:
     value: T
 
     def to_dict(self) -> dict[str, Any]:
@@ -27,10 +25,10 @@ class ErrorResult:
         return result
 
 
-Result = SuccessResult[T] | ErrorResult
+type Result[T] = SuccessResult[T] | ErrorResult
 
 
-def ok(value: T) -> SuccessResult[T]:
+def ok[T](value: T) -> SuccessResult[T]:
     return SuccessResult(value=value)
 
 

--- a/src/dev10x/hooks/audit.py
+++ b/src/dev10x/hooks/audit.py
@@ -225,6 +225,8 @@ def summarize(*, records: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
             elif phase == "wrap":
                 wrap_only.append(rec)
             continue
+        if not isinstance(phase, str):
+            continue
         bucket = by_span.setdefault(span_id, {})
         bucket[phase] = rec
 

--- a/src/dev10x/hooks/edit_validator.py
+++ b/src/dev10x/hooks/edit_validator.py
@@ -8,9 +8,12 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from dev10x.domain.hook_input import HookResult
+
+if TYPE_CHECKING:
+    from dev10x.domain.rule_engine import RuleEngine
 
 _YAML_PATH = Path(__file__).parent.parent / "validators" / "command-skill-map.yaml"
 

--- a/src/dev10x/mcp/audit.py
+++ b/src/dev10x/mcp/audit.py
@@ -2,13 +2,31 @@
 
 Wraps the skill-audit 3-script pipeline as MCP tools so the
 skill-audit skill can process sessions without Bash allow-rules.
+
+Also exposes hook-audit log discovery tools so agents can
+inspect the audit-wrap JSONL stream without hunting for the
+log directory with raw shell commands (GH-29).
 """
 
 from __future__ import annotations
 
+import json
+import os
+from datetime import date
+from pathlib import Path
 from typing import Any
 
 from dev10x.mcp.subprocess_utils import async_run_script
+
+_DEFAULT_HOOK_AUDIT_DIR = "/tmp/Dev10x/hook-audit"
+
+
+def _resolve_audit_dir() -> Path:
+    return Path(os.environ.get("DEV10X_HOOK_AUDIT_DIR", _DEFAULT_HOOK_AUDIT_DIR))
+
+
+def _today_log_path(audit_dir: Path) -> Path:
+    return audit_dir / f"hooks-{date.today().isoformat()}.jsonl"
 
 
 async def extract_session(
@@ -72,3 +90,66 @@ async def analyze_permissions(
         return {"error": result.stderr.strip()}
 
     return {"success": True, "output": result.stdout.strip()}
+
+
+async def hook_log_path() -> dict[str, Any]:
+    audit_dir = _resolve_audit_dir()
+    today_log = _today_log_path(audit_dir)
+
+    available = []
+    if audit_dir.exists():
+        available = sorted(p.name for p in audit_dir.glob("hooks-*.jsonl"))
+
+    return {
+        "audit_dir": str(audit_dir),
+        "today_log": str(today_log),
+        "today_log_exists": today_log.exists(),
+        "audit_dir_exists": audit_dir.exists(),
+        "available_logs": available,
+        "audit_disabled": os.environ.get("DEV10X_HOOK_AUDIT", "1").lower()
+        in {"0", "false", "no", "off"},
+    }
+
+
+async def hook_recent(
+    *,
+    limit: int = 50,
+    hook_name: str | None = None,
+    span_id: str | None = None,
+    log_path: str | None = None,
+) -> dict[str, Any]:
+    target = Path(log_path) if log_path else _today_log_path(_resolve_audit_dir())
+
+    if not target.exists():
+        return {
+            "log_path": str(target),
+            "exists": False,
+            "records": [],
+            "error": f"audit log not found: {target}",
+        }
+
+    records: list[dict[str, Any]] = []
+    with target.open("r", encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if hook_name and rec.get("hook") != hook_name:
+                continue
+            if span_id and rec.get("span_id") != span_id:
+                continue
+            records.append(rec)
+
+    if limit > 0:
+        records = records[-limit:]
+
+    return {
+        "log_path": str(target),
+        "exists": True,
+        "count": len(records),
+        "records": records,
+    }

--- a/src/dev10x/mcp/github.py
+++ b/src/dev10x/mcp/github.py
@@ -424,7 +424,7 @@ async def resolve_review_thread(
         if isinstance(repo_result, ErrorResult):
             return repo_result
         return await _pr_comment_resolve(
-            resolved_repo=repo_result.value,
+            resolved_repo=str(repo_result.value),
             comment_ids=comment_ids,
         )
 
@@ -503,7 +503,7 @@ async def request_review(
         return repo_result
     resolved_repo = repo_result.value
 
-    fields: dict[str, str | list[str]] = {}
+    fields: dict[str, str | int | list[str]] = {}
     if team:
         fields["team_reviewers"] = [r.split("/")[-1] for r in reviewers]
     else:

--- a/src/dev10x/mcp/server_cli.py
+++ b/src/dev10x/mcp/server_cli.py
@@ -872,5 +872,49 @@ async def audit_analyze_permissions(
     )
 
 
+@server.tool()
+async def audit_hook_log_path() -> dict:
+    """Return the active audit-wrap JSONL log directory and today's log file.
+
+    Resolves DEV10X_HOOK_AUDIT_DIR (default /tmp/Dev10x/hook-audit) so
+    agents can locate hook-audit data without grep-hunting (GH-29).
+
+    Returns:
+        Dictionary with keys: audit_dir, today_log, today_log_exists,
+        audit_dir_exists, available_logs, audit_disabled
+    """
+    from dev10x.mcp import audit
+
+    return await audit.hook_log_path()
+
+
+@server.tool()
+async def audit_hook_recent(
+    limit: int = 50,
+    hook_name: str | None = None,
+    span_id: str | None = None,
+    log_path: str | None = None,
+) -> dict:
+    """Return recent records from the audit-wrap JSONL log.
+
+    Args:
+        limit: Maximum records to return (most recent). 0 returns all.
+        hook_name: Optional filter on the "hook" field.
+        span_id: Optional filter on the "span_id" field.
+        log_path: Optional explicit log file path. Defaults to today.
+
+    Returns:
+        Dictionary with keys: log_path, exists, count, records
+    """
+    from dev10x.mcp import audit
+
+    return await audit.hook_recent(
+        limit=limit,
+        hook_name=hook_name,
+        span_id=span_id,
+        log_path=log_path,
+    )
+
+
 def main() -> None:
     server.run()

--- a/src/dev10x/skills/audit/cli_friction.py
+++ b/src/dev10x/skills/audit/cli_friction.py
@@ -126,7 +126,9 @@ RULES: tuple[Rule, ...] = (
         rule_id="raw-gh-repo",
         pattern=re.compile(_CMD_START + r"gh\s+repo\s+view\b"),
         message="Raw `gh repo view` command in skill doc",
-        suggestion="Use `mcp__plugin_Dev10x_cli__pr_detect` (returns repo) or `detect_base_branch`",
+        suggestion=(
+            "Use `mcp__plugin_Dev10x_cli__pr_detect` (returns repo) or `detect_base_branch`"
+        ),
     ),
     Rule(
         rule_id="raw-git-commit",
@@ -146,7 +148,10 @@ RULES: tuple[Rule, ...] = (
         rule_id="raw-git-rebase",
         pattern=re.compile(_CMD_START + r"git\s+rebase\b"),
         message="Raw `git rebase` command in skill doc",
-        suggestion="Use `Skill(Dev10x:git-groom)` for history rewrites, `Skill(Dev10x:git)` for unattended rebases",
+        suggestion=(
+            "Use `Skill(Dev10x:git-groom)` for history rewrites, "
+            "`Skill(Dev10x:git)` for unattended rebases"
+        ),
     ),
     Rule(
         rule_id="raw-git-branch",

--- a/src/dev10x/skills/audit/extract_session.py
+++ b/src/dev10x/skills/audit/extract_session.py
@@ -188,9 +188,8 @@ def process_jsonl(jsonl_path: str, out: TextIO) -> None:
 
             if tool_results:
                 for tr in tool_results:
-                    out.write(
-                        f"<details><summary>Tool result ({tr['tool_use_id'][:12]}...)</summary>\n\n"
-                    )
+                    summary_id = tr["tool_use_id"][:12]
+                    out.write(f"<details><summary>Tool result ({summary_id}...)</summary>\n\n")
                     out.write(f"```\n{tr['content']}\n```\n")
                     out.write("</details>\n\n")
 

--- a/src/dev10x/skills/notifications/slack_review_request.py
+++ b/src/dev10x/skills/notifications/slack_review_request.py
@@ -152,7 +152,10 @@ def cmd_prepare(args: argparse.Namespace) -> None:
                 {
                     "skip": False,
                     "ask": True,
-                    "reason": f"No config found for '{repo_name}'. User should provide channel and mentions.",
+                    "reason": (
+                        f"No config found for '{repo_name}'. "
+                        "User should provide channel and mentions."
+                    ),
                     "channel": None,
                     "mentions": [],
                     "message": None,

--- a/tests/hooks/test_session_formatters.py
+++ b/tests/hooks/test_session_formatters.py
@@ -100,7 +100,7 @@ class TestFormatPlanSummary:
 
     def test_excludes_completed_from_remaining(self, plan: dict) -> None:
         result = _format_plan_summary(plan=plan)
-        lines = [l for l in result.splitlines() if "Set up workspace" in l]
+        lines = [line for line in result.splitlines() if "Set up workspace" in line]
         assert not lines
 
     def test_includes_work_type(self, plan: dict) -> None:

--- a/tests/hooks/test_session_stop_hooks.py
+++ b/tests/hooks/test_session_stop_hooks.py
@@ -22,14 +22,10 @@ class TestSessionPersist:
     def test_creates_state_file(self, runner: CliRunner, tmp_path: Path) -> None:
         import dev10x.hooks.session as mod
 
-        state_dir = tmp_path / ".claude" / "projects" / "_session_state"
-
         def fake_toplevel() -> str:
             return str(tmp_path / "myproject")
 
         (tmp_path / "myproject").mkdir(parents=True)
-
-        original_home = Path.home
 
         def fake_home() -> Path:
             return tmp_path

--- a/tests/mcp/test_audit.py
+++ b/tests/mcp/test_audit.py
@@ -142,3 +142,102 @@ class TestAnalyzePermissions:
         call_args = mock_run.call_args
         assert "/tmp/settings.json" in call_args.args[1:]
         assert "/tmp/output.md" in call_args.args[1:]
+
+
+class TestHookLogPath:
+    @pytest.mark.asyncio
+    async def test_resolves_default_dir(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.delenv("DEV10X_HOOK_AUDIT_DIR", raising=False)
+        monkeypatch.delenv("DEV10X_HOOK_AUDIT", raising=False)
+        result = await audit_mod.hook_log_path()
+        assert result["audit_dir"] == "/tmp/Dev10x/hook-audit"
+        assert result["audit_disabled"] is False
+
+    @pytest.mark.asyncio
+    async def test_honors_env_override(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setenv("DEV10X_HOOK_AUDIT_DIR", str(tmp_path))
+        result = await audit_mod.hook_log_path()
+        assert result["audit_dir"] == str(tmp_path)
+        assert result["audit_dir_exists"] is True
+        assert result["today_log_exists"] is False
+        assert result["available_logs"] == []
+
+    @pytest.mark.asyncio
+    async def test_lists_available_logs(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setenv("DEV10X_HOOK_AUDIT_DIR", str(tmp_path))
+        (tmp_path / "hooks-2026-04-28.jsonl").write_text("{}\n")
+        (tmp_path / "hooks-2026-04-29.jsonl").write_text("{}\n")
+        (tmp_path / "unrelated.txt").write_text("x")
+        result = await audit_mod.hook_log_path()
+        assert result["available_logs"] == [
+            "hooks-2026-04-28.jsonl",
+            "hooks-2026-04-29.jsonl",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_audit_disabled_flag(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setenv("DEV10X_HOOK_AUDIT_DIR", str(tmp_path))
+        monkeypatch.setenv("DEV10X_HOOK_AUDIT", "0")
+        result = await audit_mod.hook_log_path()
+        assert result["audit_disabled"] is True
+
+
+class TestHookRecent:
+    @pytest.mark.asyncio
+    async def test_missing_log_returns_error(self, tmp_path) -> None:
+        target = tmp_path / "hooks-2099-01-01.jsonl"
+        result = await audit_mod.hook_recent(log_path=str(target))
+        assert result["exists"] is False
+        assert result["records"] == []
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_reads_records_with_limit(self, tmp_path) -> None:
+        log = tmp_path / "log.jsonl"
+        log.write_text(
+            '{"hook": "a", "span_id": "s1"}\n'
+            "\n"
+            "not-json\n"
+            '{"hook": "b", "span_id": "s2"}\n'
+            '{"hook": "c", "span_id": "s3"}\n'
+        )
+        result = await audit_mod.hook_recent(log_path=str(log), limit=2)
+        assert result["count"] == 2
+        assert [r["hook"] for r in result["records"]] == ["b", "c"]
+
+    @pytest.mark.asyncio
+    async def test_filters_by_hook_name(self, tmp_path) -> None:
+        log = tmp_path / "log.jsonl"
+        log.write_text(
+            '{"hook": "session-start", "span_id": "s1"}\n'
+            '{"hook": "validate-bash", "span_id": "s2"}\n'
+            '{"hook": "session-start", "span_id": "s3"}\n'
+        )
+        result = await audit_mod.hook_recent(
+            log_path=str(log),
+            hook_name="session-start",
+        )
+        assert result["count"] == 2
+        assert all(r["hook"] == "session-start" for r in result["records"])
+
+    @pytest.mark.asyncio
+    async def test_filters_by_span_id(self, tmp_path) -> None:
+        log = tmp_path / "log.jsonl"
+        log.write_text('{"hook": "a", "span_id": "abc"}\n{"hook": "b", "span_id": "xyz"}\n')
+        result = await audit_mod.hook_recent(log_path=str(log), span_id="xyz")
+        assert result["count"] == 1
+        assert result["records"][0]["span_id"] == "xyz"
+
+    @pytest.mark.asyncio
+    async def test_zero_limit_returns_all(self, tmp_path) -> None:
+        log = tmp_path / "log.jsonl"
+        log.write_text('{"hook": "a"}\n{"hook": "b"}\n{"hook": "c"}\n')
+        result = await audit_mod.hook_recent(log_path=str(log), limit=0)
+        assert result["count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_default_path_uses_today(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setenv("DEV10X_HOOK_AUDIT_DIR", str(tmp_path))
+        result = await audit_mod.hook_recent()
+        assert result["exists"] is False
+        assert "hooks-" in result["log_path"]

--- a/tests/skills/gh-pr-monitor/test_pr_notify.py
+++ b/tests/skills/gh-pr-monitor/test_pr_notify.py
@@ -106,7 +106,10 @@ class TestFormatSlackMessage:
 
 class TestExtractJtbd:
     def test_extracts_when_block(self):
-        body = "## Summary\n\n**When** reconciling payments\n**wants to** see order number\n\n## Details"
+        body = (
+            "## Summary\n\n**When** reconciling payments\n"
+            "**wants to** see order number\n\n## Details"
+        )
         assert (
             extract_jtbd(body=body)
             == "**When** reconciling payments **wants to** see order number"

--- a/tests/skills/upgrade-cleanup/test_clean_project_files.py
+++ b/tests/skills/upgrade-cleanup/test_clean_project_files.py
@@ -44,12 +44,18 @@ class TestIsShellFragment:
 
 class TestIsOldVersion:
     def test_detects_old_version(self) -> None:
-        rule = "Bash(/home/user/.claude/plugins/cache/Dev10x-Guru/dev10x-claude/0.16.0/scripts/foo.sh:*)"
+        rule = (
+            "Bash(/home/user/.claude/plugins/cache/Dev10x-Guru/"
+            "dev10x-claude/0.16.0/scripts/foo.sh:*)"
+        )
 
         assert clean_mod.is_old_version(rule, "0.33.0") is True
 
     def test_current_version_is_not_old(self) -> None:
-        rule = "Bash(/home/user/.claude/plugins/cache/Dev10x-Guru/dev10x-claude/0.33.0/scripts/foo.sh:*)"
+        rule = (
+            "Bash(/home/user/.claude/plugins/cache/Dev10x-Guru/"
+            "dev10x-claude/0.33.0/scripts/foo.sh:*)"
+        )
 
         assert clean_mod.is_old_version(rule, "0.33.0") is False
 
@@ -57,7 +63,10 @@ class TestIsOldVersion:
         assert clean_mod.is_old_version("Bash(git log:*)", "0.33.0") is False
 
     def test_returns_false_when_no_current_version(self) -> None:
-        rule = "Bash(/home/user/.claude/plugins/cache/Dev10x-Guru/dev10x-claude/0.16.0/scripts/foo.sh:*)"
+        rule = (
+            "Bash(/home/user/.claude/plugins/cache/Dev10x-Guru/"
+            "dev10x-claude/0.16.0/scripts/foo.sh:*)"
+        )
 
         assert clean_mod.is_old_version(rule, None) is False
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -71,7 +71,7 @@ class TestLazyGroup:
         group._lazy_subcommands["dummy"] = f"{dummy_cmd.__module__}.dummy_cmd"
 
         ctx = click.Context(group)
-        cmd = group.get_command(ctx=ctx, cmd_name="hook")
+        group.get_command(ctx=ctx, cmd_name="hook")
 
         # hook is a real lazy subcommand in cli
         result = cli.get_command(ctx=click.Context(cli), cmd_name="hook")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -56,7 +56,6 @@ class TestConfigCaching:
         if not yaml_path.exists():
             pytest.skip("command-skill-map.yaml not found")
 
-        cache_path = tmp_path / "config.msgpack"
         yaml_copy = tmp_path / "config.yaml"
         yaml_copy.write_text(yaml_path.read_text())
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -287,7 +287,9 @@ class TestPythonEntryPointLoadability:
             pytest.param(
                 "dev10x.hooks.edit_validator",
                 marks=pytest.mark.xfail(
-                    reason="Circular import: edit_validator → domain → rule_engine → edit_validator"
+                    reason=(
+                        "Circular import: edit_validator → domain → rule_engine → edit_validator"
+                    )
                 ),
             ),
             "dev10x.commands.hook",

--- a/tests/validators/test_prefix_friction.py
+++ b/tests/validators/test_prefix_friction.py
@@ -124,7 +124,10 @@ class TestCdNoopChain:
 
     def test_blocks_cd_matching_cwd_with_env_git(self, validator: PrefixFrictionValidator) -> None:
         inp = _make_input(
-            command="cd /work/example/.worktrees/app-pos-4 && GIT_SEQUENCE_EDITOR=true git develop-rebase --autosquash",
+            command=(
+                "cd /work/example/.worktrees/app-pos-4 && "
+                "GIT_SEQUENCE_EDITOR=true git develop-rebase --autosquash"
+            ),
             cwd="/work/example/.worktrees/app-pos-4",
         )
         result = validator.validate(inp=inp)


### PR DESCRIPTION
**When** running Dev10x:ticket-scope or Dev10x:fanout-parallel in a routine session, **I want to** land the audit-driven enforcement and documentation fixes (instructions read-back, mandatory delegations, template selection, PoC gate, fanout child-process gotchas, audit-log MCP), **so future agent runs can** follow the documented contract without rediscovering bypassed phases, undocumented `--bare` and budget pitfalls, or grep-hunting for hook-audit logs.

---

[`0e17dcfd`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/37/commits/0e17dcfd876f94b35dbae40d762cf319c92cf21f) ♻️ GH-26 Enforce instructions.md read at ticket-scope startup
[`cb1b3d43`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/37/commits/cb1b3d438ad8c50dc3a3e3c0d99e659c38559a53) ♻️ GH-27 Enforce jtbd delegation in ticket-scope Phase 4b
[`276fcf69`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/37/commits/276fcf6938f2c83cb6d71913565d3372b4f57388) ♻️ GH-28 Enforce template selection in ticket-scope Phase 5.1
[`1da02389`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/37/commits/1da0238902723369f2f8b8cf71118e81db45b647) ✨ GH-33 Add PoC option to ticket-scope approval gate
[`9ed86908`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/37/commits/9ed869083361c3b3194e2ff5ec7895d8281bf571) 📝 GH-30 Document --bare strips OAuth in fanout-parallel children
[`37c9938b`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/37/commits/37c9938b2b0684b7181e291e3a91b2c39ba61f8c) 📝 GH-31 Document fanout-parallel cold-load budget floor
[`c8514efe`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/37/commits/c8514efe5b83fa89329de8d1a3757dadb1863444) 📝 GH-32 Document fanout-parallel hook propagation surprises
[`6bea15a9`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/37/commits/6bea15a975509b8a7bbb0e646cc9bad4a844fa4d) ✨ GH-29 Expose audit-wrap log discovery via MCP tools
[`dae23bfa`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/37/commits/dae23bfa688c413f1c8bbffaf8e35cb64c6ae6a6) 🎨 Sort imports in skill-audit script entry points
[`61987087`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/37/commits/619870875839d0d935488ee55a8943a956004f76) 🎨 Modernize Result generics with PEP 695 syntax
[`036b8cfc`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/37/commits/036b8cfca85c813a955dd5f814310d7a5c3b484a) 🎨 Resolve RuleEngine F821 in edit_validator hook
[`7d8d8670`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/37/commits/7d8d8670cc942df9fdebd029ba2e2846d7f5dad1) 🎨 Wrap long suggestion strings in src/dev10x
[`60cee58d`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/37/commits/60cee58da6f120921c8737dc2d9569b1b37e6aa5) 🎨 Wrap long literal strings in test files
[`82877c6e`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/37/commits/82877c6ea04acdaebc5a19766b63e657599b1dd0) 🎨 Remove dead test variables and rename ambiguous loop var
[`7080be4e`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/37/commits/7080be4e35ce3010427b7627ff92df5c107a5264) 🐛 Resolve pre-existing mypy errors in MCP github and hook audit
[`d5e9dc54`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/37/commits/d5e9dc549a123796dadaef19455dab350b3f7655) 🎨 Scope pre-PR mypy invocation to src/ to match config

Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/26
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/27
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/28
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/29
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/30
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/31
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/32
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/33

---

## Notes

This bundle landed eight skill-audit findings in one PR plus
boy-scout cleanup of pre-existing lint/type debt that blocked
the pre-PR checks:

- **ticket-scope** (GH-26, 27, 28, 33): enforcement language
  for the instructions.md read, jtbd delegation, template
  selection, plus a PoC option in the scope-approval gate
- **fanout-parallel** (GH-30, 31, 32): documented `--bare`
  OAuth strip, ~$0.20–0.50 child cold-load floor, and
  parent-hook propagation behaviour
- **MCP audit tools** (GH-29): `audit_hook_log_path` and
  `audit_hook_recent` so agents stop grep-hunting for the
  audit-wrap JSONL stream
- **Boy-scout cleanup**: 24 ruff errors → 0, 3 mypy errors →
  0, pre-PR mypy now scoped to `src/` matching config
