### PR TITLE
✨ GH-47/GH-48 Enable per-skill Read rules and rule-shape investigator

### DIFF
--- a/skills/permission-investigator/SKILL.md
+++ b/skills/permission-investigator/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: Dev10x:permission-investigator
+description: >
+  Materialize a fixture, mutate settings with candidate rule shapes,
+  and dispatch subagents to record which shapes the permission engine
+  auto-approves vs prompts. Aggregates results into a markdown matrix
+  and computes a delta against the rule shapes shipped by
+  Dev10x:plugin-maintenance.
+  TRIGGER when: permission prompts persist after plugin-maintenance
+  cleanup, or new rule shapes need empirical validation before being
+  shipped in projects.yaml.
+  DO NOT TRIGGER when: a single rule needs ad-hoc debugging — write
+  it to settings and reload instead.
+user-invocable: true
+invocation-name: Dev10x:permission-investigator
+allowed-tools:
+  - Bash(uv run dev10x:*)
+  - mcp__plugin_Dev10x_cli__issue_create
+  - Agent(general-purpose)
+  - AskUserQuestion
+  - TaskCreate
+  - TaskUpdate
+  - Read
+---
+
+# Permission Pattern Investigator (GH-47)
+
+Empirically tests which permission rule shapes Claude Code's
+engine auto-approves vs prompts on. Mutates settings, dispatches
+a subagent in a fresh session per cell, records outcomes, and
+produces a markdown matrix plus a delta report against the rules
+currently shipped by `Dev10x:plugin-maintenance`.
+
+> **Why this exists:** The engine matches rule strings literally
+> against the prompt-displayed path. `~/`, `/home/<user>/`, and
+> `${HOME}/` are not normalized. `*` segments work; `**` and
+> `*/**` do not. Manual experimentation found these patterns —
+> this skill replays them on demand and surfaces drift after
+> plugin upgrades.
+
+## Orchestration
+
+This skill follows `references/task-orchestration.md` patterns.
+
+**REQUIRED: Create tasks before ANY work.** Execute these
+`TaskCreate` calls at startup:
+
+1. `TaskCreate(subject="Phase 1: Prepare fixtures and matrix", activeForm="Preparing fixtures")`
+2. `TaskCreate(subject="Phase 2: Dispatch matrix cells", activeForm="Dispatching cells")`
+3. `TaskCreate(subject="Phase 3: Aggregate report and delta", activeForm="Aggregating report")`
+4. `TaskCreate(subject="Phase 4: Restore settings and clean up", activeForm="Restoring settings")`
+
+Set sequential dependencies: each phase blocked by the previous.
+
+## Phase 1: Prepare
+
+Run the prepare command. It materializes the fixture skill file
+under `~/.claude/plugins/cache/Test-Org/Investigator/9.9.9/`,
+creates a project-local `settings.local.json` stub, snapshots
+the user's global settings, and persists the matrix shell to
+`/tmp/Dev10x/permission-investigator/matrix.json`.
+
+```
+uv run dev10x permission investigate prepare
+```
+
+Read back the cell list — it is the source of truth for Phase 2:
+
+```
+Read /tmp/Dev10x/permission-investigator/matrix.json
+```
+
+## Phase 2: Dispatch
+
+For **every cell** in the matrix, run this loop:
+
+1. Apply the rule shape:
+
+   ```
+   uv run dev10x permission investigate apply <cell_id>
+   ```
+
+2. **REQUIRED: Dispatch a fresh subagent** to exercise the
+   corresponding tool call against the fixture file. Use a
+   `general-purpose` agent (Read tool requires no extra
+   permissions; Bash needs the engine to evaluate the applied
+   rule shape). Keep prompts short — the agent only needs to
+   know whether the call was auto-approved or surfaced a prompt.
+
+   ```
+   Agent(
+     subagent_type="general-purpose",
+     model="haiku",
+     description=f"Probe cell {cell_id}",
+     prompt=f"""Attempt to read this file:
+       {fixture_path}
+       (or for Bash cells, run `cat {fixture_path}`)
+
+       Return one of:
+       - AUTO_APPROVED — the call ran without a permission prompt
+       - PROMPTED — a permission prompt was surfaced
+       - ERROR: <message> — the call failed for another reason
+
+       Do not retry. Do not modify settings. Report exactly one
+       line.""")
+   ```
+
+3. Record the outcome:
+
+   ```
+   uv run dev10x permission investigate record <cell_id> \
+     --auto-approved   # or --prompted
+   ```
+
+4. Move to the next cell.
+
+**Auto-advance:** Do not pause between cells. The matrix is
+complete when every cell has a recorded outcome.
+
+## Phase 3: Aggregate
+
+Render the matrix and compute the delta against current
+`plugin-maintenance` rules:
+
+```
+uv run dev10x permission investigate report \
+  --output /tmp/Dev10x/permission-investigator/report.md
+uv run dev10x permission investigate delta
+```
+
+**REQUIRED: Call `AskUserQuestion`** (do NOT use plain text)
+when at least one rule is flagged ineffective. Options:
+
+- File upstream issue (Recommended) — open a GH-47 follow-up
+  issue at `Dev10x-Guru/Dev10x-Claude` with the matrix and
+  proposed rule-shape changes
+- Save report only — keep the markdown for review, no upstream
+  filing
+- Discard — restore settings and exit without saving
+
+When the user picks "File upstream issue", invoke the issue
+creation MCP tool with the report body:
+
+```
+mcp__plugin_Dev10x_cli__issue_create(
+  title="Permission Pattern Investigator: <date> drift report",
+  body=<contents of report.md>,
+  labels=["permission-friction", "from-investigator"],
+  repo="Dev10x-Guru/Dev10x-Claude",
+)
+```
+
+## Phase 4: Restore
+
+Always restore settings, even when the run fails or the user
+discards the report:
+
+```
+uv run dev10x permission investigate restore
+```
+
+The workdir under `/tmp/Dev10x/permission-investigator/` is
+left in place so the user can inspect the matrix state after
+the run. It is a temp directory; the next `prepare` call
+overwrites it.
+
+## Decision Gates
+
+| Gate | Trigger | Default in adaptive |
+|------|---------|---------------------|
+| Phase 3 disposition | Delta non-empty | "File upstream" auto-selected |
+| Restore on error | Any phase fails | Always run restore |
+
+Adaptive friction auto-selects the recommended option. Strict
+and guided friction prompt for confirmation.
+
+## Notes
+
+- **Workdir:** `/tmp/Dev10x/permission-investigator/` — fixtures,
+  snapshots, and `matrix.json` live here.
+- **Fresh sessions:** the matrix only produces signal when each
+  cell runs in a session where prior cells have not poisoned
+  the engine cache. The dispatched subagents satisfy this — they
+  start clean. Running probes inline in the parent session is
+  not equivalent.
+- **Coverage budget:** the default matrix is two tools (Read,
+  Bash) × three prefixes × four wildcards × three locations =
+  72 cells. Each cell is one short subagent invocation; total
+  runtime is dominated by the engine's prompt-or-not decision.
+- **Restore is mandatory:** never leave settings dirty. Phase 4
+  runs even when an earlier phase fails.
+
+## Resources
+
+- `references/eval-criteria.md` — none required for this skill.
+- Python implementation: `src/dev10x/skills/permission_investigator/`
+- CLI: `dev10x permission investigate <subcommand>`

--- a/skills/plugin-maintenance/SKILL.md
+++ b/skills/plugin-maintenance/SKILL.md
@@ -70,6 +70,7 @@ on the mode. Execute these `TaskCreate` calls at startup:
 2. `TaskCreate(subject="Ensure workspace directories", activeForm="Registering workspace dirs")`
 3. `TaskCreate(subject="Ensure base permissions", activeForm="Ensuring base perms")`
 4. `TaskCreate(subject="Ensure script coverage", activeForm="Verifying script rules")`
+5. `TaskCreate(subject="Ensure read coverage", activeForm="Verifying Read rules")`
 
 **Full mode:**
 
@@ -80,9 +81,10 @@ on the mode. Execute these `TaskCreate` calls at startup:
 5. `TaskCreate(subject="Generalize session-specific permissions", activeForm="Generalizing perms")`
 6. `TaskCreate(subject="Enumerate MCP tool globs", activeForm="Enumerating MCP globs")`
 7. `TaskCreate(subject="Ensure script coverage", activeForm="Verifying script rules")`
-8. `TaskCreate(subject="Merge worktree permissions", activeForm="Merging worktree perms")`
-9. `TaskCreate(subject="Audit permissions for friction", activeForm="Auditing permissions")`
-10. `TaskCreate(subject="Clean project files", activeForm="Cleaning project files")`
+8. `TaskCreate(subject="Ensure read coverage", activeForm="Verifying Read rules")`
+9. `TaskCreate(subject="Merge worktree permissions", activeForm="Merging worktree perms")`
+10. `TaskCreate(subject="Audit permissions for friction", activeForm="Auditing permissions")`
+11. `TaskCreate(subject="Clean project files", activeForm="Cleaning project files")`
 
 Set sequential dependencies. Mark each step `in_progress` when
 starting and `completed` when done. Steps that produce no
@@ -268,7 +270,39 @@ mcp__plugin_Dev10x_cli__update_paths(ensure_scripts=true)
 - `hooks/scripts/*.py`, `hooks/scripts/*.sh` — hook implementations
 - `skills/*/scripts/*.py`, `skills/*/scripts/*.sh` — skill scripts
 
-### 8. Merge worktree permissions *(full only)*
+### 8. Ensure read coverage **[bootstrap]**
+
+Verify that every skill folder and recognized top-level plugin
+directory has a per-folder `Read(...)` allow rule. Empirical
+evidence shows the engine matches rule strings literally against
+the prompt-displayed path, so each rule ships in two variants —
+`Read(~/...)` and `Read(/home/<user>/...)` — and uses a single
+`*` wildcard rather than `*/**` (GH-47).
+
+> **Why both variants:** The permission engine does not normalize
+> `~/` and `/home/<user>/`, so emitting both shapes is the
+> belt-and-suspenders fix until the engine learns to.
+
+1. Dry run:
+
+```
+mcp__plugin_Dev10x_cli__update_paths(ensure_reads=true, dry_run=true)
+```
+
+2. Apply:
+
+```
+mcp__plugin_Dev10x_cli__update_paths(ensure_reads=true)
+```
+
+**What gets emitted (per skill, per top-level dir):**
+- `Read(~/.claude/plugins/cache/<pub>/<plugin>/<version>/skills/<name>/*)`
+- `Read(/home/<user>/.claude/plugins/cache/<pub>/<plugin>/<version>/skills/<name>/*)`
+
+The version segment is shared with `update-paths`, so both
+variants update in lockstep on plugin upgrade.
+
+### 9. Merge worktree permissions *(full only)*
 
 Worktrees accumulate allow rules during sessions that the main
 project never sees. This script collects stable permissions from
@@ -289,7 +323,7 @@ ${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/scripts/merge-worktree-permissions.
 Session-specific noise is filtered out automatically; only
 stable, reusable permissions are merged.
 
-### 9. Audit permissions for friction *(full only)*
+### 10. Audit permissions for friction *(full only)*
 
 Dispatch the `permission-auditor` agent to perform a comprehensive
 7-phase security and friction audit. The agent analyzes:
@@ -315,7 +349,7 @@ Agent(subagent_type="Dev10x:permission-auditor",
 The agent produces a severity-categorized report with specific
 fix proposals. Review and apply selectively.
 
-### 10. Clean project files *(full only)*
+### 11. Clean project files *(full only)*
 
 Strip redundant rules from project `settings.local.json` files
 that are now covered by global `~/.claude/settings.json`. Also
@@ -371,6 +405,7 @@ users do not need to migrate config files.
 | `ensure_base` | Add missing base permissions from projects.yaml |
 | `generalize` | Replace session-specific args with wildcard patterns |
 | `ensure_scripts` | Verify all plugin scripts have allow rules; add missing |
+| `ensure_reads` | Emit per-skill folder Read rules with `~/` + `/home/<user>/` twins |
 
 ### update-paths.py CLI
 

--- a/src/dev10x/commands/permission.py
+++ b/src/dev10x/commands/permission.py
@@ -25,9 +25,7 @@ def permission() -> None:
     is_flag=True,
     help="Print one line per changed file (count) instead of full per-file details",
 )
-@click.option(
-    "--restore", is_flag=True, help="Restore settings from most recent backups"
-)
+@click.option("--restore", is_flag=True, help="Restore settings from most recent backups")
 def update_paths(
     *,
     dry_run: bool,
@@ -258,9 +256,7 @@ def init() -> None:
     is_flag=True,
     help="Print one line per changed file (count) instead of full per-file details",
 )
-@click.option(
-    "--restore", is_flag=True, help="Restore settings from most recent backups"
-)
+@click.option("--restore", is_flag=True, help="Restore settings from most recent backups")
 def clean(*, dry_run: bool, verbose: bool, summary: bool, restore: bool) -> None:
     """Clean redundant permissions from project settings files."""
     from dev10x.skills.permission import clean_project_files as mod
@@ -382,9 +378,7 @@ def enumerate_mcp(*, dry_run: bool, quiet: bool) -> None:
 
 @permission.command(name="merge-worktree")
 @click.option("--dry-run", is_flag=True, help="Show changes without modifying files")
-@click.option(
-    "--restore", is_flag=True, help="Restore settings from most recent backups"
-)
+@click.option("--restore", is_flag=True, help="Restore settings from most recent backups")
 def merge_worktree(*, dry_run: bool, restore: bool) -> None:
     """Merge worktree permissions back into main project settings."""
     from dev10x.skills.permission import merge_worktree_permissions as mod
@@ -426,14 +420,324 @@ def merge_worktree(*, dry_run: bool, restore: bool) -> None:
             total_merged += count
             projects_changed += 1
         else:
-            click.echo(
-                f"\n{main_project} — up to date ({len(worktree_dirs)} worktrees)"
-            )
+            click.echo(f"\n{main_project} — up to date ({len(worktree_dirs)} worktrees)")
 
     if total_merged == 0:
         click.echo("\nAll projects up to date.")
     else:
         verb = "Would merge" if dry_run else "Merged"
-        click.echo(
-            f"\n{verb} {total_merged} permissions into {projects_changed} projects."
+        click.echo(f"\n{verb} {total_merged} permissions into {projects_changed} projects.")
+
+
+@permission.group()
+def investigate() -> None:
+    """Permission Pattern Investigator (GH-47).
+
+    Materialize fixtures, mutate settings with candidate rule shapes,
+    and aggregate per-shape outcomes into a markdown report. The
+    subagent dispatch loop that exercises each cell is orchestrated
+    from the ``Dev10x:permission-investigator`` skill.
+    """
+
+
+_INVESTIGATOR_NS = "permission-investigator"
+
+
+def _investigator_workdir() -> Path:
+    return Path("/tmp/Dev10x") / _INVESTIGATOR_NS
+
+
+def _matrix_state_path(*, workdir: Path | None = None) -> Path:
+    """Return the matrix.json path for the given workdir.
+
+    When ``workdir`` is None, falls back to the default workdir.
+    Apply/record/report/restore commands resolve workdir from the
+    persisted state so a `prepare --workdir X` run can be driven
+    end-to-end without losing track of the matrix.
+    """
+    return (workdir or _investigator_workdir()) / "matrix.json"
+
+
+def _resolve_state_path() -> Path:
+    """Find matrix.json by checking the default workdir first.
+
+    The default location is the bootstrap point — `prepare` always
+    writes the initial copy there. If a non-default workdir was
+    supplied to `prepare`, the state file at the default location
+    contains a `redirect` pointer to the real matrix path.
+    """
+    default = _matrix_state_path()
+    if not default.is_file():
+        return default
+    try:
+        import json as _json
+
+        data = _json.loads(default.read_text())
+        redirect = data.get("redirect")
+        if redirect:
+            return Path(redirect)
+    except (OSError, ValueError):
+        pass
+    return default
+
+
+@investigate.command(name="prepare")
+@click.option(
+    "--workdir",
+    type=click.Path(),
+    default=None,
+    help="Override workdir (default: /tmp/Dev10x/permission-investigator)",
+)
+def investigate_prepare(*, workdir: str | None) -> None:
+    """Materialize fixtures and snapshot the user's settings files."""
+    import json as _json
+    from dataclasses import asdict
+
+    from dev10x.skills.permission_investigator import fixtures
+    from dev10x.skills.permission_investigator.matrix import generate_matrix
+
+    work = Path(workdir) if workdir else _investigator_workdir()
+    paths = fixtures.materialize_fixtures(workdir=work, user_home=Path.home())
+
+    snapshot_dir = work / "snapshots"
+    fixtures.snapshot_settings(
+        settings_path=paths.global_settings,
+        snapshot_dir=snapshot_dir,
+    )
+    fixtures.snapshot_settings(
+        settings_path=paths.project_settings,
+        snapshot_dir=snapshot_dir,
+    )
+
+    matrix = generate_matrix()
+    state = {
+        "fixture": {
+            "fixture_root": str(paths.fixture_root),
+            "fixture_relpath": str(paths.fixture_relpath),
+            "plugin_skill_file": str(paths.plugin_skill_file),
+            "project_settings": str(paths.project_settings),
+            "global_settings": str(paths.global_settings),
+            "workdir": str(paths.workdir),
+            "publisher_root": str(paths.publisher_root),
+        },
+        "cells": [
+            {
+                "cell_id": cell.cell_id,
+                "shape": asdict(cell.shape),
+                "location": cell.location,
+            }
+            for cell in matrix.cells
+        ],
+        "results": {},
+    }
+    real_state_path = _matrix_state_path(workdir=work)
+    real_state_path.parent.mkdir(parents=True, exist_ok=True)
+    real_state_path.write_text(_json.dumps(state, indent=2))
+
+    if work != _investigator_workdir():
+        default_state_path = _matrix_state_path()
+        default_state_path.parent.mkdir(parents=True, exist_ok=True)
+        default_state_path.write_text(_json.dumps({"redirect": str(real_state_path)}, indent=2))
+
+    click.echo(f"Workdir: {work}")
+    click.echo(f"Fixture: {paths.plugin_skill_file}")
+    click.echo(f"Cells: {len(matrix.cells)}")
+
+
+@investigate.command(name="apply")
+@click.argument("cell_id")
+def investigate_apply(*, cell_id: str) -> None:
+    """Apply the rule shape for ``cell_id`` to the appropriate target file(s)."""
+    import json as _json
+
+    from dev10x.skills.permission_investigator import fixtures
+    from dev10x.skills.permission_investigator.matrix import RuleShape
+
+    state_path = _resolve_state_path()
+    if not state_path.is_file():
+        click.echo("ERROR: state missing — run `prepare` first.", err=True)
+        sys.exit(1)
+    state = _json.loads(state_path.read_text())
+
+    cell = next((c for c in state["cells"] if c["cell_id"] == cell_id), None)
+    if cell is None:
+        click.echo(f"ERROR: unknown cell_id {cell_id}", err=True)
+        sys.exit(1)
+
+    shape = RuleShape(**cell["shape"])
+    rule = shape.render(
+        fixture_relpath=state["fixture"]["fixture_relpath"],
+        user_home=str(Path.home()),
+    )
+
+    targets: list[Path] = []
+    if cell["location"] in ("project", "both"):
+        targets.append(Path(state["fixture"]["project_settings"]))
+    if cell["location"] in ("global", "both"):
+        targets.append(Path(state["fixture"]["global_settings"]))
+
+    for target in targets:
+        fixtures.apply_rule(rule=rule, target=target)
+
+    click.echo(f"Applied rule: {rule}")
+    click.echo(f"Targets: {len(targets)}")
+
+
+@investigate.command(name="record")
+@click.argument("cell_id")
+@click.option(
+    "--auto-approved/--prompted",
+    default=False,
+    help="Whether the dispatcher tool call was auto-approved",
+)
+@click.option("--error", default=None, help="Error message, if any")
+@click.option("--notes", default="", help="Free-form notes from the dispatcher")
+def investigate_record(
+    *,
+    cell_id: str,
+    auto_approved: bool,
+    error: str | None,
+    notes: str,
+) -> None:
+    """Record the outcome for one cell into the persisted matrix."""
+    import json as _json
+
+    state_path = _resolve_state_path()
+    if not state_path.is_file():
+        click.echo("ERROR: state missing — run `prepare` first.", err=True)
+        sys.exit(1)
+    state = _json.loads(state_path.read_text())
+
+    state.setdefault("results", {})[cell_id] = {
+        "cell_id": cell_id,
+        "auto_approved": bool(auto_approved),
+        "prompted": not bool(auto_approved),
+        "error": error,
+        "notes": notes,
+    }
+    state_path.write_text(_json.dumps(state, indent=2))
+    click.echo(f"Recorded {cell_id}")
+
+
+@investigate.command(name="restore")
+def investigate_restore() -> None:
+    """Restore settings files from the pre-run snapshots."""
+    import json as _json
+
+    from dev10x.skills.permission_investigator import fixtures
+
+    state_path = _resolve_state_path()
+    if not state_path.is_file():
+        click.echo("Nothing to restore — state missing.")
+        return
+    state = _json.loads(state_path.read_text())
+    snapshot_dir = Path(state["fixture"]["workdir"]) / "snapshots"
+
+    for key in ("global_settings", "project_settings"):
+        target = Path(state["fixture"][key])
+        snap = snapshot_dir / f"{target.name}.snapshot"
+        if snap.is_file():
+            fixtures.restore_settings(snapshot_path=snap, target_path=target)
+            click.echo(f"Restored {target}")
+
+    publisher_root_str = state["fixture"].get("publisher_root")
+    if publisher_root_str:
+        publisher_root = Path(publisher_root_str)
+        if publisher_root.is_dir():
+            import shutil as _shutil
+
+            _shutil.rmtree(publisher_root)
+            click.echo(f"Removed fixture publisher tree {publisher_root}")
+
+
+@investigate.command(name="report")
+@click.option(
+    "--output",
+    type=click.Path(),
+    default=None,
+    help="Write the report to this path (default: stdout)",
+)
+def investigate_report(*, output: str | None) -> None:
+    """Render the populated matrix as a markdown report."""
+    import json as _json
+
+    from dev10x.skills.permission_investigator.matrix import (
+        Matrix,
+        MatrixCell,
+        MatrixResult,
+        RuleShape,
+    )
+    from dev10x.skills.permission_investigator.report import render_markdown_report
+
+    state_path = _resolve_state_path()
+    if not state_path.is_file():
+        click.echo("ERROR: state missing — run `prepare` first.", err=True)
+        sys.exit(1)
+    state = _json.loads(state_path.read_text())
+
+    matrix = Matrix()
+    for cell_data in state.get("cells", []):
+        shape = RuleShape(**cell_data["shape"])
+        matrix.cells.append(
+            MatrixCell(
+                shape=shape,
+                location=cell_data["location"],
+                cell_id=cell_data["cell_id"],
+            )
         )
+    for cell_id, result_data in state.get("results", {}).items():
+        matrix.add_result(MatrixResult(**result_data))
+
+    rendered = render_markdown_report(matrix)
+    if output:
+        Path(output).write_text(rendered)
+        click.echo(f"Wrote report to {output}")
+    else:
+        click.echo(rendered)
+
+
+@investigate.command(name="delta")
+def investigate_delta() -> None:
+    """Compare matrix outcomes against current plugin-maintenance rules."""
+    import json as _json
+
+    from dev10x.skills.permission import update_paths as paths_mod
+    from dev10x.skills.permission_investigator.matrix import (
+        Matrix,
+        MatrixCell,
+        MatrixResult,
+        RuleShape,
+    )
+    from dev10x.skills.permission_investigator.report import compute_delta
+
+    state_path = _resolve_state_path()
+    if not state_path.is_file():
+        click.echo("ERROR: state missing — run `prepare` first.", err=True)
+        sys.exit(1)
+    state = _json.loads(state_path.read_text())
+
+    matrix = Matrix()
+    for cell_data in state.get("cells", []):
+        matrix.cells.append(
+            MatrixCell(
+                shape=RuleShape(**cell_data["shape"]),
+                location=cell_data["location"],
+                cell_id=cell_data["cell_id"],
+            )
+        )
+    for cell_id, result_data in state.get("results", {}).items():
+        matrix.add_result(MatrixResult(**result_data))
+
+    config_path = paths_mod.find_config()
+    config = paths_mod.load_config(config_path)
+    base_permissions = config.get("base_permissions", [])
+
+    delta = compute_delta(matrix=matrix, base_permissions=base_permissions)
+
+    click.echo("Ineffective rules currently shipped:")
+    for rule in delta.ineffective_rules or ["  (none)"]:
+        click.echo(f"  - {rule}")
+    click.echo()
+    click.echo("Suggested replacements:")
+    for line in delta.suggested_rules or ["  (none — matrix incomplete or all prompt)"]:
+        click.echo(f"  * {line}")

--- a/src/dev10x/commands/permission.py
+++ b/src/dev10x/commands/permission.py
@@ -214,6 +214,34 @@ def ensure_scripts(*, dry_run: bool, quiet: bool) -> None:
     )
 
 
+@permission.command(name="ensure-reads")
+@click.option("--dry-run", is_flag=True, help="Show changes without modifying files")
+@click.option("--quiet", is_flag=True, help="Suppress per-file details")
+def ensure_reads(*, dry_run: bool, quiet: bool) -> None:
+    """Emit per-skill folder Read rules with ~/ + /home/<user>/ twins."""
+    from dev10x.skills.permission import update_paths as mod
+
+    config_path = mod.find_config()
+    config = mod.load_config(config_path)
+
+    settings_files = mod.find_settings_files(
+        roots=config.get("roots", []),
+        include_user=config.get("include_user_settings", True),
+    )
+    if not settings_files:
+        click.echo("No settings files found.")
+        return
+
+    sys.exit(
+        mod._ensure_reads(
+            config=config,
+            settings_files=settings_files,
+            dry_run=dry_run,
+            quiet=quiet,
+        )
+    )
+
+
 @permission.command()
 def init() -> None:
     """Create userspace config from plugin default."""

--- a/src/dev10x/mcp/permission.py
+++ b/src/dev10x/mcp/permission.py
@@ -20,6 +20,7 @@ def _run_sub_command(
     generalize: bool = False,
     ensure_scripts: bool = False,
     ensure_workspace: bool = False,
+    ensure_reads: bool = False,
     dry_run: bool = False,
     quiet: bool = False,
 ) -> dict[str, Any]:
@@ -65,6 +66,13 @@ def _run_sub_command(
                 dry_run=dry_run,
                 quiet=quiet,
             )
+        if ensure_reads and rc == 0:
+            rc = mod._ensure_reads(
+                config=config,
+                settings_files=settings_files,
+                dry_run=dry_run,
+                quiet=quiet,
+            )
 
     output = buf.getvalue().strip()
     if rc != 0:
@@ -80,16 +88,18 @@ async def update_paths(
     generalize: bool = False,
     ensure_scripts: bool = False,
     ensure_workspace: bool = False,
+    ensure_reads: bool = False,
     init: bool = False,
     quiet: bool = False,
 ) -> dict[str, Any]:
-    if ensure_base or generalize or ensure_scripts or ensure_workspace:
+    if ensure_base or generalize or ensure_scripts or ensure_workspace or ensure_reads:
         return await asyncio.to_thread(
             _run_sub_command,
             ensure_base=ensure_base,
             generalize=generalize,
             ensure_scripts=ensure_scripts,
             ensure_workspace=ensure_workspace,
+            ensure_reads=ensure_reads,
             dry_run=dry_run,
             quiet=quiet,
         )

--- a/src/dev10x/mcp/server_cli.py
+++ b/src/dev10x/mcp/server_cli.py
@@ -344,9 +344,7 @@ async def generate_commit_list(pr_number: int, base_branch: str | None = None) -
     """
     from dev10x.mcp import github as gh
 
-    return (
-        await gh.generate_commit_list(pr_number=pr_number, base_branch=base_branch)
-    ).to_dict()
+    return (await gh.generate_commit_list(pr_number=pr_number, base_branch=base_branch)).to_dict()
 
 
 @server.tool()
@@ -362,9 +360,7 @@ async def post_summary_comment(issue_id: str, summary_text: str) -> dict:
     """
     from dev10x.mcp import github as gh
 
-    return (
-        await gh.post_summary_comment(issue_id=issue_id, summary_text=summary_text)
-    ).to_dict()
+    return (await gh.post_summary_comment(issue_id=issue_id, summary_text=summary_text)).to_dict()
 
 
 @server.tool()
@@ -419,9 +415,7 @@ async def pr_notify(
 
 
 @server.tool()
-async def push_safe(
-    args: list[str], protected_branches: list[str] | None = None
-) -> dict:
+async def push_safe(args: list[str], protected_branches: list[str] | None = None) -> dict:
     """Safely push git branches with protection for main/develop.
 
     Args:
@@ -433,9 +427,7 @@ async def push_safe(
     """
     from dev10x.mcp import git as git_tools
 
-    return (
-        await git_tools.push_safe(args=args, protected_branches=protected_branches)
-    ).to_dict()
+    return (await git_tools.push_safe(args=args, protected_branches=protected_branches)).to_dict()
 
 
 @server.tool()
@@ -451,9 +443,7 @@ async def rebase_groom(seq_path: str, base_ref: str) -> dict:
     """
     from dev10x.mcp import git as git_tools
 
-    return (
-        await git_tools.rebase_groom(seq_path=seq_path, base_ref=base_ref)
-    ).to_dict()
+    return (await git_tools.rebase_groom(seq_path=seq_path, base_ref=base_ref)).to_dict()
 
 
 @server.tool()
@@ -474,9 +464,7 @@ async def create_worktree(
     """
     from dev10x.mcp import git as git_tools
 
-    return (
-        await git_tools.create_worktree(branch=branch, base=base, path=path)
-    ).to_dict()
+    return (await git_tools.create_worktree(branch=branch, base=base, path=path)).to_dict()
 
 
 @server.tool()
@@ -508,9 +496,7 @@ async def start_split_rebase(commit_hash: str, base_branch: str = "develop") -> 
     from dev10x.mcp import git as git_tools
 
     return (
-        await git_tools.start_split_rebase(
-            commit_hash=commit_hash, base_branch=base_branch
-        )
+        await git_tools.start_split_rebase(commit_hash=commit_hash, base_branch=base_branch)
     ).to_dict()
 
 
@@ -747,6 +733,7 @@ async def update_paths(
     ensure_base: bool = False,
     generalize: bool = False,
     ensure_scripts: bool = False,
+    ensure_reads: bool = False,
     init: bool = False,
     quiet: bool = False,
 ) -> dict:
@@ -758,6 +745,7 @@ async def update_paths(
         ensure_base: Add missing base permissions from projects.yaml
         generalize: Replace session-specific args with wildcards
         ensure_scripts: Verify all plugin scripts have allow rules
+        ensure_reads: Emit per-skill Read rules with ~/ + /home/<user>/ twins
         init: Create userspace config from plugin default
         quiet: Suppress per-file details
 
@@ -772,6 +760,7 @@ async def update_paths(
         ensure_base=ensure_base,
         generalize=generalize,
         ensure_scripts=ensure_scripts,
+        ensure_reads=ensure_reads,
         init=init,
         quiet=quiet,
     )

--- a/src/dev10x/skills/permission/clean_project_files.py
+++ b/src/dev10x/skills/permission/clean_project_files.py
@@ -22,14 +22,18 @@ from pathlib import Path
 
 import yaml
 
-USERSPACE_CONFIG = Path.home() / ".claude" / "skills" / "Dev10x:upgrade-cleanup" / "projects.yaml"
+USERSPACE_CONFIG = (
+    Path.home() / ".claude" / "skills" / "Dev10x:upgrade-cleanup" / "projects.yaml"
+)
 PLUGIN_CONFIG = (
     Path(__file__).resolve().parents[4] / "skills" / "upgrade-cleanup" / "projects.yaml"
 )
 GLOBAL_SETTINGS = Path.home() / ".claude" / "settings.json"
 
 PLUGIN_NAMES = r"(?:Dev10x|dev10x(?:-claude)?)"
-VERSION_PATTERN = re.compile(rf"plugins/cache/[^/]+/{PLUGIN_NAMES}/(\d+\.\d+\.\d+)", re.IGNORECASE)
+VERSION_PATTERN = re.compile(
+    rf"plugins/cache/[^/]+/{PLUGIN_NAMES}/(\d+\.\d+\.\d+)", re.IGNORECASE
+)
 PUBLISHER_PATTERN = re.compile(rf"plugins/cache/([^/]+)/{PLUGIN_NAMES}/", re.IGNORECASE)
 
 ENV_PREFIX_PATTERN = re.compile(r"^Bash\([A-Z_]+=")
@@ -53,6 +57,23 @@ SHELL_FRAGMENTS = frozenset(
 )
 
 DOUBLE_SLASH_PATTERN = re.compile(r"\(//")
+
+# Patterns superseded by ensure-reads per-skill enumeration (GH-48).
+# The `Read(...Dev10x/*/**)` glob does not reliably match in Claude
+# Code's permission engine — keep the deprecated rule list narrow and
+# explicit so future deprecations stay searchable.
+DEPRECATED_READ_GLOBS: tuple[re.Pattern[str], ...] = (
+    re.compile(
+        r"^Read\((?:~|/home/[^/]+)/\.claude/plugins/cache/[^/]+/"
+        rf"{PLUGIN_NAMES}/\*/\*\*\)$",
+        re.IGNORECASE,
+    ),
+)
+
+
+def is_deprecated_read_glob(rule: str) -> bool:
+    return any(p.match(rule) for p in DEPRECATED_READ_GLOBS)
+
 
 HOOK_ENABLED_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"^Bash\(gh pr create"),
@@ -95,6 +116,7 @@ class RemovalResult:
     wildcard_bypasses: list[str] = field(default_factory=list)
     allow_deny_contradictions: list[tuple[str, str]] = field(default_factory=list)
     ask_shadowed_by_allow: list[tuple[str, str]] = field(default_factory=list)
+    deprecated_globs: list[str] = field(default_factory=list)
     kept: list[str] = field(default_factory=list)
 
     @property
@@ -106,6 +128,7 @@ class RemovalResult:
             + len(self.env_noise)
             + len(self.shell_fragments)
             + len(self.double_slash)
+            + len(self.deprecated_globs)
         )
 
 
@@ -295,6 +318,10 @@ def classify_rules(
             result.double_slash.append(rule)
             continue
 
+        if is_deprecated_read_glob(rule):
+            result.deprecated_globs.append(rule)
+            continue
+
         result.kept.append(rule)
 
     return result
@@ -381,13 +408,17 @@ def _format_messages(
             messages.append(f"    deny:  {deny}")
 
     if result.ask_shadowed_by_allow:
-        messages.append(f"  ⚠ ASK SHADOWED BY ALLOW ({len(result.ask_shadowed_by_allow)}):")
+        messages.append(
+            f"  ⚠ ASK SHADOWED BY ALLOW ({len(result.ask_shadowed_by_allow)}):"
+        )
         for ask, allow in result.ask_shadowed_by_allow:
             messages.append(f"    ask:   {ask}")
             messages.append(f"    allow: {allow}")
 
     if result.exact_duplicates:
-        messages.append(f"  - {len(result.exact_duplicates)} exact duplicates of global rules")
+        messages.append(
+            f"  - {len(result.exact_duplicates)} exact duplicates of global rules"
+        )
         if verbose:
             for rule in result.exact_duplicates:
                 messages.append(f"    {rule}")
@@ -411,7 +442,9 @@ def _format_messages(
                 messages.append(f"    {rule}")
 
     if result.shell_fragments:
-        messages.append(f"  - {len(result.shell_fragments)} shell control flow fragments")
+        messages.append(
+            f"  - {len(result.shell_fragments)} shell control flow fragments"
+        )
         if verbose:
             for rule in result.shell_fragments:
                 messages.append(f"    {rule}")
@@ -420,6 +453,15 @@ def _format_messages(
         messages.append(f"  - {len(result.double_slash)} double-slash paths")
         if verbose:
             for rule in result.double_slash:
+                messages.append(f"    {rule}")
+
+    if result.deprecated_globs:
+        messages.append(
+            f"  - {len(result.deprecated_globs)} deprecated Read globs"
+            " (superseded by ensure-reads)"
+        )
+        if verbose:
+            for rule in result.deprecated_globs:
                 messages.append(f"    {rule}")
 
     if result.hook_enabled:

--- a/src/dev10x/skills/permission/update_paths.py
+++ b/src/dev10x/skills/permission/update_paths.py
@@ -276,6 +276,17 @@ SCRIPT_SCAN_GLOBS: list[str] = [
     "skills/*/scripts/*.sh",
 ]
 
+READ_TOP_LEVEL_DIRS: tuple[str, ...] = (
+    "agents",
+    "commands",
+    "references",
+    "hooks",
+    "hooks/scripts",
+    "bin",
+    "servers",
+    "lib",
+)
+
 
 def scan_plugin_scripts(plugin_root: Path) -> list[Path]:
     scripts: list[Path] = []
@@ -323,6 +334,125 @@ def verify_script_coverage(
         else:
             missing.append(rule)
     return covered, missing
+
+
+def scan_skill_directories(
+    plugin_root: Path,
+) -> list[str]:
+    """Return the list of skill directory names under plugin_root/skills."""
+    skills_dir = plugin_root / "skills"
+    if not skills_dir.is_dir():
+        return []
+    return sorted(p.name for p in skills_dir.iterdir() if p.is_dir())
+
+
+def scan_top_level_dirs(
+    plugin_root: Path,
+) -> list[str]:
+    """Return top-level subpaths under plugin_root that exist and contain files."""
+    present: list[str] = []
+    for sub in READ_TOP_LEVEL_DIRS:
+        target = plugin_root / sub
+        if target.is_dir():
+            present.append(sub)
+    return present
+
+
+def build_read_allow_rules(
+    *,
+    plugin_root: Path,
+    user_home: Path,
+) -> list[str]:
+    """Build per-skill and per-top-level Read rules with ~/ + /home/<user>/ twins.
+
+    For each skill folder and recognized top-level dir under
+    plugin_root, emit two Read rules — one anchored at ``~/`` and
+    one anchored at ``/home/<user>/`` — so the permission engine
+    matches whichever shape the prompt uses.
+
+    Both variants share the version segment, so :func:`update_file`'s
+    version regex updates them in lockstep when the plugin upgrades.
+    """
+    home = user_home.expanduser().resolve()
+    try:
+        relative = plugin_root.relative_to(home)
+    except ValueError:
+        return []
+
+    base_rel = str(relative)
+    relpaths: list[str] = [base_rel]
+    for skill in scan_skill_directories(plugin_root):
+        relpaths.append(f"{base_rel}/skills/{skill}")
+    for top in scan_top_level_dirs(plugin_root):
+        relpaths.append(f"{base_rel}/{top}")
+
+    rules: list[str] = []
+    for rel in relpaths:
+        rules.append(f"Read(~/{rel}/*)")
+        rules.append(f"Read({home}/{rel}/*)")
+    return rules
+
+
+def verify_read_coverage(
+    settings_path: Path,
+    expected_rules: list[str],
+) -> tuple[list[str], list[str]]:
+    """Return (covered, missing) Read rules for the given settings file.
+
+    Matching is exact — Claude Code's permission engine compares
+    rule strings literally. Wildcard expansion is not attempted.
+    """
+    content = settings_path.read_text()
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError:
+        return [], expected_rules
+
+    allow_list: list[str] = data.get("permissions", {}).get("allow", [])
+    allow_set = set(allow_list)
+
+    covered: list[str] = []
+    missing: list[str] = []
+    for rule in expected_rules:
+        if rule in allow_set:
+            covered.append(rule)
+        else:
+            missing.append(rule)
+    return covered, missing
+
+
+def ensure_read_rules(
+    settings_path: Path,
+    missing_rules: list[str],
+    *,
+    dry_run: bool = False,
+) -> tuple[int, list[str]]:
+    """Append missing Read rules to ``settings_path``.
+
+    Idempotent — only appends rules not already present. Backed up
+    via :mod:`dev10x.skills.permission.backup`.
+    """
+    if not missing_rules:
+        return 0, []
+
+    if not dry_run:
+        from dev10x.skills.permission.backup import create_backup
+        from dev10x.skills.permission.file_lock import locked_json_update
+
+        create_backup(settings_path)
+        with locked_json_update(path=settings_path) as data:
+            if "permissions" not in data:
+                data["permissions"] = {}
+            if "allow" not in data["permissions"]:
+                data["permissions"]["allow"] = []
+            existing = set(data["permissions"]["allow"])
+            for rule in missing_rules:
+                if rule not in existing:
+                    data["permissions"]["allow"].append(rule)
+                    existing.add(rule)
+
+    messages = [f"  + {rule}" for rule in missing_rules]
+    return len(missing_rules), messages
 
 
 def ensure_script_rules(
@@ -701,6 +831,67 @@ def _ensure_scripts(
     else:
         verb = "Would add" if dry_run else "Added"
         print(f"{verb} {total_added} script rules across {files_changed} files.")
+
+    return 0
+
+
+def _ensure_reads(
+    *,
+    config: dict,
+    settings_files: list[Path],
+    dry_run: bool,
+    quiet: bool = False,
+) -> int:
+    cache_dir = Path(config["plugin_cache"]).expanduser()
+    target_version = detect_latest_version(cache_dir)
+    if not target_version:
+        print(f"ERROR: No versions found in {cache_dir}", file=sys.stderr)
+        return 1
+
+    plugin_root = cache_dir / target_version
+    expected_rules = build_read_allow_rules(
+        plugin_root=plugin_root,
+        user_home=Path.home(),
+    )
+    if not expected_rules:
+        print(f"No Read rules to emit for {plugin_root}")
+        return 0
+
+    if not quiet:
+        print(f"Plugin root: {plugin_root}")
+        print(f"Read rules expected: {len(expected_rules)} (twins included)")
+        if dry_run:
+            print("(dry run — no files will be modified)\n")
+
+    total_added = 0
+    files_changed = 0
+
+    for path in sorted(settings_files):
+        _covered, missing = verify_read_coverage(
+            settings_path=path,
+            expected_rules=expected_rules,
+        )
+        if not missing:
+            continue
+
+        count, messages = ensure_read_rules(
+            settings_path=path,
+            missing_rules=missing,
+            dry_run=dry_run,
+        )
+        if count > 0:
+            if not quiet:
+                print(f"\n{path}")
+                for msg in messages:
+                    print(msg)
+            total_added += count
+            files_changed += 1
+
+    if total_added == 0:
+        print("All settings files have complete Read coverage.")
+    else:
+        verb = "Would add" if dry_run else "Added"
+        print(f"{verb} {total_added} Read rules across {files_changed} files.")
 
     return 0
 

--- a/src/dev10x/skills/permission_investigator/__init__.py
+++ b/src/dev10x/skills/permission_investigator/__init__.py
@@ -1,0 +1,11 @@
+"""Permission Pattern Investigator (GH-47).
+
+Materializes a controlled fixture, applies candidate rule shapes
+to target settings files, and aggregates per-shape results into a
+matrix that records whether the engine auto-approved or prompted.
+
+This package owns the deterministic, non-Claude pieces. The
+subagent dispatch loop that actually exercises each rule shape
+lives in ``skills/permission-investigator/SKILL.md`` because the
+Agent tool is only callable from Claude tool-use protocol.
+"""

--- a/src/dev10x/skills/permission_investigator/fixtures.py
+++ b/src/dev10x/skills/permission_investigator/fixtures.py
@@ -1,0 +1,134 @@
+"""Fixture materialization, settings snapshot, and restore.
+
+Each investigation run materializes a deterministic fixture under
+the user's HOME so tool-call probes have a real path to read or
+execute. Settings files are snapshotted before any mutation and
+restored on tear-down so the user's permission state is never
+left dirty if a run fails.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+WORKDIR_NAMESPACE = "permission-investigator"
+
+
+@dataclass(frozen=True)
+class FixturePaths:
+    """Filesystem layout for one investigation run."""
+
+    workdir: Path
+    fixture_root: Path
+    fixture_relpath: str
+    plugin_skill_file: Path
+    project_settings: Path
+    global_settings: Path
+    publisher_root: Path
+
+    def cleanup(self) -> None:
+        if self.workdir.is_dir():
+            shutil.rmtree(self.workdir)
+        if self.publisher_root.is_dir():
+            shutil.rmtree(self.publisher_root)
+
+
+def materialize_fixtures(
+    *,
+    workdir: Path,
+    user_home: Path,
+    publisher: str = "Test-Org",
+    plugin: str = "Investigator",
+    version: str = "9.9.9",
+    skill_name: str = "probe-skill",
+) -> FixturePaths:
+    """Create a controlled fixture tree under ``workdir``.
+
+    Returns paths the dispatcher needs: a plugin-style skill file
+    (under HOME so `~/...` rules resolve), a project-local settings
+    stub, and a pointer to the user's global settings.
+    """
+    workdir.mkdir(parents=True, exist_ok=True)
+
+    fixture_relpath = f".claude/plugins/cache/{publisher}/{plugin}/{version}/skills/{skill_name}"
+    fixture_root = user_home / fixture_relpath
+    fixture_root.mkdir(parents=True, exist_ok=True)
+    plugin_skill_file = fixture_root / "SKILL.md"
+    plugin_skill_file.write_text(
+        f"# Probe — {publisher}/{plugin}/{version}\n\nFixture for permission investigation.\n"
+    )
+
+    publisher_root = user_home / ".claude" / "plugins" / "cache" / publisher
+
+    project_settings = workdir / "project_settings.local.json"
+    project_settings.write_text(json.dumps({"permissions": {"allow": []}}, indent=2))
+
+    global_settings = user_home / ".claude" / "settings.json"
+
+    return FixturePaths(
+        workdir=workdir,
+        fixture_root=fixture_root,
+        fixture_relpath=f"{fixture_relpath}/SKILL.md",
+        plugin_skill_file=plugin_skill_file,
+        project_settings=project_settings,
+        global_settings=global_settings,
+        publisher_root=publisher_root,
+    )
+
+
+def snapshot_settings(*, settings_path: Path, snapshot_dir: Path) -> Path | None:
+    """Save a copy of ``settings_path`` to ``snapshot_dir`` and return its path."""
+    if not settings_path.is_file():
+        return None
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+    snapshot_path = snapshot_dir / f"{settings_path.name}.snapshot"
+    shutil.copy2(settings_path, snapshot_path)
+    return snapshot_path
+
+
+def restore_settings(*, snapshot_path: Path, target_path: Path) -> None:
+    """Replace ``target_path`` with ``snapshot_path`` (taken pre-mutation)."""
+    if not snapshot_path.is_file():
+        return
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(snapshot_path, target_path)
+
+
+def apply_rule(
+    *,
+    rule: str,
+    target: Path,
+) -> None:
+    """Append ``rule`` to ``target``'s permissions.allow list (idempotent).
+
+    Creates the file with a minimal skeleton if it does not exist.
+    """
+    if target.is_file():
+        data = json.loads(target.read_text())
+    else:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        data = {"permissions": {"allow": []}}
+
+    data.setdefault("permissions", {})
+    data["permissions"].setdefault("allow", [])
+    if rule not in data["permissions"]["allow"]:
+        data["permissions"]["allow"].append(rule)
+    target.write_text(json.dumps(data, indent=2) + "\n")
+
+
+def remove_rule(
+    *,
+    rule: str,
+    target: Path,
+) -> None:
+    """Remove ``rule`` from ``target``'s permissions.allow list."""
+    if not target.is_file():
+        return
+    data = json.loads(target.read_text())
+    allow = data.get("permissions", {}).get("allow", [])
+    if rule in allow:
+        allow.remove(rule)
+        target.write_text(json.dumps(data, indent=2) + "\n")

--- a/src/dev10x/skills/permission_investigator/matrix.py
+++ b/src/dev10x/skills/permission_investigator/matrix.py
@@ -1,0 +1,207 @@
+"""Matrix definition for rule-shape investigation.
+
+Each :class:`MatrixCell` pairs a candidate rule shape with the
+fixture path it should authorize and the rule-location dimension
+(global / project / both / neither). The skill loops through the
+generated matrix, applies each cell, dispatches a subagent to
+exercise the corresponding tool call, and records the outcome.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from itertools import product
+from typing import Literal
+
+ToolKind = Literal["Read", "Bash", "Edit", "Write", "MCP"]
+RuleLocation = Literal["global", "project", "both", "neither"]
+PathPrefix = Literal["tilde", "home_user", "env_home", "relative"]
+WildcardShape = Literal[
+    "literal",
+    "single_star",
+    "trailing_slash_star",
+    "double_star",
+    "star_double_star",
+    "mid_path_star",
+]
+
+
+@dataclass(frozen=True)
+class RuleShape:
+    """One candidate rule shape (the LHS of a permission allow rule)."""
+
+    tool: ToolKind
+    prefix: PathPrefix
+    wildcard: WildcardShape
+
+    def render(self, *, fixture_relpath: str, user_home: str) -> str:
+        """Render the rule string for this shape against a fixture path.
+
+        ``fixture_relpath`` is the path *relative to user home* — e.g.
+        ``.claude/plugins/cache/Test/Plugin/9.9.9/skills/x/SKILL.md``.
+        """
+        prefix = _PREFIX_RENDERERS[self.prefix](user_home=user_home)
+        body = _WILDCARD_RENDERERS[self.wildcard](relpath=fixture_relpath)
+        path = f"{prefix}/{body}" if prefix else body
+        if self.tool == "MCP":
+            return "mcp__plugin_Dev10x_cli__detect_tracker"
+        return f"{self.tool}({path})"
+
+
+@dataclass(frozen=True)
+class MatrixCell:
+    """A single matrix coordinate: shape + where it lives + outcome slot."""
+
+    shape: RuleShape
+    location: RuleLocation
+    cell_id: str
+
+    @property
+    def label(self) -> str:
+        return f"{self.shape.tool}/{self.shape.prefix}/{self.shape.wildcard}@{self.location}"
+
+
+@dataclass
+class MatrixResult:
+    """Outcome recorded by the dispatcher for one cell."""
+
+    cell_id: str
+    auto_approved: bool
+    prompted: bool
+    error: str | None = None
+    notes: str = ""
+
+    @property
+    def status(self) -> str:
+        if self.error:
+            return "error"
+        if self.auto_approved and not self.prompted:
+            return "works"
+        if self.prompted:
+            return "prompts"
+        return "unknown"
+
+
+@dataclass
+class Matrix:
+    """A complete matrix — input cells plus collected results."""
+
+    cells: list[MatrixCell] = field(default_factory=list)
+    results: dict[str, MatrixResult] = field(default_factory=dict)
+
+    def add_result(self, result: MatrixResult) -> None:
+        self.results[result.cell_id] = result
+
+    def coverage(self) -> tuple[int, int]:
+        return len(self.results), len(self.cells)
+
+
+def _tilde_prefix(*, user_home: str) -> str:
+    del user_home
+    return "~"
+
+
+def _home_user_prefix(*, user_home: str) -> str:
+    return user_home
+
+
+def _env_home_prefix(*, user_home: str) -> str:
+    del user_home
+    return "${HOME}"
+
+
+def _relative_prefix(*, user_home: str) -> str:
+    del user_home
+    return ""
+
+
+_PREFIX_RENDERERS = {
+    "tilde": _tilde_prefix,
+    "home_user": _home_user_prefix,
+    "env_home": _env_home_prefix,
+    "relative": _relative_prefix,
+}
+
+
+def _literal_wildcard(*, relpath: str) -> str:
+    return relpath
+
+
+def _single_star_wildcard(*, relpath: str) -> str:
+    parts = relpath.rsplit("/", 1)
+    if len(parts) == 1:
+        return "*"
+    return f"{parts[0]}/*"
+
+
+def _trailing_slash_star_wildcard(*, relpath: str) -> str:
+    parts = relpath.rsplit("/", 1)
+    if len(parts) == 1:
+        return "*/"
+    return f"{parts[0]}/*/"
+
+
+def _double_star_wildcard(*, relpath: str) -> str:
+    parts = relpath.rsplit("/", 1)
+    if len(parts) == 1:
+        return "**"
+    return f"{parts[0]}/**"
+
+
+def _star_double_star_wildcard(*, relpath: str) -> str:
+    parts = relpath.split("/")
+    if len(parts) <= 1:
+        return "*/**"
+    return f"{'/'.join(parts[:-1])}/*/**"
+
+
+def _mid_path_star_wildcard(*, relpath: str) -> str:
+    parts = relpath.split("/")
+    if len(parts) < 2:
+        return relpath
+    mid = max(0, len(parts) // 2)
+    parts[mid] = "*"
+    return "/".join(parts)
+
+
+_WILDCARD_RENDERERS = {
+    "literal": _literal_wildcard,
+    "single_star": _single_star_wildcard,
+    "trailing_slash_star": _trailing_slash_star_wildcard,
+    "double_star": _double_star_wildcard,
+    "star_double_star": _star_double_star_wildcard,
+    "mid_path_star": _mid_path_star_wildcard,
+}
+
+
+DEFAULT_TOOLS: tuple[ToolKind, ...] = ("Read", "Bash")
+DEFAULT_PREFIXES: tuple[PathPrefix, ...] = ("tilde", "home_user", "env_home")
+DEFAULT_WILDCARDS: tuple[WildcardShape, ...] = (
+    "literal",
+    "single_star",
+    "double_star",
+    "star_double_star",
+)
+DEFAULT_LOCATIONS: tuple[RuleLocation, ...] = ("global", "project", "both")
+
+
+def generate_matrix(
+    *,
+    tools: tuple[ToolKind, ...] = DEFAULT_TOOLS,
+    prefixes: tuple[PathPrefix, ...] = DEFAULT_PREFIXES,
+    wildcards: tuple[WildcardShape, ...] = DEFAULT_WILDCARDS,
+    locations: tuple[RuleLocation, ...] = DEFAULT_LOCATIONS,
+) -> Matrix:
+    """Generate the cartesian product of dimensions as a Matrix."""
+    matrix = Matrix()
+    for tool, prefix, wildcard, location in product(
+        tools, prefixes, wildcards, locations
+    ):
+        shape = RuleShape(tool=tool, prefix=prefix, wildcard=wildcard)
+        cell = MatrixCell(
+            shape=shape,
+            location=location,
+            cell_id=f"{tool}.{prefix}.{wildcard}.{location}",
+        )
+        matrix.cells.append(cell)
+    return matrix

--- a/src/dev10x/skills/permission_investigator/report.py
+++ b/src/dev10x/skills/permission_investigator/report.py
@@ -1,0 +1,162 @@
+"""Aggregate matrix outcomes into a markdown report and delta.
+
+The report consumes a populated :class:`Matrix` (results recorded
+by the dispatcher) plus the current ``base_permissions`` shipped
+by ``plugin-maintenance``. It produces:
+
+1. A grouped outcome matrix per dimension.
+2. A list of currently-shipped rules whose shape matches a row
+   marked "prompts" — these are the friction-causing entries.
+3. A list of suggested replacements drawn from rows marked "works".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from dev10x.skills.permission_investigator.matrix import (
+    Matrix,
+    MatrixResult,
+    PathPrefix,
+    WildcardShape,
+)
+
+
+@dataclass
+class Delta:
+    ineffective_rules: list[str]
+    suggested_rules: list[str]
+
+
+def aggregate_results(matrix: Matrix) -> dict[str, list[MatrixResult]]:
+    """Group results by status (works / prompts / error / unknown)."""
+    grouped: dict[str, list[MatrixResult]] = {
+        "works": [],
+        "prompts": [],
+        "error": [],
+        "unknown": [],
+    }
+    cell_index = {cell.cell_id: cell for cell in matrix.cells}
+    for cell_id, result in matrix.results.items():
+        if cell_id not in cell_index:
+            continue
+        grouped.setdefault(result.status, []).append(result)
+    return grouped
+
+
+def render_markdown_report(matrix: Matrix) -> str:
+    """Render the matrix as a markdown table grouped by tool kind."""
+    grouped = aggregate_results(matrix)
+
+    lines: list[str] = ["# Permission Pattern Investigation"]
+    lines.append("")
+    seen, total = matrix.coverage()
+    lines.append(f"Cells executed: **{seen}/{total}**")
+    lines.append("")
+
+    lines.append("## Outcome counts")
+    lines.append("")
+    lines.append("| Status | Count |")
+    lines.append("|--------|-------|")
+    for status in ("works", "prompts", "error", "unknown"):
+        lines.append(f"| {status} | {len(grouped.get(status, []))} |")
+    lines.append("")
+
+    lines.append("## Per-cell results")
+    lines.append("")
+    lines.append("| Cell | Tool | Prefix | Wildcard | Location | Status | Notes |")
+    lines.append("|------|------|--------|----------|----------|--------|-------|")
+    for cell in matrix.cells:
+        result = matrix.results.get(cell.cell_id)
+        status = result.status if result else "(not run)"
+        notes = (result.notes if result else "").replace("|", "\\|")
+        lines.append(
+            f"| `{cell.cell_id}` | {cell.shape.tool} | {cell.shape.prefix} | "
+            f"{cell.shape.wildcard} | {cell.location} | {status} | {notes} |"
+        )
+    lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def compute_delta(
+    *,
+    matrix: Matrix,
+    base_permissions: list[str],
+) -> Delta:
+    """Identify shipped rules whose shape failed in the matrix.
+
+    A rule is flagged ineffective when at least one matrix cell with
+    a matching wildcard/prefix shape was recorded as ``prompts``.
+    """
+    prompting_shapes = _shapes_for_status(matrix=matrix, status="prompts")
+    working_shapes = _shapes_for_status(matrix=matrix, status="works")
+
+    ineffective: list[str] = []
+    for rule in base_permissions:
+        prefix, wildcard = _classify_rule(rule)
+        if prefix is None or wildcard is None:
+            continue
+        if (prefix, wildcard) in prompting_shapes:
+            ineffective.append(rule)
+
+    suggestions: list[str] = []
+    for prefix, wildcard in sorted(working_shapes):
+        suggestions.append(
+            f"prefer prefix={prefix} wildcard={wildcard} in plugin-maintenance"
+        )
+
+    return Delta(ineffective_rules=ineffective, suggested_rules=suggestions)
+
+
+def _shapes_for_status(
+    *,
+    matrix: Matrix,
+    status: str,
+) -> set[tuple[PathPrefix, WildcardShape]]:
+    return {
+        (cell.shape.prefix, cell.shape.wildcard)
+        for cell in matrix.cells
+        if (result := matrix.results.get(cell.cell_id)) and result.status == status
+    }
+
+
+def _classify_rule(rule: str) -> tuple[PathPrefix | None, WildcardShape | None]:
+    body = _extract_path(rule)
+    if body is None:
+        return None, None
+
+    prefix: PathPrefix
+    if body.startswith("~/"):
+        prefix = "tilde"
+    elif body.startswith("/home/"):
+        prefix = "home_user"
+    elif body.startswith("${HOME}"):
+        prefix = "env_home"
+    else:
+        prefix = "relative"
+
+    if "*/**" in body:
+        wildcard: WildcardShape = "star_double_star"
+    elif "**" in body:
+        wildcard = "double_star"
+    elif body.endswith("/*"):
+        wildcard = "single_star"
+    elif body.endswith("/*/"):
+        wildcard = "trailing_slash_star"
+    elif "*" in body and not body.endswith("*"):
+        wildcard = "mid_path_star"
+    elif "*" not in body:
+        wildcard = "literal"
+    else:
+        wildcard = "single_star"
+
+    return prefix, wildcard
+
+
+def _extract_path(rule: str) -> str | None:
+    if "(" not in rule or not rule.endswith(")"):
+        return None
+    inner = rule.split("(", 1)[1][:-1]
+    if ":" in inner:
+        inner = inner.split(":", 1)[0]
+    return inner

--- a/tests/mcp/test_permission.py
+++ b/tests/mcp/test_permission.py
@@ -83,6 +83,7 @@ class TestUpdatePathsSubCommandRoute:
             generalize=False,
             ensure_scripts=False,
             ensure_workspace=False,
+            ensure_reads=False,
             dry_run=True,
             quiet=False,
         )
@@ -101,6 +102,7 @@ class TestUpdatePathsSubCommandRoute:
             generalize=True,
             ensure_scripts=False,
             ensure_workspace=False,
+            ensure_reads=False,
             dry_run=False,
             quiet=False,
         )
@@ -119,6 +121,26 @@ class TestUpdatePathsSubCommandRoute:
             generalize=False,
             ensure_scripts=True,
             ensure_workspace=False,
+            ensure_reads=False,
+            dry_run=False,
+            quiet=False,
+        )
+
+    @pytest.mark.asyncio
+    @patch("dev10x.mcp.permission._run_sub_command")
+    async def test_ensure_reads_routes_to_sub_command(
+        self,
+        mock_sub: AsyncMock,
+    ) -> None:
+        mock_sub.return_value = {"success": True, "output": "Added 12 Read rules"}
+        result = await perm_mod.update_paths(ensure_reads=True)
+        assert result["success"] is True
+        mock_sub.assert_called_once_with(
+            ensure_base=False,
+            generalize=False,
+            ensure_scripts=False,
+            ensure_workspace=False,
+            ensure_reads=True,
             dry_run=False,
             quiet=False,
         )
@@ -182,6 +204,16 @@ class TestRunSubCommand:
         result = perm_mod._run_sub_command(ensure_scripts=True)
         assert result["success"] is True
         mock_scripts.assert_called_once()
+
+    @patch(f"{MOD_PATH}._ensure_reads", return_value=0)
+    def test_ensure_reads_calls_underlying_function(
+        self,
+        mock_reads: AsyncMock,
+        mock_mod: dict,
+    ) -> None:
+        result = perm_mod._run_sub_command(ensure_reads=True)
+        assert result["success"] is True
+        mock_reads.assert_called_once()
 
     @patch(f"{MOD_PATH}._ensure_base", return_value=1)
     def test_returns_error_on_nonzero_exit(

--- a/tests/skills/permission-investigator/test_fixtures.py
+++ b/tests/skills/permission-investigator/test_fixtures.py
@@ -1,0 +1,167 @@
+"""Tests for fixture materialization, snapshot, and rule mutation (GH-47)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dev10x.skills.permission_investigator.fixtures import (
+    apply_rule,
+    materialize_fixtures,
+    remove_rule,
+    restore_settings,
+    snapshot_settings,
+)
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path) -> Path:
+    home = tmp_path / "home" / "tester"
+    home.mkdir(parents=True)
+    return home
+
+
+@pytest.fixture
+def workdir(tmp_path: Path) -> Path:
+    return tmp_path / "investigator-work"
+
+
+class TestMaterializeFixtures:
+    def test_creates_plugin_skill_file_under_home(
+        self,
+        workdir: Path,
+        fake_home: Path,
+    ) -> None:
+        paths = materialize_fixtures(workdir=workdir, user_home=fake_home)
+
+        assert paths.plugin_skill_file.is_file()
+        assert paths.plugin_skill_file.is_relative_to(fake_home)
+        assert paths.plugin_skill_file.read_text().startswith("# Probe")
+
+    def test_creates_empty_project_settings_file(
+        self,
+        workdir: Path,
+        fake_home: Path,
+    ) -> None:
+        paths = materialize_fixtures(workdir=workdir, user_home=fake_home)
+
+        data = json.loads(paths.project_settings.read_text())
+
+        assert data == {"permissions": {"allow": []}}
+
+    def test_fixture_relpath_resolves_relative_to_home(
+        self,
+        workdir: Path,
+        fake_home: Path,
+    ) -> None:
+        paths = materialize_fixtures(workdir=workdir, user_home=fake_home)
+
+        assert (fake_home / paths.fixture_relpath).is_file()
+
+    def test_cleanup_removes_workdir(
+        self,
+        workdir: Path,
+        fake_home: Path,
+    ) -> None:
+        paths = materialize_fixtures(workdir=workdir, user_home=fake_home)
+
+        paths.cleanup()
+
+        assert not workdir.exists()
+
+    def test_cleanup_removes_publisher_root_under_home(
+        self,
+        workdir: Path,
+        fake_home: Path,
+    ) -> None:
+        paths = materialize_fixtures(workdir=workdir, user_home=fake_home)
+        assert paths.publisher_root.is_dir()
+
+        paths.cleanup()
+
+        assert not paths.publisher_root.exists()
+        assert not paths.fixture_root.exists()
+
+
+class TestSnapshotAndRestore:
+    def test_snapshot_returns_none_when_target_missing(self, tmp_path: Path) -> None:
+        result = snapshot_settings(
+            settings_path=tmp_path / "missing.json",
+            snapshot_dir=tmp_path / "snaps",
+        )
+
+        assert result is None
+
+    def test_snapshot_copies_existing_file(self, tmp_path: Path) -> None:
+        target = tmp_path / "settings.json"
+        target.write_text('{"permissions": {"allow": ["Bash(git log:*)"]}}')
+
+        snap = snapshot_settings(
+            settings_path=target,
+            snapshot_dir=tmp_path / "snaps",
+        )
+
+        assert snap is not None
+        assert snap.is_file()
+        assert json.loads(snap.read_text()) == json.loads(target.read_text())
+
+    def test_restore_overwrites_target_with_snapshot(self, tmp_path: Path) -> None:
+        target = tmp_path / "settings.json"
+        target.write_text('{"permissions": {"allow": ["original"]}}')
+        snap = snapshot_settings(
+            settings_path=target,
+            snapshot_dir=tmp_path / "snaps",
+        )
+        assert snap is not None
+        target.write_text('{"permissions": {"allow": ["mutated"]}}')
+
+        restore_settings(snapshot_path=snap, target_path=target)
+
+        assert json.loads(target.read_text()) == {"permissions": {"allow": ["original"]}}
+
+
+class TestApplyAndRemoveRule:
+    def test_apply_rule_creates_file_when_missing(self, tmp_path: Path) -> None:
+        target = tmp_path / "fresh-settings.json"
+
+        apply_rule(rule="Read(~/x)", target=target)
+
+        data = json.loads(target.read_text())
+        assert data["permissions"]["allow"] == ["Read(~/x)"]
+
+    def test_apply_rule_is_idempotent(self, tmp_path: Path) -> None:
+        target = tmp_path / "settings.json"
+        target.write_text('{"permissions": {"allow": ["Read(~/x)"]}}')
+
+        apply_rule(rule="Read(~/x)", target=target)
+        apply_rule(rule="Read(~/x)", target=target)
+
+        data = json.loads(target.read_text())
+        assert data["permissions"]["allow"].count("Read(~/x)") == 1
+
+    def test_apply_rule_appends_new_rule(self, tmp_path: Path) -> None:
+        target = tmp_path / "settings.json"
+        target.write_text('{"permissions": {"allow": ["Read(~/x)"]}}')
+
+        apply_rule(rule="Bash(ls:*)", target=target)
+
+        data = json.loads(target.read_text())
+        assert data["permissions"]["allow"] == ["Read(~/x)", "Bash(ls:*)"]
+
+    def test_remove_rule_drops_match(self, tmp_path: Path) -> None:
+        target = tmp_path / "settings.json"
+        target.write_text('{"permissions": {"allow": ["Read(~/x)", "Bash(ls:*)"]}}')
+
+        remove_rule(rule="Read(~/x)", target=target)
+
+        data = json.loads(target.read_text())
+        assert data["permissions"]["allow"] == ["Bash(ls:*)"]
+
+    def test_remove_rule_is_noop_when_target_missing(self, tmp_path: Path) -> None:
+        target = tmp_path / "missing.json"
+
+        remove_rule(rule="anything", target=target)
+
+        assert not target.exists()

--- a/tests/skills/permission-investigator/test_matrix.py
+++ b/tests/skills/permission-investigator/test_matrix.py
@@ -1,0 +1,197 @@
+"""Tests for the matrix dimension generator and rule renderer (GH-47)."""
+
+from __future__ import annotations
+
+import pytest
+
+from dev10x.skills.permission_investigator.matrix import (
+    DEFAULT_LOCATIONS,
+    DEFAULT_PREFIXES,
+    DEFAULT_TOOLS,
+    DEFAULT_WILDCARDS,
+    Matrix,
+    MatrixResult,
+    RuleShape,
+    generate_matrix,
+)
+
+
+class TestRuleShapeRender:
+    @pytest.fixture
+    def fixture_relpath(self) -> str:
+        return ".claude/plugins/cache/Test/Plugin/9.9.9/skills/probe/SKILL.md"
+
+    @pytest.fixture
+    def home(self) -> str:
+        return "/home/janusz"
+
+    def test_tilde_literal_uses_tilde_prefix_and_full_path(
+        self,
+        fixture_relpath: str,
+        home: str,
+    ) -> None:
+        shape = RuleShape(tool="Read", prefix="tilde", wildcard="literal")
+
+        rendered = shape.render(fixture_relpath=fixture_relpath, user_home=home)
+
+        assert rendered == f"Read(~/{fixture_relpath})"
+
+    def test_home_user_single_star_replaces_filename(
+        self,
+        fixture_relpath: str,
+        home: str,
+    ) -> None:
+        shape = RuleShape(tool="Read", prefix="home_user", wildcard="single_star")
+
+        rendered = shape.render(fixture_relpath=fixture_relpath, user_home=home)
+
+        expected_dir = (
+            "/home/janusz/.claude/plugins/cache/Test/Plugin/9.9.9/skills/probe"
+        )
+        assert rendered == f"Read({expected_dir}/*)"
+
+    def test_env_home_double_star(
+        self,
+        fixture_relpath: str,
+        home: str,
+    ) -> None:
+        shape = RuleShape(tool="Read", prefix="env_home", wildcard="double_star")
+
+        rendered = shape.render(fixture_relpath=fixture_relpath, user_home=home)
+
+        assert rendered.startswith("Read(${HOME}/")
+        assert rendered.endswith("/**)")
+
+    def test_star_double_star_inserts_double_segment(
+        self,
+        fixture_relpath: str,
+        home: str,
+    ) -> None:
+        shape = RuleShape(tool="Read", prefix="tilde", wildcard="star_double_star")
+
+        rendered = shape.render(fixture_relpath=fixture_relpath, user_home=home)
+
+        assert "/*/**" in rendered
+
+    def test_mid_path_star_replaces_a_segment(
+        self,
+        fixture_relpath: str,
+        home: str,
+    ) -> None:
+        shape = RuleShape(tool="Read", prefix="tilde", wildcard="mid_path_star")
+
+        rendered = shape.render(fixture_relpath=fixture_relpath, user_home=home)
+
+        assert "/*/" in rendered
+
+    def test_relative_prefix_emits_no_leading_slash(
+        self,
+        fixture_relpath: str,
+        home: str,
+    ) -> None:
+        shape = RuleShape(tool="Read", prefix="relative", wildcard="literal")
+
+        rendered = shape.render(fixture_relpath=fixture_relpath, user_home=home)
+
+        assert rendered == f"Read({fixture_relpath})"
+
+    def test_mcp_tool_kind_returns_canonical_mcp_name(
+        self,
+        fixture_relpath: str,
+        home: str,
+    ) -> None:
+        shape = RuleShape(tool="MCP", prefix="tilde", wildcard="literal")
+
+        rendered = shape.render(fixture_relpath=fixture_relpath, user_home=home)
+
+        assert rendered.startswith("mcp__plugin_Dev10x_cli__")
+
+
+class TestGenerateMatrix:
+    def test_default_matrix_has_full_cartesian_product(self) -> None:
+        matrix = generate_matrix()
+
+        expected_count = (
+            len(DEFAULT_TOOLS)
+            * len(DEFAULT_PREFIXES)
+            * len(DEFAULT_WILDCARDS)
+            * len(DEFAULT_LOCATIONS)
+        )
+        assert len(matrix.cells) == expected_count
+
+    def test_cell_ids_are_unique(self) -> None:
+        matrix = generate_matrix()
+
+        ids = [cell.cell_id for cell in matrix.cells]
+
+        assert len(ids) == len(set(ids))
+
+    def test_custom_dimensions_shrink_matrix(self) -> None:
+        matrix = generate_matrix(
+            tools=("Read",),
+            prefixes=("tilde",),
+            wildcards=("literal", "single_star"),
+            locations=("project",),
+        )
+
+        assert len(matrix.cells) == 2
+
+    def test_starts_with_no_results(self) -> None:
+        matrix = generate_matrix()
+
+        assert matrix.coverage() == (0, len(matrix.cells))
+
+
+class TestMatrixResultStatus:
+    def test_works_when_auto_approved_and_not_prompted(self) -> None:
+        result = MatrixResult(
+            cell_id="x",
+            auto_approved=True,
+            prompted=False,
+        )
+
+        assert result.status == "works"
+
+    def test_prompts_when_prompted_flag_set(self) -> None:
+        result = MatrixResult(
+            cell_id="x",
+            auto_approved=False,
+            prompted=True,
+        )
+
+        assert result.status == "prompts"
+
+    def test_error_short_circuits_status(self) -> None:
+        result = MatrixResult(
+            cell_id="x",
+            auto_approved=True,
+            prompted=False,
+            error="boom",
+        )
+
+        assert result.status == "error"
+
+
+class TestMatrixCoverage:
+    def test_reports_results_added(self) -> None:
+        matrix = Matrix()
+        matrix.cells.append(
+            generate_matrix(
+                tools=("Read",),
+                prefixes=("tilde",),
+                wildcards=("literal",),
+                locations=("project",),
+            ).cells[0]
+        )
+        matrix.add_result(
+            MatrixResult(
+                cell_id=matrix.cells[0].cell_id,
+                auto_approved=True,
+                prompted=False,
+            )
+        )
+
+        seen, total = matrix.coverage()
+
+        assert seen == 1
+        assert total == 1

--- a/tests/skills/permission-investigator/test_report.py
+++ b/tests/skills/permission-investigator/test_report.py
@@ -1,0 +1,149 @@
+"""Tests for matrix aggregation, markdown report, and delta (GH-47)."""
+
+from __future__ import annotations
+
+import pytest
+
+from dev10x.skills.permission_investigator.matrix import (
+    Matrix,
+    MatrixCell,
+    MatrixResult,
+    RuleShape,
+)
+from dev10x.skills.permission_investigator.report import (
+    aggregate_results,
+    compute_delta,
+    render_markdown_report,
+)
+
+
+def _cell(*, prefix: str, wildcard: str, location: str = "project") -> MatrixCell:
+    shape = RuleShape(tool="Read", prefix=prefix, wildcard=wildcard)  # type: ignore[arg-type]
+    return MatrixCell(
+        shape=shape,
+        location=location,  # type: ignore[arg-type]
+        cell_id=f"Read.{prefix}.{wildcard}.{location}",
+    )
+
+
+def _result(*, cell_id: str, status: str) -> MatrixResult:
+    if status == "works":
+        return MatrixResult(cell_id=cell_id, auto_approved=True, prompted=False)
+    if status == "prompts":
+        return MatrixResult(cell_id=cell_id, auto_approved=False, prompted=True)
+    if status == "error":
+        return MatrixResult(
+            cell_id=cell_id,
+            auto_approved=False,
+            prompted=False,
+            error="boom",
+        )
+    raise ValueError(f"unknown status {status}")
+
+
+@pytest.fixture
+def populated_matrix() -> Matrix:
+    matrix = Matrix()
+    cells = [
+        _cell(prefix="tilde", wildcard="single_star"),
+        _cell(prefix="home_user", wildcard="double_star"),
+        _cell(prefix="env_home", wildcard="literal"),
+    ]
+    for cell in cells:
+        matrix.cells.append(cell)
+    matrix.add_result(_result(cell_id=cells[0].cell_id, status="works"))
+    matrix.add_result(_result(cell_id=cells[1].cell_id, status="prompts"))
+    matrix.add_result(_result(cell_id=cells[2].cell_id, status="error"))
+    return matrix
+
+
+class TestAggregateResults:
+    def test_groups_results_by_status(self, populated_matrix: Matrix) -> None:
+        grouped = aggregate_results(populated_matrix)
+
+        assert len(grouped["works"]) == 1
+        assert len(grouped["prompts"]) == 1
+        assert len(grouped["error"]) == 1
+
+    def test_ignores_results_without_matching_cell(self) -> None:
+        matrix = Matrix()
+        matrix.add_result(
+            MatrixResult(cell_id="orphan", auto_approved=True, prompted=False)
+        )
+
+        grouped = aggregate_results(matrix)
+
+        assert grouped["works"] == []
+
+
+class TestRenderMarkdownReport:
+    def test_includes_outcome_counts_table(self, populated_matrix: Matrix) -> None:
+        rendered = render_markdown_report(populated_matrix)
+
+        assert "## Outcome counts" in rendered
+        assert "works" in rendered
+        assert "prompts" in rendered
+
+    def test_lists_each_cell(self, populated_matrix: Matrix) -> None:
+        rendered = render_markdown_report(populated_matrix)
+
+        for cell in populated_matrix.cells:
+            assert cell.cell_id in rendered
+
+    def test_marks_unrun_cells_as_not_run(self) -> None:
+        matrix = Matrix()
+        matrix.cells.append(_cell(prefix="tilde", wildcard="literal"))
+
+        rendered = render_markdown_report(matrix)
+
+        assert "(not run)" in rendered
+
+
+class TestComputeDelta:
+    def test_flags_rules_whose_shape_matched_a_prompting_cell(self) -> None:
+        matrix = Matrix()
+        cell = _cell(prefix="home_user", wildcard="star_double_star")
+        matrix.cells.append(cell)
+        matrix.add_result(_result(cell_id=cell.cell_id, status="prompts"))
+
+        delta = compute_delta(
+            matrix=matrix,
+            base_permissions=[
+                "Read(/home/janusz/.claude/plugins/cache/Dev10x-Guru/Dev10x/*/**)",
+                "Bash(git log:*)",
+            ],
+        )
+
+        assert any(
+            "*/**" in rule for rule in delta.ineffective_rules
+        ), "Expected the */** rule to be flagged"
+        assert all(
+            "git log" not in rule for rule in delta.ineffective_rules
+        ), "Bash rules should not be flagged by Read prompts"
+
+    def test_no_rules_flagged_when_all_cells_work(self) -> None:
+        matrix = Matrix()
+        cell = _cell(prefix="tilde", wildcard="single_star")
+        matrix.cells.append(cell)
+        matrix.add_result(_result(cell_id=cell.cell_id, status="works"))
+
+        delta = compute_delta(
+            matrix=matrix,
+            base_permissions=["Read(~/.claude/plugins/cache/Test/Plugin/9.9.9/x/*)"],
+        )
+
+        assert delta.ineffective_rules == []
+        assert any("single_star" in line for line in delta.suggested_rules)
+
+    def test_skips_rules_outside_recognised_shape(self) -> None:
+        matrix = Matrix()
+        cell = _cell(prefix="tilde", wildcard="literal")
+        matrix.cells.append(cell)
+        matrix.add_result(_result(cell_id=cell.cell_id, status="prompts"))
+
+        delta = compute_delta(
+            matrix=matrix,
+            base_permissions=["mcp__plugin_Dev10x_cli__detect_tracker"],
+        )
+
+        assert delta.ineffective_rules == []

--- a/tests/skills/upgrade-cleanup/test_clean_project_files.py
+++ b/tests/skills/upgrade-cleanup/test_clean_project_files.py
@@ -136,6 +136,31 @@ class TestIsHookEnabled:
         assert clean_mod.is_hook_enabled(rule) is False
 
 
+class TestIsDeprecatedReadGlob:
+    @pytest.mark.parametrize(
+        "rule",
+        [
+            "Read(~/.claude/plugins/cache/Dev10x-Guru/Dev10x/*/**)",
+            "Read(/home/janusz/.claude/plugins/cache/Dev10x-Guru/Dev10x/*/**)",
+            "Read(~/.claude/plugins/cache/Other-Org/dev10x-claude/*/**)",
+        ],
+    )
+    def test_detects_deprecated_globs(self, rule: str) -> None:
+        assert clean_mod.is_deprecated_read_glob(rule) is True
+
+    @pytest.mark.parametrize(
+        "rule",
+        [
+            "Read(~/.claude/plugins/cache/Dev10x-Guru/Dev10x/0.68.0/skills/git/*)",
+            "Read(/home/janusz/.claude/plugins/cache/Dev10x-Guru/Dev10x/0.68.0/*)",
+            "Read(~/.claude/memory/Dev10x/**)",
+            "Bash(git log:*)",
+        ],
+    )
+    def test_rejects_non_deprecated_rules(self, rule: str) -> None:
+        assert clean_mod.is_deprecated_read_glob(rule) is False
+
+
 class TestClassifyRules:
     GLOBAL_RULES = {
         "Bash(git log:*)",
@@ -180,6 +205,22 @@ class TestClassifyRules:
 
         assert len(result.old_versions) == 1
         assert result.kept == []
+
+    def test_classifies_deprecated_read_globs(self) -> None:
+        rules = [
+            "Read(~/.claude/plugins/cache/Dev10x-Guru/Dev10x/*/**)",
+            "Read(/home/janusz/.claude/plugins/cache/Dev10x-Guru/Dev10x/*/**)",
+        ]
+
+        result = clean_mod.classify_rules(
+            rules,
+            global_rules=self.GLOBAL_RULES,
+            current_version="0.69.0",
+        )
+
+        assert result.deprecated_globs == rules
+        assert result.kept == []
+        assert result.total_removed == 2
 
     def test_classifies_env_noise(self) -> None:
         rules = [

--- a/tests/skills/upgrade-cleanup/test_ensure_reads.py
+++ b/tests/skills/upgrade-cleanup/test_ensure_reads.py
@@ -1,0 +1,259 @@
+"""Tests for the ensure-reads action (GH-48).
+
+Covers the per-skill Read rule emitter that ships ~/ and /home/<user>/
+twin variants. Tests use throwaway fixture trees so they do not depend
+on the real plugin cache layout.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dev10x.skills.permission.update_paths import (
+    READ_TOP_LEVEL_DIRS,
+    build_read_allow_rules,
+    ensure_read_rules,
+    scan_skill_directories,
+    scan_top_level_dirs,
+    verify_read_coverage,
+)
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path) -> Path:
+    """Materialize a HOME-like directory and return its path."""
+    home = tmp_path / "home" / "tester"
+    home.mkdir(parents=True)
+    return home
+
+
+@pytest.fixture
+def fake_plugin_root(fake_home: Path) -> Path:
+    """Materialize a plugin cache layout under fake_home.
+
+    Mirrors the real shape:
+      <home>/.claude/plugins/cache/<publisher>/<plugin>/<version>/
+        skills/<name>/
+        agents/
+        commands/
+        hooks/scripts/
+        bin/
+        ...
+    """
+    plugin_root = (
+        fake_home / ".claude" / "plugins" / "cache" / "Dev10x-Guru" / "Dev10x" / "9.9.9"
+    )
+    skills_dir = plugin_root / "skills"
+    for skill in ["alpha-skill", "beta-skill"]:
+        (skills_dir / skill).mkdir(parents=True)
+        (skills_dir / skill / "SKILL.md").write_text("# " + skill)
+
+    for top in ["agents", "commands", "hooks/scripts", "bin"]:
+        target = plugin_root / top
+        target.mkdir(parents=True, exist_ok=True)
+        (target / "marker").write_text("present")
+
+    return plugin_root
+
+
+class TestScanSkillDirectories:
+    def test_returns_skill_names_in_sorted_order(self, fake_plugin_root: Path) -> None:
+        result = scan_skill_directories(fake_plugin_root)
+
+        assert result == ["alpha-skill", "beta-skill"]
+
+    def test_returns_empty_list_when_skills_dir_missing(self, tmp_path: Path) -> None:
+        empty_root = tmp_path / "empty"
+        empty_root.mkdir()
+
+        assert scan_skill_directories(empty_root) == []
+
+    def test_ignores_files_only_returns_directories(
+        self, fake_plugin_root: Path
+    ) -> None:
+        (fake_plugin_root / "skills" / "stray-file.txt").write_text("not a skill")
+
+        result = scan_skill_directories(fake_plugin_root)
+
+        assert "stray-file.txt" not in result
+
+
+class TestScanTopLevelDirs:
+    def test_returns_only_existing_dirs(self, fake_plugin_root: Path) -> None:
+        result = scan_top_level_dirs(fake_plugin_root)
+
+        for present in ["agents", "commands", "hooks/scripts", "bin"]:
+            assert present in result
+        for absent in ["servers", "lib", "references", "hooks"]:
+            # `hooks` exists implicitly because hooks/scripts was created
+            if absent == "hooks":
+                assert absent in result
+                continue
+            assert absent not in result
+
+    def test_returns_subset_of_known_dirs(self, fake_plugin_root: Path) -> None:
+        result = scan_top_level_dirs(fake_plugin_root)
+
+        assert set(result).issubset(set(READ_TOP_LEVEL_DIRS))
+
+
+class TestBuildReadAllowRules:
+    def test_emits_twin_variants_for_each_skill(
+        self,
+        fake_plugin_root: Path,
+        fake_home: Path,
+    ) -> None:
+        rules = build_read_allow_rules(
+            plugin_root=fake_plugin_root,
+            user_home=fake_home,
+        )
+
+        rules_set = set(rules)
+        suffix = "Dev10x-Guru/Dev10x/9.9.9/skills/alpha-skill/*"
+        assert f"Read(~/.claude/plugins/cache/{suffix})" in rules_set
+        assert f"Read({fake_home}/.claude/plugins/cache/{suffix})" in rules_set
+
+    def test_emits_twin_variants_for_version_root(
+        self,
+        fake_plugin_root: Path,
+        fake_home: Path,
+    ) -> None:
+        rules = build_read_allow_rules(
+            plugin_root=fake_plugin_root,
+            user_home=fake_home,
+        )
+
+        version_rel = "Dev10x-Guru/Dev10x/9.9.9"
+        rules_set = set(rules)
+        assert f"Read(~/.claude/plugins/cache/{version_rel}/*)" in rules_set
+        assert f"Read({fake_home}/.claude/plugins/cache/{version_rel}/*)" in rules_set
+
+    def test_emits_rules_for_all_present_top_level_dirs(
+        self,
+        fake_plugin_root: Path,
+        fake_home: Path,
+    ) -> None:
+        rules = build_read_allow_rules(
+            plugin_root=fake_plugin_root,
+            user_home=fake_home,
+        )
+
+        for top in scan_top_level_dirs(fake_plugin_root):
+            tilde = f"Read(~/.claude/plugins/cache/Dev10x-Guru/Dev10x/9.9.9/{top}/*)"
+            assert tilde in rules
+
+    def test_returns_empty_when_plugin_root_outside_home(
+        self,
+        tmp_path: Path,
+        fake_home: Path,
+    ) -> None:
+        outside = tmp_path / "other-place" / "Dev10x" / "1.0.0"
+        outside.mkdir(parents=True)
+
+        rules = build_read_allow_rules(
+            plugin_root=outside,
+            user_home=fake_home,
+        )
+
+        assert rules == []
+
+    def test_uses_single_star_wildcard_only(
+        self,
+        fake_plugin_root: Path,
+        fake_home: Path,
+    ) -> None:
+        rules = build_read_allow_rules(
+            plugin_root=fake_plugin_root,
+            user_home=fake_home,
+        )
+
+        for rule in rules:
+            assert "/**" not in rule, f"Rule uses unsupported '**' glob: {rule}"
+            assert "*/**" not in rule
+
+
+class TestVerifyReadCoverage:
+    def test_splits_rules_into_covered_and_missing(self, tmp_path: Path) -> None:
+        settings = tmp_path / "settings.json"
+        settings.write_text(
+            json.dumps(
+                {
+                    "permissions": {
+                        "allow": [
+                            "Read(~/.claude/plugins/cache/X/Dev10x/1.0/skills/a/*)",
+                            "Bash(unrelated)",
+                        ]
+                    }
+                }
+            )
+        )
+
+        expected = [
+            "Read(~/.claude/plugins/cache/X/Dev10x/1.0/skills/a/*)",
+            "Read(~/.claude/plugins/cache/X/Dev10x/1.0/skills/b/*)",
+        ]
+
+        covered, missing = verify_read_coverage(settings, expected)
+
+        assert covered == ["Read(~/.claude/plugins/cache/X/Dev10x/1.0/skills/a/*)"]
+        assert missing == ["Read(~/.claude/plugins/cache/X/Dev10x/1.0/skills/b/*)"]
+
+    def test_treats_invalid_json_as_missing_everything(self, tmp_path: Path) -> None:
+        settings = tmp_path / "settings.json"
+        settings.write_text("{ not valid json")
+
+        covered, missing = verify_read_coverage(settings, ["Read(foo)"])
+
+        assert covered == []
+        assert missing == ["Read(foo)"]
+
+
+class TestEnsureReadRules:
+    def test_appends_missing_rules_idempotently(self, tmp_path: Path) -> None:
+        settings = tmp_path / "settings.json"
+        settings.write_text(json.dumps({"permissions": {"allow": ["Read(existing)"]}}))
+
+        ensure_read_rules(
+            settings,
+            ["Read(new-1)", "Read(new-2)"],
+            dry_run=False,
+        )
+        # Second call should not duplicate.
+        ensure_read_rules(
+            settings,
+            ["Read(new-1)", "Read(new-2)"],
+            dry_run=False,
+        )
+
+        data = json.loads(settings.read_text())
+        allow = data["permissions"]["allow"]
+        assert allow.count("Read(new-1)") == 1
+        assert allow.count("Read(new-2)") == 1
+        assert "Read(existing)" in allow
+
+    def test_dry_run_does_not_modify_file(self, tmp_path: Path) -> None:
+        settings = tmp_path / "settings.json"
+        settings.write_text(json.dumps({"permissions": {"allow": []}}))
+
+        count, messages = ensure_read_rules(
+            settings,
+            ["Read(would-add)"],
+            dry_run=True,
+        )
+
+        assert count == 1
+        assert any("Read(would-add)" in m for m in messages)
+        data = json.loads(settings.read_text())
+        assert data["permissions"]["allow"] == []
+
+    def test_returns_zero_when_nothing_missing(self, tmp_path: Path) -> None:
+        settings = tmp_path / "settings.json"
+        settings.write_text(json.dumps({"permissions": {"allow": []}}))
+
+        count, messages = ensure_read_rules(settings, [], dry_run=False)
+
+        assert count == 0
+        assert messages == []


### PR DESCRIPTION
**When** working with Dev10x plugin skills across multiple sessions, **the solo maintainer wants to** read plugin files without per-invocation approval prompts and trust that maintenance commands emit rule shapes the permission engine actually accepts, **so the maintainer can** stay in flow on real work instead of clicking through Read prompts and hand-debugging which path/wildcard combinations the engine matches.

---

- [`8438ced6`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/50/commits/8438ced69fe8b8bfde32afe06092e69b0e5d3170) ✨ GH-48 Enable per-skill Read rule emission with ~/ + /home twins
- [`4628d673`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/50/commits/4628d673a6fb63bd6bca54a5f4163b483ffd4b53) ✨ GH-47 Enable empirical investigation of permission rule shapes

---

Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/47
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/48
