### PR TITLE
📝 GH-53 Point pre-0.67 changelog refs to legacy repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,10 +131,10 @@ Released 2026-04-29
   these skills run without approval friction ([GH-11](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/11))
 - **Allow scoped `pr_comments` listings on heavily reviewed PRs**
   — pagination + filtering avoid response-size limits on PRs with
-  hundreds of threads ([GH-997](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/997))
+  hundreds of threads ([GH-997](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/997))
 - **Enable batched comment hiding via single GraphQL mutation** —
   one round-trip hides many comments instead of N requests
-  ([GH-987](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/987))
+  ([GH-987](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/987))
 - **Enable bootstrap coverage for uv/yq/git/gh patterns** —
   bootstrap allow rules cover the toolchain seen across skills
   out of the box ([GH-20](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/20))
@@ -143,16 +143,16 @@ Released 2026-04-29
 
 - **Halt PR creation when pre-PR checks fail** — `gh-pr-create`
   no longer pushes a draft PR when type-check or test gates
-  failed ([GH-998](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/998))
+  failed ([GH-998](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/998))
 - **Enforce ticket-create haiku dispatch and tracker fast-fail**
   — tracker mismatches surface immediately and ticket creation
-  uses the right model tier ([GH-998](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/998))
+  uses the right model tier ([GH-998](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/998))
 - **Enforce slack-review-request prepare script use** — Slack
   notifications go through the prepared script so token handling
-  stays consistent ([GH-998](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/998))
+  stays consistent ([GH-998](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/998))
 - **Allow numeric-string comment IDs on `pr_comment` reply** —
   reply tool accepts both forms returned by upstream APIs
-  ([GH-995](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/995))
+  ([GH-995](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/995))
 
 ### Refactors
 
@@ -160,7 +160,7 @@ Released 2026-04-29
   through MCP wrappers, fixing audit findings and removing the
   raw-CLI bypass ([GH-12](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/12))
 - **Guard `request-review` against approved PR pings** — already-
-  approved PRs no longer ping reviewers redundantly ([GH-993](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/993))
+  approved PRs no longer ping reviewers redundantly ([GH-993](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/993))
 
 ## 0.67.0 — Maintenance & Repository History Pruning
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -267,9 +267,9 @@ Released 2026-04-20
   and drop the non-existent `claude plugin add --local`
   subcommand from the local-development path
 
-[GH-965]: https://github.com/Dev10x-Guru/dev10x-claude/issues/965
-[GH-966]: https://github.com/Dev10x-Guru/dev10x-claude/issues/966
-[GH-970]: https://github.com/Dev10x-Guru/dev10x-claude/issues/970
+[GH-965]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/965
+[GH-966]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/966
+[GH-970]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/970
 
 ## 0.65.0 — Hook Performance & Control
 
@@ -303,10 +303,10 @@ Released 2026-04-19
   for `DEV10X_SKIP_CMD_VALIDATION`, which users reject for
   transient outages ([GH-957])
 
-[GH-413]: https://github.com/Dev10x-Guru/dev10x-claude/issues/413
-[GH-860]: https://github.com/Dev10x-Guru/dev10x-claude/issues/860
-[GH-957]: https://github.com/Dev10x-Guru/dev10x-claude/issues/957
-[GH-959]: https://github.com/Dev10x-Guru/dev10x-claude/issues/959
+[GH-413]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/413
+[GH-860]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/860
+[GH-957]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/957
+[GH-959]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/959
 
 ## 0.64.0 — Platform Reach & Merge Safety
 
@@ -369,16 +369,16 @@ Released 2026-04-18
   session-local scheduler lock file is now gitignored so it
   cannot land alongside unrelated skill changes ([GH-955])
 
-[GH-882]: https://github.com/Dev10x-Guru/dev10x-claude/issues/882
-[GH-906]: https://github.com/Dev10x-Guru/dev10x-claude/issues/906
-[GH-908]: https://github.com/Dev10x-Guru/dev10x-claude/issues/908
-[GH-946]: https://github.com/Dev10x-Guru/dev10x-claude/issues/946
-[GH-947]: https://github.com/Dev10x-Guru/dev10x-claude/issues/947
-[GH-948]: https://github.com/Dev10x-Guru/dev10x-claude/issues/948
-[GH-949]: https://github.com/Dev10x-Guru/dev10x-claude/issues/949
-[GH-952]: https://github.com/Dev10x-Guru/dev10x-claude/issues/952
-[GH-953]: https://github.com/Dev10x-Guru/dev10x-claude/issues/953
-[GH-955]: https://github.com/Dev10x-Guru/dev10x-claude/issues/955
+[GH-882]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/882
+[GH-906]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/906
+[GH-908]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/908
+[GH-946]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/946
+[GH-947]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/947
+[GH-948]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/948
+[GH-949]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/949
+[GH-952]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/952
+[GH-953]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/953
+[GH-955]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/955
 
 ## 0.63.0 — Solo Shipping & Playbook Resilience
 
@@ -434,17 +434,17 @@ Released 2026-04-15
 - **Update gitignore for backup settings files** — settings
   backup files are now excluded from version control
 
-[GH-897]: https://github.com/Dev10x-Guru/dev10x-claude/issues/897
-[GH-907]: https://github.com/Dev10x-Guru/dev10x-claude/issues/907
-[GH-910]: https://github.com/Dev10x-Guru/dev10x-claude/issues/910
-[GH-934]: https://github.com/Dev10x-Guru/dev10x-claude/issues/934
-[GH-936]: https://github.com/Dev10x-Guru/dev10x-claude/issues/936
-[GH-938]: https://github.com/Dev10x-Guru/dev10x-claude/issues/938
-[GH-939]: https://github.com/Dev10x-Guru/dev10x-claude/issues/939
-[GH-940]: https://github.com/Dev10x-Guru/dev10x-claude/issues/940
-[GH-941]: https://github.com/Dev10x-Guru/dev10x-claude/issues/941
-[GH-942]: https://github.com/Dev10x-Guru/dev10x-claude/issues/942
-[GH-943]: https://github.com/Dev10x-Guru/dev10x-claude/issues/943
+[GH-897]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/897
+[GH-907]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/907
+[GH-910]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/910
+[GH-934]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/934
+[GH-936]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/936
+[GH-938]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/938
+[GH-939]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/939
+[GH-940]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/940
+[GH-941]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/941
+[GH-942]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/942
+[GH-943]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/943
 
 ## 0.62.0 — Issue Milestones & Permission Safety
 
@@ -1225,34 +1225,34 @@ Released 2026-03-30
 - **Tighten git commit -F allow pattern** — CI allow rules
   match the mktmp-based commit flow ([GH-418])
 
-[GH-418]: https://github.com/Dev10x-Guru/dev10x-claude/issues/418
-[GH-483]: https://github.com/Dev10x-Guru/dev10x-claude/issues/483
-[GH-484]: https://github.com/Dev10x-Guru/dev10x-claude/issues/484
-[GH-485]: https://github.com/Dev10x-Guru/dev10x-claude/issues/485
-[GH-486]: https://github.com/Dev10x-Guru/dev10x-claude/issues/486
-[GH-487]: https://github.com/Dev10x-Guru/dev10x-claude/issues/487
-[GH-488]: https://github.com/Dev10x-Guru/dev10x-claude/issues/488
-[GH-489]: https://github.com/Dev10x-Guru/dev10x-claude/issues/489
-[GH-490]: https://github.com/Dev10x-Guru/dev10x-claude/issues/490
-[GH-491]: https://github.com/Dev10x-Guru/dev10x-claude/issues/491
-[GH-492]: https://github.com/Dev10x-Guru/dev10x-claude/issues/492
-[GH-493]: https://github.com/Dev10x-Guru/dev10x-claude/issues/493
-[GH-503]: https://github.com/Dev10x-Guru/dev10x-claude/issues/503
-[GH-504]: https://github.com/Dev10x-Guru/dev10x-claude/issues/504
-[GH-506]: https://github.com/Dev10x-Guru/dev10x-claude/issues/506
-[GH-507]: https://github.com/Dev10x-Guru/dev10x-claude/issues/507
-[GH-508]: https://github.com/Dev10x-Guru/dev10x-claude/issues/508
-[GH-515]: https://github.com/Dev10x-Guru/dev10x-claude/issues/515
-[GH-528]: https://github.com/Dev10x-Guru/dev10x-claude/issues/528
-[GH-531]: https://github.com/Dev10x-Guru/dev10x-claude/issues/531
-[GH-532]: https://github.com/Dev10x-Guru/dev10x-claude/issues/532
-[GH-533]: https://github.com/Dev10x-Guru/dev10x-claude/issues/533
-[GH-534]: https://github.com/Dev10x-Guru/dev10x-claude/issues/534
-[GH-535]: https://github.com/Dev10x-Guru/dev10x-claude/issues/535
-[GH-536]: https://github.com/Dev10x-Guru/dev10x-claude/issues/536
-[GH-537]: https://github.com/Dev10x-Guru/dev10x-claude/issues/537
-[GH-539]: https://github.com/Dev10x-Guru/dev10x-claude/issues/539
-[GH-549]: https://github.com/Dev10x-Guru/dev10x-claude/issues/549
+[GH-418]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/418
+[GH-483]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/483
+[GH-484]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/484
+[GH-485]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/485
+[GH-486]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/486
+[GH-487]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/487
+[GH-488]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/488
+[GH-489]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/489
+[GH-490]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/490
+[GH-491]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/491
+[GH-492]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/492
+[GH-493]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/493
+[GH-503]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/503
+[GH-504]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/504
+[GH-506]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/506
+[GH-507]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/507
+[GH-508]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/508
+[GH-515]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/515
+[GH-528]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/528
+[GH-531]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/531
+[GH-532]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/532
+[GH-533]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/533
+[GH-534]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/534
+[GH-535]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/535
+[GH-536]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/536
+[GH-537]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/537
+[GH-539]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/539
+[GH-549]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/549
 [9630a11]: https://github.com/Dev10x-Guru/dev10x-claude/commit/9630a11
 [d88ef81]: https://github.com/Dev10x-Guru/dev10x-claude/commit/d88ef81
 [d0acaf4]: https://github.com/Dev10x-Guru/dev10x-claude/commit/d0acaf4
@@ -1282,13 +1282,13 @@ Released 2026-03-28
 - **Prevent groom step bypass via self-assessment** — groom
   skill always presents strategy gate ([GH-505])
 
-[GH-482]: https://github.com/Dev10x-Guru/dev10x-claude/issues/482
-[GH-496]: https://github.com/Dev10x-Guru/dev10x-claude/issues/496
-[GH-498]: https://github.com/Dev10x-Guru/dev10x-claude/issues/498
-[GH-499]: https://github.com/Dev10x-Guru/dev10x-claude/issues/499
-[GH-501]: https://github.com/Dev10x-Guru/dev10x-claude/issues/501
-[GH-502]: https://github.com/Dev10x-Guru/dev10x-claude/issues/502
-[GH-505]: https://github.com/Dev10x-Guru/dev10x-claude/issues/505
+[GH-482]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/482
+[GH-496]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/496
+[GH-498]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/498
+[GH-499]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/499
+[GH-501]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/501
+[GH-502]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/502
+[GH-505]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/505
 
 ## 0.41.0 — Orchestration Guardrails & Plan Persistence
 
@@ -1324,12 +1324,12 @@ Released 2026-03-27
 - **Ensure dispatcher tests match commit hook rules** —
   test suite validates hook-to-skill routing ([GH-473])
 
-[GH-414]: https://github.com/Dev10x-Guru/dev10x-claude/issues/414
-[GH-465]: https://github.com/Dev10x-Guru/dev10x-claude/issues/465
-[GH-470]: https://github.com/Dev10x-Guru/dev10x-claude/issues/470
-[GH-473]: https://github.com/Dev10x-Guru/dev10x-claude/issues/473
-[GH-475]: https://github.com/Dev10x-Guru/dev10x-claude/issues/475
-[GH-477]: https://github.com/Dev10x-Guru/dev10x-claude/issues/477
+[GH-414]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/414
+[GH-465]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/465
+[GH-470]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/470
+[GH-473]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/473
+[GH-475]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/475
+[GH-477]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/477
 
 ## 0.40.0 — Delegation Hardening & Fixup Skill Gaps
 
@@ -1377,13 +1377,13 @@ Released 2026-03-26
 - **Embed asciinema demo in README** — interactive terminal demo
   on the project landing page ([64d4a2e])
 
-[GH-445]: https://github.com/Dev10x-Guru/dev10x-claude/issues/445
-[GH-447]: https://github.com/Dev10x-Guru/dev10x-claude/issues/447
-[GH-448]: https://github.com/Dev10x-Guru/dev10x-claude/issues/448
-[GH-458]: https://github.com/Dev10x-Guru/dev10x-claude/issues/458
-[GH-459]: https://github.com/Dev10x-Guru/dev10x-claude/issues/459
-[GH-463]: https://github.com/Dev10x-Guru/dev10x-claude/issues/463
-[GH-464]: https://github.com/Dev10x-Guru/dev10x-claude/issues/464
+[GH-445]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/445
+[GH-447]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/447
+[GH-448]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/448
+[GH-458]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/458
+[GH-459]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/459
+[GH-463]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/463
+[GH-464]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/464
 [a09a2d6]: https://github.com/Dev10x-Guru/dev10x-claude/commit/a09a2d6
 [cf14b16]: https://github.com/Dev10x-Guru/dev10x-claude/commit/cf14b16
 [64d4a2e]: https://github.com/Dev10x-Guru/dev10x-claude/commit/64d4a2e
@@ -1426,12 +1426,12 @@ Released 2026-03-25
   that allow rules enabling hooks must not be removed even when
   the hook redirects the command ([GH-419])
 
-[GH-419]: https://github.com/Dev10x-Guru/dev10x-claude/issues/419
-[GH-426]: https://github.com/Dev10x-Guru/dev10x-claude/issues/426
-[GH-427]: https://github.com/Dev10x-Guru/dev10x-claude/issues/427
-[GH-428]: https://github.com/Dev10x-Guru/dev10x-claude/issues/428
-[GH-429]: https://github.com/Dev10x-Guru/dev10x-claude/issues/429
-[GH-441]: https://github.com/Dev10x-Guru/dev10x-claude/issues/441
+[GH-419]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/419
+[GH-426]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/426
+[GH-427]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/427
+[GH-428]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/428
+[GH-429]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/429
+[GH-441]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/441
 [#442]: https://github.com/Dev10x-Guru/dev10x-claude/pull/442
 [23229f3]: https://github.com/Dev10x-Guru/dev10x-claude/commit/23229f3
 [57e3830]: https://github.com/Dev10x-Guru/dev10x-claude/commit/57e3830
@@ -1468,8 +1468,8 @@ Released 2026-03-24
 - **Data-driven skill redirect ADR** — propose friction-level
   based redirect system for hook validators ([GH-417])
 
-[GH-417]: https://github.com/Dev10x-Guru/dev10x-claude/issues/417
-[GH-422]: https://github.com/Dev10x-Guru/dev10x-claude/issues/422
+[GH-417]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/417
+[GH-422]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/422
 
 ## 0.37.0 — Skill Compliance Enforcement
 
@@ -1508,11 +1508,11 @@ eliminates the permission friction that incentivized bypasses.
   documents Skill() invocation assertion patterns, enabling
   detection of enforcement bypass regressions ([b90c5de])
 
-[GH-397]: https://github.com/Dev10x-Guru/dev10x-claude/issues/397
-[GH-399]: https://github.com/Dev10x-Guru/dev10x-claude/issues/399
-[GH-400]: https://github.com/Dev10x-Guru/dev10x-claude/issues/400
-[GH-401]: https://github.com/Dev10x-Guru/dev10x-claude/issues/401
-[GH-407]: https://github.com/Dev10x-Guru/dev10x-claude/issues/407
+[GH-397]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/397
+[GH-399]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/399
+[GH-400]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/400
+[GH-401]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/401
+[GH-407]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/407
 [b90c5de]: https://github.com/Dev10x-Guru/dev10x-claude/commit/b90c5de
 
 ## 0.36.0 — PR Monitor Visibility & MCP Bugfix
@@ -1535,8 +1535,8 @@ blocked all comment operations.
   `--pr` in cli_server.py so reply, resolve, and thread
   operations work correctly ([GH-393])
 
-[GH-392]: https://github.com/Dev10x-Guru/dev10x-claude/issues/392
-[GH-393]: https://github.com/Dev10x-Guru/dev10x-claude/issues/393
+[GH-392]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/392
+[GH-393]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/393
 
 ## 0.35.0 — Orchestration Integrity & Maintenance Skills
 
@@ -2325,99 +2325,99 @@ in a single plugin.
 
 ---
 
-[GH-1]: https://github.com/Dev10x-Guru/dev10x-claude/issues/1
-[GH-7]: https://github.com/Dev10x-Guru/dev10x-claude/issues/7
-[GH-10]: https://github.com/Dev10x-Guru/dev10x-claude/issues/10
-[GH-15]: https://github.com/Dev10x-Guru/dev10x-claude/issues/15
-[GH-17]: https://github.com/Dev10x-Guru/dev10x-claude/issues/17
-[GH-19]: https://github.com/Dev10x-Guru/dev10x-claude/issues/19
-[GH-31]: https://github.com/Dev10x-Guru/dev10x-claude/issues/31
-[GH-33]: https://github.com/Dev10x-Guru/dev10x-claude/issues/33
-[GH-35]: https://github.com/Dev10x-Guru/dev10x-claude/issues/35
-[GH-44]: https://github.com/Dev10x-Guru/dev10x-claude/issues/44
-[GH-45]: https://github.com/Dev10x-Guru/dev10x-claude/issues/45
-[GH-50]: https://github.com/Dev10x-Guru/dev10x-claude/issues/50
-[GH-54]: https://github.com/Dev10x-Guru/dev10x-claude/issues/54
-[GH-59]: https://github.com/Dev10x-Guru/dev10x-claude/issues/59
-[GH-68]: https://github.com/Dev10x-Guru/dev10x-claude/issues/68
-[GH-70]: https://github.com/Dev10x-Guru/dev10x-claude/issues/70
-[GH-79]: https://github.com/Dev10x-Guru/dev10x-claude/issues/79
-[GH-84]: https://github.com/Dev10x-Guru/dev10x-claude/issues/84
-[GH-86]: https://github.com/Dev10x-Guru/dev10x-claude/issues/86
-[GH-87]: https://github.com/Dev10x-Guru/dev10x-claude/issues/87
-[GH-118]: https://github.com/Dev10x-Guru/dev10x-claude/issues/118
-[GH-121]: https://github.com/Dev10x-Guru/dev10x-claude/issues/121
-[GH-126]: https://github.com/Dev10x-Guru/dev10x-claude/issues/126
-[GH-131]: https://github.com/Dev10x-Guru/dev10x-claude/issues/131
-[GH-133]: https://github.com/Dev10x-Guru/dev10x-claude/issues/133
-[GH-134]: https://github.com/Dev10x-Guru/dev10x-claude/issues/134
-[GH-135]: https://github.com/Dev10x-Guru/dev10x-claude/issues/135
-[GH-140]: https://github.com/Dev10x-Guru/dev10x-claude/issues/140
-[GH-143]: https://github.com/Dev10x-Guru/dev10x-claude/issues/143
-[GH-144]: https://github.com/Dev10x-Guru/dev10x-claude/issues/144
-[GH-151]: https://github.com/Dev10x-Guru/dev10x-claude/issues/151
-[GH-153]: https://github.com/Dev10x-Guru/dev10x-claude/issues/153
-[GH-154]: https://github.com/Dev10x-Guru/dev10x-claude/issues/154
-[GH-157]: https://github.com/Dev10x-Guru/dev10x-claude/issues/157
-[GH-159]: https://github.com/Dev10x-Guru/dev10x-claude/issues/159
-[GH-179]: https://github.com/Dev10x-Guru/dev10x-claude/issues/179
-[GH-180]: https://github.com/Dev10x-Guru/dev10x-claude/issues/180
-[GH-187]: https://github.com/Dev10x-Guru/dev10x-claude/issues/187
-[GH-188]: https://github.com/Dev10x-Guru/dev10x-claude/issues/188
-[GH-196]: https://github.com/Dev10x-Guru/dev10x-claude/issues/196
-[GH-200]: https://github.com/Dev10x-Guru/dev10x-claude/issues/200
-[GH-208]: https://github.com/Dev10x-Guru/dev10x-claude/issues/208
-[GH-209]: https://github.com/Dev10x-Guru/dev10x-claude/issues/209
-[GH-213]: https://github.com/Dev10x-Guru/dev10x-claude/issues/213
-[GH-219]: https://github.com/Dev10x-Guru/dev10x-claude/issues/219
-[GH-225]: https://github.com/Dev10x-Guru/dev10x-claude/issues/225
-[GH-226]: https://github.com/Dev10x-Guru/dev10x-claude/issues/226
-[GH-227]: https://github.com/Dev10x-Guru/dev10x-claude/issues/227
-[GH-231]: https://github.com/Dev10x-Guru/dev10x-claude/issues/231
-[GH-232]: https://github.com/Dev10x-Guru/dev10x-claude/issues/232
-[GH-237]: https://github.com/Dev10x-Guru/dev10x-claude/issues/237
-[GH-244]: https://github.com/Dev10x-Guru/dev10x-claude/issues/244
-[GH-247]: https://github.com/Dev10x-Guru/dev10x-claude/issues/247
-[GH-251]: https://github.com/Dev10x-Guru/dev10x-claude/issues/251
-[GH-252]: https://github.com/Dev10x-Guru/dev10x-claude/issues/252
-[GH-253]: https://github.com/Dev10x-Guru/dev10x-claude/issues/253
-[GH-258]: https://github.com/Dev10x-Guru/dev10x-claude/issues/258
-[GH-259]: https://github.com/Dev10x-Guru/dev10x-claude/issues/259
-[GH-260]: https://github.com/Dev10x-Guru/dev10x-claude/issues/260
-[GH-261]: https://github.com/Dev10x-Guru/dev10x-claude/issues/261
-[GH-263]: https://github.com/Dev10x-Guru/dev10x-claude/issues/263
-[GH-267]: https://github.com/Dev10x-Guru/dev10x-claude/issues/267
-[GH-269]: https://github.com/Dev10x-Guru/dev10x-claude/issues/269
-[GH-270]: https://github.com/Dev10x-Guru/dev10x-claude/issues/270
-[GH-271]: https://github.com/Dev10x-Guru/dev10x-claude/issues/271
-[GH-272]: https://github.com/Dev10x-Guru/dev10x-claude/issues/272
-[GH-273]: https://github.com/Dev10x-Guru/dev10x-claude/issues/273
-[GH-274]: https://github.com/Dev10x-Guru/dev10x-claude/issues/274
-[GH-275]: https://github.com/Dev10x-Guru/dev10x-claude/issues/275
-[GH-277]: https://github.com/Dev10x-Guru/dev10x-claude/issues/277
-[GH-280]: https://github.com/Dev10x-Guru/dev10x-claude/issues/280
-[GH-283]: https://github.com/Dev10x-Guru/dev10x-claude/issues/283
-[GH-288]: https://github.com/Dev10x-Guru/dev10x-claude/issues/288
-[GH-313]: https://github.com/Dev10x-Guru/dev10x-claude/issues/313
-[GH-345]: https://github.com/Dev10x-Guru/dev10x-claude/issues/345
-[GH-348]: https://github.com/Dev10x-Guru/dev10x-claude/issues/348
-[GH-351]: https://github.com/Dev10x-Guru/dev10x-claude/issues/351
-[GH-353]: https://github.com/Dev10x-Guru/dev10x-claude/issues/353
-[GH-354]: https://github.com/Dev10x-Guru/dev10x-claude/issues/354
-[GH-355]: https://github.com/Dev10x-Guru/dev10x-claude/issues/355
-[GH-356]: https://github.com/Dev10x-Guru/dev10x-claude/issues/356
-[GH-357]: https://github.com/Dev10x-Guru/dev10x-claude/issues/357
-[GH-358]: https://github.com/Dev10x-Guru/dev10x-claude/issues/358
-[GH-363]: https://github.com/Dev10x-Guru/dev10x-claude/issues/363
-[GH-366]: https://github.com/Dev10x-Guru/dev10x-claude/issues/366
-[GH-367]: https://github.com/Dev10x-Guru/dev10x-claude/issues/367
-[GH-371]: https://github.com/Dev10x-Guru/dev10x-claude/issues/371
-[GH-375]: https://github.com/Dev10x-Guru/dev10x-claude/issues/375
-[GH-376]: https://github.com/Dev10x-Guru/dev10x-claude/issues/376
-[GH-382]: https://github.com/Dev10x-Guru/dev10x-claude/issues/382
-[GH-384]: https://github.com/Dev10x-Guru/dev10x-claude/issues/384
-[GH-385]: https://github.com/Dev10x-Guru/dev10x-claude/issues/385
-[GH-386]: https://github.com/Dev10x-Guru/dev10x-claude/issues/386
+[GH-1]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/1
+[GH-7]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/7
+[GH-10]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/10
+[GH-15]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/15
+[GH-17]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/17
+[GH-19]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/19
+[GH-31]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/31
+[GH-33]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/33
+[GH-35]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/35
+[GH-44]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/44
+[GH-45]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/45
+[GH-50]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/50
+[GH-54]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/54
+[GH-59]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/59
+[GH-68]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/68
+[GH-70]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/70
+[GH-79]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/79
+[GH-84]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/84
+[GH-86]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/86
+[GH-87]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/87
+[GH-118]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/118
+[GH-121]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/121
+[GH-126]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/126
+[GH-131]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/131
+[GH-133]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/133
+[GH-134]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/134
+[GH-135]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/135
+[GH-140]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/140
+[GH-143]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/143
+[GH-144]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/144
+[GH-151]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/151
+[GH-153]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/153
+[GH-154]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/154
+[GH-157]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/157
+[GH-159]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/159
+[GH-179]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/179
+[GH-180]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/180
+[GH-187]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/187
+[GH-188]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/188
+[GH-196]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/196
+[GH-200]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/200
+[GH-208]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/208
+[GH-209]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/209
+[GH-213]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/213
+[GH-219]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/219
+[GH-225]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/225
+[GH-226]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/226
+[GH-227]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/227
+[GH-231]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/231
+[GH-232]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/232
+[GH-237]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/237
+[GH-244]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/244
+[GH-247]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/247
+[GH-251]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/251
+[GH-252]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/252
+[GH-253]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/253
+[GH-258]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/258
+[GH-259]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/259
+[GH-260]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/260
+[GH-261]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/261
+[GH-263]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/263
+[GH-267]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/267
+[GH-269]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/269
+[GH-270]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/270
+[GH-271]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/271
+[GH-272]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/272
+[GH-273]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/273
+[GH-274]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/274
+[GH-275]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/275
+[GH-277]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/277
+[GH-280]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/280
+[GH-283]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/283
+[GH-288]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/288
+[GH-313]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/313
+[GH-345]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/345
+[GH-348]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/348
+[GH-351]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/351
+[GH-353]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/353
+[GH-354]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/354
+[GH-355]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/355
+[GH-356]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/356
+[GH-357]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/357
+[GH-358]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/358
+[GH-363]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/363
+[GH-366]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/366
+[GH-367]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/367
+[GH-371]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/371
+[GH-375]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/375
+[GH-376]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/376
+[GH-382]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/382
+[GH-384]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/384
+[GH-385]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/385
+[GH-386]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/386
 [#243]: https://github.com/Dev10x-Guru/dev10x-claude/pull/243
 [#267]: https://github.com/Dev10x-Guru/dev10x-claude/pull/267
 [#270]: https://github.com/Dev10x-Guru/dev10x-claude/pull/270

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,43 +12,43 @@ Released 2026-05-01
 - **Enable empirical investigation of permission rule shapes** —
   audit tooling captures real-world permission rule patterns so
   prefix-friction diagnostics rest on observed behavior instead
-  of assumptions ([GH-47])
+  of assumptions ([GH-47](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/47))
 - **Emit per-skill Read rules with `~/` + `/home` twins** —
   `plugin-maintenance` writes both expansions so Read rules match
   regardless of which form Claude resolves at allow-check time
-  ([GH-48])
+  ([GH-48](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/48))
 - **Detect Write-overwrite, workspace, and exit-code friction in
   audit** — three new diagnostics surface common permission
   prompt causes that previously slipped past audit reports
-  ([GH-46])
+  ([GH-46](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/46))
 - **Prefer working-dir scripts when CWD is plugin source** —
   hooks and skills resolve script paths to the active checkout
   rather than the installed plugin, so local edits take effect
-  immediately ([GH-42])
+  immediately ([GH-42](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/42))
 - **Register `/tmp/Dev10x` workspace via `plugin-maintenance`
   bootstrap** — first-run setup adds the workspace allow rule so
-  `mktmp` and friends stop prompting on fresh installs ([GH-40])
+  `mktmp` and friends stop prompting on fresh installs ([GH-40](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/40))
 - **Stop pre-creating files in `mktmp` to avoid Write-overwrite
   prompt** — the MCP tool returns a fresh path without touching
   it, so the first Write call no longer trips the overwrite gate
-  ([GH-39])
+  ([GH-39](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/39))
 - **Expose audit-wrap log discovery via MCP tools** —
   `audit_hook_log_path` and `audit_hook_recent` let skills query
-  hook timing data without shelling out ([GH-29])
+  hook timing data without shelling out ([GH-29](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/29))
 - **Add PoC option to `ticket-scope` approval gate** — scoping a
   proof-of-concept ticket no longer forces the full template
-  treatment ([GH-33])
+  treatment ([GH-33](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/33))
 - **Auto-detect Slack state to skip redundant prompts** —
   `slack-review-request` checks for an existing token before
-  prompting, smoothing the request-review flow ([GH-19])
+  prompting, smoothing the request-review flow ([GH-19](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/19))
 
 ### Fixes
 
 - **Fix Server Tests workflow path** — the CI path filter now
-  matches the relocated MCP server module ([GH-9])
+  matches the relocated MCP server module ([GH-9](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/9))
 - **Use REST API for PR body updates to avoid Projects-classic
   exit 1** — `gh-pr-create` update mode bypasses a `gh` GraphQL
-  failure on repos still attached to classic projects ([GH-41])
+  failure on repos still attached to classic projects ([GH-41](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/41))
 - **Resolve pre-existing mypy errors in MCP github and hook
   audit** — strict typing passes again after the GitHub-domain
   lift
@@ -60,51 +60,51 @@ Released 2026-05-01
 
 - **Lift the GitHub domain into a top-level package** — MCP
   GitHub helpers move out of the server-internal namespace so
-  CLI tools and tests can share them ([GH-9])
+  CLI tools and tests can share them ([GH-9](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/9))
 - **Lift simple MCP domains into top-level packages** —
   cohesive single-purpose MCP modules become standalone packages
-  for easier reuse ([GH-9])
+  for easier reuse ([GH-9](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/9))
 - **Reuse subprocess utilities outside the MCP layer** — the
   shared subprocess helper graduates out of `mcp/` so audit and
-  CLI consumers stop duplicating it ([GH-9])
+  CLI consumers stop duplicating it ([GH-9](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/9))
 - **Enforce template selection in `ticket-scope` Phase 5.1** —
   skill body blocks free-text drift through the template gate
-  ([GH-28])
+  ([GH-28](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/28))
 - **Enforce `jtbd` delegation in `ticket-scope` Phase 4b** —
   Job Story drafting routes through the dedicated skill
-  ([GH-27])
+  ([GH-27](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/27))
 - **Enforce `instructions.md` read at `ticket-scope` startup** —
   body content loads explicitly so phase logic is visible to the
-  agent ([GH-26])
+  agent ([GH-26](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/26))
 - **Preserve hook guardrails outside split-rebase docs** —
   `git-commit-split` references hook rules instead of redefining
-  them ([GH-15])
+  them ([GH-15](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/15))
 - **Enable consistent coverage gates in skill scripts** — every
-  skill script enforces the same coverage threshold ([GH-13])
+  skill script enforces the same coverage threshold ([GH-13](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/13))
 - **Route raw `git` CLI in skill bodies through wrappers** —
   skills call the safe-rebase / safe-push wrappers instead of
-  raw `git` so guardrails stay in force ([GH-14])
+  raw `git` so guardrails stay in force ([GH-14](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/14))
 
 ### Documentation
 
 - **Document fanout-parallel hook propagation surprises** —
   parent hooks may not run inside fanout children; the rule lives
-  next to the skill ([GH-32])
+  next to the skill ([GH-32](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/32))
 - **Document fanout-parallel cold-load budget floor** — children
   pay a fixed cold-load cost, so fanout below the floor is
-  slower than serial ([GH-31])
+  slower than serial ([GH-31](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/31))
 - **Document `--bare` strips OAuth in fanout-parallel children**
   — bare clones lose token auth, breaking `gh` calls inside
-  fanout children ([GH-30])
+  fanout children ([GH-30](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/30))
 - **Clarify mode prompt overrides preserve skills delegation** —
   override examples no longer suggest dropping skill calls
-  ([GH-45])
+  ([GH-45](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/45))
 - **Forbid skill partial-read downgrade in `work-on`** — the
   skill always reads the full body to keep orchestration
-  contracts intact ([GH-44])
+  contracts intact ([GH-44](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/44))
 - **Enforce `gh-pr-respond` for all PR review comments** —
   responding directly via `gh` bypasses validation gates
-  ([GH-43])
+  ([GH-43](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/43))
 
 ### Polish
 
@@ -114,31 +114,6 @@ Released 2026-05-01
 - **Sort imports in `skill-audit` script entry points**
 - **Remove dead test variables and rename ambiguous loop var**
 
-[GH-1]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/1
-[GH-9]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/9
-[GH-13]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/13
-[GH-14]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/14
-[GH-15]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/15
-[GH-19]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/19
-[GH-26]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/26
-[GH-27]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/27
-[GH-28]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/28
-[GH-29]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/29
-[GH-30]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/30
-[GH-31]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/31
-[GH-32]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/32
-[GH-33]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/33
-[GH-39]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/39
-[GH-40]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/40
-[GH-41]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/41
-[GH-42]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/42
-[GH-43]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/43
-[GH-44]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/44
-[GH-45]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/45
-[GH-46]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/46
-[GH-47]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/47
-[GH-48]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/48
-
 ## 0.68.0 — First-Run Setup & PR-Skill Hardening
 
 Released 2026-04-29
@@ -147,55 +122,45 @@ Released 2026-04-29
 
 - **Streamline first-run permission setup** — bootstrap walks new
   users through the minimum permission set so the plugin works
-  without per-tool prompting on day one ([GH-1])
+  without per-tool prompting on day one ([GH-1](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/1))
 - **Detect raw CLI in skill docs to prevent MCP/Skill bypass** —
   reviewer surfaces `gh`/`git` shell-outs in skill bodies that
-  should route through MCP tools or sibling skills ([GH-5])
+  should route through MCP tools or sibling skills ([GH-5](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/5))
 - **Eliminate per-invocation permission prompts in 18 skills** —
   audit-driven sweep adds the missing `allowed-tools` entries so
-  these skills run without approval friction ([GH-11])
+  these skills run without approval friction ([GH-11](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/11))
 - **Allow scoped `pr_comments` listings on heavily reviewed PRs**
   — pagination + filtering avoid response-size limits on PRs with
-  hundreds of threads ([GH-997])
+  hundreds of threads ([GH-997](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/997))
 - **Enable batched comment hiding via single GraphQL mutation** —
   one round-trip hides many comments instead of N requests
-  ([GH-987])
+  ([GH-987](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/987))
 - **Enable bootstrap coverage for uv/yq/git/gh patterns** —
   bootstrap allow rules cover the toolchain seen across skills
-  out of the box ([GH-20])
+  out of the box ([GH-20](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/20))
 
 ### Fixes
 
 - **Halt PR creation when pre-PR checks fail** — `gh-pr-create`
   no longer pushes a draft PR when type-check or test gates
-  failed ([GH-998])
+  failed ([GH-998](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/998))
 - **Enforce ticket-create haiku dispatch and tracker fast-fail**
   — tracker mismatches surface immediately and ticket creation
-  uses the right model tier ([GH-998])
+  uses the right model tier ([GH-998](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/998))
 - **Enforce slack-review-request prepare script use** — Slack
   notifications go through the prepared script so token handling
-  stays consistent ([GH-998])
+  stays consistent ([GH-998](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/998))
 - **Allow numeric-string comment IDs on `pr_comment` reply** —
   reply tool accepts both forms returned by upstream APIs
-  ([GH-995])
+  ([GH-995](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/995))
 
 ### Refactors
 
 - **Eliminate raw `gh` CLI in PR-skill bodies** — PR skills route
   through MCP wrappers, fixing audit findings and removing the
-  raw-CLI bypass ([GH-12])
+  raw-CLI bypass ([GH-12](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/12))
 - **Guard `request-review` against approved PR pings** — already-
-  approved PRs no longer ping reviewers redundantly ([GH-993])
-
-[GH-987]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/987
-[GH-993]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/993
-[GH-995]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/995
-[GH-997]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/997
-[GH-998]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/998
-[GH-5]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/5
-[GH-11]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/11
-[GH-12]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/12
-[GH-20]: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/20
+  approved PRs no longer ping reviewers redundantly ([GH-993](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/993))
 
 ## 0.67.0 — Maintenance & Repository History Pruning
 
@@ -229,7 +194,7 @@ Released 2026-04-20
   worktree-absolute paths drop out of the merge filter, the
   `session-start-reload.py` allow rule is annotated, and
   `update-paths`/`clean` gain a `--summary` flag so the post-
-  v0.65.0 upgrade pass no longer needs hand-holding ([GH-965])
+  v0.65.0 upgrade pass no longer needs hand-holding ([GH-965](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/965))
 
 ### Refactors
 
@@ -238,18 +203,18 @@ Released 2026-04-20
   git-commit, gh-pr-monitor, gh-pr-respond, fanout, git-groom,
   qa-self, scope, git-commit-split, playbook, ticket-scope,
   gh-pr-merge, gh-pr-create) so `git log --follow` preserves
-  history ahead of the frontmatter split ([GH-970])
+  history ahead of the frontmatter split ([GH-970](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/970))
 - **Split skill frontmatter from body via instructions.md** —
   each oversized skill now ships a ~30–50 line SKILL.md (YAML
   frontmatter plus a pointer) with the body in `instructions.md`,
   so MOTD index and skill discovery costs drop and the body only
-  loads once a skill is invoked ([GH-970])
+  loads once a skill is invoked ([GH-970](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/970))
 - **Split task-orchestration.md into per-pattern files** —
   the 649-line shared reference shrinks to a 50-line index
   that links to per-pattern files under `references/orchestration/`,
   so downstream consumers keep working without edits and
   pattern detail loads only when a skill links the specific
-  file ([GH-970])
+  file ([GH-970](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/970))
 
 ### Documentation
 
@@ -259,17 +224,13 @@ Released 2026-04-20
   enumerates third-party integrations with credential scopes,
   and provides data deletion commands plus the audit-log
   disable switch, closing the disclosure gap flagged by an
-  external security audit ([GH-966])
+  external security audit ([GH-966](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/966))
 - **Enable reliable plugin install via shell CLI** — install
   instructions now prefer `claude plugin marketplace add` and
   `claude plugin install` shell commands (run outside a Claude
   Code session) over the unreliable `/plugin` slash commands,
   and drop the non-existent `claude plugin add --local`
   subcommand from the local-development path
-
-[GH-965]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/965
-[GH-966]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/966
-[GH-970]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/970
 
 ## 0.65.0 — Hook Performance & Control
 
@@ -282,31 +243,26 @@ Released 2026-04-19
   runs 2), replacing 8 `uv run --project` wrappers with
   direct-shebang scripts so every session feels faster without
   paying uv project resolution and CLI import cost per hook
-  ([GH-959])
+  ([GH-959](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/959))
 - **Surface per-hook execution timing for latency triage** —
   `@audit_hook` plus an `audit-wrap` shell wrapper capture
   body-phase and total (including uv startup) timing per
   invocation to `/tmp/Dev10x/logs/hooks-*.jsonl`, with
   `dev10x hook audit summary` and `prune` subcommands so slow
-  hooks are diagnosable before users complain ([GH-860])
+  hooks are diagnosable before users complain ([GH-860](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/860))
 - **Let users dial hook strictness per session** — validator
   specs now carry `rule_id` (DX001–DX008), `profile`
   (minimal/standard/strict), and `experimental` flags, so
   `DEV10X_HOOK_PROFILE`, `DEV10X_HOOK_DISABLE`, and
   `DEV10X_HOOK_EXPERIMENTAL` can drop opinionated rules for
   throwaway work while keeping safety-critical guardrails on
-  shared-repo commits ([GH-413])
+  shared-repo commits ([GH-413](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/413))
 - **Guide users to reconnect MCP instead of bypassing hook** —
   when the `Dev10x_cli` MCP server is unavailable, use-tool
   block messages now instruct the agent to ask the user to
   reconnect rather than fall back to wrapper scripts or reach
   for `DEV10X_SKIP_CMD_VALIDATION`, which users reject for
-  transient outages ([GH-957])
-
-[GH-413]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/413
-[GH-860]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/860
-[GH-957]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/957
-[GH-959]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/959
+  transient outages ([GH-957](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/957))
 
 ## 0.64.0 — Platform Reach & Merge Safety
 
@@ -318,67 +274,56 @@ Released 2026-04-18
   any AI assistant (Claude Code, Copilot, Windsurf, Continue,
   Cursor, or custom targets) with `dev10x platform add/list/remove`
   so Dev10x can extend beyond its original two-host scope without
-  per-user path editing ([GH-908])
+  per-user path editing ([GH-908](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/908))
 - **Automate PyPI publishing on release tags** — `v*` tag pushes
   publish the `dev10x` package via OIDC trusted publishing, so
   users can `pip install Dev10x` for CI scripts and hook
-  integration without manual upload steps ([GH-953])
+  integration without manual upload steps ([GH-953](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/953))
 - **Guide new users through Dev10x onboarding** — `dev10x init`
   seeds starter config and prints a Next 5 Commands quick-start
   card, replacing the zero-direction `/help` landing with a
-  frictionless guided setup ([GH-906])
+  frictionless guided setup ([GH-906](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/906))
 - **Prevent silent merges past unresolved CI checks** —
   `Dev10x:gh-pr-merge` now blocks on `PENDING`, `IN_PROGRESS`, or
   any `bucket:fail` state and requires an explicit reason for
   override, closing the gap that shipped a bundle while e2e was
-  still running ([GH-955])
+  still running ([GH-955](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/955))
 - **Enforce instruction budget for large skills** — new
   `dev10x skill count-instructions` command measures actionable
   instructions and warns when skills exceed the 150-instruction
-  reliability threshold from QRSPI research ([GH-882])
+  reliability threshold from QRSPI research ([GH-882](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/882))
 - **Offer structured retry after rejected commands** — when a
   user rejects a CLI command, `Dev10x:skill-reinforcement` now
   fires `AskUserQuestion` with retry/manual/cancel options
   instead of a plain-text follow-up that could silently auto-
-  advance ([GH-952])
+  advance ([GH-952](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/952))
 - **Prefer bundled PR for same-milestone multi-issue work** —
   `Dev10x:work-on` auto-selects a bundled PR strategy when all
   tickets share a milestone under solo-maintainer mode, cutting
   N branch switches, CI cycles, and merges down to one
-  ([GH-948])
+  ([GH-948](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/948))
 - **Enable MCP glob enumeration in upgrade-cleanup** — new
   `dev10x permission enumerate-mcp` subcommand replaces
   `mcp__plugin_Dev10x_*` wildcards with enumerated tool names,
   eliminating the manual approval prompts Claude Code fires when
-  globs silently match nothing ([GH-947])
+  globs silently match nothing ([GH-947](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/947))
 - **Enable Supabase env bootstrap in worktree hooks** — post-
   checkout hooks now copy `.env.supabase` into new worktrees so
   local Supabase connectivity works without manual file copying
-  ([GH-946])
+  ([GH-946](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/946))
 
 ### Refactors
 
 - **Isolate Dev10x scratch files under /tmp/Dev10x/** — plugin
   scratch files, session state, and the mktmp binary moved from
   the shared `/tmp/claude/` namespace to `/tmp/Dev10x/`, letting
-  users scope allow rules to plugin-only paths ([GH-949])
+  users scope allow rules to plugin-only paths ([GH-949](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/949))
 
 ### Chores
 
 - **Keep scheduled_tasks.lock out of version control** — the
   session-local scheduler lock file is now gitignored so it
-  cannot land alongside unrelated skill changes ([GH-955])
-
-[GH-882]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/882
-[GH-906]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/906
-[GH-908]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/908
-[GH-946]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/946
-[GH-947]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/947
-[GH-948]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/948
-[GH-949]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/949
-[GH-952]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/952
-[GH-953]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/953
-[GH-955]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/955
+  cannot land alongside unrelated skill changes ([GH-955](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/955))
 
 ## 0.63.0 — Solo Shipping & Playbook Resilience
 
@@ -389,14 +334,14 @@ Released 2026-04-15
 - **Enable auto-merge in solo-maintainer shipping pipeline** —
   solo maintainers no longer need to manually merge every PR;
   the shipping pipeline now includes a conditional merge step
-  ([GH-940])
+  ([GH-940](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/940))
 - **Enable playbook schema version tracking** — playbook files
   include a version field bumped automatically on release so
-  drift between skills and core plugin is detectable ([GH-910])
+  drift between skills and core plugin is detectable ([GH-910](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/910))
 - **Enable decision-aware session resume guidance** — resumed
   sessions surface pending decisions from task metadata and
   inject friction-level guidance so agents re-ask or
-  auto-advance correctly ([GH-934])
+  auto-advance correctly ([GH-934](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/934))
 
 ### Fixes
 
@@ -404,47 +349,35 @@ Released 2026-04-15
   permissions** — upgrade cleanup detects and removes top-level
   MCP wildcard patterns that Claude Code ignores at runtime,
   preventing false coverage from hiding missing tool entries
-  ([GH-943], [GH-942])
+  ([GH-943](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/943), [GH-942](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/942))
 - **Prevent fragment shadowing from dropping skills** — user
   playbook fragments that shadow defaults now inherit skills,
   agent, model, and modes fields instead of silently dropping
-  them ([GH-938])
+  them ([GH-938](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/938))
 - **Prevent ACC review-requested from failing solo mode** —
   review-requested checks are skipped in solo-maintainer mode
-  where no reviewers are ever assigned ([GH-939])
+  where no reviewers are ever assigned ([GH-939](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/939))
 - **Resolve upgrade-cleanup broken script flags** — MCP tool
   routes ensure-base, generalize, and ensure-scripts to Python
   functions directly instead of passing invalid CLI flags
-  ([GH-936])
+  ([GH-936](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/936))
 
 ### Refactors
 
 - **Simplify onboarding skill with reference redirect** —
   extracted tour content to a references file, reducing
-  SKILL.md from 202 to ~40 lines ([GH-897])
+  SKILL.md from 202 to ~40 lines ([GH-897](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/897))
 
 ### Docs
 
 - **Document CLI startup performance baseline** — baseline
   metrics and monitoring instructions for regression tracking
-  ([GH-907])
+  ([GH-907](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/907))
 - **Clarify tier 2 path after old projects/ removal** — config
   resolution docs updated to reflect the canonical
-  `~/.claude/memory/Dev10x/` path ([GH-941])
+  `~/.claude/memory/Dev10x/` path ([GH-941](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/941))
 - **Update gitignore for backup settings files** — settings
   backup files are now excluded from version control
-
-[GH-897]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/897
-[GH-907]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/907
-[GH-910]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/910
-[GH-934]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/934
-[GH-936]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/936
-[GH-938]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/938
-[GH-939]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/939
-[GH-940]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/940
-[GH-941]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/941
-[GH-942]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/942
-[GH-943]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/943
 
 ## 0.62.0 — Issue Milestones & Permission Safety
 
@@ -454,22 +387,22 @@ Released 2026-04-14
 
 - **Enable milestone assignment on issue creation** — ticket-create
   skill assigns milestones when specified, keeping project tracking
-  aligned from the start ([GH-926])
+  aligned from the start ([GH-926](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/926))
 - **Enable rollback for upgrade-cleanup bulk edits** — bulk settings
   modifications create timestamped backups so changes can be reverted
-  if something goes wrong ([GH-921])
+  if something goes wrong ([GH-921](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/921))
 - **Enable CLI access to permission scripts** — permission audit and
   cleanup scripts are accessible from the dev10x CLI entry point
-  ([GH-924])
+  ([GH-924](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/924))
 
 ### Fixes
 
 - **Prevent wildcard rules from stripping permissions** — upgrade
   cleanup no longer removes valid allow rules when wildcard patterns
-  overlap with specific entries ([GH-922])
+  overlap with specific entries ([GH-922](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/922))
 - **Strengthen recurring audit finding guards** — audit-report skill
   checks for duplicate findings before filing, preventing redundant
-  GitHub issues ([GH-928])
+  GitHub issues ([GH-928](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/928))
 
 ### Docs
 
@@ -485,52 +418,52 @@ Released 2026-04-14
 
 - **Surface permission-denied diagnostics** — hooks detect blocked
   tool calls and provide actionable guidance on missing allow rules
-  or hook configuration ([GH-918])
+  or hook configuration ([GH-918](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/918))
 - **Improve upgrade-cleanup audit reporting** — upgrade-cleanup
   produces structured, severity-categorized findings instead of
-  flat text output ([GH-914])
+  flat text output ([GH-914](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/914))
 - **Enable direct review thread resolution** — gh-pr-respond can
   resolve review threads directly after posting fixup commits,
-  reducing round-trips ([GH-902])
+  reducing round-trips ([GH-902](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/902))
 
 ### Fixes
 
 - **Stabilize uv dep resolution test assertion** — fix flaky test
-  that depended on exact pip resolver output ordering ([GH-913])
+  that depended on exact pip resolver output ordering ([GH-913](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/913))
 
 ### Tests
 
 - **Validate uv shebang script dependencies** — new test ensures
   all PEP 723 inline-metadata scripts declare valid, resolvable
-  dependencies ([GH-913])
+  dependencies ([GH-913](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/913))
 
 ### Docs & Skills
 
 - **Persist session state across context resets** — session-stop
   hook preserves branch, plan, and task state so resumed sessions
-  recover context automatically ([GH-917])
+  recover context automatically ([GH-917](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/917))
 - **Detect architecture violations in PR review** — review skill
-  checks for Clean Architecture boundary crossings ([GH-916])
+  checks for Clean Architecture boundary crossings ([GH-916](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/916))
 - **Ensure monitor fallback on permission failure** — PR monitor
   retries with reduced permissions instead of failing silently
-  ([GH-901])
+  ([GH-901](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/901))
 - **Support natural-language input in work-on** — work-on accepts
-  free-text task descriptions alongside ticket URLs ([GH-886])
+  free-text task descriptions alongside ticket URLs ([GH-886](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/886))
 - **Prefer vertical slice decomposition in scope** — scope skill
-  favors feature slices over horizontal layer splits ([GH-885])
+  favors feature slices over horizontal layer splits ([GH-885](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/885))
 - **Monitor context fill at phase boundaries** — work-on tracks
-  context window usage and warns before overflow ([GH-884])
+  context window usage and warns before overflow ([GH-884](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/884))
 - **Surface design analysis as a review gate** — scope skill
-  requires design review before implementation begins ([GH-883])
+  requires design review before implementation begins ([GH-883](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/883))
 - **Prevent confirmation bias with blind research** — brainstorming
-  skill gathers evidence before presenting options ([GH-881])
+  skill gathers evidence before presenting options ([GH-881](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/881))
 - **Enable skill instruction count tracking** — skill-index reports
-  instruction line counts for budget monitoring ([GH-877])
+  instruction line counts for budget monitoring ([GH-877](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/877))
 - **Resolve hook error handling standardization** — align hook exit
-  codes and error messages across Python and shell ([GH-826])
+  codes and error messages across Python and shell ([GH-826](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/826))
 - **Resolve milestone findings** — address M3–M6 architecture,
   pattern adoption, test coverage, and cross-cutting consistency
-  findings ([GH-811], [GH-812], [GH-813], [GH-814])
+  findings ([GH-811](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/811), [GH-812](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/812), [GH-813](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/813), [GH-814](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/814))
 
 ## 0.60.0 — Multi-Issue Bundling & Audit Clarity
 
@@ -540,31 +473,31 @@ Released 2026-04-13
 
 - **Bundle multiple issues in work-on** — work-on skill accepts
   multiple ticket URLs or IDs in a single invocation, gathering
-  context in parallel and building a unified task list ([GH-868])
+  context in parallel and building a unified task list ([GH-868](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/868))
 - **Separate audit detection from solution design** — permission
   auditor splits finding identification from fix proposals so
-  users review problems before seeing solutions ([GH-904])
+  users review problems before seeing solutions ([GH-904](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/904))
 
 ### Fixes
 
 - **Restore MCP server dependencies** — re-add yaml and msgpack
   dependencies removed during consolidation so MCP servers start
-  without import errors ([GH-911])
+  without import errors ([GH-911](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/911))
 - **Enforce PR reference update after groom force-push** — groom
   skill now updates the PR head ref after force-pushing rebased
-  commits, preventing stale SHA references ([GH-900])
+  commits, preventing stale SHA references ([GH-900](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/900))
 - **Prevent misleading completion messages in fixup** — fixup
   skill no longer reports success when the underlying commit
-  was not created ([GH-899])
+  was not created ([GH-899](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/899))
 - **Prevent wildcard allow-rule proposals in audit** — permission
   auditor blocks overly broad glob patterns that would bypass
-  security boundaries ([GH-903])
+  security boundaries ([GH-903](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/903))
 
 ### Docs
 
 - **Clarify gh-pr-respond as PR comment entry point** — update
   skill description to direct users to gh-pr-respond instead
-  of gh-pr-fixup for handling review comments ([GH-898])
+  of gh-pr-fixup for handling review comments ([GH-898](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/898))
 
 ## 0.59.0 — Permission Automation & Review Intelligence
 
@@ -574,73 +507,73 @@ Released 2026-04-13
 
 - **Auto-detect semantic-release config** — release-notes skill
   now discovers project-specific ticket patterns and output
-  targets without manual configuration ([GH-585])
+  targets without manual configuration ([GH-585](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/585))
 - **Auto-groom fixup commits in CI** — PR monitor detects
   fixup! commits and triggers automatic interactive rebase
-  before merge readiness ([GH-869])
+  before merge readiness ([GH-869](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/869))
 - **Pre-approve temp file and MCP permissions** — new permission
   namespaces eliminate approval prompts for temp files, plugin
-  scripts, MCP tools, and git aliases ([GH-878])
+  scripts, MCP tools, and git aliases ([GH-878](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/878))
 - **Simplify code after review** — post-review pipeline step
   scans changed files for reuse and quality improvements
-  ([GH-874])
+  ([GH-874](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/874))
 - **Filter review findings by confidence** — review skill drops
   low-confidence findings to reduce noise in PR comments
-  ([GH-872])
+  ([GH-872](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/872))
 - **Detect silent failures in reviews** — new reviewer agent
   catches swallowed exceptions and missing error logging
-  ([GH-873])
+  ([GH-873](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/873))
 - **Verify plugin script coverage** — pre-PR check ensures all
   plugin scripts referenced in skills have test coverage
-  ([GH-876])
+  ([GH-876](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/876))
 - **Invoke scripts via MCP instead of paths** — MCP server
   wraps plugin scripts so skills avoid path-dependent Bash
-  allow rules ([GH-807])
+  allow rules ([GH-807](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/807))
 - **Persist upgrade-cleanup config** — cleanup preferences
-  survive across sessions via YAML settings file ([GH-862])
+  survive across sessions via YAML settings file ([GH-862](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/862))
 
 ### Improvements
 
 - **Extensible PR comment action dispatch** — comment handler
-  uses registry pattern for adding new reply actions ([GH-827])
+  uses registry pattern for adding new reply actions ([GH-827](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/827))
 - **Self-formatting session state objects** — state dataclasses
   render their own display strings, removing format duplication
-  ([GH-820], [GH-823])
+  ([GH-820](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/820), [GH-823](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/823))
 - **Canonical rule evaluation via RuleEngine** — single
   evaluation path replaces scattered rule-checking code
-  ([GH-818])
+  ([GH-818](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/818))
 - **Single-source YAML rule parsing** — rule definitions load
-  from YAML instead of duplicated Python dicts ([GH-822])
+  from YAML instead of duplicated Python dicts ([GH-822](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/822))
 - **Path-independent plan context updates** — plan sync works
-  from any working directory without hardcoded paths ([GH-802])
+  from any working directory without hardcoded paths ([GH-802](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/802))
 - **Type-safe MCP tool returns** — MCP tools return typed dicts
   instead of raw strings, catching schema mismatches early
-  ([GH-819])
+  ([GH-819](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/819))
 - **Validated repository references** — repo URL construction
   uses validated objects instead of string concatenation
-  ([GH-821])
+  ([GH-821](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/821))
 
 ### Fixes
 
 - **Prevent shipping pipeline skill regressions** — pin
   eval assertions that caught behavioral drift in PR create,
-  groom, and merge skills ([GH-851])
+  groom, and merge skills ([GH-851](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/851))
 - **Block fanout completion before monitors finish** — gate
   now waits for all background PR monitors before advancing
-  ([GH-859])
+  ([GH-859](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/859))
 - **Fix plugin cache lookup after repo rename** — cache key
   derivation uses canonical repo name, not stale path
-  ([GH-861])
+  ([GH-861](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/861))
 - **Detect stale plugin paths with different casing** — path
   comparison is now case-insensitive on case-folding
-  filesystems ([GH-864])
+  filesystems ([GH-864](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/864))
 
 ### Tests
 
 - **MCP GitHub tool coverage** — add unit tests for PR detect,
-  issue get, and comment reply MCP tools ([GH-825])
+  issue get, and comment reply MCP tools ([GH-825](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/825))
 - **Domain module regression safety** — add integration tests
-  for core domain module imports and wiring ([GH-824])
+  for core domain module imports and wiring ([GH-824](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/824))
 
 ## 0.58.0 — Session Safety & Config Hygiene
 
@@ -651,28 +584,28 @@ Released 2026-04-09
 - **Surface background agent progress in caller** — add
   caller-side task tracking for background monitor agents so
   supervisors see in-progress work instead of an idle session
-  ([GH-854])
+  ([GH-854](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/854))
 - **Prevent auditing wrong session via gate** — skill-audit
   now confirms resolved session identity before proceeding,
   blocking silent fallback to alternate path encodings
-  ([GH-805])
+  ([GH-805](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/805))
 
 ### Improvements
 
 - **Normalize config paths to canonical locations** — remove
   deprecated Tier 3 path references from 16 skills, consolidate
   bare memory configs under Dev10x/ subdirectory, and align
-  config-resolution docs with actual resolution order ([GH-849])
+  config-resolution docs with actual resolution order ([GH-849](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/849))
 
 ### Fixes
 
 - **Preserve git alias rules from cleanup** — permission
   maintenance no longer removes git alias allow rules that
   worktree sessions depend on for branch-switching and commit
-  grooming ([GH-852], [GH-853])
+  grooming ([GH-852](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/852), [GH-853](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/853))
 - **Prevent session.yaml overwrite of active modes** — Phase 0
   now reads before writing, preserving existing active_modes
-  instead of overwriting with empty defaults ([GH-846])
+  instead of overwriting with empty defaults ([GH-846](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/846))
 
 ## 0.57.0 — Plugin Naming Consistency
 
@@ -691,23 +624,23 @@ Released 2026-04-09
 
 - **Enable parallel fanout experimentation** — dispatch
   worktree-isolated agents in parallel to validate newer
-  Claude Code capability assumptions ([GH-781])
+  Claude Code capability assumptions ([GH-781](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/781))
 - **Allow maintenance commits to bypass JTBD** — configurable
   bypass gitmoji set lets changelog/version-bump commits skip
-  outcome-focused title enforcement ([GH-797])
+  outcome-focused title enforcement ([GH-797](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/797))
 
 ### Improvements
 
 - **Delegate tracker CRUD to background agents** — project-scope
   and ticket-create offload Linear/GitHub API calls to a haiku
   agent, returning compact summaries instead of dumping 26k token
-  API responses into context ([GH-842])
+  API responses into context ([GH-842](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/842))
 - **Unblock MCP event loop from subprocess calls** — convert all
   MCP tool handlers to async using asyncio subprocess, eliminating
-  up to 60s blocking during shell execution ([GH-815])
+  up to 60s blocking during shell execution ([GH-815](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/815))
 - **Enable batch thread resolution in PR comments** — resolve
   all review threads in two GraphQL calls instead of O(2N)
-  sequential calls, avoiding rate limits in large PRs ([GH-828])
+  sequential calls, avoiding rate limits in large PRs ([GH-828](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/828))
 - **Surface lesson-learned guidance from stale PRs** — extract
   orchestration anti-patterns, test-pattern checks, and hook
   state documentation from 5 stale draft PRs into rules
@@ -716,35 +649,35 @@ Released 2026-04-09
 
 - **Enforce named parameter Skill() syntax** — fix positional
   Skill() calls in ticket-create and ticket-jtbd that caused
-  agent misrouting ([GH-804])
+  agent misrouting ([GH-804](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/804))
 - **Enforce PR comment resolution in fanout** — Phase 5 now
   blocks completion until all PR review comments are resolved;
-  per-item check added in Phase 3 ([GH-829])
+  per-item check added in Phase 3 ([GH-829](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/829))
 - **Prevent plan gate skip at adaptive friction** — clarify
   that auto-select means execute the recommended option, not
-  skip the approval gate entirely ([GH-808])
+  skip the approval gate entirely ([GH-808](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/808))
 - **Enable portable plugin path in pr-monitor** — replace
   hardcoded versioned path with ${CLAUDE_PLUGIN_ROOT} variable
-  ([GH-806])
+  ([GH-806](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/806))
 - **Prevent session state race between sessions** — atomic
   os.rename() claim prevents two concurrent sessions from
-  reading and deleting the same state file ([GH-816])
+  reading and deleting the same state file ([GH-816](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/816))
 
 ### Security
 
 - **Protect settings.json from concurrent writes** — introduce
   fcntl advisory locking with atomic write-then-rename so
   concurrent sessions cannot overwrite each other's changes
-  ([GH-817])
+  ([GH-817](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/817))
 
 ### Breaking Changes
 
 - **Isolate codex port to separate repo** — remove codex-skills/
   directory (45 skill ports), codex install/validate scripts,
-  and docs/codex.md ([GH-678])
+  and docs/codex.md ([GH-678](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/678))
 - **Unify documentation under docs/ directory** — ADRs moved
   from doc/adr/ to docs/adr/; update any external links or
-  scripts referencing the old path ([GH-838])
+  scripts referencing the old path ([GH-838](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/838))
 
 ## 0.55.0 — Merge Safety & Skill Guardrails
 
@@ -753,35 +686,35 @@ Released 2026-04-08
 ### Features
 
 - **Resolve skill-audit findings across 5 skills** — address
-  accumulated audit findings for improved compliance ([GH-760])
+  accumulated audit findings for improved compliance ([GH-760](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/760))
 - **Preserve fixup commit links after grooming** — groom no
-  longer drops fixup commit references from PR threads ([GH-777])
+  longer drops fixup commit references from PR threads ([GH-777](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/777))
 - **Strengthen skill delegation guardrails** — prevent agents
-  from bypassing skill orchestration contracts ([GH-759])
+  from bypassing skill orchestration contracts ([GH-759](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/759))
 - **Prevent undetected cd+git chaining** — hook now catches
-  cd-then-git patterns that break allow rules ([GH-763])
+  cd-then-git patterns that break allow rules ([GH-763](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/763))
 - **Prevent false positives on skill-required rules** — permission
-  auditor no longer flags rules that skills actively need ([GH-790])
+  auditor no longer flags rules that skills actively need ([GH-790](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/790))
 - **Enable publisher rename in permission paths** — update-paths
-  handles publisher directory renames correctly ([GH-791])
+  handles publisher directory renames correctly ([GH-791](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/791))
 
 ### Refactoring
 
 - **Enable single-source hook implementations** — consolidate
-  12 standalone hook scripts into dev10x CLI subcommands ([GH-748])
+  12 standalone hook scripts into dev10x CLI subcommands ([GH-748](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/748))
 
 ### Fixes
 
 - **Prevent false green on draft-to-ready** — CI monitor now
-  re-checks status after PR transitions from draft ([GH-774])
+  re-checks status after PR transitions from draft ([GH-774](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/774))
 - **Prevent orchestrator from pre-empting groom** — merge skill
-  waits for groom completion before proceeding ([GH-776])
+  waits for groom completion before proceeding ([GH-776](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/776))
 - **Prevent inline CI polling in merge skill** — delegates
-  polling to monitor agent instead of inline loops ([GH-775])
+  polling to monitor agent instead of inline loops ([GH-775](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/775))
 - **Prevent merge failure in worktree setups** — gh pr merge
-  now uses --repo flag in worktree contexts ([GH-773])
+  now uses --repo flag in worktree contexts ([GH-773](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/773))
 - **Prevent CI check cascade failure** — handle partial check
-  results without aborting the entire merge flow ([GH-772])
+  results without aborting the entire merge flow ([GH-772](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/772))
 
 ## 0.54.0 — Hook Consolidation & Lazy Imports
 
@@ -790,44 +723,44 @@ Released 2026-04-08
 ### Features
 
 - **Enable SessionStart hooks via dev10x hook session** — unified
-  hook entry point for session startup ([GH-741])
+  hook entry point for session startup ([GH-741](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/741))
 - **Enable SessionStop hooks via dev10x hook session** — unified
-  hook entry point for session teardown ([GH-742])
+  hook entry point for session teardown ([GH-742](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/742))
 - **Enable Skill and PostToolUse hooks via dev10x hook** — unified
-  hook entry point for tool-use lifecycle ([GH-743])
+  hook entry point for tool-use lifecycle ([GH-743](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/743))
 - **Centralize config into ~/.claude/memory/Dev10x** — single
-  location for all plugin configuration ([GH-726])
+  location for all plugin configuration ([GH-726](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/726))
 
 ### Performance
 
 - **Defer heavy imports to command invocation** — lazy-load
-  expensive modules to reduce CLI startup time ([GH-746])
+  expensive modules to reduce CLI startup time ([GH-746](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/746))
 
 ### Refactoring
 
 - **Enable cli_server as thin uv shim** — reduce server startup
-  overhead with lightweight wrapper ([GH-744])
+  overhead with lightweight wrapper ([GH-744](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/744))
 - **Enable db_server as thin uv shim** — reduce server startup
-  overhead with lightweight wrapper ([GH-745])
+  overhead with lightweight wrapper ([GH-745](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/745))
 
 ### Fixes
 
 - **Resolve hook failures on systems without PyYAML** — graceful
-  fallback when optional dependency is missing ([GH-766])
+  fallback when optional dependency is missing ([GH-766](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/766))
 - **Prevent false positive on explicit JSONL path** — path
-  validation no longer flags valid JSONL files ([GH-762])
+  validation no longer flags valid JSONL files ([GH-762](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/762))
 
 ### Documentation
 
 - **Clarify glob pattern syntax in config-resolution** — improve
-  examples for file matching patterns ([GH-757])
+  examples for file matching patterns ([GH-757](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/757))
 
 ### Tests
 
 - **Enable CLI startup time benchmarking** — measure and track
-  startup performance regressions ([GH-749])
+  startup performance regressions ([GH-749](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/749))
 - **Enable server tests to measure mcp package coverage** —
-  expanded test coverage for MCP servers ([GH-745])
+  expanded test coverage for MCP servers ([GH-745](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/745))
 
 ## 0.52.0 — Marketplace & Repo Migration
 
@@ -858,31 +791,31 @@ Released 2026-04-07
 
 - **Allow user override for infrastructure CI failures** — users
   can bypass infrastructure-only CI failures when appropriate
-  ([GH-730])
+  ([GH-730](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/730))
 
 ### Fixes
 
 - **Enforce fanout audit, monitor, and fixup safety** — fanout
   skill validates audit completion, monitors, and fixup commits
-  before proceeding ([GH-724])
+  before proceeding ([GH-724](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/724))
 - **Enforce Check 1b in gh-pr-merge** — merge gate validates
-  all required checks before allowing merge ([GH-728])
+  all required checks before allowing merge ([GH-728](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/728))
 - **Prevent play step collapsing in work-on** — work-on skill
-  preserves individual play steps during execution ([GH-729])
+  preserves individual play steps during execution ([GH-729](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/729))
 - **Prevent CI actions from running on merged PRs** — CI
-  workflows skip already-merged pull requests ([GH-721])
+  workflows skip already-merged pull requests ([GH-721](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/721))
 
 ### Tooling
 
 - **Enable direct invocation of entry-point scripts** — scripts
-  can be called directly without wrapper commands ([GH-732])
+  can be called directly without wrapper commands ([GH-732](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/732))
 - **Update partner name in marketplace configuration** — align
   marketplace metadata with current branding
 
 ### Tests
 
 - **Prevent script permission regressions** — test coverage for
-  script file permissions ([GH-731])
+  script file permissions ([GH-731](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/731))
 
 ## 0.49.0 — Cross-Context Auditing & Review Coverage
 
@@ -891,24 +824,24 @@ Released 2026-04-06
 ### Features
 
 - **Ensure reviewers flag new classes without tests** — code
-  review agents detect untested new classes ([GH-704])
+  review agents detect untested new classes ([GH-704](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/704))
 - **Enable cross-context query detection in audits** — skill
-  audit detects queries spanning multiple contexts ([GH-713])
+  audit detects queries spanning multiple contexts ([GH-713](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/713))
 
 ### Fixes
 
 - **Resolve plugin install failure from invalid key** — fix
   invalid configuration key blocking plugin installation
-  ([GH-723])
+  ([GH-723](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/723))
 - **Align phase selection spec with Phase I addition** — phase
-  selection matches updated phase definitions ([GH-713])
+  selection matches updated phase definitions ([GH-713](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/713))
 - **Resolve batch review findings from 6 PRs** — address
-  accumulated review findings across multiple PRs ([GH-709])
+  accumulated review findings across multiple PRs ([GH-709](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/709))
 
 ### Documentation
 
 - **Document merge_mode and merge_strategy config** — add
-  configuration reference for merge behavior options ([GH-707])
+  configuration reference for merge behavior options ([GH-707](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/707))
 - **Clarify reference file discoverability and template
   guidance** — improve documentation for reference files
 
@@ -920,12 +853,12 @@ Released 2026-04-05
 
 - **Per-step modes and friction in playbooks** — playbook steps
   can declare execution modes and friction levels independently
-  ([GH-712])
+  ([GH-712](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/712))
 
 ### Fixes
 
 - **Ensure acceptance criteria run before merge** — acceptance
-  criteria checks execute before merge gate proceeds ([GH-711])
+  criteria checks execute before merge gate proceeds ([GH-711](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/711))
 
 ## 0.47.0 — Skill Reinforcement & Merge Safety
 
@@ -935,47 +868,47 @@ Released 2026-04-05
 
 - **PermissionDenied hook corrections** — hooks detect and
   correct permission-denied errors with targeted guidance
-  ([GH-705])
+  ([GH-705](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/705))
 - **Merged PR audit for unaddressed findings** — surface
-  unresolved review threads after merge ([GH-699])
+  unresolved review threads after merge ([GH-699](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/699))
 - **Autonomous merge cascade in AFK mode** — unattended
   merge pipelines complete without manual intervention
-  ([GH-688])
+  ([GH-688](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/688))
 - **Session friction level prompt** — prompt users to select
-  friction level at session start ([GH-689])
+  friction level at session start ([GH-689](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/689))
 - **Comprehensive architecture auditing** — architecture
-  advisor covers broader design evaluation ([GH-687])
+  advisor covers broader design evaluation ([GH-687](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/687))
 
 ### Fixes
 
 - **Prevent merging with unaddressed review comments** —
   merge gate blocks when review threads remain open
-  ([GH-698])
+  ([GH-698](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/698))
 - **Prevent false positive on uv shebang hooks** — rule
   engine skips uv shebang lines in script validation
-  ([GH-705])
+  ([GH-705](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/705))
 - **Enable background CI monitor to poll autonomously** —
-  CI monitor runs without blocking the session ([GH-695])
+  CI monitor runs without blocking the session ([GH-695](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/695))
 - **Resolve unaddressed PR #691 review findings** — fix
-  outstanding review comments from prior PR ([GH-697])
+  outstanding review comments from prior PR ([GH-697](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/697))
 - **Resolve circular import in rule_engine** — break import
-  cycle in Python package structure ([GH-681])
+  cycle in Python package structure ([GH-681](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/681))
 - **Resolve fanout audit findings** — address audit issues
-  in parallel work stream orchestrator ([GH-693])
+  in parallel work stream orchestrator ([GH-693](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/693))
 
 ### Refactoring
 
 - **Rule-engine commit allowlist** — allowlist-based commit
-  validation replaces ad-hoc checks ([GH-705])
+  validation replaces ad-hoc checks ([GH-705](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/705))
 - **Global skill-reinforcement overrides** — skill redirect
-  rules configurable at global scope ([GH-705])
+  rules configurable at global scope ([GH-705](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/705))
 
 ### Tests
 
 - **Ensure Python entry point loadability** — verify all
-  CLI entry points import without error ([GH-681])
+  CLI entry points import without error ([GH-681](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/681))
 - **Ensure Python script entry point loadability** — extend
-  entry point tests to skill scripts ([GH-681])
+  entry point tests to skill scripts ([GH-681](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/681))
 
 ## 0.46.0 — Architecture Consolidation & Performance
 
@@ -985,93 +918,93 @@ Released 2026-04-04
 
 - **Unified Python package structure** — all validators, hooks,
   and CLI tools consolidated into `src/dev10x/` package with
-  lazy-loading entry point ([GH-588], [GH-589])
+  lazy-loading entry point ([GH-588](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/588), [GH-589](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/589))
 - **RuleEngine for unified rule evaluation** — single engine
-  replaces per-validator rule dispatch ([GH-644])
+  replaces per-validator rule dispatch ([GH-644](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/644))
 - **Typed config loading via Protocol** — config system uses
-  Protocol-based contracts for type safety ([GH-650])
+  Protocol-based contracts for type safety ([GH-650](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/650))
 - **Friction-level tiered enforcement** — skill redirect hooks
-  support configurable friction levels per command ([GH-530])
+  support configurable friction levels per command ([GH-530](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/530))
 - **Executable acceptance criteria checks** — verify
-  definition-of-done criteria programmatically ([GH-640])
+  definition-of-done criteria programmatically ([GH-640](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/640))
 - **Structured decision widgets** — AskUserQuestion gates use
-  rich option widgets instead of plain text ([GH-636])
+  rich option widgets instead of plain text ([GH-636](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/636))
 - **Pre-merge validation gate** — blocking check before merge
-  ensures CI and review requirements are met ([GH-635])
+  ensures CI and review requirements are met ([GH-635](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/635))
 - **On-demand PR review audits** — trigger review audits
-  outside the normal PR lifecycle ([GH-551])
+  outside the normal PR lifecycle ([GH-551](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/551))
 - **Configurable protected branch lists** — per-project
-  protected branches without hardcoding ([GH-578])
+  protected branches without hardcoding ([GH-578](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/578))
 - **Permission-aware dispatch in fanout** — parallel work
-  streams respect permission boundaries ([GH-562])
+  streams respect permission boundaries ([GH-562](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/562))
 - **Project-level commit gitmoji mapping** — projects can
-  override default gitmoji conventions ([GH-585])
+  override default gitmoji conventions ([GH-585](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/585))
 - **Groom skill conflict resolution** — interactive rebase
-  handles merge conflicts gracefully ([GH-625])
+  handles merge conflicts gracefully ([GH-625](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/625))
 
 ### Performance
 
 - **msgpack-cached config loading** — config reads use msgpack
-  cache, reducing hook latency ([GH-591], [GH-652], [GH-653])
+  cache, reducing hook latency ([GH-591](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/591), [GH-652](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/652), [GH-653](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/653))
 - **Lazy validator imports** — validators load only when
-  needed, cutting startup time ([GH-654])
+  needed, cutting startup time ([GH-654](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/654))
 - **Startup time regression tests** — benchmark suite prevents
-  hook performance regressions ([GH-656], [GH-657], [GH-658])
+  hook performance regressions ([GH-656](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/656), [GH-657](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/657), [GH-658](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/658))
 
 ### Refactoring
 
 - **Domain-driven validator architecture** — validators use
   Protocol conformance, shared GitContext, and reusable domain
-  value objects ([GH-648], [GH-649], [GH-651])
+  value objects ([GH-648](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/648), [GH-649](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/649), [GH-651](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/651))
 - **Unified Rule/Config across all validators** — single Rule
-  and Config types replace per-validator duplicates ([GH-645])
+  and Config types replace per-validator duplicates ([GH-645](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/645))
 - **Single SQL validation source** — SQL checks consolidated
-  into one module ([GH-647])
+  into one module ([GH-647](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/647))
 - **Domain-driven plan persistence** — plan storage uses
-  domain models instead of raw file I/O ([GH-646])
+  domain models instead of raw file I/O ([GH-646](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/646))
 - **Tell Don't Ask on EditRule** — EditRule encapsulates its
-  own decision logic ([GH-643])
+  own decision logic ([GH-643](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/643))
 - **First-class skill script packages** — skill scripts are
-  proper Python packages with imports ([GH-604])
+  proper Python packages with imports ([GH-604](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/604))
 - **Isolated tool modules** — Git, GitHub, and utility tools
-  split into focused modules ([GH-600], [GH-601])
+  split into focused modules ([GH-600](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/600), [GH-601](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/601))
 - **Python-based session hook dispatch** — session hooks
-  migrate from shell to Python ([GH-598])
+  migrate from shell to Python ([GH-598](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/598))
 - **CLI-based validators** — Edit/Write and Bash validation
-  use Click CLI commands ([GH-594], [GH-596], [GH-597])
+  use Click CLI commands ([GH-594](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/594), [GH-596](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/596), [GH-597](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/597))
 - **Unified test directory** — all tests under `tests/`
-  mirroring `src/` structure ([GH-595], [GH-607])
+  mirroring `src/` structure ([GH-595](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/595), [GH-607](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/607))
 - **Deterministic test data via fakers** — factory-based
-  test data generation ([GH-592])
+  test data generation ([GH-592](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/592))
 - **Deprecated hook scripts removed** — old shell shims
-  cleaned up ([GH-610])
+  cleaned up ([GH-610](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/610))
 
 ### Fixes
 
 - **Resolve macOS bash 3.2 hook errors** — hooks now work
-  on macOS default bash ([GH-661])
+  on macOS default bash ([GH-661](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/661))
 - **Resolve permission-maintenance noise filter gaps** —
-  false positive noise in permission audits ([GH-579])
+  false positive noise in permission audits ([GH-579](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/579))
 
 ### Docs
 
 - **Reflect new src/ and tests/ layout** — documentation
-  updated to match consolidated structure ([GH-611])
+  updated to match consolidated structure ([GH-611](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/611))
 - **Document TOML vs YAML benchmark decision** — ADR for
-  config format choice ([GH-655])
+  config format choice ([GH-655](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/655))
 - **Showcase orchestration and planning in README** —
   feature highlights for new users
 - **Coverage reporting in pytest runs** — test output
-  includes coverage data ([GH-608])
+  includes coverage data ([GH-608](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/608))
 
 ### Tests
 
 - **End-to-end validation of refactored plugin** — full
-  plugin integration test suite ([GH-612])
+  plugin integration test suite ([GH-612](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/612))
 - **Regex compilation benchmarking** — benchmark suite for
-  compiled regex patterns ([GH-657])
+  compiled regex patterns ([GH-657](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/657))
 - **Hook performance benchmarking** — pytest-benchmark
-  integration for hook validators ([GH-656])
+  integration for hook validators ([GH-656](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/656))
 
 ## 0.45.0 — CI Safety & Hook Config
 
@@ -1080,29 +1013,29 @@ Released 2026-04-01
 ### Features
 
 - **CI merge-conflict detection** — CI pipeline now detects
-  merge conflicts before allowing PR progression ([GH-563])
+  merge conflicts before allowing PR progression ([GH-563](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/563))
 - **Safe deterministic transcript analysis** — enable
-  transcript analysis with reproducible, safe parsing ([GH-565])
+  transcript analysis with reproducible, safe parsing ([GH-565](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/565))
 
 ### Improvements
 
 - **Config-driven hook validation** — all hooks use YAML-driven
-  validation instead of hardcoded patterns ([GH-572])
+  validation instead of hardcoded patterns ([GH-572](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/572))
 - **Clarify memory path conventions** — db skill documents
-  correct memory file path patterns ([GH-567])
+  correct memory file path patterns ([GH-567](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/567))
 
 ### Fixes
 
 - **Prevent PR ready with unaddressed findings** — PR cannot
-  be marked ready when body-level findings remain ([GH-564])
+  be marked ready when body-level findings remain ([GH-564](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/564))
 - **Detect quoted paths in cd/git-C checks** — noop detection
-  handles quoted directory paths correctly ([GH-568])
+  handles quoted directory paths correctly ([GH-568](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/568))
 - **Remove unused CD_PREFIX_RE pattern** — dead regex cleanup
 
 ### Tests
 
 - **Hook rule validation coverage** — ensure allow rules
-  permit legitimate skill command invocations ([GH-572])
+  permit legitimate skill command invocations ([GH-572](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/572))
 
 ## 0.44.0 — MCP Expansion & Hook Hardening
 
@@ -1111,20 +1044,20 @@ Released 2026-03-31
 ### Features
 
 - **MCP redirect for gh issue create** — issue creation routes
-  through MCP tool instead of raw CLI ([GH-552])
+  through MCP tool instead of raw CLI ([GH-552](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/552))
 
 ### Improvements
 
 - **Block direct git-push-safe invocation** — prevent users from
   calling push-safe directly via CLI, redirect to skill wrapper
-  with safety guards ([GH-560])
+  with safety guards ([GH-560](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/560))
 
 ### Fixes
 
 - **Prevent monitor green during CI run** — monitor no longer
-  reports premature success before CI completion ([GH-553])
+  reports premature success before CI completion ([GH-553](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/553))
 - **Unblock commit from non-mktmp temp files** — allow commits
-  from temporary files created outside mktmp system ([GH-554])
+  from temporary files created outside mktmp system ([GH-554](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/554))
 
 ## 0.43.0 — Skill Ecosystem & Compliance Hardening
 
@@ -1134,49 +1067,49 @@ Released 2026-03-30
 
 - **Competitive multi-agent design exploration** — ADR evaluation
   dispatches domain-specific architect agents in parallel for
-  adversarial trade-off analysis ([GH-483])
+  adversarial trade-off analysis ([GH-483](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/483))
 - **YAML-driven skill redirect with friction levels** — PreToolUse
   hooks intercept raw CLI commands and redirect to skill wrappers
-  with configurable friction ([GH-418])
+  with configurable friction ([GH-418](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/418))
 - **Automated security review of changes** — reviewer-security
   agent scans diffs for OWASP vulnerabilities and hardcoded
-  secrets ([GH-490])
+  secrets ([GH-490](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/490))
 - **CI-enforced test coverage for servers** — MCP server Python
-  code now requires pytest coverage in CI ([GH-493])
+  code now requires pytest coverage in CI ([GH-493](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/493))
 - **Guided discovery for new users** — onboarding skill index
-  and MOTD help new users find relevant skills ([GH-488])
+  and MOTD help new users find relevant skills ([GH-488](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/488))
 - **Context window optimization** — systematic compaction
-  patterns reduce token usage in long sessions ([GH-489])
+  patterns reduce token usage in long sessions ([GH-489](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/489))
 - **Per-project model selection for dispatch** — playbook steps
-  can override agent model tier per project ([GH-491])
+  can override agent model tier per project ([GH-491](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/491))
 - **Skill reinforcement for missing commands** — agent detects
-  raw CLI usage and redirects to proper skills ([GH-506])
+  raw CLI usage and redirects to proper skills ([GH-506](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/506))
 - **Proactive skill-audit triggers** — audit phase fires
-  automatically when session processes 3+ items ([GH-537])
+  automatically when session processes 3+ items ([GH-537](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/537))
 - **MCP redirect for gh issue view** — issue fetching routes
-  through MCP tool instead of raw CLI ([GH-539])
+  through MCP tool instead of raw CLI ([GH-539](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/539))
 - **Harden gh-pr-create skill compliance** — PR creation
-  enforces all delegation and formatting rules ([GH-533])
+  enforces all delegation and formatting rules ([GH-533](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/533))
 
 ### Improvements
 
 - **Standardize tracker detection via MCP tool** — all skills
-  use `detect_tracker` MCP call instead of script ([GH-507])
+  use `detect_tracker` MCP call instead of script ([GH-507](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/507))
 - **Reduce scoping wall-clock time** — background exploration
-  agents parallelize codebase analysis ([GH-485])
+  agents parallelize codebase analysis ([GH-485](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/485))
 - **Standardize skill trigger suffixes** — consistent TRIGGER/
-  DO NOT TRIGGER patterns across all skills ([GH-484])
+  DO NOT TRIGGER patterns across all skills ([GH-484](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/484))
 - **Enable standalone invocation of pipeline steps** — skills
-  in pipelines can run independently ([GH-487])
+  in pipelines can run independently ([GH-487](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/487))
 - **Prefer MCP tool for PR context detection** — gh-context
-  routes through MCP by default ([GH-534])
+  routes through MCP by default ([GH-534](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/534))
 - **Allow inline synthesis when context suffices** — JTBD
   drafting skips full skill when session has rich context
-  ([GH-536])
+  ([GH-536](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/536))
 - **Establish canonical eval schema** — standardized JSON
-  format for skill evaluation assertions ([GH-515])
+  format for skill evaluation assertions ([GH-515](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/515))
 - **Clarify decision gate assertion naming** — eval patterns
-  use consistent signal names ([GH-488])
+  use consistent signal names ([GH-488](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/488))
 - **Prevent uv.lock drift after version bumps** — lock file
   stays in sync with pyproject.toml ([9630a11])
 
@@ -1184,75 +1117,47 @@ Released 2026-03-30
 
 - **Harden fanout and git skill guardrails** — Phase 5 checks
   PR comments, issues use sequential Skill(), MCP push_safe
-  promoted, bypassPermissions documented ([GH-549])
+  promoted, bypassPermissions documented ([GH-549](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/549))
 - **Enforce test skill delegation in routing** — test step
-  routes through skill wrapper, not raw pytest ([GH-504])
+  routes through skill wrapper, not raw pytest ([GH-504](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/504))
 - **Enforce skill-create delegation in routing** — skill
-  creation uses proper skill, not inline logic ([GH-503])
+  creation uses proper skill, not inline logic ([GH-503](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/503))
 - **Prevent skill-audit from targeting current session** —
-  audit dispatches to separate session context ([GH-508])
+  audit dispatches to separate session context ([GH-508](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/508))
 - **Resolve 3 complex skill-audit findings** — mixed
   compliance gaps in multiple skills ([d88ef81])
 - **Self-healing for wrong mktmp namespace** — mktmp
   auto-corrects misrouted temp files ([d0acaf4])
 - **Block cd+rev-parse chaining in hooks** — PreToolUse
-  hook catches compound commands ([GH-528])
+  hook catches compound commands ([GH-528](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/528))
 - **Prevent inline audit summary deviation** — audit
-  results use structured output, not free text ([GH-531])
+  results use structured output, not free text ([GH-531](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/531))
 - **Mandate mktmp for commit message temp files** — commit
-  skill always uses mktmp for collision-free paths ([GH-532])
+  skill always uses mktmp for collision-free paths ([GH-532](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/532))
 - **Harden scope skill review compliance** — scope skill
-  follows all review checklist items ([GH-485])
+  follows all review checklist items ([GH-485](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/485))
 - **Resolve checklist numbering conflict** — PR body
-  checklist renders correctly ([GH-486])
+  checklist renders correctly ([GH-486](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/486))
 
 ### Security
 
 - **Enforce SKILL.md size discipline in reviewer** — reviewer
-  flags skills exceeding line budgets ([GH-486])
+  flags skills exceeding line budgets ([GH-486](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/486))
 
 ### Documentation
 
 - **Surface skill-pipelines in rule index** — pipeline
-  composition patterns documented in INDEX.md ([GH-487])
+  composition patterns documented in INDEX.md ([GH-487](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/487))
 - **Prevent MCP tool names used as CLI commands** — docs
-  clarify MCP names are tool-call primitives only ([GH-535])
+  clarify MCP names are tool-call primitives only ([GH-535](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/535))
 - **Enable prospective users to evaluate Dev10x** — public
-  evaluation guide for potential adopters ([GH-492])
+  evaluation guide for potential adopters ([GH-492](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/492))
 
 ### CI
 
 - **Tighten git commit -F allow pattern** — CI allow rules
-  match the mktmp-based commit flow ([GH-418])
+  match the mktmp-based commit flow ([GH-418](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/418))
 
-[GH-418]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/418
-[GH-483]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/483
-[GH-484]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/484
-[GH-485]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/485
-[GH-486]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/486
-[GH-487]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/487
-[GH-488]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/488
-[GH-489]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/489
-[GH-490]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/490
-[GH-491]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/491
-[GH-492]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/492
-[GH-493]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/493
-[GH-503]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/503
-[GH-504]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/504
-[GH-506]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/506
-[GH-507]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/507
-[GH-508]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/508
-[GH-515]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/515
-[GH-528]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/528
-[GH-531]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/531
-[GH-532]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/532
-[GH-533]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/533
-[GH-534]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/534
-[GH-535]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/535
-[GH-536]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/536
-[GH-537]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/537
-[GH-539]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/539
-[GH-549]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/549
 [9630a11]: https://github.com/Dev10x-Guru/dev10x-claude/commit/9630a11
 [d88ef81]: https://github.com/Dev10x-Guru/dev10x-claude/commit/d88ef81
 [d0acaf4]: https://github.com/Dev10x-Guru/dev10x-claude/commit/d0acaf4
@@ -1265,30 +1170,22 @@ Released 2026-03-28
 
 - **Persistent plan tracking across compaction** — task plans
   survive context window compaction via file-backed state
-  ([GH-482])
+  ([GH-482](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/482))
 
 ### Bug Fixes
 
 - **Resolve skill-audit TaskCreate validation failures** —
-  audit skill handles missing task fields gracefully ([GH-496])
+  audit skill handles missing task fields gracefully ([GH-496](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/496))
 - **Ensure audit-report delegates to ticket-create** — report
-  filing routes through proper skill wrapper ([GH-498])
+  filing routes through proper skill wrapper ([GH-498](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/498))
 - **Resolve script allow-rule permission friction** — script
-  paths match updated plugin directory layout ([GH-499])
+  paths match updated plugin directory layout ([GH-499](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/499))
 - **Prevent premature merge from SKIPPING checks** — CI
-  monitor excludes SKIPPING from pass count ([GH-501])
+  monitor excludes SKIPPING from pass count ([GH-501](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/501))
 - **Prevent inline triage bypass in gh-pr-respond** — all
-  comments route through triage before fixup ([GH-502])
+  comments route through triage before fixup ([GH-502](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/502))
 - **Prevent groom step bypass via self-assessment** — groom
-  skill always presents strategy gate ([GH-505])
-
-[GH-482]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/482
-[GH-496]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/496
-[GH-498]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/498
-[GH-499]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/499
-[GH-501]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/501
-[GH-502]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/502
-[GH-505]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/505
+  skill always presents strategy gate ([GH-505](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/505))
 
 ## 0.41.0 — Orchestration Guardrails & Plan Persistence
 
@@ -1298,38 +1195,31 @@ Released 2026-03-27
 
 - **Per-skill model selection for agents** — agent specs and
   skill dispatch choose model tier based on task complexity
-  ([GH-470])
+  ([GH-470](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/470))
 - **Harden work-on orchestration guardrails** — skill routing
-  enforcement table survives context compaction ([GH-477])
+  enforcement table survives context compaction ([GH-477](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/477))
 - **Plan persistence across compaction** — plans backed by
-  files survive context window resets ([GH-414])
+  files survive context window resets ([GH-414](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/414))
 
 ### Improvements
 
 - **Clarify skill docs for nested mode and push** — nested
-  invocation exemptions and push safety documented ([GH-475])
+  invocation exemptions and push safety documented ([GH-475](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/475))
 
 ### Bug Fixes
 
 - **Prevent marking PR ready with unaddressed comments** —
-  post-CI comment re-check catches late bot reviews ([GH-465])
+  post-CI comment re-check catches late bot reviews ([GH-465](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/465))
 
 ### Security
 
 - **Enforce git-commit skill via PreToolUse hook** — raw
-  `git commit` blocked; must use Dev10x:git-commit ([GH-473])
+  `git commit` blocked; must use Dev10x:git-commit ([GH-473](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/473))
 
 ### Tests
 
 - **Ensure dispatcher tests match commit hook rules** —
-  test suite validates hook-to-skill routing ([GH-473])
-
-[GH-414]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/414
-[GH-465]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/465
-[GH-470]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/470
-[GH-473]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/473
-[GH-475]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/475
-[GH-477]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/477
+  test suite validates hook-to-skill routing ([GH-473](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/473))
 
 ## 0.40.0 — Delegation Hardening & Fixup Skill Gaps
 
@@ -1338,26 +1228,26 @@ Released 2026-03-26
 ### Features
 
 - **Frictionless issue creation from skills** — skills can now
-  create GitHub issues without approval prompts ([GH-445])
+  create GitHub issues without approval prompts ([GH-445](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/445))
 - **Strengthen delegation bypass prevention** — skills enforce
-  proper delegation chains instead of raw CLI calls ([GH-458])
+  proper delegation chains instead of raw CLI calls ([GH-458](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/458))
 - **Resolve gh-pr-fixup skill gaps** — fixup skill now handles
-  all edge cases surfaced by audit ([GH-459])
+  all edge cases surfaced by audit ([GH-459](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/459))
 
 ### Improvements
 
 - **Harden work-on skill against audit regressions** — work-on
   orchestration no longer drifts when audit findings change
-  ([GH-448])
+  ([GH-448](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/448))
 - **Prevent raw command bypass in PR creation** — PR creation
   enforces skill delegation instead of raw `gh pr create`
-  ([GH-448])
+  ([GH-448](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/448))
 - **Prevent delegation bypass in gh-pr-respond** — response skill
-  enforces proper triage-then-fixup pipeline ([GH-447])
+  enforces proper triage-then-fixup pipeline ([GH-447](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/447))
 - **Prevent premature CI exit in gh-pr-monitor** — monitor waits
-  for all checks before declaring success ([GH-447])
+  for all checks before declaring success ([GH-447](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/447))
 - **Enforce triage delegation for all comment types** — every
-  review comment routes through triage before fixup ([GH-463])
+  review comment routes through triage before fixup ([GH-463](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/463))
 - **Enhance eval signal patterns** — delegation bypass detection
   uses more precise signal matching ([a09a2d6])
 - **Clear PR merge policy and consolidation guidance** — document
@@ -1366,24 +1256,17 @@ Released 2026-03-26
 ### Bug Fixes
 
 - **Resolve pr_comment_reply HTTP 422 on integer fields** — MCP
-  tool now serialises numeric fields correctly ([GH-447])
+  tool now serialises numeric fields correctly ([GH-447](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/447))
 - **Resolve skill audit findings in fixup and respond** — fix
-  compliance gaps found during audit ([GH-459])
+  compliance gaps found during audit ([GH-459](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/459))
 - **Prevent false positive unaddressed thread reports** — thread
-  status detection no longer flags resolved threads ([GH-464])
+  status detection no longer flags resolved threads ([GH-464](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/464))
 
 ### Documentation
 
 - **Embed asciinema demo in README** — interactive terminal demo
   on the project landing page ([64d4a2e])
 
-[GH-445]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/445
-[GH-447]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/447
-[GH-448]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/448
-[GH-458]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/458
-[GH-459]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/459
-[GH-463]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/463
-[GH-464]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/464
 [a09a2d6]: https://github.com/Dev10x-Guru/dev10x-claude/commit/a09a2d6
 [cf14b16]: https://github.com/Dev10x-Guru/dev10x-claude/commit/cf14b16
 [64d4a2e]: https://github.com/Dev10x-Guru/dev10x-claude/commit/64d4a2e
@@ -1398,9 +1281,9 @@ Released 2026-03-25
   architecture, and infrastructure agents now ship with the plugin
   for use on any codebase ([57e3830])
 - **Quiet mode for update-paths.py** — suppress noisy output when
-  running permission path updates ([GH-428])
+  running permission path updates ([GH-428](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/428))
 - **Allow git reset without permission friction** — reset commands
-  no longer trigger unnecessary approval prompts ([GH-441])
+  no longer trigger unnecessary approval prompts ([GH-441](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/441))
 
 ### Improvements
 
@@ -1410,28 +1293,22 @@ Released 2026-03-25
 - **Rebrand repo from dev10x-ai to Dev10x** — repository name,
   URLs, and marketplace references updated ([#442])
 - **Tighten work-on approval gate and routing** — stricter approval
-  flow prevents unintended auto-advance past decision gates ([GH-429])
+  flow prevents unintended auto-advance past decision gates ([GH-429](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/429))
 
 ### Bug Fixes
 
 - **Prevent permission-maintenance bootstrap loop** — break the
-  cycle where permission maintenance triggers itself ([GH-426])
+  cycle where permission maintenance triggers itself ([GH-426](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/426))
 - **Prevent stale permissions after worktree merge** — merged
   worktree rules are cleaned up so they don't cause false
-  allow/deny matches ([GH-427])
+  allow/deny matches ([GH-427](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/427))
 
 ### Documentation
 
 - **Prevent misclassification of hook-enabled rules** — clarify
   that allow rules enabling hooks must not be removed even when
-  the hook redirects the command ([GH-419])
+  the hook redirects the command ([GH-419](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/419))
 
-[GH-419]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/419
-[GH-426]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/426
-[GH-427]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/427
-[GH-428]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/428
-[GH-429]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/429
-[GH-441]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/441
 [#442]: https://github.com/Dev10x-Guru/dev10x-claude/pull/442
 [23229f3]: https://github.com/Dev10x-Guru/dev10x-claude/commit/23229f3
 [57e3830]: https://github.com/Dev10x-Guru/dev10x-claude/commit/57e3830
@@ -1461,15 +1338,12 @@ Released 2026-03-24
 
 - **Restore PR comment and review tools** — re-enable
   `pr_comment_reply` and review MCP tools that were
-  inadvertently disabled ([GH-422])
+  inadvertently disabled ([GH-422](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/422))
 
 ### Documentation
 
 - **Data-driven skill redirect ADR** — propose friction-level
-  based redirect system for hook validators ([GH-417])
-
-[GH-417]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/417
-[GH-422]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/422
+  based redirect system for hook validators ([GH-417](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/417))
 
 ## 0.37.0 — Skill Compliance Enforcement
 
@@ -1486,33 +1360,28 @@ eliminates the permission friction that incentivized bypasses.
 - **Auto-deny wrong-tool drift** — PreToolUse hook blocks raw
   CLI commands (git commit -m, gh pr create, git push) that
   should go through skill wrappers, while allowing skill-internal
-  patterns like -F and --fixup ([GH-397])
+  patterns like -F and --fixup ([GH-397](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/397))
 - **Frictionless PR comment replies** — new `pr_comment_reply`
   MCP tool replaces raw `gh api` calls in gh-pr-fixup,
   gh-pr-respond, and gh-pr-triage, removing per-invocation
-  Bash permission prompts ([GH-399])
+  Bash permission prompts ([GH-399](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/399))
 
 ### Improvements
 
 - **Sub-skill delegation enforcement** — gh-pr-respond gains
   REQUIRED: Skill() markers at all 5 delegation points (triage,
   fixup, groom, push, monitor), plus branch location pre-check
-  and stash guard in git-groom ([GH-400])
+  and stash guard in git-groom ([GH-400](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/400))
 - **Review delegation bypass prevention** — gh-pr-respond adds
   negative instruction prohibiting manual fixes; skill-reinforcement
-  gains workflow-context checking for delegation bypasses ([GH-401])
+  gains workflow-context checking for delegation bypasses ([GH-401](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/401))
 - **Audit-driven skill hardening** — gh-pr-respond, gh-pr-fixup,
   and git-fixup gain mandatory markers for parallel dispatch,
-  test gates, and CWD pre-checks based on audit findings ([GH-407])
+  test gates, and CWD pre-checks based on audit findings ([GH-407](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/407))
 - **Eval schema for Skill() assertions** — evaluation schema
   documents Skill() invocation assertion patterns, enabling
   detection of enforcement bypass regressions ([b90c5de])
 
-[GH-397]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/397
-[GH-399]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/399
-[GH-400]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/400
-[GH-401]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/401
-[GH-407]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/407
 [b90c5de]: https://github.com/Dev10x-Guru/dev10x-claude/commit/b90c5de
 
 ## 0.36.0 — PR Monitor Visibility & MCP Bugfix
@@ -1527,16 +1396,13 @@ blocked all comment operations.
 
 - **PR monitor status reporting** — monitor agent surfaces
   CI check details, unhandled review comments, and reviewer
-  assignment status instead of completing silently ([GH-392])
+  assignment status instead of completing silently ([GH-392](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/392))
 
 ### Bug Fixes
 
 - **pr_comments parameter mapping** — fix `--pr-number` to
   `--pr` in cli_server.py so reply, resolve, and thread
-  operations work correctly ([GH-393])
-
-[GH-392]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/392
-[GH-393]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/393
+  operations work correctly ([GH-393](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/393))
 
 ## 0.35.0 — Orchestration Integrity & Maintenance Skills
 
@@ -1550,61 +1416,61 @@ and CI deduplication eliminates wasted review runs.
 
 - **Memory health auditing** — new `Dev10x:memory-maintenance`
   skill detects stale paths, script-calling instructions,
-  contradictions, and MEMORY.md index drift ([GH-375])
+  contradictions, and MEMORY.md index drift ([GH-375](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/375))
 - **Playbook drift detection** — new `Dev10x:playbook-maintenance`
   skill compares user overrides against defaults, surfacing new
-  steps and prompt changes with severity levels ([GH-366])
+  steps and prompt changes with severity levels ([GH-366](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/366))
 - **Skill-usage reinforcement** — orchestration skill identifies
   CLI commands that should be replaced by dedicated skills or MCP
-  tools, with prefix-matched command-to-skill mapping ([GH-384])
+  tools, with prefix-matched command-to-skill mapping ([GH-384](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/384))
 - **Project settings cleanup** — permission-maintenance gains
   Step 6 to strip duplicate, wildcard-covered, and stale rules
-  from project settings files ([GH-386])
+  from project settings files ([GH-386](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/386))
 - **CI SHA deduplication** — GitHub Actions workflows skip
   redundant runs when a peer workflow already handles the same
-  commit SHA ([GH-382])
+  commit SHA ([GH-382](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/382))
 
 ### Improvements
 
 - **Skill delegation enforcement** — work-on requires post-step
   Skill() verification and prohibits pipeline collapse during
-  fanout execution ([GH-367])
+  fanout execution ([GH-367](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/367))
 - **CI re-monitoring after force push** — git-groom and work-on
   mandate `Dev10x:gh-pr-monitor` after any force push to avoid
-  stale CI results ([GH-371])
+  stale CI results ([GH-371](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/371))
 - **Task reconciliation after delegation** — work-on reconciles
   parent task state after child skill completion, preventing
-  orphaned tasks ([GH-376])
+  orphaned tasks ([GH-376](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/376))
 - **Wrong-database prevention** — db-psql requires target database
   comment prefix on manual SQL and sets PGAPPNAME for process
-  identification ([GH-363])
+  identification ([GH-363](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/363))
 - **Scope-aware fanout parsing** — fanout distinguishes scope URLs
   from specific item URLs, restricting scans to matching commands
-  ([GH-351])
+  ([GH-351](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/351))
 - **Skill routing through compaction** — compaction preservation
   directive keeps routing tables intact across context compression
-  ([GH-358])
+  ([GH-358](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/358))
 - **Unmatched play fallback** — work-on routes unmatched plays to
   the feature play instead of failing, and bans merge operations
-  in gh-pr-monitor ([GH-357])
+  in gh-pr-monitor ([GH-357](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/357))
 - **CWD-based worktree detection** — ticket-branch detects
-  worktree context from current working directory ([GH-353])
+  worktree context from current working directory ([GH-353](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/353))
 - **Auto-filing audit findings** — skill-audit findings file
-  automatically as GitHub issues ([GH-356])
+  automatically as GitHub issues ([GH-356](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/356))
 - **Nested-mode task exemption** — formalized exemption for
-  TaskCreate in nested skill invocations ([GH-355])
+  TaskCreate in nested skill invocations ([GH-355](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/355))
 
 ### Bug Fixes
 
 - **Auditor deny-rule overreach** — permission-auditor now uses
   three-tier classification (deny/ask/hook-protected/skip) instead
   of blanket deny recommendations that blocked legitimate skills
-  ([GH-385])
+  ([GH-385](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/385))
 - **Premature completion gate** — work-on completion gate no longer
-  fires before all tasks are finished ([GH-354])
+  fires before all tasks are finished ([GH-354](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/354))
 - **Explore agent source failures** — GitHub/JIRA fetch subagents
   switched from Explore to general-purpose to gain Bash access
-  ([GH-348])
+  ([GH-348](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/348))
 
 ## 0.34.0 — Fanout Safety & Skill Consistency
 
@@ -1618,13 +1484,13 @@ all skills.
 
 - **Fanout delegation safety** — prevent delegation bypass and
   wrong-branch commits with stricter orchestration guards
-  ([GH-345])
+  ([GH-345](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/345))
 
 ### Improvements
 
 - **Trigger/skip standardization** — consistent trigger and skip
   documentation across all skills, completing the effort started
-  in v0.33.0 ([GH-313])
+  in v0.33.0 ([GH-313](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/313))
 
 ## 0.33.0 — Orchestration Discipline & Session Resilience
 
@@ -1638,33 +1504,33 @@ verification becomes a reusable skill.
 
 - **Session resilience** — pre-compaction hook preserves critical
   context, session state persists across restarts, and skill
-  invocation metrics are tracked for audit ([GH-310]–[GH-317])
+  invocation metrics are tracked for audit ([GH-310](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/310)–[GH-317](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/317))
 - **Fanout orchestration discipline** — work-on delegation is now
   REQUIRED with enforcement language, per-issue subtask tracking,
-  and new Monitor + Audit phases ([GH-338], [GH-339])
+  and new Monitor + Audit phases ([GH-338](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/338), [GH-339](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/339))
 - **Full shipping pipeline in gh-pr-respond** — post-response
   continuation expanded from groom+push+monitor to the complete
   groom → push → ready → monitor → merge lifecycle with
-  solo-maintainer auto-merge support ([GH-338], [GH-339])
+  solo-maintainer auto-merge support ([GH-338](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/338), [GH-339](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/339))
 - **Reusable definition-of-done verification** — extracted
   `Dev10x:verify-acc-dod` skill for consistent acceptance checks
-  across work-on, fanout, and future orchestrators ([GH-340])
+  across work-on, fanout, and future orchestrators ([GH-340](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/340))
 
 ### Improvements
 
 - **Task tracking in DDD and permission-maintenance** — both skills
   gain TaskCreate/TaskUpdate orchestration for supervisor visibility
-  ([GH-41])
+  ([GH-41](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/41))
 - **Statusline enrichment** — branch name and worktree context shown
-  in terminal statusline ([GH-312])
+  in terminal statusline ([GH-312](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/312))
 - **Skill scaffolding** — `Dev10x:skill-create` generates directory
-  structure with scripts via `scaffold.sh` ([GH-314])
+  structure with scripts via `scaffold.sh` ([GH-314](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/314))
 - **Plugin health verification** — install and verify scripts validate
-  plugin structure after updates ([GH-315])
+  plugin structure after updates ([GH-315](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/315))
 - **Marketplace metadata** — enriched `marketplace.json` for better
-  plugin discovery ([GH-317])
+  plugin discovery ([GH-317](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/317))
 - **Trigger/skip standardization** — consistent trigger and skip
-  documentation across 13+ skills ([GH-313])
+  documentation across 13+ skills ([GH-313](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/313))
 
 ## 0.32.0 — Permission Friction & Review Hardening
 
@@ -1678,10 +1544,10 @@ and work-on enforces playbook verification before plan generation.
 
 - **Playbook verification in work-on** — Phase 3 now requires reading
   and verifying a playbook file before generating tasks, preventing
-  ad-hoc plan generation that skips configured steps ([GH-308])
+  ad-hoc plan generation that skips configured steps ([GH-308](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/308))
 - **GitHub async timing checks** — code review agents detect stale
   `gh pr checks` results after force-pushes by verifying check count
-  against expected baselines ([GH-318])
+  against expected baselines ([GH-318](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/318))
 - **Table/implementation skew detection** — code review agents flag
   documentation tables that diverge from actual implementation
 
@@ -1689,33 +1555,33 @@ and work-on enforces playbook verification before plan generation.
 
 - **Reduced permission friction** — normalized `scripts/:*` to
   `scripts/*:*` across all `allowed-tools` declarations in skill-audit,
-  py-uv, skill-create, and codex-skills equivalents ([GH-321])
+  py-uv, skill-create, and codex-skills equivalents ([GH-321](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/321))
 - **Smarter sensitive file hook** — `block-sensitive-file-write.py` now
   uses basename matching instead of substring, eliminating false
-  positives on sidecar metadata files like `.vars` ([GH-322])
+  positives on sidecar metadata files like `.vars` ([GH-322](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/322))
 - **Project-scope anti-patterns** — documented command substitution and
   env var prefix friction patterns to avoid in `gh` commands, switched
-  sidecar files from `.env` to `.vars` ([GH-322])
+  sidecar files from `.env` to `.vars` ([GH-322](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/322))
 - **Autosquash alias prefix** — `env` command prefix added to
   `GIT_SEQUENCE_EDITOR=true` in autosquash aliases for consistent
-  shell expansion ([GH-319])
+  shell expansion ([GH-319](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/319))
 - **Skill name normalization** — Dev10x skill names normalized across
   documentation and scripts for consistency
 - **Semicolon false positive fix** — SQL safety hook no longer blocks
   semicolons inside string literals like `STRING_AGG(name, '; ')`
-  ([GH-320])
+  ([GH-320](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/320))
 
 ### Bug Fixes
 
 - **Skill-audit permission prompt** — `extract-session.sh` no longer
   triggers approval prompts on every invocation due to mismatched
-  `allowed-tools` glob pattern ([GH-321])
+  `allowed-tools` glob pattern ([GH-321](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/321))
 
 ### Documentation
 
 - **Updated skill pattern references** — all `scripts/:*` documentation
   examples updated to `scripts/*:*` across skill-audit, skill-create,
-  and their codex-skills equivalents ([GH-309])
+  and their codex-skills equivalents ([GH-309](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/309))
 
 ## 0.31.0 — MCP Consolidation & Parallel Workflows
 
@@ -1729,24 +1595,24 @@ stream processing with context compaction.
 
 - **MCP tools for PR creation** — 6 gh-pr-create scripts and pr-notify
   wrapped as 7 MCP tools in gh_server.py, enabling dual-path transition
-  with existing Bash paths ([GH-191])
+  with existing Bash paths ([GH-191](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/191))
 - **Universal branch aliases** — git log, diff, rebase, and autosquash
   aliases now support main and master alongside existing develop,
-  development, and trunk variants ([GH-288])
+  development, and trunk variants ([GH-288](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/288))
 - **Non-destructive CTE in db queries** — db hook allows WITH clauses
-  that don't modify data, unblocking analytical queries ([GH-303])
+  that don't modify data, unblocking analytical queries ([GH-303](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/303))
 - **Slack thread investigation** — new plugin skill investigates Slack
   bug reports, root-causes in codebase, and creates Linear tickets
   ([#298])
 - **Guided Slack integration setup** — interactive skill walks through
-  Slack app creation, token configuration, and channel setup ([GH-14])
+  Slack app creation, token configuration, and channel setup ([GH-14](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/14))
 - **macOS Keychain credential retrieval** — secrets can be stored and
-  retrieved via macOS Keychain as an alternative to env vars ([GH-119])
+  retrieved via macOS Keychain as an alternative to env vars ([GH-119](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/119))
 
 ### Improvements
 
 - **MCP server consolidation** — reduced from 4 servers to 2 (cli →
-  git + utils, gh stays), cutting startup overhead ([GH-194])
+  git + utils, gh stays), cutting startup overhead ([GH-194](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/194))
 - **Parallel work stream processing** — work-on dispatches independent
   tasks concurrently instead of sequentially ([#301])
 - **Context compaction in orchestration** — skills compact context at
@@ -1768,15 +1634,15 @@ stream processing with context compaction.
 ### Testing
 
 - **Automated hook testing** — pytest CI pipeline validates hook
-  scripts with unit tests ([GH-214])
+  scripts with unit tests ([GH-214](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/214))
 - **CI concurrency groups** — prevent duplicate CI runs on rapid
-  pushes to the same branch ([GH-214])
+  pushes to the same branch ([GH-214](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/214))
 
 ### Bug Fixes
 
 - **Non-interactive autosquash** — autosquash aliases wrap
   GIT_SEQUENCE_EDITOR=true to avoid escaping issues that broke alias
-  expansion ([GH-288])
+  expansion ([GH-288](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/288))
 
 ## 0.30.0 — Disciplined Orchestration
 
@@ -1790,43 +1656,43 @@ names, and script-path leaks are eliminated across the tooling surface.
 ### Features
 
 - **MCP tool access for git skills** — git-domain skills can call MCP
-  tools directly instead of shelling out via Bash wrappers ([GH-192])
+  tools directly instead of shelling out via Bash wrappers ([GH-192](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/192))
 - **Permission management skill** — base permission management enables
-  structured allow/deny rule handling ([GH-274])
+  structured allow/deny rule handling ([GH-274](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/274))
 - **Slack file cleanup** — cleanup Slack config files and prompt for
-  missing configuration ([GH-271])
+  missing configuration ([GH-271](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/271))
 - **Goodbye message** — session exit shows a resume command so users can
-  pick up where they left off ([GH-272])
+  pick up where they left off ([GH-272](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/272))
 - **Block `$(cat ...)` substitution** — hook blocks command substitution
-  via `cat` to prevent file content leaks in shell commands ([GH-277])
+  via `cat` to prevent file content leaks in shell commands ([GH-277](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/277))
 
 ### Improvements
 
 - **Aligned session skill names** — 11 session skills get consistent
-  `Dev10x:` prefixed invocation names ([GH-224], [GH-102])
+  `Dev10x:` prefixed invocation names ([GH-224](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/224), [GH-102](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/102))
 - **Script-path leak elimination** — skill tooling no longer leaks
-  resolved cache paths in allowed-tools or Bash calls ([GH-280],
-  [GH-275], [GH-283])
+  resolved cache paths in allowed-tools or Bash calls ([GH-280](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/280),
+  [GH-275](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/275), [GH-283](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/283))
 - **Destructive git commands ADR** — documented the decision to block
-  destructive git operations by default ([GH-269])
+  destructive git operations by default ([GH-269](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/269))
 - **Orchestration guardrail evals** — eval assertions enforce Phase 3
-  mechanical planning and supervisor sign-off ([GH-248], [GH-273])
+  mechanical planning and supervisor sign-off ([GH-248](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/248), [GH-273](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/273))
 
 ### Bug Fixes
 
 - **Supervisor sign-off required** — plan completion gate now requires
-  explicit supervisor confirmation instead of auto-completing ([GH-273])
+  explicit supervisor confirmation instead of auto-completing ([GH-273](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/273))
 - **Natural language plan mapping** — phrases like "show me the plan"
-  route to AskUserQuestion gate, not plan mode ([GH-248])
+  route to AskUserQuestion gate, not plan mode ([GH-248](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/248))
 - **Mechanical Phase 3** — plan generation enforces 1:1 task-to-step
-  mapping from playbook, preventing step collapsing ([GH-248], [GH-273])
+  mapping from playbook, preventing step collapsing ([GH-248](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/248), [GH-273](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/273))
 - **Phase task verification** — Phase 2 blocked until all 4 phase tasks
-  are confirmed to exist ([GH-248])
+  are confirmed to exist ([GH-248](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/248))
 - **ExitPlanMode prohibition** — work-on sessions cannot use Claude
-  Code's built-in plan mode, preserving task tracking ([GH-248])
+  Code's built-in plan mode, preserving task tracking ([GH-248](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/248))
 - **MCP-aware subagent routing** — Phase 2 fetches requiring MCP tools
   (Linear, Slack, Sentry) route to general-purpose agents, not Explore
-  agents which lack MCP access ([GH-155])
+  agents which lack MCP access ([GH-155](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/155))
 
 ## 0.29.0 — Smoother Shipping
 
@@ -1839,24 +1705,24 @@ tracking for faster unattended execution.
 ### Improvements
 
 - **Unattended PR creation** — gh-pr-create supports `--unattended` flag
-  with documented detection conditions and gate bypass rules ([GH-263])
+  with documented detection conditions and gate bypass rules ([GH-263](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/263))
 - **Delegated skills skip TaskCreate** — skills invoked as subtasks of a
-  parent orchestrator skip internal task tracking, reducing noise ([GH-258])
+  parent orchestrator skip internal task tracking, reducing noise ([GH-258](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/258))
 - **Body-only review handling** — gh-pr-respond Mode B handles reviews with
-  body text but no inline comments, common from CI bots ([GH-258])
+  body text but no inline comments, common from CI bots ([GH-258](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/258))
 - **Non-skippable monitor output** — gh-pr-monitor Step 4 marked as
-  non-skippable so users always see background agent progress ([GH-259])
+  non-skippable so users always see background agent progress ([GH-259](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/259))
 - **Reduced work-on friction** — workspace detection extracted to script,
-  implicit plan approval when user provides a complete plan ([GH-253])
+  implicit plan approval when user provides a complete plan ([GH-253](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/253))
 - **Friction-free grooming** — raw GIT_SEQUENCE_EDITOR rebase replaced with
-  git autosquash-develop alias to avoid env-prefix permission friction ([GH-253])
+  git autosquash-develop alias to avoid env-prefix permission friction ([GH-253](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/253))
 
 ### Bug Fixes
 
 - **Husky v4 and Yarn Berry in worktrees** — detect Husky version, bootstrap
-  ~/.huskyrc for v4, use version-aware yarn install flags ([GH-222])
+  ~/.huskyrc for v4, use version-aware yarn install flags ([GH-222](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/222))
 - **Fish shell GraphQL compatibility** — convert GraphQL examples to
-  double-quoted with escaped `$` to prevent fish interpolation ([GH-258])
+  double-quoted with escaped `$` to prevent fish interpolation ([GH-258](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/258))
 
 ## 0.28.0 — Conflict-Free PRs
 
@@ -1870,11 +1736,11 @@ obfuscation blocks.
 
 - **Conflict-free PRs** — PR creation and monitoring detect merge conflicts
   via `git merge-tree` and GitHub's mergeable API, with auto-rebase +
-  force-with-lease resolution ([GH-261])
+  force-with-lease resolution ([GH-261](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/261))
 - **Consistent skill naming** — 9 skills get proper `Dev10x:` invocation
-  names with documented branding rationale ([GH-234])
+  names with documented branding rationale ([GH-234](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/234))
 - **Friction-free issue status checks** — jq concatenation pattern replaces
-  interpolation to avoid obfuscation detection ([GH-260])
+  interpolation to avoid obfuscation detection ([GH-260](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/260))
 - **Full changelog** — all 22 releases (v0.2.0–v0.27.0) documented with
   themed headlines and linked issue references
 - **MCP server permission review checks** — reviewer-infra now explicitly
@@ -1897,16 +1763,16 @@ subshell commands.
 
 - **Self-healing code review** — work-on shipping pipeline now dispatches
   `Dev10x:review` + `Dev10x:review-fix` to autonomously create fixup commits
-  for review findings ([GH-252])
+  for review findings ([GH-252](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/252))
 - **Full task visibility in unattended mode** — git-commit and gh-pr-create
   create all startup tasks regardless of mode; auto-skipped tasks are
-  immediately marked completed with reason ([GH-251])
+  immediately marked completed with reason ([GH-251](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/251))
 - **GitHub Issues in project-scope** — Phase 3 Tracker Dispatch now supports
   GitHub Issues alongside Linear and JIRA, with batch creation pattern for
-  10+ issues ([GH-244])
+  10+ issues ([GH-244](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/244))
 - **Auto-approval for safe subshells** — new `HookAllow` result type lets
   read-only subshell commands like `basename "$(git rev-parse ...)"` pass
-  without permission prompts ([GH-247])
+  without permission prompts ([GH-247](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/247))
 - **Worktree permission merging** — merge allow rules accumulated in worktree
   sessions back into the main project settings
 - **Batch plugin permission updates** — auto-detect latest plugin version
@@ -1914,7 +1780,7 @@ subshell commands.
 
 ### Bug Fixes
 
-- Prevent path errors when CWD drifts during session ([GH-251])
+- Prevent path errors when CWD drifts during session ([GH-251](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/251))
 
 ## 0.26.0 — Release Notes as a Skill
 
@@ -1943,25 +1809,25 @@ Python edit.
 
 - **Reusable playbook fragments** — extract shared step sequences (like the
   9-step shipping pipeline) into named fragments, reducing duplication from
-  36 of 55 steps across 4 plays ([GH-232])
+  36 of 55 steps across 4 plays ([GH-232](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/232))
 - **Unattended git-commit** — when invoked by an orchestrating skill with
   an active task list, all interactive gates are bypassed: auto-stage,
-  auto-select commit type, auto-generate problem/solution ([GH-237])
+  auto-select commit type, auto-generate problem/solution ([GH-237](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/237))
 - **Automated ruff formatting** — PostToolUse hook runs `ruff format` +
-  `ruff check --fix` on every Python file edit ([GH-231])
+  `ruff check --fix` on every Python file edit ([GH-231](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/231))
 - **Post-response shipping continuation** — gh-pr-respond now offers to
-  groom, push, and monitor CI after fixup commits ([GH-225])
+  groom, push, and monitor CI after fixup commits ([GH-225](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/225))
 - **Redundant command detection** — hook blocks `git -C <path>` when CWD
-  already matches, and `cd <cwd> && ...` noop chains ([GH-225])
+  already matches, and `cd <cwd> && ...` noop chains ([GH-225](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/225))
 - **Respond playbook comment hiding** — gh-pr-respond can hide obsolete
-  review comments after addressing them ([GH-226])
+  review comments after addressing them ([GH-226](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/226))
 - **uv-managed test execution** — pyproject.toml with pytest/ruff dev deps
-  so `uv run pytest` works without extra flags ([GH-225])
+  so `uv run pytest` works without extra flags ([GH-225](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/225))
 
 ### Bug Fixes
 
 - **Skill-audit enforcement gaps** — AskUserQuestion rule extended to global
-  scope, Linear API fallback for non-autolinked prefixes ([GH-227])
+  scope, Linear API fallback for non-autolinked prefixes ([GH-227](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/227))
 - Ensure release script stages pyproject.toml after bump
 
 ## 0.24.0 — Auto-Advance Pipeline
@@ -1974,7 +1840,7 @@ draft PR creation proceed automatically with a code-reviewer agent step.
 ### Features
 
 - **Auto-advance shipping pipeline** — commits and draft PR creation proceed
-  without blocking on preview approval, with code-reviewer agent step ([GH-213])
+  without blocking on preview approval, with code-reviewer agent step ([GH-213](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/213))
 - Community link added to README
 
 ## 0.23.0 — Domain-Driven Design Workshops
@@ -1987,12 +1853,12 @@ Claude Code sessions.
 ### Features
 
 - **DDD workshop skill** — bootstrap Domain-Driven Design Event Storming
-  workshops for domain exploration and modeling ([GH-219])
+  workshops for domain exploration and modeling ([GH-219](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/219))
 
 ### Bug Fixes
 
 - Declare missing `allowed-tools` in 6 skills to eliminate per-invocation
-  approval prompts ([GH-70])
+  approval prompts ([GH-70](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/70))
 
 ## 0.22.0 — Playbook Architecture
 
@@ -2007,26 +1873,26 @@ one with ~80% overhead reduction. User-space config overrides ship.
 - **Playbook architecture** — generalize work plans into reusable,
   customizable playbooks with convention-based discovery. Any orchestration
   skill can become playbook-powered by adding `references/playbook.yaml`.
-  User overrides stored per-skill in memory ([GH-209])
+  User overrides stored per-skill in memory ([GH-209](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/209))
 - **Guided work plan customization** — dedicated `Dev10x:work-plan` skill
-  with list, view, edit, and reset subcommands ([GH-209])
+  with list, view, edit, and reset subcommands ([GH-209](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/209))
 - **Per-project work plan customization** — projects can override plan
-  templates without modifying plugin source ([GH-140])
+  templates without modifying plugin source ([GH-140](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/140))
 - **Consolidated hook dispatcher** — replace 7 separate hook processes
   with one unified Python dispatcher using a validator registry.
-  ~80-85% hook overhead reduction ([GH-208])
+  ~80-85% hook overhead reduction ([GH-208](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/208))
 - **User-space config overrides** — `~/.claude/skill-index/` for
-  `families.yaml` and `hidden.yaml` without modifying plugin source ([GH-10])
+  `families.yaml` and `hidden.yaml` without modifying plugin source ([GH-10](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/10))
 - **Alias enforcement** — block raw `git` commands with env-var prefixes
-  or `$(git merge-base ...)` subshells when aliases exist ([GH-200])
+  or `$(git merge-base ...)` subshells when aliases exist ([GH-200](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/200))
 - **Automated issue closing** — GitHub Actions workflow parses `Fixes:` URLs
-  from merged PR bodies and closes referenced issues ([GH-209])
+  from merged PR bodies and closes referenced issues ([GH-209](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/209))
 
 ### Refactoring
 
 - Split reviewer-skill into structure and behavior specs
 - Trim CLAUDE.md to stay within 100-line budget
-- Prefer jq and yq over manual JSON/YAML parsing ([GH-196])
+- Prefer jq and yq over manual JSON/YAML parsing ([GH-196](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/196))
 
 ## 0.21.0 — One-Command Review Requests
 
@@ -2038,17 +1904,17 @@ PR creation now works in repos without a develop branch.
 ### Features
 
 - **Combined review request skill** — `Dev10x:request-review` assigns
-  GitHub reviewers and posts Slack notification in one command ([GH-188])
+  GitHub reviewers and posts Slack notification in one command ([GH-188](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/188))
 - **PR creation without develop** — gh-pr-create works in repos that
-  use main as their only branch ([GH-180])
+  use main as their only branch ([GH-180](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/180))
 - **Prevent WIP in worktrees** — new worktrees no longer inherit
   uncommitted changes from the parent branch
 - **Dynamic base branch validation** — hook validates PR target branch
-  at creation time ([GH-187])
+  at creation time ([GH-187](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/187))
 
 ### Bug Fixes
 
-- Prevent silent project linkage failures in Linear ([GH-153])
+- Prevent silent project linkage failures in Linear ([GH-153](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/153))
 
 ## 0.20.0 — Reliable Skill Orchestration
 
@@ -2061,9 +1927,9 @@ orchestration steps actually fire instead of being skipped as examples.
 
 - **Bundled call spec pattern** — complex tool call specifications live
   in `tool-calls/` sidecar files, referenced from SKILL.md enforcement
-  markers ([GH-179])
+  markers ([GH-179](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/179))
 - **Numbered list enforcement** — 39 skills updated to use numbered lists
-  (not code blocks) for mandatory TaskCreate/AskUserQuestion calls ([GH-179])
+  (not code blocks) for mandatory TaskCreate/AskUserQuestion calls ([GH-179](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/179))
 - Centralize rules documentation into INDEX.md
 
 ## 0.19.0 — MCP Tools & Project Scoping
@@ -2077,31 +1943,31 @@ Dozens of enforcement fixes improve skill reliability.
 ### Features
 
 - **MCP tools** — GitHub, Git, and Database operations exposed as MCP
-  server tools, replacing fragile Bash-based wrappers ([GH-126])
+  server tools, replacing fragile Bash-based wrappers ([GH-126](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/126))
 - **Project-scope skill** — scaffold multi-ticket projects with milestones,
   blocking relationships, and tracker integration. Supports Linear, JIRA,
-  and GitHub Issues ([GH-154])
+  and GitHub Issues ([GH-154](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/154))
 - **Skill eval criteria** — measurable quality gates for skill behavior,
-  enabling automated detection of decision gate violations ([GH-133])
+  enabling automated detection of decision gate violations ([GH-133](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/133))
 - **Auto-resolved PR reviewers** — GitHub team reviewers resolved
-  automatically from CODEOWNERS ([GH-118])
+  automatically from CODEOWNERS ([GH-118](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/118))
 - **Temp file MCP tool** — `mktmp` tool prevents temp file collisions
-  across concurrent sessions ([GH-143])
+  across concurrent sessions ([GH-143](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/143))
 - **Upstream issue filing from audits** — skill-audit findings can be
-  filed as GitHub issues at the plugin repo ([GH-135])
+  filed as GitHub issues at the plugin repo ([GH-135](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/135))
 - **Parallel subagent dispatch** — skill-audit runs analysis phases
-  concurrently ([GH-131])
+  concurrently ([GH-131](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/131))
 - **Pre-approved tool access** — 17 skills declare `allowed-tools`
-  to eliminate per-invocation approval prompts ([GH-70])
+  to eliminate per-invocation approval prompts ([GH-70](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/70))
 
 ### Bug Fixes
 
-- Enforce AskUserQuestion at all decision gates ([GH-133], [GH-151])
-- Enforce TaskCreate orchestration at startup ([GH-134])
-- Prevent Write tool error in commit workflow ([GH-126])
-- Prevent GIT_SEQUENCE_EDITOR permission friction ([GH-121])
-- Exclude .claude/worktrees/ from hook copies ([GH-144])
-- Allow bare fixup commits from humans ([GH-159])
+- Enforce AskUserQuestion at all decision gates ([GH-133](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/133), [GH-151](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/151))
+- Enforce TaskCreate orchestration at startup ([GH-134](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/134))
+- Prevent Write tool error in commit workflow ([GH-126](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/126))
+- Prevent GIT_SEQUENCE_EDITOR permission friction ([GH-121](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/121))
+- Exclude .claude/worktrees/ from hook copies ([GH-144](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/144))
+- Allow bare fixup commits from humans ([GH-159](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/159))
 
 ## 0.18.0 — Documentation
 
@@ -2232,11 +2098,11 @@ criteria verification round out the release.
 - **Family-grouped skill index** — adaptive-density display with YAML
   config for families and hidden skills
 - **Acceptance criteria verification** — work-on checks criteria before
-  shipping ([GH-86])
+  shipping ([GH-86](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/86))
 - **Session guidance** — surface wrapper discovery and git alias
-  recommendations at session start ([GH-87])
-- **Slack review readability** — improved formatting ([GH-54])
-- Preserve plugin permissions across upgrades ([GH-79])
+  recommendations at session start ([GH-87](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/87))
+- **Slack review readability** — improved formatting ([GH-54](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/54))
+- Preserve plugin permissions across upgrades ([GH-79](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/79))
 
 ### Bug Fixes
 
@@ -2269,11 +2135,11 @@ always-loaded token overhead.
 - **QA automation** — portable plugin skills for QA test execution
 - **ADR creation** — Architecture Decision Records as a plugin skill
 - **Context-aware rule loading** — reduce always-loaded rules by scoping
-  them to relevant file patterns ([GH-68])
+  them to relevant file patterns ([GH-68](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/68))
 - **Obsolete review summary hiding** — automatically hide stale PR review
-  summaries in interactive and CI modes ([GH-44])
-- **User task injection** — inject tasks during work-on execution ([GH-59])
-- **Temp file collision prevention** — namespace-based temp files ([GH-19])
+  summaries in interactive and CI modes ([GH-44](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/44))
+- **User task injection** — inject tasks during work-on execution ([GH-59](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/59))
+- **Temp file collision prevention** — namespace-based temp files ([GH-19](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/19))
 - **Workspace-agnostic Slack** — notifications work from any directory
 - **Reusable technical scoping** — base scoping workflow for tickets and ADRs
 
@@ -2319,105 +2185,12 @@ in a single plugin.
   JTBD guidance
 - **Plugin-distributed hooks** — safety and quality hooks shipped with
   the plugin
-- **Self-executing Python** — UV-based script execution ([GH-17])
+- **Self-executing Python** — UV-based script execution ([GH-17](https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/17))
 - **Self-improving review system** — lessons from PR reviews automatically
   strengthen review checks
 
 ---
 
-[GH-1]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/1
-[GH-7]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/7
-[GH-10]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/10
-[GH-15]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/15
-[GH-17]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/17
-[GH-19]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/19
-[GH-31]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/31
-[GH-33]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/33
-[GH-35]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/35
-[GH-44]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/44
-[GH-45]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/45
-[GH-50]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/50
-[GH-54]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/54
-[GH-59]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/59
-[GH-68]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/68
-[GH-70]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/70
-[GH-79]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/79
-[GH-84]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/84
-[GH-86]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/86
-[GH-87]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/87
-[GH-118]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/118
-[GH-121]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/121
-[GH-126]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/126
-[GH-131]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/131
-[GH-133]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/133
-[GH-134]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/134
-[GH-135]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/135
-[GH-140]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/140
-[GH-143]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/143
-[GH-144]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/144
-[GH-151]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/151
-[GH-153]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/153
-[GH-154]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/154
-[GH-157]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/157
-[GH-159]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/159
-[GH-179]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/179
-[GH-180]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/180
-[GH-187]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/187
-[GH-188]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/188
-[GH-196]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/196
-[GH-200]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/200
-[GH-208]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/208
-[GH-209]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/209
-[GH-213]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/213
-[GH-219]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/219
-[GH-225]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/225
-[GH-226]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/226
-[GH-227]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/227
-[GH-231]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/231
-[GH-232]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/232
-[GH-237]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/237
-[GH-244]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/244
-[GH-247]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/247
-[GH-251]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/251
-[GH-252]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/252
-[GH-253]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/253
-[GH-258]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/258
-[GH-259]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/259
-[GH-260]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/260
-[GH-261]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/261
-[GH-263]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/263
-[GH-267]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/267
-[GH-269]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/269
-[GH-270]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/270
-[GH-271]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/271
-[GH-272]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/272
-[GH-273]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/273
-[GH-274]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/274
-[GH-275]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/275
-[GH-277]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/277
-[GH-280]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/280
-[GH-283]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/283
-[GH-288]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/288
-[GH-313]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/313
-[GH-345]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/345
-[GH-348]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/348
-[GH-351]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/351
-[GH-353]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/353
-[GH-354]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/354
-[GH-355]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/355
-[GH-356]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/356
-[GH-357]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/357
-[GH-358]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/358
-[GH-363]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/363
-[GH-366]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/366
-[GH-367]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/367
-[GH-371]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/371
-[GH-375]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/375
-[GH-376]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/376
-[GH-382]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/382
-[GH-384]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/384
-[GH-385]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/385
-[GH-386]: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/386
 [#243]: https://github.com/Dev10x-Guru/dev10x-claude/pull/243
 [#267]: https://github.com/Dev10x-Guru/dev10x-claude/pull/267
 [#270]: https://github.com/Dev10x-Guru/dev10x-claude/pull/270


### PR DESCRIPTION
**When** I follow a `[GH-N]` link in the changelog for a release before 0.67.0, **I want to** land on the original issue thread in the archived repo, **so I can** read the historical context that drove that change instead of hitting a 404 or an unrelated ticket in the current repo.

---

[`dece5f1e`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/54/commits/dece5f1e64fe35cfc4f849654a18db2dd2eeb6fc) 📝 GH-53 Point pre-0.67 changelog refs to legacy repo
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/53

---