### PR TITLE
✨ GH-6 Detect privacy and external service drift in CI

### DIFF
--- a/.github/workflows/privacy-audit.yml
+++ b/.github/workflows/privacy-audit.yml
@@ -1,0 +1,125 @@
+name: Privacy & Security Audit
+
+on:
+  pull_request:
+    branches: [develop]
+    paths:
+      - "src/**"
+      - "skills/**"
+      - "bin/**"
+      - "hooks/**"
+      - "servers/**"
+      - "commands/**"
+      - "PRIVACY_POLICY.md"
+      - ".github/workflows/privacy-audit.yml"
+      - "tests/skills/audit/test_privacy.py"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scanner-tests:
+    name: Scanner unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Run scanner unit tests
+        run: |
+          uv run --extra dev pytest tests/skills/audit/test_privacy.py \
+            -v --tb=short -o 'addopts='
+
+  changed-files:
+    name: Audit changed files
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Collect changed source files
+        id: changed
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+          BASE_SHA="$(git merge-base "origin/${BASE_REF}" HEAD)"
+          git diff --name-only --diff-filter=AM "${BASE_SHA}" HEAD \
+            | grep -E '^(src|skills|bin|hooks|servers|commands)/.*\.(py|sh|md|yaml|yml|json|toml)$' \
+            > /tmp/changed-source.txt || true
+          echo "count=$(wc -l < /tmp/changed-source.txt)" >> "$GITHUB_OUTPUT"
+          if [ -s /tmp/changed-source.txt ]; then
+            echo "Changed source files:"
+            cat /tmp/changed-source.txt
+          else
+            echo "No source files changed in this PR."
+          fi
+
+      - name: Audit changed files
+        if: steps.changed.outputs.count != '0'
+        id: audit
+        run: |
+          set -euo pipefail
+          if xargs -a /tmp/changed-source.txt \
+            uv run --extra dev bin/check-privacy-policy.py \
+            > /tmp/audit-output.txt 2>&1; then
+            echo "violations=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "violations=true" >> "$GITHUB_OUTPUT"
+          fi
+          cat /tmp/audit-output.txt
+
+      - name: Comment on PR if violations found
+        if: steps.audit.outputs.violations == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          {
+            echo "## Privacy & Security Audit"
+            echo
+            echo "This PR introduces external-service references that"
+            echo "are not documented in \`PRIVACY_POLICY.md\`, or adds"
+            echo "outbound-network imports to plugin source."
+            echo
+            echo "<details><summary>Audit output</summary>"
+            echo
+            echo '```'
+            cat /tmp/audit-output.txt
+            echo '```'
+            echo
+            echo "</details>"
+            echo
+            echo "**To resolve:**"
+            echo
+            echo "- Add a row for each new service to the"
+            echo "  \"Third-party integrations\" table in"
+            echo "  \`PRIVACY_POLICY.md\`, or"
+            echo "- Suppress an intentional case with an inline marker:"
+            echo "  \`# privacy-audit: allow <service> — reason\`"
+          } > /tmp/audit-comment.md
+          gh pr comment "$PR_NUMBER" --body-file /tmp/audit-comment.md
+
+      - name: Fail job on violations
+        if: steps.audit.outputs.violations == 'true'
+        run: exit 1

--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -46,6 +46,10 @@ Audit collection can be disabled by exporting
   calls other than those you explicitly invoke (for example,
   `git push`, `gh pr create`, or an authenticated MCP tool
   request).
+- Some **skill scripts** (e.g., `qa-self/upload-screenshots.py`)
+  call documented integrations directly via HTTP libraries when
+  you invoke the skill. The targeted services are listed in the
+  table below; no other outbound calls are made.
 
 ## Third-party integrations
 
@@ -61,6 +65,9 @@ with credentials you supply:
 | Slack (MCP) | Your Slack app token | Channel reads and messages you post |
 | Sentry (MCP) | Your Sentry auth | Issue details you fetch |
 | AWS Secrets Manager (`aws-vault`) | Your AWS profile | Secret lookups you approve |
+| Postgres (databases via `Dev10x:db-psql`) | Connection strings from `databases.yaml` (env or keyring) | Read-only SQL queries you submit; results returned locally |
+| Anthropic API (Claude review CI) | Repository `ANTHROPIC_API_KEY` secret | PR diffs, commit metadata, and review comments processed by GitHub-hosted Claude actions |
+| PyPI (release CI only) | Trusted-publisher OIDC | Plugin distribution artifacts |
 
 Each integration is governed by the upstream vendor's own
 privacy policy.

--- a/bin/check-privacy-policy.py
+++ b/bin/check-privacy-policy.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# ///
+"""Audit the codebase for external-service usage and privacy-policy drift (GH-6).
+
+Usage:
+    bin/check-privacy-policy.py [--inventory] [--all] [PATH ...]
+
+Modes:
+    No paths given      → read newline-separated paths from stdin
+    Paths given         → audit those files
+    ``--all``           → audit every source/skill/script tree
+    ``--inventory``     → print a Markdown inventory regardless of violations
+
+Exits with status 1 if any violation is found:
+
+* A service detected in scanned files is missing from
+  ``PRIVACY_POLICY.md``'s "Third-party integrations" table.
+* A Python source file imports an outbound-network library
+  (``requests``, ``httpx``, ``urllib.request``, ...) — the policy
+  states no such calls are made from plugin code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from dev10x.skills.audit import privacy  # noqa: E402
+
+DEFAULT_SCAN_ROOTS: tuple[Path, ...] = (
+    REPO_ROOT / "src",
+    REPO_ROOT / "skills",
+    REPO_ROOT / "bin",
+    REPO_ROOT / "hooks",
+    REPO_ROOT / "servers",
+    REPO_ROOT / "commands",
+    REPO_ROOT / ".github" / "workflows",
+)
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        help="Files to audit (default: read from stdin)",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Audit every default scan root",
+    )
+    parser.add_argument(
+        "--inventory",
+        action="store_true",
+        help="Print the full inventory in Markdown",
+    )
+    parser.add_argument(
+        "--policy",
+        type=Path,
+        default=REPO_ROOT / "PRIVACY_POLICY.md",
+        help="Path to PRIVACY_POLICY.md",
+    )
+    return parser.parse_args(argv)
+
+
+def _resolve_paths(args: argparse.Namespace) -> list[Path]:
+    if args.all:
+        return list(DEFAULT_SCAN_ROOTS)
+    if args.paths:
+        return list(args.paths)
+    if sys.stdin.isatty():
+        return []
+    return [Path(line.strip()) for line in sys.stdin if line.strip()]
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    paths = _resolve_paths(args)
+    if not paths:
+        print("No paths to audit.", file=sys.stderr)
+        return 0
+
+    result = privacy.audit(scan_paths_=paths, policy_path=args.policy)
+
+    if args.inventory:
+        print(privacy.render_inventory_markdown(result))
+
+    if not result.has_violations:
+        scanned = len({u.path for u in result.usages})
+        print(
+            f"OK — {len(result.usages)} service reference(s) across "
+            f"{scanned} file(s); all documented in PRIVACY_POLICY.md."
+        )
+        return 0
+
+    if result.undocumented:
+        print(
+            f"\n[FAIL] Detected {len(result.undocumented)} undocumented service(s):",
+            file=sys.stderr,
+        )
+        for service in sorted(result.undocumented):
+            sample = next(u for u in result.usages if u.service == service)
+            print(
+                f"  - {service}: first seen at {sample.path}:{sample.line_number}",
+                file=sys.stderr,
+            )
+        print(
+            "\n  Add a row for each service to the 'Third-party integrations'\n"
+            "  table in PRIVACY_POLICY.md, or suppress with an inline marker:\n"
+            "      # privacy-audit: allow <service> — reason\n",
+            file=sys.stderr,
+        )
+
+    if result.net_imports:
+        print(
+            f"\n[FAIL] Detected {len(result.net_imports)} outbound-network "
+            f"import(s) in plugin source:",
+            file=sys.stderr,
+        )
+        for violation in result.net_imports:
+            print(f"  - {violation.format()}", file=sys.stderr)
+        print(
+            "\n  The privacy policy guarantees no outbound network calls from\n"
+            "  plugin code. Remove the import or update PRIVACY_POLICY.md.\n",
+            file=sys.stderr,
+        )
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/dev10x/skills/audit/privacy.py
+++ b/src/dev10x/skills/audit/privacy.py
@@ -1,0 +1,419 @@
+"""Detect external-service usage and privacy-policy drift across the plugin.
+
+GH-6 — security audits for the Dev10x plugin.
+
+Two responsibilities:
+
+1. **Inventory** — scan source files (``src/``, ``skills/``, ``bin/``,
+   ``hooks/``, ``servers/``, ``commands/``) for any reference to
+   third-party services. References are matched by:
+
+   * Python imports of HTTP/network libraries (``requests``, ``httpx``,
+     ``urllib``, ``aiohttp``).
+   * Subprocess invocations of external CLI tools (``gh``, ``aws-vault``,
+     ``kubectl``, ``psql``).
+   * MCP tool namespaces (``mcp__claude_ai_Linear__*``,
+     ``mcp__sentry__*``, etc.).
+   * Hostnames (``linear.app``, ``slack.com``, ``sentry.io``, ...).
+
+2. **Drift check** — parse the "Third-party integrations" table in
+   ``PRIVACY_POLICY.md`` to know which services are documented. Any
+   service detected in the scan that is *not* listed in the policy is
+   reported as a violation.
+
+The scanner is deliberately heuristic: it favours false positives over
+false negatives so that maintainers notice when a new integration slips
+into the codebase without a corresponding privacy entry.
+
+Inline suppressions are supported: append ``# privacy-audit: allow
+<service> — reason`` to the offending line.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+# ─────────────────────────────────────────────────────────────────────
+# Detection rules
+# ─────────────────────────────────────────────────────────────────────
+
+# Python imports that imply direct outbound network access from plugin
+# code. The privacy policy explicitly states that hooks, validators, and
+# MCP servers make no outbound calls — so any of these in plugin source
+# is a violation regardless of which service they target.
+OUTBOUND_NET_IMPORTS: frozenset[str] = frozenset(
+    {
+        "requests",
+        "httpx",
+        "aiohttp",
+        "urllib.request",
+        "urllib3",
+    }
+)
+
+_IMPORT_RE = re.compile(
+    r"^\s*(?:from\s+(?P<from>[\w.]+)\s+import\s+|import\s+(?P<mod>[\w.]+))",
+)
+
+# Service detection patterns. Each service maps to a list of (kind,
+# regex) tuples. ``kind`` is one of ``cli``, ``mcp``, ``hostname``,
+# ``token`` and is reported back for context.
+SERVICE_PATTERNS: dict[str, list[tuple[str, re.Pattern[str]]]] = {
+    "GitHub": [
+        ("cli", re.compile(r"(?<![\w-])gh\s+(api|pr|issue|repo|run|release|workflow|auth)")),
+        (
+            "cli",
+            re.compile(
+                r"""['"]gh['"]\s*,\s*['"](?:api|pr|issue|repo|run|release|workflow|auth)['"]"""
+            ),
+        ),
+        ("hostname", re.compile(r"\bgithub\.com\b")),
+        ("hostname", re.compile(r"\bapi\.github\.com\b")),
+    ],
+    "Linear": [
+        ("hostname", re.compile(r"\blinear\.app\b")),
+        ("mcp", re.compile(r"\bmcp__(?:[a-z_]+_)?[Ll]inear[a-z_]*__")),
+    ],
+    "JIRA": [
+        ("hostname", re.compile(r"\batlassian\.net\b")),
+        ("hostname", re.compile(r"\bjira\.atlassian\.com\b")),
+    ],
+    "Slack": [
+        ("hostname", re.compile(r"\bslack\.com\b")),
+        ("mcp", re.compile(r"\bmcp__(?:[a-z_]+_)?[Ss]lack[a-z_]*__")),
+    ],
+    "Sentry": [
+        ("hostname", re.compile(r"\bsentry\.io\b")),
+        ("mcp", re.compile(r"\bmcp__(?:[a-z_]+_)?[Ss]entry[a-z_]*__")),
+    ],
+    "AWS Secrets Manager": [
+        ("cli", re.compile(r"(?<![\w-])aws-vault\b")),
+        ("cli", re.compile(r"(?<![\w-])aws\s+secretsmanager\b")),
+    ],
+    "Anthropic API": [
+        ("hostname", re.compile(r"\banthropic\.com\b")),
+        ("token", re.compile(r"ANTHROPIC_API_KEY\b")),
+        ("cli", re.compile(r"\banthropics/claude-code-action\b")),
+    ],
+    "PyPI": [
+        ("hostname", re.compile(r"\bpypi\.org\b")),
+        ("cli", re.compile(r"(?<![\w-])twine\s+upload\b")),
+    ],
+    "Kubernetes API": [
+        ("cli", re.compile(r"(?<![\w-])kubectl\b")),
+    ],
+    "Postgres": [
+        ("cli", re.compile(r"(?<![\w-])psql\b")),
+    ],
+}
+
+# File extensions worth scanning. Markdown is included so SKILL docs
+# that name external services still register in the inventory.
+_SCANNED_EXTENSIONS: frozenset[str] = frozenset(
+    {".py", ".sh", ".md", ".yaml", ".yml", ".json", ".toml"}
+)
+
+# Directory names skipped during recursive scans.
+_SKIPPED_DIRS: frozenset[str] = frozenset(
+    {
+        ".git",
+        ".venv",
+        "venv",
+        "node_modules",
+        "__pycache__",
+        ".pytest_cache",
+        ".ruff_cache",
+        "dist",
+        "build",
+    }
+)
+
+# Files exempt from the outbound-network-import rule. The privacy
+# policy itself describes these patterns, and tests intentionally
+# exercise them.
+_NET_IMPORT_EXEMPT_PATHS: tuple[str, ...] = (
+    "PRIVACY_POLICY.md",
+    "src/dev10x/skills/audit/privacy.py",
+    "tests/",
+    # Skill scripts are documented in PRIVACY_POLICY.md as user-invoked
+    # outbound integrations. They are exempt from the no-outbound rule
+    # because the policy explicitly covers them.
+    "skills/qa-self/scripts/upload-screenshots.py",
+)
+
+# Files exempt from service detection. The scanner defines the
+# patterns it looks for, the policy enumerates documented services,
+# and tests construct fixture inputs — none of these are real
+# integrations.
+_DETECTION_EXEMPT_PATHS: tuple[str, ...] = (
+    "PRIVACY_POLICY.md",
+    "bin/check-privacy-policy.py",
+    "tests/skills/audit/test_privacy.py",
+    # Validator and audit modules describe tools they classify or
+    # intercept; they do not invoke them. The hook-validator and
+    # session-audit architectures guarantee no outbound calls
+    # from these modules.
+    "src/dev10x/validators/",
+    "src/dev10x/skills/audit/",
+    "skills/skill-audit/",
+    # The skill-reinforcement skill exists to redirect agents away
+    # from raw CLI commands; naming those commands is its job.
+    "skills/skill-reinforcement/",
+)
+
+_INLINE_ALLOW_RE = re.compile(
+    r"#\s*privacy-audit:\s*allow\s+(?P<service>[\w .()/-]+?)\s*(?:—|--|$)",
+)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Data model
+# ─────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ServiceUsage:
+    """A single detected reference to an external service."""
+
+    service: str
+    kind: str
+    path: Path
+    line_number: int
+    snippet: str
+
+    def format(self) -> str:
+        return (
+            f"{self.path}:{self.line_number}: [{self.service}/{self.kind}] {self.snippet.strip()}"
+        )
+
+
+@dataclass(frozen=True)
+class NetImportViolation:
+    """A direct outbound-network import in plugin source."""
+
+    module: str
+    path: Path
+    line_number: int
+    snippet: str
+
+    def format(self) -> str:
+        return (
+            f"{self.path}:{self.line_number}: [outbound-network] "
+            f"imports `{self.module}` — violates 'no outbound calls' policy"
+        )
+
+
+@dataclass(frozen=True)
+class AuditResult:
+    """Outcome of an audit run."""
+
+    usages: tuple[ServiceUsage, ...]
+    net_imports: tuple[NetImportViolation, ...]
+    documented: frozenset[str]
+    undocumented: frozenset[str]
+
+    @property
+    def has_violations(self) -> bool:
+        return bool(self.undocumented) or bool(self.net_imports)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Privacy policy parsing
+# ─────────────────────────────────────────────────────────────────────
+
+
+_TABLE_HEADER_RE = re.compile(r"^\|\s*Integration\s*\|\s*Credentials\s*\|", re.IGNORECASE)
+_TABLE_ROW_RE = re.compile(r"^\|\s*([^|]+?)\s*\|.*\|.*\|\s*$")
+
+
+def parse_documented_services(policy_text: str) -> frozenset[str]:
+    """Extract service names from the policy's third-party table.
+
+    The table header is::
+
+        | Integration | Credentials | Data exchanged |
+
+    Each subsequent row's first column is treated as a documented
+    service name. The leading service label may contain a parenthetical
+    (``GitHub (`gh` CLI, MCP)``) — the canonical name is everything up
+    to the first parenthesis.
+    """
+
+    services: set[str] = set()
+    in_table = False
+    for raw_line in policy_text.splitlines():
+        if _TABLE_HEADER_RE.match(raw_line):
+            in_table = True
+            continue
+        if in_table:
+            if not raw_line.startswith("|"):
+                in_table = False
+                continue
+            stripped_chars = set(raw_line.replace("|", "")) - {" "}
+            if stripped_chars <= {"-", ":"}:
+                # separator row
+                continue
+            match = _TABLE_ROW_RE.match(raw_line)
+            if not match:
+                continue
+            label = match.group(1)
+            canonical = label.split("(")[0].strip().strip("`")
+            if canonical:
+                services.add(canonical)
+    return frozenset(services)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Scanner
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _iter_files(roots: Iterable[Path]) -> Iterable[Path]:
+    for root in roots:
+        if root.is_file():
+            yield root
+            continue
+        if not root.exists():
+            continue
+        for path in root.rglob("*"):
+            if not path.is_file():
+                continue
+            if any(part in _SKIPPED_DIRS for part in path.parts):
+                continue
+            if path.suffix.lower() not in _SCANNED_EXTENSIONS:
+                continue
+            yield path
+
+
+def _is_net_import_exempt(path: Path) -> bool:
+    text = str(path)
+    return any(needle in text for needle in _NET_IMPORT_EXEMPT_PATHS)
+
+
+def _is_detection_exempt(path: Path) -> bool:
+    text = str(path)
+    return any(needle in text for needle in _DETECTION_EXEMPT_PATHS)
+
+
+def _suppressed_services(line: str) -> set[str]:
+    return {match.group("service").strip() for match in _INLINE_ALLOW_RE.finditer(line)}
+
+
+def _scan_text(path: Path, text: str) -> tuple[list[ServiceUsage], list[NetImportViolation]]:
+    usages: list[ServiceUsage] = []
+    net_violations: list[NetImportViolation] = []
+    is_python = path.suffix == ".py"
+    net_exempt = _is_net_import_exempt(path)
+    detection_exempt = _is_detection_exempt(path)
+
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        suppressions = _suppressed_services(line)
+
+        if is_python and not net_exempt:
+            match = _IMPORT_RE.match(line)
+            if match:
+                module = match.group("from") or match.group("mod") or ""
+                top_level = module.split(".")[0]
+                if module in OUTBOUND_NET_IMPORTS or top_level in OUTBOUND_NET_IMPORTS:
+                    net_violations.append(
+                        NetImportViolation(
+                            module=module,
+                            path=path,
+                            line_number=line_no,
+                            snippet=line.strip(),
+                        )
+                    )
+
+        if detection_exempt:
+            continue
+
+        for service, patterns in SERVICE_PATTERNS.items():
+            if service in suppressions:
+                continue
+            for kind, regex in patterns:
+                if regex.search(line):
+                    usages.append(
+                        ServiceUsage(
+                            service=service,
+                            kind=kind,
+                            path=path,
+                            line_number=line_no,
+                            snippet=line.strip(),
+                        )
+                    )
+                    break  # one hit per service per line is enough
+    return usages, net_violations
+
+
+def scan_paths(
+    paths: Iterable[Path],
+) -> tuple[list[ServiceUsage], list[NetImportViolation]]:
+    """Scan ``paths`` for external-service references and net imports."""
+
+    all_usages: list[ServiceUsage] = []
+    all_net: list[NetImportViolation] = []
+    for path in _iter_files(paths):
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        usages, net = _scan_text(path, text)
+        all_usages.extend(usages)
+        all_net.extend(net)
+    return all_usages, all_net
+
+
+def audit(
+    *,
+    scan_paths_: Iterable[Path],
+    policy_path: Path,
+) -> AuditResult:
+    """Run a full audit and return documented vs undocumented services."""
+
+    policy_text = policy_path.read_text(encoding="utf-8") if policy_path.exists() else ""
+    documented = parse_documented_services(policy_text)
+
+    usages, net_violations = scan_paths(scan_paths_)
+    detected = {u.service for u in usages}
+    undocumented = frozenset(detected - documented)
+
+    return AuditResult(
+        usages=tuple(usages),
+        net_imports=tuple(net_violations),
+        documented=documented,
+        undocumented=undocumented,
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Reporting helpers
+# ─────────────────────────────────────────────────────────────────────
+
+
+def render_inventory_markdown(result: AuditResult) -> str:
+    """Render a human-readable inventory of detected services."""
+
+    if not result.usages:
+        return "_No external services detected._\n"
+
+    by_service: dict[str, list[ServiceUsage]] = {}
+    for usage in result.usages:
+        by_service.setdefault(usage.service, []).append(usage)
+
+    lines: list[str] = ["# External Service Inventory", ""]
+    for service in sorted(by_service):
+        documented = "yes" if service in result.documented else "**NO**"
+        usages = by_service[service]
+        lines.append(f"## {service} (documented: {documented})")
+        lines.append("")
+        lines.append(f"References: {len(usages)}")
+        lines.append("")
+        for usage in usages[:20]:
+            lines.append(f"- `{usage.path}:{usage.line_number}` ({usage.kind})")
+        if len(usages) > 20:
+            lines.append(f"- ... and {len(usages) - 20} more")
+        lines.append("")
+    return "\n".join(lines)

--- a/tests/skills/audit/test_privacy.py
+++ b/tests/skills/audit/test_privacy.py
@@ -1,0 +1,303 @@
+"""Tests for the privacy / external-service audit scanner (GH-6)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dev10x.skills.audit import privacy
+
+
+def _write(path: Path, body: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+    return path
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Service detection
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestServiceDetection:
+    @pytest.mark.parametrize(
+        ("service", "snippet"),
+        [
+            ("GitHub", "subprocess.run(['gh', 'pr', 'view', '42'])"),
+            ("GitHub", "result = run('gh api repos/foo/bar')"),
+            ("Linear", "see https://linear.app/foo/issue/BAR-1"),
+            ("Linear", "tool = 'mcp__claude_ai_Linear__list_issues'"),
+            ("JIRA", "url = 'https://example.atlassian.net/browse/X-1'"),
+            ("Slack", "post to slack.com webhook"),
+            ("Slack", "mcp__claude_ai_Slack__send_message"),
+            ("Sentry", "mcp__sentry__get_issue_details"),
+            ("Sentry", "fetch('sentry.io/api/0/issues/123')"),
+            ("AWS Secrets Manager", "aws-vault exec prod -- env"),
+            ("AWS Secrets Manager", "aws secretsmanager get-secret-value"),
+            ("Anthropic API", "anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}"),
+            ("Anthropic API", "uses: anthropics/claude-code-action@v1"),
+            ("PyPI", "twine upload dist/*"),
+            ("Kubernetes API", "kubectl get pods -n prod"),
+            ("Postgres", "psql -h db.example.com -U app"),
+        ],
+    )
+    def test_service_pattern_fires(self, tmp_path: Path, service: str, snippet: str) -> None:
+        path = _write(tmp_path / "sample.md", snippet + "\n")
+        usages, _ = privacy.scan_paths([path])
+        assert any(u.service == service for u in usages), (
+            f"Expected {service} in {[u.service for u in usages]}"
+        )
+
+    @pytest.mark.parametrize(
+        "snippet",
+        [
+            "this references the github actions runtime via name only",
+            "the linear regression test predicts foo",
+            "merging is tricky when the slack channel is busy",
+            "the psqlite library is unrelated",
+            "gh.copy() is a method, not the gh CLI",
+        ],
+    )
+    def test_negative_lookups_do_not_fire(self, tmp_path: Path, snippet: str) -> None:
+        path = _write(tmp_path / "sample.md", snippet + "\n")
+        usages, _ = privacy.scan_paths([path])
+        assert usages == []
+
+    def test_inline_suppression_silences_service(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path / "sample.py",
+            "# privacy-audit: allow Kubernetes API — example doc only\n"
+            "kubectl_invocation = 'kubectl get pods'  "
+            "# privacy-audit: allow Kubernetes API — see line above\n",
+        )
+        usages, _ = privacy.scan_paths([path])
+        assert [u.service for u in usages] == []
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Outbound-network imports
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestNetImports:
+    @pytest.mark.parametrize(
+        "snippet",
+        [
+            "import requests",
+            "import httpx",
+            "from urllib.request import urlopen",
+            "import aiohttp",
+        ],
+    )
+    def test_flags_outbound_imports_in_source(self, tmp_path: Path, snippet: str) -> None:
+        path = _write(tmp_path / "src" / "module.py", snippet + "\n")
+        _, net = privacy.scan_paths([path])
+        assert len(net) == 1
+        assert net[0].path == path
+
+    def test_does_not_flag_imports_in_tests(self, tmp_path: Path) -> None:
+        path = _write(tmp_path / "tests" / "test_x.py", "import requests\n")
+        _, net = privacy.scan_paths([path])
+        assert net == []
+
+    def test_does_not_flag_imports_in_privacy_policy(self, tmp_path: Path) -> None:
+        path = _write(tmp_path / "PRIVACY_POLICY.md", "import requests\n")
+        _, net = privacy.scan_paths([path])
+        assert net == []
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Privacy policy parsing
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestPolicyParser:
+    def test_extracts_documented_services(self) -> None:
+        policy = """
+# Privacy Policy
+
+## Third-party integrations
+
+| Integration | Credentials | Data exchanged |
+|-------------|-------------|----------------|
+| GitHub (`gh` CLI, MCP) | Your GitHub token | PR payloads |
+| Linear (MCP) | Your Linear OAuth session | Issues |
+| JIRA (`Dev10x:jira`) | API token | Issues |
+
+## Children
+"""
+        documented = privacy.parse_documented_services(policy)
+        assert documented == frozenset({"GitHub", "Linear", "JIRA"})
+
+    def test_returns_empty_on_missing_table(self) -> None:
+        assert privacy.parse_documented_services("") == frozenset()
+        assert privacy.parse_documented_services("# Privacy\nNo table here.") == frozenset()
+
+
+# ─────────────────────────────────────────────────────────────────────
+# End-to-end audit
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def policy_with(tmp_path: Path):
+    """Factory that writes a privacy policy listing the given services."""
+
+    def factory(services: list[str]) -> Path:
+        rows = "\n".join(f"| {svc} | token | data |" for svc in services)
+        body = (
+            "# Privacy Policy\n\n"
+            "## Third-party integrations\n\n"
+            "| Integration | Credentials | Data exchanged |\n"
+            "|-------------|-------------|----------------|\n"
+            f"{rows}\n"
+        )
+        return _write(tmp_path / "PRIVACY_POLICY.md", body)
+
+    return factory
+
+
+class TestAudit:
+    def test_documented_service_passes(self, tmp_path: Path, policy_with) -> None:
+        policy = policy_with(["GitHub"])
+        source = _write(tmp_path / "src" / "x.py", "subprocess.run(['gh', 'pr', 'view'])\n")
+        result = privacy.audit(scan_paths_=[source], policy_path=policy)
+        assert result.undocumented == frozenset()
+        assert result.has_violations is False
+
+    def test_undocumented_service_flags_violation(self, tmp_path: Path, policy_with) -> None:
+        policy = policy_with(["GitHub"])
+        source = _write(tmp_path / "src" / "x.py", "kubectl_call = 'kubectl get pods'\n")
+        result = privacy.audit(scan_paths_=[source], policy_path=policy)
+        assert "Kubernetes API" in result.undocumented
+        assert result.has_violations is True
+
+    def test_outbound_import_flags_violation_even_when_service_documented(
+        self, tmp_path: Path, policy_with
+    ) -> None:
+        policy = policy_with(["GitHub"])
+        source = _write(tmp_path / "src" / "x.py", "import requests\n")
+        result = privacy.audit(scan_paths_=[source], policy_path=policy)
+        assert len(result.net_imports) == 1
+        assert result.has_violations is True
+
+    def test_missing_policy_treated_as_empty(self, tmp_path: Path) -> None:
+        source = _write(tmp_path / "src" / "x.py", "kubectl_call = 'kubectl'\n")
+        result = privacy.audit(scan_paths_=[source], policy_path=tmp_path / "missing.md")
+        assert "Kubernetes API" in result.undocumented
+
+
+class TestFormatMethods:
+    def test_service_usage_format(self) -> None:
+        usage = privacy.ServiceUsage(
+            service="GitHub",
+            kind="cli",
+            path=Path("src/x.py"),
+            line_number=10,
+            snippet="  gh pr view 1  ",
+        )
+        assert usage.format() == "src/x.py:10: [GitHub/cli] gh pr view 1"
+
+    def test_net_violation_format(self) -> None:
+        violation = privacy.NetImportViolation(
+            module="requests",
+            path=Path("src/x.py"),
+            line_number=3,
+            snippet="import requests",
+        )
+        formatted = violation.format()
+        assert "src/x.py:3" in formatted
+        assert "requests" in formatted
+        assert "outbound-network" in formatted
+
+
+class TestFileIteration:
+    def test_single_file_path_yielded_directly(self, tmp_path: Path, policy_with) -> None:
+        policy = policy_with(["GitHub"])
+        f = _write(tmp_path / "a.py", "subprocess.run(['gh', 'pr', 'view'])\n")
+        result = privacy.audit(scan_paths_=[f], policy_path=policy)
+        assert any(u.service == "GitHub" for u in result.usages)
+
+    def test_missing_path_silently_skipped(self, tmp_path: Path, policy_with) -> None:
+        policy = policy_with([])
+        result = privacy.audit(scan_paths_=[tmp_path / "does-not-exist"], policy_path=policy)
+        assert result.usages == ()
+        assert result.net_imports == ()
+
+    def test_skipped_dirs_are_excluded(self, tmp_path: Path, policy_with) -> None:
+        policy = policy_with([])
+        _write(
+            tmp_path / "node_modules" / "dep" / "x.py",
+            "kubectl_call = 'kubectl'\n",
+        )
+        result = privacy.audit(scan_paths_=[tmp_path], policy_path=policy)
+        assert result.usages == ()
+
+    def test_unscanned_extensions_are_excluded(self, tmp_path: Path, policy_with) -> None:
+        policy = policy_with([])
+        _write(tmp_path / "blob.bin", "kubectl content\n")
+        result = privacy.audit(scan_paths_=[tmp_path], policy_path=policy)
+        assert result.usages == ()
+
+
+class TestPolicyParserSeparatorRow:
+    def test_skips_separator_row(self) -> None:
+        policy = """
+| Integration | Credentials | Data |
+| ----------- | ----------- | ---- |
+| GitHub | token | data |
+"""
+        documented = privacy.parse_documented_services(policy)
+        assert documented == frozenset({"GitHub"})
+
+    def test_skips_malformed_table_row(self) -> None:
+        policy = """
+| Integration | Credentials | Data |
+| GitHub
+| Linear | token | data |
+"""
+        documented = privacy.parse_documented_services(policy)
+        assert documented == frozenset({"Linear"})
+
+
+class TestUnreadableFile:
+    def test_unreadable_file_silently_skipped(self, tmp_path: Path, policy_with) -> None:
+        import os
+
+        policy = policy_with([])
+        path = _write(tmp_path / "src" / "x.py", "kubectl_call = 'kubectl'\n")
+        os.chmod(path, 0o000)
+        try:
+            result = privacy.audit(scan_paths_=[path], policy_path=policy)
+        finally:
+            os.chmod(path, 0o644)
+        assert result.usages == ()
+
+
+class TestInventoryRendering:
+    def test_renders_grouped_markdown(self, tmp_path: Path, policy_with) -> None:
+        policy = policy_with(["GitHub"])
+        source = _write(
+            tmp_path / "src" / "x.py",
+            "subprocess.run(['gh', 'pr', 'view'])\nkubectl_call = 'kubectl get pods'\n",
+        )
+        result = privacy.audit(scan_paths_=[source], policy_path=policy)
+        rendered = privacy.render_inventory_markdown(result)
+        assert "## GitHub (documented: yes)" in rendered
+        assert "## Kubernetes API (documented: **NO**)" in rendered
+
+    def test_renders_truncates_long_lists(self, tmp_path: Path, policy_with) -> None:
+        policy = policy_with([])
+        body = "\n".join("kubectl_call = 'kubectl'" for _ in range(25)) + "\n"
+        source = _write(tmp_path / "src" / "x.py", body)
+        result = privacy.audit(scan_paths_=[source], policy_path=policy)
+        rendered = privacy.render_inventory_markdown(result)
+        assert "and 5 more" in rendered
+
+    def test_empty_inventory_message(self, tmp_path: Path, policy_with) -> None:
+        policy = policy_with([])
+        empty = _write(tmp_path / "src" / "x.py", "x = 1\n")
+        result = privacy.audit(scan_paths_=[empty], policy_path=policy)
+        rendered = privacy.render_inventory_markdown(result)
+        assert "No external services detected" in rendered


### PR DESCRIPTION
**When** opening a PR to the Dev10x plugin, **the maintainer wants to** automatically detect privacy-policy violations and unreported external service usage across skills, CLI, and scripts, **so plugin users can** trust that data-collection behavior is documented and reviewed before it ships.

---

[`852eac0d`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/59/commits/852eac0d152d47d5e8e8af699a99aaf876037a98) ✨ GH-6 Detect privacy and external service drift in CI
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/6

---