### PR TITLE
✨ GH-60 Enable in-place PR body updates via MCP tool

### DIFF
--- a/.claude/rules/mcp-tools.md
+++ b/.claude/rules/mcp-tools.md
@@ -66,6 +66,7 @@ supporting each tool:
 | `verify_pr_state` | `cli` | PR #191 | v0.30.0+ |
 | `pre_pr_checks` | `cli` | PR #191 | v0.30.0+ |
 | `create_pr` | `cli` | PR #191 | v0.30.0+ |
+| `update_pr` | `cli` | GH-60 | v0.70.0+ |
 | `generate_commit_list` | `cli` | PR #191 | v0.30.0+ |
 | `post_summary_comment` | `cli` | PR #191 | v0.30.0+ |
 | `pr_notify` | `cli` | PR #191 | v0.30.0+ |

--- a/skills/gh-pr-create/SKILL.md
+++ b/skills/gh-pr-create/SKILL.md
@@ -17,6 +17,7 @@ allowed-tools:
   - mcp__plugin_Dev10x_cli__verify_pr_state
   - mcp__plugin_Dev10x_cli__pre_pr_checks
   - mcp__plugin_Dev10x_cli__create_pr
+  - mcp__plugin_Dev10x_cli__update_pr
   - mcp__plugin_Dev10x_cli__generate_commit_list
   - mcp__plugin_Dev10x_cli__post_summary_comment
   - mcp__plugin_Dev10x_cli__detect_tracker

--- a/skills/gh-pr-create/instructions.md
+++ b/skills/gh-pr-create/instructions.md
@@ -336,18 +336,20 @@ don't apply to this PR, then update the PR body with strikethroughs:
 
 **Strike-through format:** Replace `- [ ] item text` with `- ~item text~`
 
-**Update PR body:** Use the REST API rather than `gh pr edit` to
-avoid GraphQL Projects-classic deprecation warnings causing exit 1
-on a successful update (GH-41):
+**Update PR body:** Call the `update_pr` MCP tool. It wraps the
+REST PATCH endpoint internally (avoiding the `gh pr edit` GraphQL
+Projects-classic deprecation that exits 1 on success — GH-41) and
+is auto-permitted under `mcp__plugin_Dev10x_cli__*`:
 
-```bash
-PR_NUMBER=$(gh pr view --json number -q .number)
-REPO_NWO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
-BODY_FILE=$(mktemp)
-trap 'rm -f "$BODY_FILE"' EXIT
-printf '%s' "$UPDATED_BODY" > "$BODY_FILE"
-gh api -X PATCH "repos/$REPO_NWO/pulls/$PR_NUMBER" -F "body=@$BODY_FILE"
 ```
+mcp__plugin_Dev10x_cli__update_pr(
+    pr_number=<N>,
+    body=<updated_body>,
+)
+```
+
+Returns `{pr_number, url}`. Pass `repo` only when not detectable
+from CWD.
 
 ### Step 8: Open PR in Browser
 

--- a/skills/git-groom/SKILL.md
+++ b/skills/git-groom/SKILL.md
@@ -13,6 +13,7 @@ invocation-name: Dev10x:git-groom
 allowed-tools:
   - mcp__plugin_Dev10x_cli__mass_rewrite
   - mcp__plugin_Dev10x_cli__rebase_groom
+  - mcp__plugin_Dev10x_cli__update_pr
   - Bash(${CLAUDE_PLUGIN_ROOT}/skills/git-groom/scripts/:*)
   - Bash(${CLAUDE_PLUGIN_ROOT}/skills/git/scripts/git-rebase-groom.sh:*)
   - Bash(git reset --soft:*)

--- a/skills/git-groom/instructions.md
+++ b/skills/git-groom/instructions.md
@@ -314,7 +314,12 @@ the full rewrite lifecycle including reference updates.
    - If no PR or PR is closed/merged → skip Phase 4, mark done
    - If PR is open → proceed with updates
 2. Get the new commit hash(es): `git log --oneline develop..HEAD`
-3. Update the PR body commit links with new hashes
+3. Update the PR body commit links with new hashes via the
+   `mcp__plugin_Dev10x_cli__update_pr` MCP tool (auto-permitted under
+   `mcp__plugin_Dev10x_cli__*`; pass the rebuilt body string):
+   ```
+   mcp__plugin_Dev10x_cli__update_pr(pr_number=<N>, body=<rebuilt_body>)
+   ```
 4. Update the summary comment (first comment by the author) with new hashes
 5. If the PR body has a Job Story, preserve it unchanged
 

--- a/src/dev10x/github/__init__.py
+++ b/src/dev10x/github/__init__.py
@@ -604,6 +604,43 @@ async def create_pr(
     return ok({"pr_number": int(pr_number), "url": url})
 
 
+async def update_pr(
+    *,
+    pr_number: int,
+    body: str | None = None,
+    title: str | None = None,
+    base_branch: str | None = None,
+    repo: str | None = None,
+) -> Result[dict[str, Any]]:
+    if body is None and title is None and base_branch is None:
+        return err("update_pr requires at least one of: body, title, base_branch")
+
+    repo_result = await _resolve_repo(repo)
+    if isinstance(repo_result, ErrorResult):
+        return err(repo_result.error)
+    repo_ref = repo_result.value
+
+    fields: dict[str, str | int | list[str]] = {}
+    if body is not None:
+        fields["body"] = body
+    if title is not None:
+        fields["title"] = title
+    if base_branch is not None:
+        fields["base"] = base_branch
+
+    result = await _gh_api(
+        f"repos/{repo_ref}/pulls/{pr_number}",
+        method="PATCH",
+        fields=fields,
+    )
+
+    if result.returncode != 0:
+        return err(result.stderr.strip())
+
+    url = f"https://github.com/{repo_ref}/pull/{pr_number}"
+    return ok({"pr_number": pr_number, "url": url})
+
+
 async def generate_commit_list(
     *,
     pr_number: int,

--- a/src/dev10x/mcp/server_cli.py
+++ b/src/dev10x/mcp/server_cli.py
@@ -332,6 +332,44 @@ async def create_pr(
 
 
 @server.tool()
+async def update_pr(
+    pr_number: int,
+    body: str | None = None,
+    title: str | None = None,
+    base_branch: str | None = None,
+    repo: str | None = None,
+) -> dict:
+    """Update an existing PR's body, title, or base branch.
+
+    Mirrors create_pr for in-place updates after force-push or scope
+    changes. Wraps `gh api -X PATCH repos/{repo}/pulls/{N}`.
+
+    Args:
+        pr_number: PR number to update
+        body: New PR body (markdown). Omit to leave unchanged.
+        title: New PR title. Omit to leave unchanged.
+        base_branch: New base branch (re-target). Omit to leave unchanged.
+        repo: Repository (owner/repo). Auto-detected if omitted.
+
+    At least one of body, title, or base_branch is required.
+
+    Returns:
+        Dictionary with keys: pr_number (int), url (str)
+    """
+    from dev10x import github as gh
+
+    return (
+        await gh.update_pr(
+            pr_number=pr_number,
+            body=body,
+            title=title,
+            base_branch=base_branch,
+            repo=repo,
+        )
+    ).to_dict()
+
+
+@server.tool()
 async def generate_commit_list(pr_number: int, base_branch: str | None = None) -> dict:
     """Generate a linked commit list for a PR body.
 

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -873,3 +873,99 @@ class TestPrCommentsStrategyDispatch:
 
         assert isinstance(result, ErrorResult)
         assert "Invalid repository reference" in result.error
+
+
+class TestUpdatePr:
+    @pytest.mark.asyncio
+    @patch("dev10x.github._gh_api", new_callable=AsyncMock)
+    async def test_updates_body(
+        self,
+        mock_api: AsyncMock,
+        mock_resolve_repo: AsyncMock,
+    ) -> None:
+        mock_api.return_value = _completed(stdout="{}")
+
+        result = await gh.update_pr(pr_number=42, body="new body")
+
+        assert isinstance(result, SuccessResult)
+        assert result.value == {
+            "pr_number": 42,
+            "url": "https://github.com/owner/repo/pull/42",
+        }
+        mock_api.assert_awaited_once()
+        call = mock_api.call_args
+        assert call.args[0] == "repos/owner/repo/pulls/42"
+        assert call.kwargs["method"] == "PATCH"
+        assert call.kwargs["fields"] == {"body": "new body"}
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github._gh_api", new_callable=AsyncMock)
+    async def test_updates_title_and_base(
+        self,
+        mock_api: AsyncMock,
+        mock_resolve_repo: AsyncMock,
+    ) -> None:
+        mock_api.return_value = _completed(stdout="{}")
+
+        result = await gh.update_pr(
+            pr_number=7,
+            title="New title",
+            base_branch="main",
+        )
+
+        assert isinstance(result, SuccessResult)
+        assert mock_api.call_args.kwargs["fields"] == {
+            "title": "New title",
+            "base": "main",
+        }
+
+    @pytest.mark.asyncio
+    async def test_returns_error_when_no_fields_provided(self) -> None:
+        result = await gh.update_pr(pr_number=1)
+
+        assert isinstance(result, ErrorResult)
+        assert "at least one" in result.error.lower()
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github._gh_api", new_callable=AsyncMock)
+    async def test_returns_error_when_repo_unresolved(
+        self,
+        mock_api: AsyncMock,
+    ) -> None:
+        with patch.object(gh, "_detect_repo", new_callable=AsyncMock, return_value=None):
+            result = await gh.update_pr(pr_number=1, body="x")
+
+        assert isinstance(result, ErrorResult)
+        mock_api.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github._gh_api", new_callable=AsyncMock)
+    async def test_returns_error_on_api_failure(
+        self,
+        mock_api: AsyncMock,
+        mock_resolve_repo: AsyncMock,
+    ) -> None:
+        mock_api.return_value = _completed(returncode=1, stderr="HTTP 422: Validation Failed")
+
+        result = await gh.update_pr(pr_number=42, body="x")
+
+        assert isinstance(result, ErrorResult)
+        assert "422" in result.error
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github._gh_api", new_callable=AsyncMock)
+    async def test_uses_explicit_repo_when_provided(
+        self,
+        mock_api: AsyncMock,
+    ) -> None:
+        mock_api.return_value = _completed(stdout="{}")
+
+        result = await gh.update_pr(
+            pr_number=99,
+            body="x",
+            repo="other/proj",
+        )
+
+        assert isinstance(result, SuccessResult)
+        assert result.value["url"] == "https://github.com/other/proj/pull/99"
+        assert mock_api.call_args.args[0] == "repos/other/proj/pulls/99"


### PR DESCRIPTION
When grooming or updating a PR body after force-push, I want to call a structured MCP tool instead of raw `gh api PATCH`, so gh-pr-create update mode and git-groom Phase 4 run unattended under the existing `mcp__plugin_Dev10x_cli__*` allow glob.

---

[`93bb31b7`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/61/commits/93bb31b76c720e821f16527f0cf2c74f07f8070f) ✨ GH-60 Enable in-place PR body updates via MCP tool
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/60

---