### PR TITLE
♻️ GH-983 Reduce agent dispatch tokens via body extraction

### DIFF
--- a/.claude/rules/INDEX.md
+++ b/.claude/rules/INDEX.md
@@ -53,6 +53,7 @@ The code review system uses a **multi-agent architecture**:
 | `.claude/rules/hook-patterns.md` | When editing `hooks/**` with dual implementations | Python-shell hook equivalence |
 | `.claude/rules/performance.md` | Reference: post-dependency change monitoring | CLI startup baseline, profiling instructions |
 | `.claude/rules/skill-body-extraction.md` | When editing `skills/**` | SKILL.md body extraction pattern, token reduction |
+| `.claude/rules/agent-body-extraction.md` | When editing `agents/**` | Agent spec body extraction pattern, token reduction |
 | `references/*.md` | On-demand by skills/CI | Detailed git, review, JTBD guides |
 
 ## Loading Order

--- a/.claude/rules/agent-body-extraction.md
+++ b/.claude/rules/agent-body-extraction.md
@@ -1,0 +1,141 @@
+# Agent Body Extraction Pattern
+
+Reduce token consumption on sub-agent dispatch by moving stable
+reference content out of plugin-distributed agent specs in
+`agents/` into sibling files under `references/agents/<name>/`.
+
+## Why extract
+
+When a sub-agent is dispatched via the `Agent` tool, its full
+spec body from `agents/<name>.md` is loaded into the dispatched
+session as the system prompt. Long phase tables, classification
+matrices, and operation matrices hit the dispatcher's context
+on every dispatch — even when the agent only needs one phase.
+
+Moving stable reference content into `references/agents/<name>/*.md`
+lets the agent read only what a given phase needs, instead of
+preloading the whole spec.
+
+This pattern mirrors `skill-body-extraction.md` for skills.
+
+## What to extract
+
+**Keep inline in `agents/<name>.md`** (always needed per dispatch):
+- YAML frontmatter (`name`, `description`, `tools`, `model`, `color`)
+- Brief overview (≤20 lines) — what the agent does, when to use
+- Phase outline: numbered phases with one-paragraph summaries
+- Severity definitions and report format (gate the output)
+- Key heuristics that apply across phases
+- Anti-patterns and "Do NOT modify any files" guardrails
+
+**Move to `references/agents/<name>/`** (loaded on demand):
+- Detailed classification tables (allow-rule categories, severity
+  matrices, deny/ask/skip recommendations)
+- Phase-specific tables that span 10+ rows
+- Pattern catalogs (e.g., toxicity patterns, known-safe patterns)
+- Worked examples per phase
+- Operation tables that map inputs to recommended outputs
+
+**Keep inline even when long** when the content gates execution —
+e.g., the "IMPORTANT: Do NOT modify any files" instruction, severity
+definitions used for the final report, and the report format itself.
+Moving those risks agents producing inconsistent output.
+
+## Extraction mechanics
+
+1. Identify cohesive sections to extract — prefer sections that
+   already have a clear heading (`### Phase 3: ...`, `### Known-Safe
+   Patterns`, multi-row tables).
+2. Create `references/agents/<agent-name>/<section-slug>.md`. Use a
+   short slug (`classification.md`, `destructive-ops.md`,
+   `instruction-paths.md`).
+3. Promote the extracted section's internal headings one level up
+   so the reference file reads as a standalone doc:
+   - `### Phase 3: Allow Rule Classification` inside the agent
+     becomes `# Allow Rule Classification` (or `## Phase 3: ...`)
+     in the reference file.
+4. In the agent spec, replace the section body with a one-paragraph
+   summary plus a pointer:
+
+   ```markdown
+   ### Phase 3: Allow Rule Classification
+
+   Classify every allow rule into risk categories and note whether
+   it is structurally broken or rule-fixable. See
+   [`references/agents/permission-auditor/classification.md`](../references/agents/permission-auditor/classification.md)
+   for the full category table, HOOK_ENABLED vs DEAD_RULE
+   distinction, toxicity patterns, and known-safe patterns.
+   ```
+
+5. When the extracted section contains a guardrail referenced from
+   the phase outline (e.g., "Deny rules are absolute — only
+   recommend for never-permitted ops"), keep that gating text
+   inline in the agent spec and move only the supporting tables.
+
+## Reference path convention
+
+Plugin-distributed agents live at the repo root: `agents/<name>.md`.
+Their references live at the repo root under `references/agents/<name>/`.
+
+| File | Path |
+|------|------|
+| Agent spec | `agents/permission-auditor.md` |
+| Per-phase reference | `references/agents/permission-auditor/classification.md` |
+| Cross-agent shared reference | `references/<topic>.md` (existing convention) |
+
+Do NOT place references inside `agents/<name>/` — agent discovery
+walks `agents/*.md` and a subdirectory there can confuse tooling.
+The repo-root `references/agents/<name>/` location keeps the agent
+file flat and groups references near other shared docs.
+
+## Budget
+
+- `agents/<name>.md` (plugin-distributed): 200 lines per
+  `.claude/rules/agents.md`
+- `.claude/agents/<name>.md` (internal review-only): 50 lines —
+  rarely needs extraction; if it does, prefer splitting the agent
+  itself rather than externalizing references
+- `references/agents/<name>/*.md`: 200 lines per file. Split
+  further when a reference itself grows beyond the cap.
+
+## Reviewer checklist
+
+When reviewing an agent refactor that extracts content:
+
+1. ✓ Agent spec still contains frontmatter, phase outline,
+   severity definitions, and report-format guardrails
+2. ✓ Each extracted section has a pointer in the agent spec
+   that names the reference path
+3. ✓ Reference file headings are promoted one level (no lone
+   `###` at the top of a reference doc)
+4. ✓ No gating logic moved into references. The "Do NOT modify
+   files" instruction, severity definitions, and report shape
+   stay inline.
+5. ✓ `tools:` frontmatter is unchanged — extracting body content
+   does not add or remove tool requirements.
+6. ✓ Reference paths use relative links from the agent spec
+   (`../references/agents/<name>/<file>.md`).
+
+## Current extraction state
+
+| Agent | Original lines | Current spec | Reference files |
+|-------|---------------:|-------------:|-----------------|
+| permission-auditor | 226 | <200 | `classification.md`, `destructive-ops.md`, `instruction-paths.md` |
+
+Pending work (follow-up tickets): pytest-test-writer (156),
+issue-investigator (121). These are within the 200-line budget
+today but would benefit from the same pattern as their phase
+tables grow.
+
+## Relation to skill-body-extraction.md
+
+This rule is the agent-side analogue of
+[`skill-body-extraction.md`](skill-body-extraction.md). The
+mechanics, "what to extract" guidance, and reviewer checklist
+mirror the skill version — the only differences are:
+
+- Agents live as flat files in `agents/`, so references go to
+  a sibling repo-root directory rather than under the agent
+- The "always-keep-inline" set is shaped by sub-agent dispatch
+  semantics rather than skill orchestration (no `TaskCreate` /
+  `AskUserQuestion` calls — agents output reports, not workflows)

--- a/.claude/rules/agents.md
+++ b/.claude/rules/agents.md
@@ -47,6 +47,15 @@ include full phase logic and examples, as opposed to internal review agents
 Use the feature name as-is: `agents/permission-auditor.md`, `agents/audit-deps.md`.
 Do NOT add a `Dev10x-` prefix to the filename.
 
+## Body Extraction
+
+When an `agents/<name>.md` spec approaches or exceeds the 200-line
+budget, extract stable phase tables and reference matrices into
+`references/agents/<name>/` and replace the section body with a
+one-paragraph summary plus a pointer. See
+[`agent-body-extraction.md`](agent-body-extraction.md) for the
+full pattern, mechanics, and reviewer checklist.
+
 ## Linking from Skills
 
 Reference distributed agents in skill definitions via `SKILL.md`:

--- a/agents/permission-auditor.md
+++ b/agents/permission-auditor.md
@@ -44,135 +44,68 @@ For each registered hook:
 
 ### Phase 3: Allow Rule Classification
 
-Classify every allow rule into risk categories:
+Classify every allow rule into risk categories (DESTRUCTIVE,
+OVERLY_BROAD, CONTRADICTS_POLICY, SKILL_REQUIRED, HOOK_ENABLED,
+DEAD_RULE, WILDCARD_ESCAPE, PRIVILEGE_ESCALATION, REDUNDANT,
+SAFE). For each non-SAFE rule, note the specific dangerous
+command it permits, whether a deny rule could narrow it, and
+whether the rule should be replaced with granular alternatives.
 
-| Category | Criteria | Example |
-|----------|----------|---------|
-| **DESTRUCTIVE** | Permits irreversible operations with no skill coverage | `Bash(rm -rf:*)` allows recursive deletion |
-| **OVERLY_BROAD** | Single rule covers destructive + safe operations | `Bash(gh:*)` covers `gh repo delete` |
-| **CONTRADICTS_POLICY** | Rule conflicts with CLAUDE.md instructions | `git config:*` when CLAUDE.md says "NEVER update git config" |
-| **SKILL_REQUIRED** | Rule enables skill/worktree workflows — must not be removed | `Bash(git reset:*)` for rebase recovery in worktrees |
-| **HOOK_ENABLED** | Allow rule exists so a PreToolUse hook can fire its redirect message | `Bash(git push:*)` enabled for SkillRedirectValidator |
-| **DEAD_RULE** | Rule is overridden by a hook AND the hook does not depend on the allow rule to fire | `python3 -c "import json:*"` blocked by `block-python3-inline.py` |
-| **WILDCARD_ESCAPE** | Variable prefix acts as wildcard for any command | `Bash(VARNAME=:*)` matches `VARNAME=x; rm -rf /` |
-| **PRIVILEGE_ESCALATION** | Rule allows modifying permission settings themselves | `Write(~/.claude/**)` covers `settings.local.json` |
-| **REDUNDANT** | Duplicate of another rule | Two identical `curl -sI` entries |
-| **SAFE** | Appropriately scoped for its purpose | `Bash(git log:*)` |
+The HOOK_ENABLED vs DEAD_RULE distinction is critical: removing
+a HOOK_ENABLED rule replaces an educational redirect with a
+generic permission prompt. See ADR-0003 for the rationale.
 
-**HOOK_ENABLED vs DEAD_RULE distinction:** The permission layer
-runs before hooks. If a hook's redirect message depends on the
-allow rule passing silently (e.g., SkillRedirectValidator), the
-rule is `HOOK_ENABLED` — removing it replaces the educational
-redirect with a generic permission prompt. Only classify as
-`DEAD_RULE` when the hook blocks unconditionally regardless of
-whether the allow rule exists (e.g., `block-python3-inline.py`).
-See ADR-0003 for the full rationale.
-
-For each non-SAFE rule, note:
-- The specific dangerous command it permits
-- Whether a deny rule could narrow it
-- Whether the rule should be replaced with granular alternatives
+See [`references/agents/permission-auditor/classification.md`](../references/agents/permission-auditor/classification.md)
+for the full category table, criteria, examples, and the
+HOOK_ENABLED vs DEAD_RULE rule.
 
 ### Phase 4: Toxicity Pattern Detection
 
-For each allow rule classified as non-SAFE, determine if the issue is **structural** (no allow rule can fix it) or **rule-based** (fixable with rule changes):
+For each non-SAFE allow rule, determine if the issue is
+**structural** (no allow rule can fix it — fix the skill/hook
+pattern instead) or **rule-based** (fixable with allow/deny
+rule changes).
 
-**Structural patterns** (require skill/hook updates, not rule changes):
-- `PREFIX_POISONED_SUBSHELL`: `VAR=$(cmd) && script` — `$()` shifts prefix
-- `PREFIX_POISONED_CHAIN`: `mkdir -p /tmp && script` — `&&` shifts prefix
-- `PREFIX_POISONED_ENVVAR`: `ENV=val command` — env prefix breaks matching
-- `PREFIX_POISONED_COMMENT`: `# comment\ncommand` — `#` breaks all matching
-- `HOOK_BLOCKED_RETRY`: Pattern already blocked by hook, should never be attempted
-
-**Rule-based patterns** (fixable with allow/deny rule changes):
-- `MISSING_DENY`: Destructive variant lacks a deny override
-- `NEEDS_GRANULAR`: Broad rule should be split into safe subcommands
-- `DEAD_RULE`: Hook blocks what the rule permits (hook does not depend on the allow rule)
-- `HOOK_ENABLED`: Allow rule enables a hook's redirect message — do NOT recommend removal
-
-### Known-Safe Patterns (Skip List)
-
-These allow rules are legitimate and must NOT be flagged as
-DESTRUCTIVE, OVERLY_BROAD, or CONTRADICTS_POLICY:
-
-| Pattern | Classification | Rationale |
-|---------|---------------|-----------|
-| `Bash(git reset:*)` | SKILL_REQUIRED | Worktree rebase recovery needs `--hard`; skills gate destructive usage |
-| `Bash(git reset --hard:*)` | SKILL_REQUIRED | Explicit variant of above — same rationale |
-| `Bash(git reset --soft:*)` | SAFE | Non-destructive; moves HEAD only |
-| `Bash(git -C:*)` | SKILL_REQUIRED | Cross-repo targeting when CWD is a different worktree; CLAUDE.md forbids redundant `-C` (when CWD matches), not all `-C` usage |
-
-When encountering these patterns during Phase 3, classify them
-per the table above — do not escalate to HIGH/CRITICAL.
+See [`references/agents/permission-auditor/classification.md`](../references/agents/permission-auditor/classification.md)
+for the structural pattern catalog (PREFIX_POISONED_*,
+HOOK_BLOCKED_RETRY), the rule-based pattern catalog
+(MISSING_DENY, NEEDS_GRANULAR, DEAD_RULE, HOOK_ENABLED), and
+the Known-Safe Patterns skip list (`git reset`, `git -C`, etc.)
+that must NOT be flagged.
 
 ### Phase 5: Deny Rule Gap Analysis
 
 Check for missing protection on known destructive operations.
 
-**IMPORTANT: Deny rules are absolute — they cannot be overridden by
-skills, hooks, or user approval. Only recommend deny rules for
-operations that should NEVER be permitted. For operations that are
-sometimes legitimate (e.g., via skills), recommend "ask" rules or
-note that hook protection is sufficient.**
+**IMPORTANT: Deny rules are absolute — they cannot be overridden
+by skills, hooks, or user approval. Only recommend deny rules
+for operations that should NEVER be permitted. For operations
+that are sometimes legitimate (e.g., via skills), recommend
+"ask" rules or note that hook protection is sufficient.**
 
-#### Step 1: Inventory hook and skill coverage
+Inventory hook/skill coverage first, then classify each
+destructive operation as **deny**, **ask**, **hook-protected**,
+or **skip**.
 
-Read the plugin's `hooks.json` and each hook script to build a
-coverage map. Also inventory skills that legitimately need
-dangerous-looking operations (e.g., `Dev10x:git` needs force-push,
-`update-config` needs settings writes, `Dev10x:gh-pr-monitor` needs
-`gh pr merge`).
-
-#### Step 2: Classify each destructive operation
-
-| Operation | Recommendation | Rationale |
-|-----------|---------------|-----------|
-| `git reset --hard` | **skip** | Skills use for rebase recovery in worktrees (SKILL_REQUIRED) |
-| `git checkout .` / `git restore .` | **ask** | Dangerous but not never-legitimate |
-| `git clean` | **ask** | Rarely legitimate, but not never |
-| `git push --force` (bare) | **ask** | `Dev10x:git` handles with branch checks |
-| `git push --force-with-lease` | **skip** | Legitimately used by skills |
-| Settings file writes | **skip** | `update-config`/`upgrade-cleanup` need this |
-| Hook/plugin file writes | **skip** | `update-config` needs this |
-| `rm -rf` on non-temp paths | **deny** | No legitimate skill usage |
-| Direct database writes | **deny** if not hook-protected | Check if `sql_safety.py` covers it |
-| `gh pr merge/close` | **skip** | Skills handle with safety gates |
-
-**Classification key:**
-- **deny** — Should NEVER succeed. No skill needs it, no hook covers it.
-- **ask** — Dangerous but sometimes legitimate. User prompted each time.
-- **hook-protected** — A PreToolUse hook validates contextually.
-  Recommend keeping the hook, not adding a redundant rule.
-- **skip** — Covered by skill safety logic. Do not recommend any rule.
+See [`references/agents/permission-auditor/destructive-ops.md`](../references/agents/permission-auditor/destructive-ops.md)
+for the full inventory steps, the per-operation matrix
+(`git reset --hard`, force-push, settings writes, `rm -rf`,
+`gh pr merge`, etc.), and the classification key.
 
 ### Phase 6: Instruction File Path Audit
 
-Scan CLAUDE.md files and memory files for hardcoded script paths
-that bypass skill invocations:
+Scan CLAUDE.md files and memory files for hardcoded script
+paths that bypass skill invocations. Flag paths in CLAUDE.md
+or memory files; exclude paths inside SKILL.md (skills
+legitimately reference their own scripts).
 
-**Files to scan:**
-- `CLAUDE.md` in project root and `.claude/` directories
-- `~/.claude/CLAUDE.md` (global instructions)
-- `~/.claude/memory/Dev10x/**/*.md` (memory files)
+For each match: identify the parent skill and suggest the skill
+invocation name (or the MCP tool name when wrapped) as
+replacement.
 
-**Patterns to flag:**
-
-| Pattern | Severity | Rationale |
-|---------|----------|-----------|
-| `~/.claude/skills/*/scripts/*` | WARNING | Hardcoded skill script path — breaks on plugin updates |
-| `~/.claude/plugins/cache/*/*/skills/*/scripts/*` | WARNING | Resolved plugin cache path — ephemeral across versions |
-| `~/.claude/tools/*.py` called without skill context | LOW | May be intentional but worth noting |
-
-**For each match:**
-1. Identify the script's parent skill (from the path or nearby SKILL.md)
-2. Suggest the skill invocation name as replacement
-3. If the script is wrapped by an MCP tool, suggest the MCP tool name
-
-**Classification:**
-- Paths inside SKILL.md files are **excluded** (skills legitimately
-  reference their own scripts)
-- Paths in CLAUDE.md or memory files are **flagged** (instruction
-  leaks that bypass skill context)
+See [`references/agents/permission-auditor/instruction-paths.md`](../references/agents/permission-auditor/instruction-paths.md)
+for the file scan list, the pattern severity table, the
+per-match action steps, and the SKILL.md exclusion rule.
 
 ### Phase 7: Report & Propose
 

--- a/references/agents/permission-auditor/classification.md
+++ b/references/agents/permission-auditor/classification.md
@@ -1,0 +1,83 @@
+# Allow Rule Classification & Toxicity Patterns
+
+Reference material for the `permission-auditor` agent — Phases 3
+and 4. The agent spec links here for the full category table,
+the HOOK_ENABLED vs DEAD_RULE distinction, structural toxicity
+patterns, and known-safe patterns.
+
+## Phase 3: Allow Rule Classification
+
+Classify every allow rule into risk categories:
+
+| Category | Criteria | Example |
+|----------|----------|---------|
+| **DESTRUCTIVE** | Permits irreversible operations with no skill coverage | `Bash(rm -rf:*)` allows recursive deletion |
+| **OVERLY_BROAD** | Single rule covers destructive + safe operations | `Bash(gh:*)` covers `gh repo delete` |
+| **CONTRADICTS_POLICY** | Rule conflicts with CLAUDE.md instructions | `git config:*` when CLAUDE.md says "NEVER update git config" |
+| **SKILL_REQUIRED** | Rule enables skill/worktree workflows — must not be removed | `Bash(git reset:*)` for rebase recovery in worktrees |
+| **HOOK_ENABLED** | Allow rule exists so a PreToolUse hook can fire its redirect message | `Bash(git push:*)` enabled for SkillRedirectValidator |
+| **DEAD_RULE** | Rule is overridden by a hook AND the hook does not depend on the allow rule to fire | `python3 -c "import json:*"` blocked by `block-python3-inline.py` |
+| **WILDCARD_ESCAPE** | Variable prefix acts as wildcard for any command | `Bash(VARNAME=:*)` matches `VARNAME=x; rm -rf /` |
+| **PRIVILEGE_ESCALATION** | Rule allows modifying permission settings themselves | `Write(~/.claude/**)` covers `settings.local.json` |
+| **REDUNDANT** | Duplicate of another rule | Two identical `curl -sI` entries |
+| **SAFE** | Appropriately scoped for its purpose | `Bash(git log:*)` |
+
+### HOOK_ENABLED vs DEAD_RULE distinction
+
+The permission layer runs before hooks. If a hook's redirect
+message depends on the allow rule passing silently (e.g.,
+SkillRedirectValidator), the rule is `HOOK_ENABLED` — removing
+it replaces the educational redirect with a generic permission
+prompt. Only classify as `DEAD_RULE` when the hook blocks
+unconditionally regardless of whether the allow rule exists
+(e.g., `block-python3-inline.py`). See ADR-0003 for the full
+rationale.
+
+For each non-SAFE rule, note:
+- The specific dangerous command it permits
+- Whether a deny rule could narrow it
+- Whether the rule should be replaced with granular alternatives
+
+## Phase 4: Toxicity Pattern Detection
+
+For each allow rule classified as non-SAFE, determine if the
+issue is **structural** (no allow rule can fix it) or
+**rule-based** (fixable with rule changes).
+
+### Structural patterns (require skill/hook updates, not rule changes)
+
+- `PREFIX_POISONED_SUBSHELL`: `VAR=$(cmd) && script` — `$()`
+  shifts prefix
+- `PREFIX_POISONED_CHAIN`: `mkdir -p /tmp && script` — `&&`
+  shifts prefix
+- `PREFIX_POISONED_ENVVAR`: `ENV=val command` — env prefix
+  breaks matching
+- `PREFIX_POISONED_COMMENT`: `# comment\ncommand` — `#` breaks
+  all matching
+- `HOOK_BLOCKED_RETRY`: Pattern already blocked by hook, should
+  never be attempted
+
+### Rule-based patterns (fixable with allow/deny rule changes)
+
+- `MISSING_DENY`: Destructive variant lacks a deny override
+- `NEEDS_GRANULAR`: Broad rule should be split into safe
+  subcommands
+- `DEAD_RULE`: Hook blocks what the rule permits (hook does not
+  depend on the allow rule)
+- `HOOK_ENABLED`: Allow rule enables a hook's redirect message —
+  do NOT recommend removal
+
+## Known-Safe Patterns (Skip List)
+
+These allow rules are legitimate and must NOT be flagged as
+DESTRUCTIVE, OVERLY_BROAD, or CONTRADICTS_POLICY:
+
+| Pattern | Classification | Rationale |
+|---------|---------------|-----------|
+| `Bash(git reset:*)` | SKILL_REQUIRED | Worktree rebase recovery needs `--hard`; skills gate destructive usage |
+| `Bash(git reset --hard:*)` | SKILL_REQUIRED | Explicit variant of above — same rationale |
+| `Bash(git reset --soft:*)` | SAFE | Non-destructive; moves HEAD only |
+| `Bash(git -C:*)` | SKILL_REQUIRED | Cross-repo targeting when CWD is a different worktree; CLAUDE.md forbids redundant `-C` (when CWD matches), not all `-C` usage |
+
+When encountering these patterns during Phase 3, classify them
+per the table above — do not escalate to HIGH/CRITICAL.

--- a/references/agents/permission-auditor/destructive-ops.md
+++ b/references/agents/permission-auditor/destructive-ops.md
@@ -1,0 +1,40 @@
+# Deny Rule Gap Analysis: Destructive Operations Matrix
+
+Reference material for the `permission-auditor` agent — Phase 5.
+The agent spec links here for the inventory of hook/skill
+coverage, the per-operation classification matrix, and the
+classification key.
+
+## Step 1: Inventory hook and skill coverage
+
+Read the plugin's `hooks.json` and each hook script to build a
+coverage map. Also inventory skills that legitimately need
+dangerous-looking operations (e.g., `Dev10x:git` needs
+force-push, `update-config` needs settings writes,
+`Dev10x:gh-pr-monitor` needs `gh pr merge`).
+
+## Step 2: Classify each destructive operation
+
+| Operation | Recommendation | Rationale |
+|-----------|---------------|-----------|
+| `git reset --hard` | **skip** | Skills use for rebase recovery in worktrees (SKILL_REQUIRED) |
+| `git checkout .` / `git restore .` | **ask** | Dangerous but not never-legitimate |
+| `git clean` | **ask** | Rarely legitimate, but not never |
+| `git push --force` (bare) | **ask** | `Dev10x:git` handles with branch checks |
+| `git push --force-with-lease` | **skip** | Legitimately used by skills |
+| Settings file writes | **skip** | `update-config`/`upgrade-cleanup` need this |
+| Hook/plugin file writes | **skip** | `update-config` needs this |
+| `rm -rf` on non-temp paths | **deny** | No legitimate skill usage |
+| Direct database writes | **deny** if not hook-protected | Check if `sql_safety.py` covers it |
+| `gh pr merge/close` | **skip** | Skills handle with safety gates |
+
+## Classification Key
+
+- **deny** — Should NEVER succeed. No skill needs it, no hook
+  covers it.
+- **ask** — Dangerous but sometimes legitimate. User prompted
+  each time.
+- **hook-protected** — A PreToolUse hook validates contextually.
+  Recommend keeping the hook, not adding a redundant rule.
+- **skip** — Covered by skill safety logic. Do not recommend
+  any rule.

--- a/references/agents/permission-auditor/instruction-paths.md
+++ b/references/agents/permission-auditor/instruction-paths.md
@@ -1,0 +1,35 @@
+# Instruction File Path Audit
+
+Reference material for the `permission-auditor` agent — Phase 6.
+The agent spec links here for the file scan list, the pattern
+table, the per-match action steps, and the SKILL.md exclusion
+rule.
+
+## Files to scan
+
+- `CLAUDE.md` in project root and `.claude/` directories
+- `~/.claude/CLAUDE.md` (global instructions)
+- `~/.claude/memory/Dev10x/**/*.md` (memory files)
+
+## Patterns to flag
+
+| Pattern | Severity | Rationale |
+|---------|----------|-----------|
+| `~/.claude/skills/*/scripts/*` | WARNING | Hardcoded skill script path — breaks on plugin updates |
+| `~/.claude/plugins/cache/*/*/skills/*/scripts/*` | WARNING | Resolved plugin cache path — ephemeral across versions |
+| `~/.claude/tools/*.py` called without skill context | LOW | May be intentional but worth noting |
+
+## For each match
+
+1. Identify the script's parent skill (from the path or nearby
+   SKILL.md)
+2. Suggest the skill invocation name as replacement
+3. If the script is wrapped by an MCP tool, suggest the MCP
+   tool name
+
+## Classification
+
+- Paths inside SKILL.md files are **excluded** (skills
+  legitimately reference their own scripts)
+- Paths in CLAUDE.md or memory files are **flagged**
+  (instruction leaks that bypass skill context)


### PR DESCRIPTION
**When** maintaining the Dev10x plugin and dispatching plugin-distributed sub-agents, **I want to** keep agent specs under their 200-line budget by extracting stable phase tables into references, **so I can** cut the per-dispatch token cost and apply the same body-extraction pattern that proved out for skills.

---

[`504265fb`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/63/commits/504265fb702cc148dfff927f32c22c16e1086d7e) ♻️ GH-983 Reduce agent dispatch tokens via body extraction

---

**Note:** Source ticket lives in the deprecated `Dev10x-Claude2` repo. The PR targets the active `dev10x-claude` repo per current routing.

Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/983
