### PR TITLE
🐛 Cover user-global settings.json in upgrade-cleanup rewrites

### DIFF
--- a/src/dev10x/skills/permission/update_paths.py
+++ b/src/dev10x/skills/permission/update_paths.py
@@ -21,16 +21,12 @@ from pathlib import Path
 import yaml
 
 MEMORY_CONFIG = Path.home() / ".claude" / "memory" / "Dev10x" / "projects.yaml"
-USERSPACE_CONFIG = (
-    Path.home() / ".claude" / "skills" / "Dev10x:upgrade-cleanup" / "projects.yaml"
-)
+USERSPACE_CONFIG = Path.home() / ".claude" / "skills" / "Dev10x:upgrade-cleanup" / "projects.yaml"
 PLUGIN_CONFIG = (
     Path(__file__).resolve().parents[4] / "skills" / "upgrade-cleanup" / "projects.yaml"
 )
 PLUGIN_NAMES = r"(?:Dev10x|dev10x-claude)"
-VERSION_PATTERN = re.compile(
-    rf"(plugins/cache/)([^/]+)(/{PLUGIN_NAMES}/)(\d+\.\d+\.\d+)"
-)
+VERSION_PATTERN = re.compile(rf"(plugins/cache/)([^/]+)(/{PLUGIN_NAMES}/)(\d+\.\d+\.\d+)")
 
 
 def extract_cache_publisher(plugin_cache: str) -> str | None:
@@ -86,9 +82,11 @@ def find_settings_files(
 ) -> list[Path]:
     files: list[Path] = []
     if include_user:
-        user_settings = Path.home() / ".claude" / "settings.local.json"
-        if user_settings.exists():
-            files.append(user_settings)
+        user_dir = Path.home() / ".claude"
+        for name in ("settings.json", "settings.local.json"):
+            candidate = user_dir / name
+            if candidate.exists():
+                files.append(candidate)
 
     project_settings_dir = Path.home() / ".claude" / "projects"
     if project_settings_dir.is_dir():
@@ -220,12 +218,8 @@ def ensure_base_permissions(
             live_data["permissions"]["allow"].extend(expanded_tools)
             live_data["permissions"]["allow"].extend(missing)
 
-    messages = [
-        f"  - {wc}  (non-functional MCP wildcard removed)" for wc in stale_wildcards
-    ]
-    messages.extend(
-        f"  + {tool}  (expanded from MCP wildcard)" for tool in expanded_tools
-    )
+    messages = [f"  - {wc}  (non-functional MCP wildcard removed)" for wc in stale_wildcards]
+    messages.extend(f"  + {tool}  (expanded from MCP wildcard)" for tool in expanded_tools)
     messages.extend(f"  + {p}" for p in missing)
     return len(missing) + len(stale_wildcards) + len(expanded_tools), messages
 
@@ -913,16 +907,12 @@ def _detect_plugin_cache() -> str:
                 candidates.append(plugin_dir)
                 break
     if len(candidates) == 1:
-        return (
-            f"~/.claude/plugins/cache/{candidates[0].parent.name}/{candidates[0].name}"
-        )
+        return f"~/.claude/plugins/cache/{candidates[0].parent.name}/{candidates[0].name}"
     if len(candidates) > 1:
         names = ", ".join(f"{c.parent.name}/{c.name}" for c in candidates)
         print(f"Multiple plugin cache entries found: {names}")
         print(f"Using first match: {candidates[0].parent.name}/{candidates[0].name}")
-        return (
-            f"~/.claude/plugins/cache/{candidates[0].parent.name}/{candidates[0].name}"
-        )
+        return f"~/.claude/plugins/cache/{candidates[0].parent.name}/{candidates[0].name}"
     return "~/.claude/plugins/cache/Dev10x-Guru/Dev10x"
 
 
@@ -934,9 +924,7 @@ def _init_userspace_config() -> int:
         print(f"Config already exists: {USERSPACE_CONFIG}")
         return 0
     if not PLUGIN_CONFIG.is_file():
-        print(
-            f"ERROR: Plugin default config not found: {PLUGIN_CONFIG}", file=sys.stderr
-        )
+        print(f"ERROR: Plugin default config not found: {PLUGIN_CONFIG}", file=sys.stderr)
         return 1
     USERSPACE_CONFIG.parent.mkdir(parents=True, exist_ok=True)
     content = PLUGIN_CONFIG.read_text()

--- a/tests/skills/upgrade-cleanup/test_update_paths.py
+++ b/tests/skills/upgrade-cleanup/test_update_paths.py
@@ -5,7 +5,11 @@ from pathlib import Path
 
 import pytest
 
-from dev10x.skills.permission.update_paths import extract_cache_publisher, update_file
+from dev10x.skills.permission.update_paths import (
+    extract_cache_publisher,
+    find_settings_files,
+    update_file,
+)
 
 
 class TestExtractCachePublisher:
@@ -208,3 +212,52 @@ class TestUpdateFilePublisher:
 
         assert count == 1
         assert settings_file.read_text() == content
+
+
+class TestFindSettingsFilesUserGlobal:
+    """Regression: ~/.claude/settings.json was skipped by find_settings_files
+    when include_user=True (Dev10x-Claude2#982). Both user-global files must
+    be discovered so versioned plugin paths are rewritten there too."""
+
+    @pytest.fixture()
+    def fake_home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        home = tmp_path / "home"
+        (home / ".claude").mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+        return home
+
+    def test_includes_both_user_global_files_when_include_user(
+        self,
+        fake_home: Path,
+    ) -> None:
+        local = fake_home / ".claude" / "settings.local.json"
+        global_ = fake_home / ".claude" / "settings.json"
+        local.write_text("{}")
+        global_.write_text("{}")
+
+        files = find_settings_files(roots=[], include_user=True)
+
+        assert local.resolve() in files
+        assert global_.resolve() in files
+
+    def test_includes_settings_json_even_when_local_missing(
+        self,
+        fake_home: Path,
+    ) -> None:
+        global_ = fake_home / ".claude" / "settings.json"
+        global_.write_text("{}")
+
+        files = find_settings_files(roots=[], include_user=True)
+
+        assert global_.resolve() in files
+
+    def test_skips_user_global_files_when_include_user_false(
+        self,
+        fake_home: Path,
+    ) -> None:
+        (fake_home / ".claude" / "settings.json").write_text("{}")
+        (fake_home / ".claude" / "settings.local.json").write_text("{}")
+
+        files = find_settings_files(roots=[], include_user=False)
+
+        assert files == []


### PR DESCRIPTION
**When** running `Dev10x:upgrade-cleanup` after a plugin version bump, **I want to** have versioned plugin paths rewritten in `~/.claude/settings.json` as well as `~/.claude/settings.local.json`, **so I can** avoid silent permission prompts once the prior plugin cache is evicted.

---

[`64ef3507`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/64/commits/64ef3507018816a0babc8dc86ae1fe6649a91d63) 🐛 Cover user-global settings.json in upgrade-cleanup rewrites
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude2/issues/982

---