### PR TITLE
✨ GH-65 Enable bot identity for agent-generated PR replies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 dependencies = [
     "click>=8.0",
     "msgpack>=1.0",
+    "pyjwt[crypto]>=2.8",
     "pyyaml>=6.0",
 ]
 

--- a/references/github-app-setup.md
+++ b/references/github-app-setup.md
@@ -1,0 +1,142 @@
+# GitHub App Bot Identity Setup
+
+When configured, Dev10x posts agent-generated PR review replies and
+PR summary comments under a GitHub App identity (e.g.
+`dev10x-bot[bot]`) so reviewers can tell at a glance which messages
+came from the engineer and which came from the local agent.
+
+The feature is **opt-in**. With no configuration, every call uses
+the engineer's existing `gh auth` token — no behavior change.
+
+## What identity each call uses
+
+| Call site | Identity |
+|-----------|----------|
+| `pr_comment_reply` (review thread replies) | bot |
+| `post_summary_comment` (PR summary footer) | bot |
+| `create_pr` (PR authorship) | engineer |
+| `request_review` (reviewer assignment) | engineer |
+| `resolve_review_thread` | engineer |
+| `issue_create` | engineer |
+| `pr_notify` (Slack + reviewer ping) | engineer |
+
+Engineer-attribution stays for actions where `dev10x-bot[bot]` would
+break GitHub semantics — branch protection rules that require a human
+author/approver, reviewer assignment, and thread resolution.
+
+## Quick start: interactive wizard
+
+The fastest way to set this up is the bundled CLI. If you don't
+already have `dev10x` on your `PATH` (Claude Code marketplace
+installs the plugin but not the CLI globally), install it once
+from PyPI via [`uv`](https://docs.astral.sh/uv/):
+
+```bash
+uv tool install Dev10x
+```
+
+Then run the wizard:
+
+```bash
+dev10x github-app setup
+```
+
+It walks through App registration, prompts for the App ID,
+Installation ID (optional), and pasted private key, validates the
+key locally with a self-signed JWT, and writes
+`~/.claude/Dev10x/github-bot/{github-app.yaml,dev10x-bot.pem}`
+with `chmod 600`.
+
+Run `dev10x github-app status` to confirm the config is in place.
+
+To upgrade later: `uv tool upgrade Dev10x`.
+
+The rest of this doc covers the manual flow if you prefer to wire
+things up yourself, or want context on what each value means.
+
+## One-time GitHub App registration
+
+1. Visit
+   <https://github.com/settings/apps/new> (personal) or
+   `https://github.com/organizations/<org>/settings/apps/new` (org).
+2. Fill in:
+   - **Name:** `dev10x-bot` (or any unique name — what appears as
+     `<name>[bot]` next to the comments)
+   - **Homepage URL:** anything; it's not user-facing
+   - **Webhook:** uncheck "Active" — Dev10x doesn't receive webhooks
+3. **Repository permissions:**
+   - `Pull requests` → `Read and write` — required for review
+     replies and summary comments
+   - `Contents` → `Read-only` — required so the App can read the
+     repo before commenting
+   - All others → `No access`
+4. **Where can this App be installed:** "Only on this account" is
+   fine for personal use.
+5. Create the App, then on the App settings page:
+   - Note the **App ID** (numeric)
+   - Click **Generate a private key** — a `.pem` file downloads.
+     Move it to `~/.claude/Dev10x/github-bot/dev10x-bot.pem` and `chmod 600`.
+6. Click **Install App** in the left nav. Pick the repos you want
+   the bot to post in. After installing, the URL contains
+   `installations/<id>` — that's the **Installation ID** (optional;
+   Dev10x can resolve it per-repo automatically).
+
+## Configure Dev10x
+
+Create `~/.claude/Dev10x/github-bot/github-app.yaml`:
+
+```yaml
+github_app:
+  app_id: "123456"
+  private_key_path: "~/.claude/Dev10x/github-bot/dev10x-bot.pem"
+  # installation_id is optional — Dev10x will auto-resolve it
+  # from the target repo via the App JWT if omitted
+  installation_id: "78901234"
+  enabled: true
+```
+
+To temporarily disable the bot identity for a session, flip
+`enabled: false` (or delete the file). Calls fall back to user
+auth.
+
+## Verify the bot identity is in effect
+
+Open a draft PR on a repo where the App is installed, then ask
+Dev10x to reply to one of the PR review comments. The reply
+should show the bot avatar and `[bot]` suffix on the author
+chip. Other engineer-driven actions (PR creation, reviewer
+assignment) should keep your personal avatar.
+
+If a reply still posts under your personal account:
+
+1. Confirm the App is **installed** on the target repo (the
+   GitHub App settings page lists the repos under "Installed").
+2. Confirm `~/.claude/Dev10x/github-bot/dev10x-bot.pem` is readable
+   (`ls -l` should show `600`).
+3. Confirm `app_id` in the yaml matches the numeric App ID
+   on the App settings page.
+4. Run the failing call once more and check the Dev10x debug
+   logs — when token resolution fails (missing key, bad scope,
+   App not installed), Dev10x logs the failure and falls back
+   to user auth silently rather than erroring.
+
+## Security notes
+
+- The private key authenticates as the App. Treat it like a
+  password: store under `~/.claude/Dev10x/github-bot/`, set `chmod 600`,
+  never commit it.
+- Installation tokens (the short-lived bearer Dev10x mints from
+  the JWT) live in process memory only; they are not written
+  to disk.
+- The token is cached per-repo until 60 seconds before its
+  expiry, then refreshed transparently. Restart your Claude
+  session to drop the cache early.
+
+## Out of scope (current implementation)
+
+- The shell-script paths in `gh-pr-monitor` and a few legacy
+  comment-posting scripts still inherit the engineer's auth
+  even when the App is configured. Migration is tracked
+  separately — see the issue thread.
+- Slack notifications continue to use the existing Slack bot.
+  This document covers GitHub identity only.

--- a/src/dev10x/cli.py
+++ b/src/dev10x/cli.py
@@ -40,6 +40,7 @@ class LazyGroup(click.Group):
 @click.group(
     cls=LazyGroup,
     lazy_subcommands={
+        "github-app": "dev10x.commands.github_app.github_app",
         "hook": "dev10x.commands.hook.hook",
         "init": "dev10x.commands.init.init",
         "permission": "dev10x.commands.permission.permission",

--- a/src/dev10x/commands/github_app.py
+++ b/src/dev10x/commands/github_app.py
@@ -1,0 +1,241 @@
+"""`dev10x github-app setup` — interactive onboarding for the bot identity.
+
+Walks the user through GitHub App registration, prompts for the App
+ID, installation ID, and private key, then writes a tightly-permissioned
+config tree under ``~/.claude/Dev10x/github-bot/``. Validates the key
+locally by minting a self-signed JWT before persisting.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import click
+
+CONFIG_DIR = Path.home() / ".claude" / "Dev10x" / "github-bot"
+CONFIG_PATH = CONFIG_DIR / "github-app.yaml"
+KEY_PATH = CONFIG_DIR / "dev10x-bot.pem"
+
+NEW_APP_URL = "https://github.com/settings/apps/new"
+
+INTRO = """\
+Dev10x GitHub App setup
+━━━━━━━━━━━━━━━━━━━━━━━
+
+This walks you through wiring up a GitHub App so agent-generated PR
+review replies post under a `<your-app>[bot]` identity instead of your
+personal account.
+
+You will need to:
+  1. Register the App on github.com (one browser visit)
+  2. Install it on the repos you want the bot to comment on
+  3. Paste the App ID, Installation ID, and private key here
+
+Press Ctrl+C at any time to abort. Nothing is written until the
+final step.
+"""
+
+CREATE_APP_INSTRUCTIONS = """\
+Step 1: Register the GitHub App
+───────────────────────────────
+
+Open this URL:
+
+    {url}
+
+Fill in:
+  Name           dev10x-bot   (or any unique name; appears as
+                              `<name>[bot]` next to comments)
+  Homepage URL   anything (not user-facing)
+  Webhook        UNCHECK "Active" — Dev10x doesn't receive webhooks
+
+Repository permissions:
+  Pull requests       Read and write   (required)
+  Contents            Read-only        (required)
+  All others          No access
+
+Click "Create GitHub App". On the App settings page:
+  • Note the App ID (numeric)
+  • Click "Generate a private key" — a .pem file downloads
+"""
+
+INSTALL_INSTRUCTIONS = """\
+Step 2: Install the App
+───────────────────────
+
+On the App settings page, click "Install App" in the left nav.
+Pick the repos you want the bot to comment on.
+
+After installing, the URL contains "installations/<id>" — that's the
+Installation ID. It's optional here; Dev10x can auto-resolve it from
+each target repo if you leave the prompt blank.
+"""
+
+
+def _prompt_app_id() -> str:
+    while True:
+        value = click.prompt("App ID", type=str).strip()
+        if value.isdigit():
+            return value
+        click.echo("  App ID must be numeric (look for it on the App settings page).")
+
+
+def _prompt_installation_id() -> str | None:
+    value = click.prompt(
+        "Installation ID (blank to auto-resolve per repo)",
+        type=str,
+        default="",
+        show_default=False,
+    ).strip()
+    if not value:
+        return None
+    while not value.isdigit():
+        click.echo("  Installation ID must be numeric or blank.")
+        value = click.prompt(
+            "Installation ID (blank to auto-resolve per repo)",
+            type=str,
+            default="",
+            show_default=False,
+        ).strip()
+        if not value:
+            return None
+    return value
+
+
+def _prompt_private_key() -> str:
+    click.echo("")
+    click.echo("Paste the private key contents below.")
+    click.echo("Include the BEGIN/END lines. Finish with a blank line:")
+    click.echo("")
+    lines: list[str] = []
+    saw_end = False
+    while True:
+        line = sys.stdin.readline()
+        if not line:
+            break
+        stripped = line.rstrip("\n")
+        if saw_end and stripped == "":
+            break
+        if not stripped and not lines:
+            continue
+        lines.append(stripped)
+        if "END" in stripped and "PRIVATE KEY" in stripped:
+            saw_end = True
+    return "\n".join(lines) + "\n"
+
+
+def _validate_key_locally(*, app_id: str, private_key: str) -> str | None:
+    """Return None on success, or a human-readable error message."""
+    try:
+        import jwt
+    except ImportError:
+        return "PyJWT is not installed. Run `uv sync --extra dev`."
+    try:
+        token = jwt.encode(
+            {"iat": 0, "exp": 60, "iss": app_id},
+            private_key,
+            algorithm="RS256",
+        )
+    except Exception as exc:  # noqa: BLE001 — surface the underlying message
+        return f"Private key is not valid for RS256 signing: {exc}"
+    if not token:
+        return "JWT signing produced an empty token."
+    return None
+
+
+def _write_files(
+    *,
+    app_id: str,
+    installation_id: str | None,
+    private_key: str,
+) -> None:
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    KEY_PATH.write_text(private_key)
+    os.chmod(KEY_PATH, 0o600)
+
+    yaml_lines = [
+        "github_app:",
+        f'  app_id: "{app_id}"',
+        f'  private_key_path: "{KEY_PATH}"',
+        "  enabled: true",
+    ]
+    if installation_id:
+        yaml_lines.insert(2, f'  installation_id: "{installation_id}"')
+    CONFIG_PATH.write_text("\n".join(yaml_lines) + "\n")
+    os.chmod(CONFIG_PATH, 0o600)
+
+
+@click.group()
+def github_app() -> None:
+    """Manage the Dev10x GitHub App bot identity."""
+
+
+@github_app.command()
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Overwrite existing config without prompting.",
+)
+def setup(*, force: bool) -> None:
+    """Interactive setup wizard for the GitHub App bot identity."""
+    click.echo(INTRO)
+
+    if (CONFIG_PATH.exists() or KEY_PATH.exists()) and not force:
+        click.echo(f"Existing config at {CONFIG_DIR} — pass --force to overwrite.")
+        if not click.confirm("Overwrite?", default=False):
+            click.echo("Aborted.")
+            sys.exit(1)
+
+    click.echo(CREATE_APP_INSTRUCTIONS.format(url=NEW_APP_URL))
+    click.pause(info="Press any key when the App is created and the .pem file is downloaded… ")
+    click.echo("")
+    click.echo(INSTALL_INSTRUCTIONS)
+    click.pause(info="Press any key when the App is installed on at least one repo… ")
+    click.echo("")
+    click.echo("Step 3: Paste credentials")
+    click.echo("─────────────────────────")
+    click.echo("")
+
+    app_id = _prompt_app_id()
+    installation_id = _prompt_installation_id()
+    private_key = _prompt_private_key()
+
+    error = _validate_key_locally(app_id=app_id, private_key=private_key)
+    if error is not None:
+        click.echo(f"\n  ✗ {error}")
+        click.echo("  Re-download the .pem from the App settings page and try again.")
+        sys.exit(1)
+
+    _write_files(
+        app_id=app_id,
+        installation_id=installation_id,
+        private_key=private_key,
+    )
+
+    click.echo("")
+    click.echo("  ✓ Wrote config: " + str(CONFIG_PATH))
+    click.echo("  ✓ Wrote key:    " + str(KEY_PATH))
+    click.echo("")
+    click.echo("Next: open a draft PR on a repo where the App is installed,")
+    click.echo("then ask Dev10x to reply to a review comment. The reply should")
+    click.echo("now appear under the bot identity instead of your account.")
+
+
+@github_app.command()
+def status() -> None:
+    """Show current GitHub App config status."""
+    if not CONFIG_PATH.exists():
+        click.echo(f"No config at {CONFIG_PATH}")
+        click.echo("Run `dev10x github-app setup` to create one.")
+        sys.exit(1)
+
+    click.echo(f"Config:        {CONFIG_PATH}")
+    click.echo(f"Key:           {KEY_PATH}")
+    click.echo(f"Key readable:  {KEY_PATH.is_file() and os.access(KEY_PATH, os.R_OK)}")
+    if KEY_PATH.is_file():
+        mode = oct(KEY_PATH.stat().st_mode & 0o777)
+        click.echo(f"Key mode:      {mode}")
+        if mode != "0o600":
+            click.echo("  ⚠  Expected 0o600 — fix with: chmod 600 " + str(KEY_PATH))

--- a/src/dev10x/github/__init__.py
+++ b/src/dev10x/github/__init__.py
@@ -8,12 +8,14 @@ All public functions are async to avoid blocking the MCP event loop.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 from pathlib import Path
 from typing import Any
 
 from dev10x.domain.repository_ref import RepositoryRef
 from dev10x.domain.result import ErrorResult, Result, err, ok
+from dev10x.github.app_auth import get_bot_token
 from dev10x.subprocess_utils import (
     async_run,
     async_run_script,
@@ -37,6 +39,8 @@ async def _gh_api(
     method: str = "GET",
     fields: dict[str, str | int | list[str]] | None = None,
     jq: str | None = None,
+    repo: str | None = None,
+    as_bot: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     args = ["gh", "api"]
     if method != "GET":
@@ -54,7 +58,15 @@ async def _gh_api(
                 args.extend(["-f", f"{key}={value}"])
     args.append(endpoint)
 
-    return await async_run(args=args, timeout=30)
+    env = await _bot_env(repo=repo) if as_bot and repo else None
+    return await async_run(args=args, timeout=30, env=env)
+
+
+async def _bot_env(*, repo: str) -> dict[str, str] | None:
+    token = await get_bot_token(repo=repo)
+    if token is None:
+        return None
+    return {**os.environ, "GH_TOKEN": token, "GITHUB_TOKEN": token}
 
 
 async def _resolve_repo(
@@ -281,6 +293,8 @@ async def _pr_comment_reply(
         f"repos/{resolved_repo}/pulls/{pr_number}/comments",
         method="POST",
         fields={"body": body, "in_reply_to": comment_id_int},
+        repo=str(resolved_repo),
+        as_bot=True,
     )
     return _parse_gh_api_result(result)
 
@@ -486,6 +500,8 @@ async def pr_comment_reply(
         f"repos/{resolved_repo}/pulls/{pr_number}/comments",
         method="POST",
         fields={"body": body, "in_reply_to": comment_id_int},
+        repo=str(resolved_repo),
+        as_bot=True,
     )
 
     return _parse_gh_api_result(result)
@@ -665,11 +681,20 @@ async def post_summary_comment(
     *,
     issue_id: str,
     summary_text: str,
+    repo: str | None = None,
 ) -> Result[dict[str, Any]]:
+    env_vars: dict[str, str] = {}
+    resolved_repo = repo or await _detect_repo()
+    if resolved_repo:
+        bot_env = await _bot_env(repo=resolved_repo)
+        if bot_env is not None:
+            env_vars["GH_TOKEN"] = bot_env["GH_TOKEN"]
+            env_vars["GITHUB_TOKEN"] = bot_env["GITHUB_TOKEN"]
     result = await async_run_script(
         "skills/gh-pr-create/scripts/post-summary-comment.sh",
         issue_id,
         summary_text,
+        env_vars=env_vars or None,
     )
 
     if result.returncode != 0:

--- a/src/dev10x/github/app_auth.py
+++ b/src/dev10x/github/app_auth.py
@@ -1,0 +1,185 @@
+"""GitHub App authentication for posting agent-generated content.
+
+Loads an opt-in App configuration from
+``~/.claude/Dev10x/github-app.yaml`` and mints short-lived
+installation tokens for the configured repository. The tokens are
+cached per-repo until shortly before their expiry.
+
+When configuration is absent, malformed, or the token exchange
+fails, ``get_bot_token`` returns ``None`` so callers can fall back
+to the engineer's ``gh auth`` token without raising.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+import yaml
+
+from dev10x.subprocess_utils import async_run
+
+DEFAULT_CONFIG_PATH = Path.home() / ".claude" / "Dev10x" / "github-bot" / "github-app.yaml"
+
+
+@dataclass(frozen=True)
+class AppConfig:
+    app_id: str
+    private_key_path: Path
+    installation_id: str | None = None
+
+    @classmethod
+    def load(cls, *, path: Path | None = None) -> AppConfig | None:
+        config_path = path or DEFAULT_CONFIG_PATH
+        if not config_path.is_file():
+            return None
+        try:
+            data = yaml.safe_load(config_path.read_text()) or {}
+        except (OSError, yaml.YAMLError):
+            return None
+        block = data.get("github_app") or {}
+        if not block.get("enabled", True):
+            return None
+        app_id = block.get("app_id")
+        key_path = block.get("private_key_path")
+        if not app_id or not key_path:
+            return None
+        installation_raw = block.get("installation_id")
+        return cls(
+            app_id=str(app_id),
+            private_key_path=Path(str(key_path)).expanduser(),
+            installation_id=str(installation_raw) if installation_raw else None,
+        )
+
+
+@dataclass
+class _CachedToken:
+    token: str
+    expires_at: float
+
+
+_TOKEN_CACHE: dict[str, _CachedToken] = {}
+
+
+def _clear_cache() -> None:
+    _TOKEN_CACHE.clear()
+
+
+def _create_app_jwt(*, app_id: str, private_key: str) -> str:
+    import jwt
+
+    now = int(time.time())
+    payload = {"iat": now - 30, "exp": now + 540, "iss": app_id}
+    return jwt.encode(payload, private_key, algorithm="RS256")
+
+
+def _parse_expires_at(raw: str | None) -> float:
+    if not raw:
+        return time.time() + 3600
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return time.time() + 3600
+
+
+async def _resolve_installation_id(
+    *,
+    repo: str,
+    app_jwt: str,
+) -> str | None:
+    result = await async_run(
+        args=[
+            "gh",
+            "api",
+            "-H",
+            "Accept: application/vnd.github+json",
+            f"/repos/{repo}/installation",
+        ],
+        env={**os.environ, "GH_TOKEN": app_jwt, "GITHUB_TOKEN": app_jwt},
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        return str(json.loads(result.stdout)["id"])
+    except (json.JSONDecodeError, KeyError, TypeError):
+        return None
+
+
+async def _exchange_for_installation_token(
+    *,
+    installation_id: str,
+    app_jwt: str,
+) -> tuple[str, float] | None:
+    result = await async_run(
+        args=[
+            "gh",
+            "api",
+            "-X",
+            "POST",
+            f"/app/installations/{installation_id}/access_tokens",
+        ],
+        env={**os.environ, "GH_TOKEN": app_jwt, "GITHUB_TOKEN": app_jwt},
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    token = data.get("token")
+    if not token:
+        return None
+    return token, _parse_expires_at(data.get("expires_at"))
+
+
+async def get_bot_token(
+    *,
+    repo: str,
+    config: AppConfig | None = None,
+) -> str | None:
+    """Return an installation token for ``repo``, or ``None`` on failure.
+
+    Callers should treat ``None`` as a signal to fall back to the
+    engineer's existing ``gh auth`` credentials.
+    """
+    cached = _TOKEN_CACHE.get(repo)
+    if cached is not None:
+        if cached.expires_at - 60 > time.time():
+            return cached.token
+        _TOKEN_CACHE.pop(repo, None)
+
+    cfg = config if config is not None else AppConfig.load()
+    if cfg is None:
+        return None
+
+    try:
+        private_key = cfg.private_key_path.read_text()
+    except OSError:
+        return None
+
+    try:
+        app_jwt = _create_app_jwt(app_id=cfg.app_id, private_key=private_key)
+    except Exception:
+        return None
+
+    installation_id = cfg.installation_id or await _resolve_installation_id(
+        repo=repo,
+        app_jwt=app_jwt,
+    )
+    if installation_id is None:
+        return None
+
+    exchanged = await _exchange_for_installation_token(
+        installation_id=installation_id,
+        app_jwt=app_jwt,
+    )
+    if exchanged is None:
+        return None
+
+    token, expires_at = exchanged
+    _TOKEN_CACHE[repo] = _CachedToken(token=token, expires_at=expires_at)
+    return token

--- a/tests/commands/test_github_app.py
+++ b/tests/commands/test_github_app.py
@@ -1,0 +1,134 @@
+"""Tests for `dev10x github-app` setup wizard."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from dev10x.commands import github_app as gha
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setattr(gha, "CONFIG_DIR", tmp_path / "github-bot")
+    monkeypatch.setattr(gha, "CONFIG_PATH", tmp_path / "github-bot" / "github-app.yaml")
+    monkeypatch.setattr(gha, "KEY_PATH", tmp_path / "github-bot" / "dev10x-bot.pem")
+    return tmp_path
+
+
+class TestSetupWritesConfig:
+    @pytest.fixture
+    def fake_key(self) -> str:
+        return "-----BEGIN RSA PRIVATE KEY-----\nFAKEKEY\n-----END RSA PRIVATE KEY-----\n"
+
+    @pytest.fixture
+    def stdin_input(self, fake_key: str) -> str:
+        return "\n".join(["", "12345", "67890", *fake_key.splitlines(), ""]) + "\n"
+
+    @pytest.fixture
+    def result(
+        self,
+        fake_home: Path,
+        stdin_input: str,
+    ) -> object:
+        runner = CliRunner()
+        with patch.object(gha, "_validate_key_locally", return_value=None):
+            return runner.invoke(gha.github_app, ["setup"], input=stdin_input)
+
+    def test_exits_successfully(self, result: object) -> None:
+        assert result.exit_code == 0, result.output
+
+    def test_writes_config_file(self, result: object, fake_home: Path) -> None:
+        assert (fake_home / "github-bot" / "github-app.yaml").is_file()
+
+    def test_writes_key_file(self, result: object, fake_home: Path) -> None:
+        assert (fake_home / "github-bot" / "dev10x-bot.pem").is_file()
+
+    def test_config_contains_app_id(self, result: object, fake_home: Path) -> None:
+        config = (fake_home / "github-bot" / "github-app.yaml").read_text()
+        assert 'app_id: "12345"' in config
+
+    def test_config_contains_installation_id(
+        self,
+        result: object,
+        fake_home: Path,
+    ) -> None:
+        config = (fake_home / "github-bot" / "github-app.yaml").read_text()
+        assert 'installation_id: "67890"' in config
+
+    def test_key_file_has_600_perms(self, result: object, fake_home: Path) -> None:
+        key_path = fake_home / "github-bot" / "dev10x-bot.pem"
+        mode = stat.S_IMODE(key_path.stat().st_mode)
+        assert mode == 0o600
+
+    def test_config_file_has_600_perms(self, result: object, fake_home: Path) -> None:
+        config_path = fake_home / "github-bot" / "github-app.yaml"
+        mode = stat.S_IMODE(config_path.stat().st_mode)
+        assert mode == 0o600
+
+
+class TestSetupValidationFailure:
+    def test_aborts_when_key_invalid(self, fake_home: Path) -> None:
+        runner = CliRunner()
+        stdin_input = (
+            "\n12345\n\n-----BEGIN RSA PRIVATE KEY-----\nBADKEY\n-----END RSA PRIVATE KEY-----\n\n"
+        )
+        with patch.object(gha, "_validate_key_locally", return_value="bad signature"):
+            result = runner.invoke(gha.github_app, ["setup"], input=stdin_input)
+
+        assert result.exit_code == 1
+        assert "bad signature" in result.output
+        assert not (fake_home / "github-bot" / "github-app.yaml").exists()
+
+
+class TestSetupOptionalInstallationId:
+    def test_omits_installation_id_when_blank(self, fake_home: Path) -> None:
+        runner = CliRunner()
+        fake_key = "-----BEGIN RSA PRIVATE KEY-----\nKEY\n-----END RSA PRIVATE KEY-----\n"
+        stdin_input = "\n".join(["", "12345", "", *fake_key.splitlines(), ""]) + "\n"
+        with patch.object(gha, "_validate_key_locally", return_value=None):
+            result = runner.invoke(gha.github_app, ["setup"], input=stdin_input)
+
+        assert result.exit_code == 0, result.output
+        config = (fake_home / "github-bot" / "github-app.yaml").read_text()
+        assert "  installation_id:" not in config
+
+
+class TestSetupRejectsExistingWithoutForce:
+    def test_aborts_when_config_exists_and_no_confirm(
+        self,
+        fake_home: Path,
+    ) -> None:
+        gha.CONFIG_DIR.mkdir(parents=True)
+        gha.CONFIG_PATH.write_text("github_app:\n  app_id: '0'\n")
+
+        runner = CliRunner()
+        result = runner.invoke(gha.github_app, ["setup"], input="\nN\n")
+
+        assert result.exit_code == 1
+
+
+class TestStatus:
+    def test_reports_missing_config(self, fake_home: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(gha.github_app, ["status"])
+
+        assert result.exit_code == 1
+        assert "No config" in result.output
+
+    def test_reports_present_config(self, fake_home: Path) -> None:
+        gha.CONFIG_DIR.mkdir(parents=True)
+        gha.CONFIG_PATH.write_text("github_app:\n  app_id: '0'\n")
+        gha.KEY_PATH.write_text("KEY")
+        os.chmod(gha.KEY_PATH, 0o600)
+
+        runner = CliRunner()
+        result = runner.invoke(gha.github_app, ["status"])
+
+        assert result.exit_code == 0
+        assert str(gha.CONFIG_PATH) in result.output

--- a/tests/github/test_app_auth.py
+++ b/tests/github/test_app_auth.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dev10x.github import app_auth as auth
+
+
+@pytest.fixture(autouse=True)
+def clear_token_cache():
+    auth._clear_cache()
+    yield
+    auth._clear_cache()
+
+
+def _completed(
+    *,
+    returncode: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=[],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+class TestAppConfigLoad:
+    def test_returns_none_when_file_missing(self, tmp_path: Path) -> None:
+        result = auth.AppConfig.load(path=tmp_path / "missing.yaml")
+        assert result is None
+
+    def test_loads_full_config(self, tmp_path: Path) -> None:
+        path = tmp_path / "github-app.yaml"
+        path.write_text(
+            "github_app:\n"
+            "  app_id: '12345'\n"
+            "  installation_id: '67890'\n"
+            "  private_key_path: /keys/bot.pem\n"
+            "  enabled: true\n"
+        )
+        result = auth.AppConfig.load(path=path)
+        assert result is not None
+        assert result.app_id == "12345"
+        assert result.installation_id == "67890"
+        assert result.private_key_path == Path("/keys/bot.pem")
+
+    def test_returns_none_when_disabled(self, tmp_path: Path) -> None:
+        path = tmp_path / "github-app.yaml"
+        path.write_text(
+            "github_app:\n  app_id: '1'\n  private_key_path: /k.pem\n  enabled: false\n"
+        )
+        assert auth.AppConfig.load(path=path) is None
+
+    def test_returns_none_when_missing_required_keys(self, tmp_path: Path) -> None:
+        path = tmp_path / "github-app.yaml"
+        path.write_text("github_app:\n  enabled: true\n")
+        assert auth.AppConfig.load(path=path) is None
+
+    def test_returns_none_on_malformed_yaml(self, tmp_path: Path) -> None:
+        path = tmp_path / "github-app.yaml"
+        path.write_text("not: valid: yaml: [unclosed")
+        assert auth.AppConfig.load(path=path) is None
+
+    def test_expands_user_home_in_key_path(self, tmp_path: Path) -> None:
+        path = tmp_path / "github-app.yaml"
+        path.write_text("github_app:\n  app_id: '1'\n  private_key_path: ~/keys/bot.pem\n")
+        result = auth.AppConfig.load(path=path)
+        assert result is not None
+        assert "~" not in str(result.private_key_path)
+
+
+class TestGetBotToken:
+    @pytest.fixture
+    def app_config(self, tmp_path: Path) -> auth.AppConfig:
+        key_path = tmp_path / "bot.pem"
+        key_path.write_text(
+            "-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----\n"
+        )
+        return auth.AppConfig(
+            app_id="12345",
+            private_key_path=key_path,
+            installation_id="67890",
+        )
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_config_missing(self) -> None:
+        with patch.object(auth.AppConfig, "load", return_value=None):
+            result = await auth.get_bot_token(repo="owner/repo")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_private_key_unreadable(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        config = auth.AppConfig(
+            app_id="1",
+            private_key_path=tmp_path / "missing.pem",
+            installation_id="2",
+        )
+        result = await auth.get_bot_token(repo="owner/repo", config=config)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_mints_and_caches_token(
+        self,
+        app_config: auth.AppConfig,
+    ) -> None:
+        token_response = _completed(
+            stdout=json.dumps({"token": "ghs_secret", "expires_at": "2099-01-01T00:00:00Z"})
+        )
+        with (
+            patch.object(auth, "_create_app_jwt", return_value="jwt-token"),
+            patch(
+                "dev10x.github.app_auth.async_run",
+                new_callable=AsyncMock,
+                return_value=token_response,
+            ) as mock_run,
+        ):
+            first = await auth.get_bot_token(repo="owner/repo", config=app_config)
+            second = await auth.get_bot_token(repo="owner/repo", config=app_config)
+
+        assert first == "ghs_secret"
+        assert second == "ghs_secret"
+        assert mock_run.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_resolves_installation_id_when_absent(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        key_path = tmp_path / "bot.pem"
+        key_path.write_text("KEY")
+        config = auth.AppConfig(app_id="1", private_key_path=key_path)
+
+        responses = [
+            _completed(stdout=json.dumps({"id": 99})),
+            _completed(
+                stdout=json.dumps({"token": "ghs_x", "expires_at": "2099-01-01T00:00:00Z"})
+            ),
+        ]
+        with (
+            patch.object(auth, "_create_app_jwt", return_value="jwt"),
+            patch(
+                "dev10x.github.app_auth.async_run",
+                new_callable=AsyncMock,
+                side_effect=responses,
+            ) as mock_run,
+        ):
+            token = await auth.get_bot_token(repo="owner/repo", config=config)
+
+        assert token == "ghs_x"
+        assert mock_run.call_count == 2
+        assert "/repos/owner/repo/installation" in mock_run.call_args_list[0].kwargs["args"]
+        assert "/app/installations/99/access_tokens" in mock_run.call_args_list[1].kwargs["args"]
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_token_exchange_fails(
+        self,
+        app_config: auth.AppConfig,
+    ) -> None:
+        with (
+            patch.object(auth, "_create_app_jwt", return_value="jwt"),
+            patch(
+                "dev10x.github.app_auth.async_run",
+                new_callable=AsyncMock,
+                return_value=_completed(returncode=1, stderr="bad"),
+            ),
+        ):
+            result = await auth.get_bot_token(repo="owner/repo", config=app_config)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_refreshes_expired_cached_token(
+        self,
+        app_config: auth.AppConfig,
+    ) -> None:
+        auth._TOKEN_CACHE["owner/repo"] = auth._CachedToken(
+            token="old", expires_at=time.time() - 10
+        )
+        new_response = _completed(
+            stdout=json.dumps({"token": "fresh", "expires_at": "2099-01-01T00:00:00Z"})
+        )
+        with (
+            patch.object(auth, "_create_app_jwt", return_value="jwt"),
+            patch(
+                "dev10x.github.app_auth.async_run",
+                new_callable=AsyncMock,
+                return_value=new_response,
+            ),
+        ):
+            token = await auth.get_bot_token(repo="owner/repo", config=app_config)
+        assert token == "fresh"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_response_missing_token(
+        self,
+        app_config: auth.AppConfig,
+    ) -> None:
+        with (
+            patch.object(auth, "_create_app_jwt", return_value="jwt"),
+            patch(
+                "dev10x.github.app_auth.async_run",
+                new_callable=AsyncMock,
+                return_value=_completed(stdout=json.dumps({"expires_at": "x"})),
+            ),
+        ):
+            result = await auth.get_bot_token(repo="owner/repo", config=app_config)
+        assert result is None

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -630,6 +630,8 @@ class TestPrCommentReply:
         assert call_kwargs["method"] == "POST"
         assert call_kwargs["fields"]["body"] == "reply text"
         assert call_kwargs["fields"]["in_reply_to"] == 123
+        assert call_kwargs["as_bot"] is True
+        assert call_kwargs["repo"] == "owner/repo"
 
     @pytest.mark.asyncio
     @patch("dev10x.github._gh_api", new_callable=AsyncMock)
@@ -706,6 +708,8 @@ class TestPrCommentsActionReply:
 
         assert isinstance(result, SuccessResult)
         assert mock_api.call_args.kwargs["fields"]["in_reply_to"] == 3130499018
+        assert mock_api.call_args.kwargs["as_bot"] is True
+        assert mock_api.call_args.kwargs["repo"] == "owner/repo"
 
     @pytest.mark.asyncio
     async def test_rejects_non_numeric_comment_id(
@@ -969,3 +973,78 @@ class TestUpdatePr:
         assert isinstance(result, SuccessResult)
         assert result.value["url"] == "https://github.com/other/proj/pull/99"
         assert mock_api.call_args.args[0] == "repos/other/proj/pulls/99"
+
+
+class TestGhApiBotIdentity:
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run", new_callable=AsyncMock)
+    @patch("dev10x.github.get_bot_token", new_callable=AsyncMock)
+    async def test_swaps_env_when_as_bot_and_token_available(
+        self,
+        mock_token: AsyncMock,
+        mock_run: AsyncMock,
+    ) -> None:
+        mock_token.return_value = "ghs_bot_token"
+        mock_run.return_value = _completed(stdout="{}")
+
+        await gh._gh_api(
+            "repos/x/y/pulls/1/comments",
+            method="POST",
+            fields={"body": "hi"},
+            repo="x/y",
+            as_bot=True,
+        )
+
+        env = mock_run.call_args.kwargs["env"]
+        assert env is not None
+        assert env["GH_TOKEN"] == "ghs_bot_token"
+        assert env["GITHUB_TOKEN"] == "ghs_bot_token"
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run", new_callable=AsyncMock)
+    @patch("dev10x.github.get_bot_token", new_callable=AsyncMock)
+    async def test_falls_back_to_user_auth_when_token_unavailable(
+        self,
+        mock_token: AsyncMock,
+        mock_run: AsyncMock,
+    ) -> None:
+        mock_token.return_value = None
+        mock_run.return_value = _completed(stdout="{}")
+
+        await gh._gh_api(
+            "repos/x/y/pulls/1/comments",
+            method="POST",
+            repo="x/y",
+            as_bot=True,
+        )
+
+        assert mock_run.call_args.kwargs["env"] is None
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run", new_callable=AsyncMock)
+    @patch("dev10x.github.get_bot_token", new_callable=AsyncMock)
+    async def test_does_not_call_token_resolver_when_not_as_bot(
+        self,
+        mock_token: AsyncMock,
+        mock_run: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(stdout="{}")
+
+        await gh._gh_api("repos/x/y/issues/1", repo="x/y", as_bot=False)
+
+        assert mock_token.call_count == 0
+        assert mock_run.call_args.kwargs["env"] is None
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run", new_callable=AsyncMock)
+    @patch("dev10x.github.get_bot_token", new_callable=AsyncMock)
+    async def test_does_not_call_token_resolver_without_repo(
+        self,
+        mock_token: AsyncMock,
+        mock_run: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(stdout="{}")
+
+        await gh._gh_api("rate_limit", as_bot=True)
+
+        assert mock_token.call_count == 0

--- a/uv.lock
+++ b/uv.lock
@@ -264,6 +264,7 @@ source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "msgpack" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "pyyaml" },
 ]
 
@@ -286,6 +287,7 @@ requires-dist = [
     { name = "faker", marker = "extra == 'dev'", specifier = ">=33.0" },
     { name = "mcp", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "msgpack", specifier = ">=1.0" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.8" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "pytest-benchmark", marker = "extra == 'dev'", specifier = ">=5.0" },


### PR DESCRIPTION
**When** a Dev10x agent posts a reply on a PR review thread on the engineer's behalf, **the engineer wants** the reply to appear under a `dev10x-bot[bot]` identity rather than their personal GitHub account, **so the reviewer can** distinguish AI-generated replies from the engineer's own words and weigh them accordingly.

---

[`5f9b8fd7`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/67/commits/5f9b8fd777265c71f7ac6f44e87e51d6d22c195d) ✨ GH-65 Enable bot identity for agent-generated PR replies
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/65

---