### PR TITLE
✨ GH-69 Enable subagent status protocol parsing

### DIFF
--- a/.claude/rules/INDEX.md
+++ b/.claude/rules/INDEX.md
@@ -120,6 +120,7 @@ evaluation, and testing — usable on any project.
 | `code-reviewer.md` | Review branch changes against standards |
 | `pytest-tester.md` | Run tests and verify coverage |
 | `pytest-test-writer.md` | Write/review pytest tests |
+| `spec-reviewer.md` | Verify diff matches ticket AC (Phase 0 of review) |
 
 ### Architecture Evaluation Agents (for ADRs)
 

--- a/.claude/rules/model-selection.md
+++ b/.claude/rules/model-selection.md
@@ -89,6 +89,35 @@ When executing a playbook step with `model:`, use that model
 for any agent dispatch during the step instead of the skill's
 hardcoded default.
 
+## Inline Context vs Read-on-Demand
+
+Orthogonal to model tier: decide whether the subagent should Read
+files dynamically or receive full file content inlined into its
+prompt by the controller.
+
+| Strategy | When to use | Trade-off |
+|----------|-------------|-----------|
+| **Inline context** | Files are known upfront, ≤10 files, ≤200 lines each | Larger prompt, zero Read permission prompts in subagent |
+| **Read-on-demand** | File set unknown, broad exploration, large repos | Smaller prompt, but each Read may prompt the user |
+
+**Default to inline context** for Gather, Replicate, and Analyze
+tier dispatches. The orchestrator pre-reads files (cheap at the
+controller level) and pastes content into the prompt under
+`<file path="...">...</file>` blocks. This eliminates a class of
+"agent stalled waiting for Read approval" failures and removes
+the dependency on `mode: "dontAsk"` propagating into the
+subagent.
+
+**Use read-on-demand** only for Investigate and Explore tier
+tasks where the file set legitimately cannot be predicted. Even
+then, prefer dispatching the dedicated `Explore` subagent type,
+which has read-broad permissions baked in.
+
+Pattern adapted from
+[obra/superpowers](https://github.com/obra/superpowers) — its
+implementer/reviewer subagents receive complete file text in the
+prompt rather than reading dynamically.
+
 ## When to Revisit
 
 - Adding a new agent spec → choose model per tier table

--- a/.claude/rules/skill-body-extraction.md
+++ b/.claude/rules/skill-body-extraction.md
@@ -97,6 +97,38 @@ full dispatch pattern.
   reference itself grows beyond the cap (see
   `references/task-orchestration.md` → `references/orchestration/`)
 
+## Subagent context budget
+
+SessionStart-injected context (MOTD, SKILLS.md, plan-sync,
+session guidance) appears in the orchestrator session, but
+subagents dispatched via `Agent()` start with a fresh system
+prompt. Treat this as a feature, not a bug:
+
+- **Do NOT** rely on session context being available in
+  subagents. Inline anything the subagent needs into its prompt.
+- **Do NOT** instruct subagents to "follow the orchestration
+  contract" — they don't see it. Re-state the relevant phase
+  inline (see `references/orchestration/subagent-dispatch.md`
+  Phase Reference pattern).
+- **DO** mark sections of skill bodies that are session-only
+  (e.g., MOTD, plan-sync greetings) so future SessionStart
+  additions don't accidentally bloat subagent prompts. Use a
+  `<!-- session-only -->` HTML comment marker in the source
+  document so reviewers can spot it.
+
+When the controller passes file content inline (per
+`.claude/rules/model-selection.md` "Inline Context vs
+Read-on-Demand"), wrap each file in a clearly-delimited block:
+
+```
+<file path="src/foo.py">
+...full content...
+</file>
+```
+
+This eliminates Read permission prompts in the subagent and
+keeps the controller's pre-read cheap.
+
 ## Reviewer checklist
 
 When reviewing a skill refactor that extracts content:

--- a/agents/spec-reviewer.md
+++ b/agents/spec-reviewer.md
@@ -1,0 +1,90 @@
+---
+name: spec-reviewer
+description: |
+  Verify a code change matches its declared specification BEFORE
+  domain reviewers spend tokens on quality review. Compares the
+  diff against the linked Linear/JIRA/GitHub ticket's acceptance
+  criteria or the PR's Job Story.
+
+  Triggers: invoked by Dev10x:gh-pr-review and Dev10x:review as
+  Phase 0 spec gate. Returns PASS / FAIL_SCOPE / FAIL_MISSING /
+  FAIL_OVER so callers can short-circuit before fanning out to
+  domain reviewers.
+tools: Glob, Grep, Read, Bash
+model: sonnet
+color: yellow
+---
+
+# Spec Compliance Reviewer
+
+Run BEFORE domain reviewers (reviewer-frontend, reviewer-graphql,
+reviewer-celery, etc.) to confirm the diff matches what the
+ticket asked for. Domain reviewers focus on code quality —
+spec-reviewer focuses on whether the right code exists.
+
+Pattern adapted from
+[obra/superpowers](https://github.com/obra/superpowers)
+`subagent-driven-development` skill: spec compliance gates code
+quality.
+
+## When to invoke
+
+- Phase 0 of `Dev10x:review` (self-review before PR)
+- Phase 0 of `Dev10x:gh-pr-review` (external PR review)
+- Optional first pass before any multi-reviewer fanout
+
+Skip spec-reviewer when:
+- The change has no linked ticket and no Job Story (e.g.,
+  trivial typo fixes — flag separately)
+- The diff is purely additive infra (e.g., new agent spec) where
+  scope is self-evident from the file
+- The user explicitly asked to skip
+
+## Inputs
+
+- The diff (provided inline by the caller — do not re-read it)
+- The ticket body and acceptance criteria (provided inline)
+- The PR Job Story if present (provided inline)
+
+The caller pre-reads ticket + diff and inlines them. Do not Read
+files dynamically — that triggers permission prompts and stalls
+fanout.
+
+## Checklist
+
+1. **Acceptance criteria coverage** — every AC item in the ticket
+   has at least one corresponding code change. Missing AC → FAIL_MISSING.
+2. **Scope discipline** — every code change maps to an AC item or
+   the Job Story. Extra changes (refactors, tangential fixes) →
+   FAIL_OVER unless explicitly noted in the PR body.
+3. **Job Story alignment** — the diff enables the outcome stated
+   in the Job Story. If the change is technically correct but
+   does not enable the stated outcome → FAIL_SCOPE.
+4. **Test coverage of AC** — each AC has at least one test
+   asserting the behavior. Missing tests for an AC → FAIL_MISSING
+   (not just a quality concern — without tests the AC is
+   unverified).
+
+## Output Format
+
+End your output with exactly one status line per
+`references/orchestration/subagent-status-protocol.md`:
+
+- **PASS**: `DONE`
+- **PARTIAL**: `DONE_WITH_CONCERNS: <one-line summary>` — proceed
+  to domain reviewers but flag concerns
+- **FAIL_SCOPE / FAIL_MISSING / FAIL_OVER**: `BLOCKED: <verdict>:
+  <reason>` — caller short-circuits domain review and surfaces
+  the verdict to the user via `AskUserQuestion`
+
+Body before the status line: one paragraph per finding with
+`AC ref / file:line / verdict`.
+
+## Anti-patterns
+
+- ❌ Reviewing code quality (style, naming, refactoring
+  opportunities) — that is the domain reviewers' job
+- ❌ Reading files outside the diff — caller provides full
+  context inline
+- ❌ Suggesting fixes — return verdict only; the caller routes
+  to `Dev10x:review-fix` or `Dev10x:gh-pr-fixup`

--- a/references/orchestration/subagent-status-protocol.md
+++ b/references/orchestration/subagent-status-protocol.md
@@ -1,0 +1,149 @@
+# Subagent Status Protocol
+
+Structured status reporting for subagents dispatched via `Agent()`,
+adapted from the implementer/spec-reviewer pattern in
+[obra/superpowers](https://github.com/obra/superpowers).
+
+## Why a status protocol
+
+Dev10x orchestration hubs (work-on, fanout, skill-audit,
+gh-pr-monitor, adr-evaluate) interpret subagent results
+heuristically today. A subagent that hits a permission wall, runs
+out of context, or finishes successfully all return free-form
+prose — the controller has to guess.
+
+A structured terminal status line lets the controller branch
+deterministically: re-dispatch with more context, surface a
+decision gate to the user, or mark the task done. It also gives
+the user a stable signal across all skills.
+
+## The four statuses
+
+Every subagent prompt MUST instruct the agent to end its output
+with exactly one of:
+
+| Status | Meaning | Controller action |
+|--------|---------|-------------------|
+| `DONE` | Task complete, all acceptance criteria met | Mark task `completed`, continue pipeline |
+| `DONE_WITH_CONCERNS: <text>` | Task complete but flagged issues | Mark `completed`, surface concerns to user via batched decision queue |
+| `NEEDS_CONTEXT: <what>` | Cannot proceed without more input | Re-dispatch with the requested context, OR escalate via `AskUserQuestion` |
+| `BLOCKED: <reason>` | Permission wall, missing tool, or unrecoverable error | Fall back to main-session execution (GH-901) and surface the reason |
+
+The status MUST be the **last non-empty line** of the agent
+result. Controllers parse the trailing line of the result string
+with a strict prefix match.
+
+## Prompt template
+
+Every Agent dispatch from an orchestration skill should include
+this block near the end of the prompt:
+
+```
+Report your final status as the LAST line of your output, with
+exactly one of these prefixes:
+
+- DONE                           — task complete
+- DONE_WITH_CONCERNS: <text>     — complete but flagged
+- NEEDS_CONTEXT: <what>          — re-dispatch needed
+- BLOCKED: <reason>              — cannot proceed (permission,
+                                    missing tool, unrecoverable)
+
+Do not write anything after the status line.
+```
+
+## Controller parse pattern
+
+Pseudo-code for the controller side:
+
+```
+result = Agent(...)
+status_line = result.strip().splitlines()[-1]
+
+if status_line == "DONE":
+    TaskUpdate(taskId=..., status="completed")
+elif status_line.startswith("DONE_WITH_CONCERNS:"):
+    TaskUpdate(taskId=..., status="completed")
+    queue_decision(status_line[len("DONE_WITH_CONCERNS:"):].strip())
+elif status_line.startswith("NEEDS_CONTEXT:"):
+    redispatch_with_more_context(status_line)
+elif status_line.startswith("BLOCKED:"):
+    fallback_to_main_session(reason=status_line)
+else:
+    # Treat as BLOCKED — protocol violation
+    fallback_to_main_session(reason="missing status line")
+```
+
+## When to use which status
+
+**DONE** is the default. Use it whenever acceptance criteria are
+met, even if the agent had to retry or work around minor issues.
+
+**DONE_WITH_CONCERNS** is for "I finished the task, but the user
+should know X." Examples:
+- Code compiles but tests were skipped
+- PR comment addressed but a related concern was discovered
+- Investigation found root cause AND a tangential bug
+
+**NEEDS_CONTEXT** is for "I cannot complete this without input
+the controller can provide." Examples:
+- File mentioned in prompt does not exist — needs a corrected path
+- Prompt referenced a ticket but the ticket body was not included
+- Required environment variable not declared
+
+The controller should re-dispatch with the requested context.
+Avoid using NEEDS_CONTEXT when the right answer is to ask the
+user — use BLOCKED with a clear reason instead.
+
+**BLOCKED** is for permission walls and unrecoverable errors.
+This is the signal that triggers the GH-901 main-session
+fallback. Examples:
+- Bash command denied even with `mode: "dontAsk"`
+- Required MCP tool unavailable
+- Worktree creation failed
+- External service (gh, Linear, Sentry) returned auth error
+
+## Relationship to existing fallback patterns
+
+`gh-pr-monitor`'s GH-901 main-session fallback currently triggers
+on heuristic agent-failure detection (timeouts, unexpected exit
+codes). Adopting BLOCKED as an explicit status removes the
+guesswork: the agent self-reports the failure mode, and the
+controller's fallback path runs without ambiguity.
+
+`skill-audit`'s "return findings as strings" inversion (Wave 2,
+GH-565) becomes simpler too: each Wave 2 subagent returns
+findings followed by `DONE`, and the synthesis phase parses both
+the findings and the status uniformly across phases.
+
+## Adoption checklist
+
+When updating an orchestration skill to use this protocol:
+
+1. ✓ Every `Agent()` dispatch prompt includes the status template
+2. ✓ Controller parses the last line and branches on the status
+3. ✓ `BLOCKED` triggers the same fallback as today's heuristic
+   detection (no behavior change for the user, just a clearer
+   signal)
+4. ✓ `DONE_WITH_CONCERNS` items are queued for batched decision
+   presentation per `references/orchestration/decision-gates.md`
+5. ✓ Reviewer-skill spec (item 14a or new item) flags missing
+   status protocol in dispatched-prompt sections
+
+## Skills to migrate
+
+Priority order (highest leverage first):
+
+1. `skills/fanout/` — multi-item fanout benefits most from
+   deterministic status parsing
+2. `skills/gh-pr-monitor/` — replaces heuristic fallback
+   (GH-901)
+3. `skills/skill-audit/` — Wave 2 phases unify their result
+   shape
+4. `skills/work-on/` — Phase 2 Gather and Phase 3 execution
+   subagents
+5. `skills/adr-evaluate/` — architect dispatches
+
+Each migration is an independent PR. Update the SKILL.md
+prompt-construction sections and any `references/phases.md` /
+`references/example-plays.md` files; do not change `allowed-tools`
+or agent specs.

--- a/references/task-orchestration.md
+++ b/references/task-orchestration.md
@@ -22,6 +22,7 @@ Skills reference this index; per-pattern detail files in
 | 1 + 2 | Out-of-order execution and plan mutation | [`orchestration/plan-mutation.md`](orchestration/plan-mutation.md) |
 | 3 | `AskUserQuestion` for decisions | [`orchestration/decision-gates.md`](orchestration/decision-gates.md) |
 | 4 | Subagent dispatch, wave orchestration, fanout, permission-aware dispatch | [`orchestration/subagent-dispatch.md`](orchestration/subagent-dispatch.md) |
+| 4a | Subagent status protocol (DONE / DONE_WITH_CONCERNS / NEEDS_CONTEXT / BLOCKED) | [`orchestration/subagent-status-protocol.md`](orchestration/subagent-status-protocol.md) |
 | 5 + 6 + 7 | Teams and orchestration templates | [`orchestration/teams-and-templates.md`](orchestration/teams-and-templates.md) |
 | 8 | Progress compaction for long runs | [`orchestration/compaction.md`](orchestration/compaction.md) |
 | 9 | Task reconciliation after delegation + script operations map | [`orchestration/reconciliation.md`](orchestration/reconciliation.md) |

--- a/skills/fanout/instructions.md
+++ b/skills/fanout/instructions.md
@@ -587,6 +587,30 @@ At any pause signal, invoke `Dev10x:session-wrap-up`.
 Active worktrees and in-progress PRs are bookmarked
 automatically.
 
+## Subagent Status Protocol (GH-69)
+
+When fanout dispatches `Agent()` for read-only work (per the
+Permission-Aware Dispatch table) — including the
+`Agent(subagent_type="gh-pr-monitor")` fallback — every prompt
+MUST instruct the agent to end its output with one of:
+
+- `DONE` — task complete
+- `DONE_WITH_CONCERNS: <text>` — complete but flagged
+- `NEEDS_CONTEXT: <what>` — re-dispatch needed
+- `BLOCKED: <reason>` — permission wall or unrecoverable error
+
+The main-session controller parses the trailing line and
+branches deterministically: continue, queue concern, re-dispatch
+with more context, or escalate to the user via
+`AskUserQuestion`. A `BLOCKED:` status replaces today's
+heuristic agent-failure detection — the agent self-reports the
+failure, no guesswork.
+
+See [`references/orchestration/subagent-status-protocol.md`](
+../../references/orchestration/subagent-status-protocol.md)
+for the full prompt template, parse pattern, and migration
+notes.
+
 ## Known Limitations
 
 - **`bypassPermissions` non-propagation:** The
@@ -595,8 +619,9 @@ automatically.
   permissions, causing Write/Edit tool blocks when the user's
   settings require approval. **Mitigation:** Use the
   Permission-Aware Dispatch table in Phase 3 to route
-  write-requiring tasks to the main session (GH-549 F-04,
-  GH-555, GH-562).
+  write-requiring tasks to the main session, and the Subagent
+  Status Protocol above to surface permission walls as explicit
+  `BLOCKED:` results (GH-549 F-04, GH-555, GH-562, GH-69).
 
 - **`Skill()` unavailable in subagents:** Background agents
   cannot call `Skill()` — only the main session has access.

--- a/skills/gh-pr-monitor/instructions.md
+++ b/skills/gh-pr-monitor/instructions.md
@@ -647,35 +647,71 @@ failing checks, or incomplete work that earlier phases missed.
 
 **Permission failure propagation (GH-760 F4):** If the
 background agent hits permission limits and cannot complete
-`verify-acc-dod`, it MUST report this explicitly as
-"Acceptance criteria: INCOMPLETE — permission failure" in the
-final status report. The parent orchestrator MUST re-invoke
-`Skill(Dev10x:verify-acc-dod)` in the main session when it
-sees this status. Do NOT mark the parent's acceptance task
-as `completed` when the agent reports incomplete.
+`verify-acc-dod`, it MUST emit `BLOCKED: verify-acc-dod
+permission failure` as the status line (per the Subagent Status
+Protocol below). The parent orchestrator parses the
+`BLOCKED:` prefix and re-invokes
+`Skill(Dev10x:verify-acc-dod)` in the main session. Do NOT
+mark the parent's acceptance task as `completed` when the agent
+reports `BLOCKED:`.
 
-### Main-Session Fallback (GH-901)
+## Final Status Line (GH-69)
 
-**Hard rule:** When a background agent launched with
-`mode: dontAsk` still lacks Bash permissions or fails to
-complete any phase due to permission friction, the parent
-orchestrator MUST immediately re-run the failed phase in
-the main session. Do NOT treat a permission-failed background
-agent as a successful completion.
+After all phase reports are emitted, end your output with
+**exactly one** status line per the Subagent Status Protocol
+(see
+[`references/orchestration/subagent-status-protocol.md`](../../../references/orchestration/subagent-status-protocol.md)):
 
-**Detection:** The background agent's completion notification
-includes its final status. Check for:
-- Explicit "permission failure" or "INCOMPLETE" in the result
+- `DONE` — all phases (0–4) completed, CI green, comments
+  addressed, acceptance verified
+- `DONE_WITH_CONCERNS: <text>` — phases completed but a concern
+  was discovered (e.g., flaky CI, comment unresolved by design,
+  new tangential bug) — main session queues for batched
+  decision presentation
+- `NEEDS_CONTEXT: <what>` — phase blocked by missing context
+  the main session can provide (e.g., uncommitted local changes
+  that need to be staged) — main session re-dispatches with
+  context
+- `BLOCKED: <reason>` — permission failure, missing tool, CI
+  failure exceeding max retries, or unrecoverable error — main
+  session falls back per "Main-Session Fallback (GH-901)" below
+
+The status line MUST be the **last non-empty line** of the
+output. Do not write anything after it. The main-session
+controller reads the trailing line via strict prefix match.
+
+### Main-Session Fallback (GH-901, GH-69)
+
+**Hard rule:** When a background agent emits `BLOCKED:` as its
+status line — or fails the protocol entirely (no recognizable
+status line) — the parent orchestrator MUST immediately re-run
+the failed phase in the main session. Do NOT treat a
+permission-failed background agent as a successful completion.
+
+**Detection (primary — explicit signal, GH-69):** Parse the
+last non-empty line of the agent result:
+- `DONE` → success, mark task completed
+- `DONE_WITH_CONCERNS: <text>` → success; queue concern for
+  batched decision presentation
+- `NEEDS_CONTEXT: <what>` → re-dispatch with the requested
+  context inlined into the new prompt
+- `BLOCKED: <reason>` → fallback (this section)
+- *Anything else (no recognizable status, or status missing)*
+  → treat as `BLOCKED: protocol violation` and fall back
+
+**Detection (legacy heuristic — kept as a safety net for older
+agents that ignore the status protocol):**
 - Agent completing in under 60 seconds (suspect — likely
   skipped phases due to permission denials)
 - Missing phase completion markers in the result summary
 
 **Fallback protocol:**
-1. Log: "Background agent failed — re-running in main session"
+1. Log: "Background agent reported BLOCKED: {reason} — re-running
+   in main session"
 2. Re-invoke the monitoring skill directly (not as a background
    agent) so it inherits the main session's permissions
 3. Mark the background agent's tracking task as `completed`
-   with description "Failed — re-ran in main session"
+   with description "BLOCKED — re-ran in main session ({reason})"
 4. The main-session re-run replaces the background agent's
    results entirely
 


### PR DESCRIPTION
**When** an orchestration skill (fanout, gh-pr-monitor, skill-audit, work-on, adr-evaluate) dispatches a subagent via `Agent()` and the subagent finishes with free-form prose, **I want to** parse a single deterministic status line (`DONE` / `DONE_WITH_CONCERNS` / `NEEDS_CONTEXT` / `BLOCKED`) at the end of the result, **so I can** branch the controller flow without heuristic guessing — continue the pipeline on `DONE`, queue concerns for batched user decisions, re-dispatch with inlined context on `NEEDS_CONTEXT`, and fall back to main-session execution on `BLOCKED` instead of relying on timeout-based agent-failure detection.

---

[`d33afd86`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/71/commits/d33afd86c3eb4851788947c90fd6defadd14b35e) ✨ GH-69 Enable subagent status protocol parsing
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/69

---