### PR TITLE
✨ GH-72 Prove github-app setup credentials end-to-end

### DIFF
--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -60,6 +60,7 @@ with credentials you supply:
 | Integration | Credentials | Data exchanged |
 |-------------|-------------|----------------|
 | GitHub (`gh` CLI, MCP) | Your GitHub token | Issue / PR payloads you explicitly create or fetch |
+| GitHub App API (`dev10x github-app setup` wizard) | App ID + private key you provide | Direct calls to `api.github.com` to verify the App key matches, list installations, exchange a JWT for an installation token, and read one repo per installation before writing config |
 | Linear (MCP) | Your Linear OAuth session | Issues and comments you read or write |
 | JIRA (`Dev10x:jira`) | API token from your OS keyring | Issue lookups and comments you request |
 | Slack (MCP) | Your Slack app token | Channel reads and messages you post |

--- a/references/github-app-setup.md
+++ b/references/github-app-setup.md
@@ -41,11 +41,28 @@ Then run the wizard:
 dev10x github-app setup
 ```
 
-It walks through App registration, prompts for the App ID,
-Installation ID (optional), and pasted private key, validates the
-key locally with a self-signed JWT, and writes
-`~/.claude/Dev10x/github-bot/{github-app.yaml,dev10x-bot.pem}`
-with `chmod 600`.
+It walks through:
+
+1. **Picking an install target** — Personal, Organization, or
+   Manual. The wizard switches the registration URL accordingly
+   and tells you which "Where can this App be installed?" radio
+   to pick (see table below).
+2. **Registering the App** — opens the right URL for the chosen
+   target.
+3. **Installing it on at least one repo.**
+4. **Pointing the wizard at the downloaded `.pem`** — defaults to
+   the newest `*.private-key.pem` in `~/Downloads`. The file is
+   moved to `~/.claude/Dev10x/github-bot/dev10x-bot.pem` and
+   `chmod 600`'d. Use `--paste` for headless setups.
+5. **End-to-end verification** before writing config:
+   - `GET /app` confirms the key matches the App ID you entered
+   - `GET /app/installations` confirms the App is installed
+     somewhere
+   - Token exchange + `GET /repos/<owner>/<repo>` per
+     installation confirms the bot can actually read a target repo
+
+Failed verification leaves no config behind. On success the
+wizard prints the verified installations and target repos.
 
 Run `dev10x github-app status` to confirm the config is in place.
 
@@ -53,6 +70,37 @@ To upgrade later: `uv tool upgrade Dev10x`.
 
 The rest of this doc covers the manual flow if you prefer to wire
 things up yourself, or want context on what each value means.
+
+### Install-target choices
+
+| Choice | Registration URL | "Where can this App be installed?" |
+|--------|------------------|------------------------------------|
+| Personal account (multi-target) | `https://github.com/settings/apps/new` | **"Any account"** — required to install on org accounts you belong to |
+| Organization | `https://github.com/organizations/<org>/settings/apps/new` | Implicit — the App is owned by the org |
+| Manual | (you open the settings page yourself) | Match the scope to where the bot will comment |
+
+Picking "Only on this account" on a personal-account App blocks
+you from installing it on any org. The wizard's Personal flow
+explicitly steers you to "Any account" to avoid this trap.
+
+### Advanced: pinning a single installation
+
+`dev10x github-app setup` no longer prompts for an Installation
+ID. The bot resolves the right installation per repo at call
+time, which is the correct behavior for any user with more than
+one installation.
+
+If you specifically need to pin every call to one installation
+(rare — typically a multi-org constraint), add the field to the
+yaml by hand after running setup:
+
+```yaml
+github_app:
+  app_id: "123456"
+  private_key_path: "~/.claude/Dev10x/github-bot/dev10x-bot.pem"
+  installation_id: "78901234"   # optional pin
+  enabled: true
+```
 
 ## One-time GitHub App registration
 
@@ -70,8 +118,11 @@ things up yourself, or want context on what each value means.
    - `Contents` → `Read-only` — required so the App can read the
      repo before commenting
    - All others → `No access`
-4. **Where can this App be installed:** "Only on this account" is
-   fine for personal use.
+4. **Where can this App be installed:**
+   - Personal-account App that needs to install on orgs → **"Any
+     account"**.
+   - Org-owned App → leave the default (scope is the org).
+   - Personal-only with no org installs → "Only on this account".
 5. Create the App, then on the App settings page:
    - Note the **App ID** (numeric)
    - Click **Generate a private key** — a `.pem` file downloads.
@@ -98,6 +149,27 @@ github_app:
 To temporarily disable the bot identity for a session, flip
 `enabled: false` (or delete the file). Calls fall back to user
 auth.
+
+## Verify the setup end-to-end
+
+The wizard runs this automatically; if you set things up
+manually, you can prove the credentials work without opening a
+draft PR:
+
+1. Mint an App JWT (PyJWT + the `.pem`, 5-minute expiry).
+2. `GET https://api.github.com/app` with `Authorization: Bearer
+   <jwt>` — the `id` field must match your `app_id`.
+3. `GET https://api.github.com/app/installations` — must return
+   at least one entry.
+4. `POST /app/installations/<id>/access_tokens` — should return
+   a short-lived `token`.
+5. `GET https://api.github.com/repos/<owner>/<repo>` with
+   `Authorization: Bearer <token>` — should return the repo.
+
+If step 2 returns a different `id`, you pasted the wrong `.pem`
+or entered the wrong `app_id`. If step 3 is empty, the App is
+registered but not installed. If step 5 fails, the installation
+exists but doesn't include the target repo.
 
 ## Verify the bot identity is in effect
 

--- a/src/dev10x/commands/github_app.py
+++ b/src/dev10x/commands/github_app.py
@@ -1,24 +1,28 @@
-"""`dev10x github-app setup` — interactive onboarding for the bot identity.
+"""``dev10x github-app setup`` — interactive onboarding for the bot identity.
 
-Walks the user through GitHub App registration, prompts for the App
-ID, installation ID, and private key, then writes a tightly-permissioned
-config tree under ``~/.claude/Dev10x/github-bot/``. Validates the key
-locally by minting a self-signed JWT before persisting.
+Walks the engineer through GitHub App registration with install-target
+guidance, picks up the downloaded ``.pem`` from disk, and runs an
+end-to-end verification (App JWT → installations → installation token →
+repo read) before writing config under ``~/.claude/Dev10x/github-bot/``.
 """
 
 from __future__ import annotations
 
 import os
+import shutil
 import sys
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import click
+
+from dev10x.commands import github_app_api as api
 
 CONFIG_DIR = Path.home() / ".claude" / "Dev10x" / "github-bot"
 CONFIG_PATH = CONFIG_DIR / "github-app.yaml"
 KEY_PATH = CONFIG_DIR / "dev10x-bot.pem"
 
-NEW_APP_URL = "https://github.com/settings/apps/new"
+PERSONAL_NEW_APP_URL = "https://github.com/settings/apps/new"
 
 INTRO = """\
 Dev10x GitHub App setup
@@ -29,16 +33,17 @@ review replies post under a `<your-app>[bot]` identity instead of your
 personal account.
 
 You will need to:
-  1. Register the App on github.com (one browser visit)
-  2. Install it on the repos you want the bot to comment on
-  3. Paste the App ID, Installation ID, and private key here
+  1. Pick where the App is registered (personal vs. an org)
+  2. Register the App on github.com (one browser visit)
+  3. Install it on the repos you want the bot to comment on
+  4. Point this wizard at the downloaded .pem file
 
-Press Ctrl+C at any time to abort. Nothing is written until the
-final step.
+Press Ctrl+C at any time to abort. Nothing is written until
+verification succeeds.
 """
 
 CREATE_APP_INSTRUCTIONS = """\
-Step 1: Register the GitHub App
+Step 2: Register the GitHub App
 ───────────────────────────────
 
 Open this URL:
@@ -56,22 +61,76 @@ Repository permissions:
   Contents            Read-only        (required)
   All others          No access
 
+{install_scope_hint}
+
 Click "Create GitHub App". On the App settings page:
   • Note the App ID (numeric)
-  • Click "Generate a private key" — a .pem file downloads
+  • Click "Generate a private key" — a .pem file downloads to your
+    browser's Downloads folder. Leave it there; the wizard will
+    pick it up next.
 """
 
 INSTALL_INSTRUCTIONS = """\
-Step 2: Install the App
-───────────────────────
+Step 3: Install the App on at least one repo
+────────────────────────────────────────────
 
 On the App settings page, click "Install App" in the left nav.
-Pick the repos you want the bot to comment on.
-
-After installing, the URL contains "installations/<id>" — that's the
-Installation ID. It's optional here; Dev10x can auto-resolve it from
-each target repo if you leave the prompt blank.
+Pick the repos you want the bot to comment on. Without an
+installation, the App can't post anywhere.
 """
+
+
+def _prompt_install_target() -> dict[str, str]:
+    """Return the install-target choice: personal, org-owned, or manual."""
+    click.echo("Step 1: Where will the App be registered?")
+    click.echo("─────────────────────────────────────────")
+    click.echo("")
+    click.echo("  1) Personal account — multi-target, can install on any account")
+    click.echo("  2) Organization     — App owned by the org, scope is the org")
+    click.echo("  3) Manual           — I'll open the settings page myself")
+    click.echo("")
+    while True:
+        choice = click.prompt("Choose [1/2/3]", type=str, default="1").strip()
+        if choice == "1":
+            return {"kind": "personal"}
+        if choice == "2":
+            org = click.prompt("Org login (e.g. tiretutorinc)", type=str).strip()
+            if not org:
+                click.echo("  Org login is required for an org-owned App.")
+                continue
+            return {"kind": "org", "org": org}
+        if choice == "3":
+            return {"kind": "manual"}
+        click.echo("  Pick 1, 2, or 3.")
+
+
+def _registration_url(target: dict[str, str]) -> str:
+    if target["kind"] == "org":
+        return f"https://github.com/organizations/{target['org']}/settings/apps/new"
+    if target["kind"] == "manual":
+        return "(open the GitHub App settings page yourself)"
+    return PERSONAL_NEW_APP_URL
+
+
+def _install_scope_hint(target: dict[str, str]) -> str:
+    if target["kind"] == "personal":
+        return (
+            "Where can this GitHub App be installed?\n"
+            '  Pick "Any account" — lets you install the App on personal\n'
+            '  repos AND any orgs you belong to. The default "Only on this\n'
+            '  account" blocks org installs.'
+        )
+    if target["kind"] == "org":
+        return (
+            "Where can this GitHub App be installed?\n"
+            "  Scope is implicit — the App is owned by the org and can only\n"
+            "  be installed on it. Leave the default selection."
+        )
+    return (
+        "Where can this GitHub App be installed?\n"
+        '  Personal multi-target → "Any account".\n'
+        "  Org-owned → leave the default."
+    )
 
 
 def _prompt_app_id() -> str:
@@ -82,29 +141,40 @@ def _prompt_app_id() -> str:
         click.echo("  App ID must be numeric (look for it on the App settings page).")
 
 
-def _prompt_installation_id() -> str | None:
-    value = click.prompt(
-        "Installation ID (blank to auto-resolve per repo)",
-        type=str,
-        default="",
-        show_default=False,
-    ).strip()
-    if not value:
+def _newest_pem_in_downloads() -> Path | None:
+    downloads = Path.home() / "Downloads"
+    if not downloads.is_dir():
         return None
-    while not value.isdigit():
-        click.echo("  Installation ID must be numeric or blank.")
-        value = click.prompt(
-            "Installation ID (blank to auto-resolve per repo)",
-            type=str,
-            default="",
-            show_default=False,
-        ).strip()
-        if not value:
-            return None
-    return value
+    candidates = sorted(
+        downloads.glob("*.private-key.pem"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    return candidates[0] if candidates else None
 
 
-def _prompt_private_key() -> str:
+def _prompt_private_key_path() -> Path:
+    """Prompt for the path to the downloaded .pem; default to newest in ~/Downloads."""
+    default = _newest_pem_in_downloads()
+    if default is not None:
+        click.echo(f"  Found: {default}")
+    while True:
+        kwargs: dict[str, object] = {"type": str}
+        if default is not None:
+            kwargs["default"] = str(default)
+        raw = click.prompt("Path to .pem file", **kwargs).strip()
+        if not raw:
+            click.echo("  Path is required.")
+            continue
+        path = Path(raw).expanduser()
+        if not path.is_file():
+            click.echo(f"  No file at {path}.")
+            continue
+        return path
+
+
+def _prompt_private_key_paste() -> str:
+    """Legacy paste flow for headless setups (--paste flag)."""
     click.echo("")
     click.echo("Paste the private key contents below.")
     click.echo("Include the BEGIN/END lines. Finish with a blank line:")
@@ -127,7 +197,7 @@ def _prompt_private_key() -> str:
 
 
 def _validate_key_locally(*, app_id: str, private_key: str) -> str | None:
-    """Return None on success, or a human-readable error message."""
+    """Quick offline check: can we sign a JWT with this key?"""
     try:
         import jwt
     except ImportError:
@@ -145,26 +215,169 @@ def _validate_key_locally(*, app_id: str, private_key: str) -> str | None:
     return None
 
 
-def _write_files(
+@dataclass
+class InstallationInfo:
+    """One entry in the verification report."""
+
+    id: int
+    account: str
+    verified_repo: str | None = None
+    error: str | None = None
+
+
+@dataclass
+class VerificationResult:
+    """End-to-end verification outcome."""
+
+    success: bool
+    error: str | None = None
+    app_slug: str | None = None
+    app_id: int | None = None
+    installations: list[InstallationInfo] = field(default_factory=list)
+
+
+def _verify_setup(*, app_id: str, private_key: str) -> VerificationResult:
+    """Mint JWT, fetch App + installations, exchange a token, read a repo."""
+    try:
+        jwt_token = api.mint_app_jwt(app_id=app_id, private_key=private_key)
+    except Exception as exc:  # noqa: BLE001 — surface to user
+        return VerificationResult(success=False, error=f"Could not mint JWT: {exc}")
+
+    try:
+        app = api.get_app(jwt_token=jwt_token)
+    except api.GitHubAPIError as exc:
+        return VerificationResult(success=False, error=f"GET /app failed: {exc}")
+
+    actual_id = app.get("id")
+    if str(actual_id) != str(app_id):
+        return VerificationResult(
+            success=False,
+            error=(
+                f"App ID mismatch: the key belongs to App {actual_id} "
+                f"({app.get('slug')!r}), but you entered {app_id}. "
+                "Re-download the .pem from the correct App settings page."
+            ),
+        )
+
+    try:
+        installations = api.list_installations(jwt_token=jwt_token)
+    except api.GitHubAPIError as exc:
+        return VerificationResult(
+            success=False,
+            error=f"GET /app/installations failed: {exc}",
+        )
+
+    if not installations:
+        return VerificationResult(
+            success=False,
+            error=(
+                "App has no installations. Click 'Install App' in the App "
+                "settings page, pick at least one repo, then re-run setup."
+            ),
+            app_slug=app.get("slug"),
+            app_id=actual_id,
+        )
+
+    verified = [
+        _verify_one_installation(jwt_token=jwt_token, installation=inst) for inst in installations
+    ]
+
+    if not any(info.verified_repo for info in verified):
+        failures = "\n      ".join(
+            f"{info.account}: {info.error}" for info in verified if info.error
+        )
+        return VerificationResult(
+            success=False,
+            error=f"All installations failed verification:\n      {failures}",
+            app_slug=app.get("slug"),
+            app_id=actual_id,
+            installations=verified,
+        )
+
+    return VerificationResult(
+        success=True,
+        app_slug=app.get("slug"),
+        app_id=actual_id,
+        installations=verified,
+    )
+
+
+def _verify_one_installation(
     *,
-    app_id: str,
-    installation_id: str | None,
-    private_key: str,
-) -> None:
+    jwt_token: str,
+    installation: dict,
+) -> InstallationInfo:
+    info = InstallationInfo(
+        id=installation["id"],
+        account=installation.get("account", {}).get("login", "<unknown>"),
+    )
+    try:
+        token = api.create_installation_token(
+            jwt_token=jwt_token,
+            installation_id=installation["id"],
+        )
+    except api.GitHubAPIError as exc:
+        info.error = f"token exchange failed: {exc}"
+        return info
+
+    try:
+        repos = api.list_installation_repositories(token=token)
+    except api.GitHubAPIError as exc:
+        info.error = f"could not list installation repos: {exc}"
+        return info
+
+    if not repos:
+        info.error = "installation has no accessible repos"
+        return info
+
+    first = repos[0]
+    owner = first["owner"]["login"]
+    name = first["name"]
+    try:
+        api.get_repo(token=token, owner=owner, repo=name)
+    except api.GitHubAPIError as exc:
+        info.error = f"could not read {owner}/{name}: {exc}"
+        return info
+
+    info.verified_repo = f"{owner}/{name}"
+    return info
+
+
+def _install_key_from_path(*, source: Path) -> str:
+    """Move the user-provided .pem into KEY_PATH and chmod 600."""
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    if source.resolve() != KEY_PATH.resolve():
+        shutil.move(str(source), str(KEY_PATH))
+    os.chmod(KEY_PATH, 0o600)
+    return KEY_PATH.read_text()
+
+
+def _write_key_text(*, private_key: str) -> None:
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
     KEY_PATH.write_text(private_key)
     os.chmod(KEY_PATH, 0o600)
 
+
+def _write_config(*, app_id: str) -> None:
     yaml_lines = [
         "github_app:",
         f'  app_id: "{app_id}"',
         f'  private_key_path: "{KEY_PATH}"',
         "  enabled: true",
     ]
-    if installation_id:
-        yaml_lines.insert(2, f'  installation_id: "{installation_id}"')
     CONFIG_PATH.write_text("\n".join(yaml_lines) + "\n")
     os.chmod(CONFIG_PATH, 0o600)
+
+
+def _print_verification(result: VerificationResult) -> None:
+    click.echo("")
+    click.echo(f"  ✓ App `{result.app_slug}` (ID {result.app_id})")
+    click.echo(f"  ✓ {len(result.installations)} installation(s):")
+    for info in result.installations:
+        if info.verified_repo:
+            click.echo(f"      • {info.account} — read {info.verified_repo}")
+        else:
+            click.echo(f"      • {info.account} — FAILED: {info.error}")
 
 
 @click.group()
@@ -178,7 +391,12 @@ def github_app() -> None:
     is_flag=True,
     help="Overwrite existing config without prompting.",
 )
-def setup(*, force: bool) -> None:
+@click.option(
+    "--paste",
+    is_flag=True,
+    help="Paste the private key contents instead of pointing at a file.",
+)
+def setup(*, force: bool, paste: bool) -> None:
     """Interactive setup wizard for the GitHub App bot identity."""
     click.echo(INTRO)
 
@@ -188,19 +406,31 @@ def setup(*, force: bool) -> None:
             click.echo("Aborted.")
             sys.exit(1)
 
-    click.echo(CREATE_APP_INSTRUCTIONS.format(url=NEW_APP_URL))
-    click.pause(info="Press any key when the App is created and the .pem file is downloaded… ")
+    target = _prompt_install_target()
+    click.echo("")
+    click.echo(
+        CREATE_APP_INSTRUCTIONS.format(
+            url=_registration_url(target),
+            install_scope_hint=_install_scope_hint(target),
+        )
+    )
+    click.pause(info="Press any key when the App is created and the .pem is downloaded… ")
     click.echo("")
     click.echo(INSTALL_INSTRUCTIONS)
     click.pause(info="Press any key when the App is installed on at least one repo… ")
     click.echo("")
-    click.echo("Step 3: Paste credentials")
-    click.echo("─────────────────────────")
+    click.echo("Step 4: Provide credentials")
+    click.echo("───────────────────────────")
     click.echo("")
 
     app_id = _prompt_app_id()
-    installation_id = _prompt_installation_id()
-    private_key = _prompt_private_key()
+
+    if paste:
+        private_key = _prompt_private_key_paste()
+        key_source: Path | None = None
+    else:
+        key_source = _prompt_private_key_path()
+        private_key = key_source.read_text()
 
     error = _validate_key_locally(app_id=app_id, private_key=private_key)
     if error is not None:
@@ -208,19 +438,29 @@ def setup(*, force: bool) -> None:
         click.echo("  Re-download the .pem from the App settings page and try again.")
         sys.exit(1)
 
-    _write_files(
-        app_id=app_id,
-        installation_id=installation_id,
-        private_key=private_key,
-    )
+    click.echo("")
+    click.echo("Step 5: End-to-end verification")
+    click.echo("───────────────────────────────")
+    click.echo("  Calling GitHub API to confirm the App, installations, and repo access…")
+    result = _verify_setup(app_id=app_id, private_key=private_key)
+    if not result.success:
+        click.echo(f"\n  ✗ {result.error}")
+        click.echo("  Config not written. Fix the issue above and re-run setup.")
+        sys.exit(1)
+
+    _print_verification(result)
+
+    if key_source is not None:
+        _install_key_from_path(source=key_source)
+    else:
+        _write_key_text(private_key=private_key)
+    _write_config(app_id=app_id)
 
     click.echo("")
-    click.echo("  ✓ Wrote config: " + str(CONFIG_PATH))
-    click.echo("  ✓ Wrote key:    " + str(KEY_PATH))
+    click.echo(f"  ✓ Wrote config: {CONFIG_PATH}")
+    click.echo(f"  ✓ Wrote key:    {KEY_PATH}")
     click.echo("")
-    click.echo("Next: open a draft PR on a repo where the App is installed,")
-    click.echo("then ask Dev10x to reply to a review comment. The reply should")
-    click.echo("now appear under the bot identity instead of your account.")
+    click.echo("Done. Agent-generated PR replies will now post under the bot identity.")
 
 
 @github_app.command()

--- a/src/dev10x/commands/github_app_api.py
+++ b/src/dev10x/commands/github_app_api.py
@@ -1,0 +1,121 @@
+"""GitHub API helpers for the App setup wizard.
+
+Wraps the endpoints needed to verify an App identity end-to-end:
+
+- ``GET /app`` — the key ↔ App ID match check
+- ``GET /app/installations`` — proves the App is installed somewhere
+- ``POST /app/installations/{id}/access_tokens`` — token exchange
+- ``GET /installation/repositories`` — installation can list repos
+- ``GET /repos/{owner}/{repo}`` — installation token can read a repo
+
+Uses stdlib ``urllib.request`` plus the existing ``PyJWT`` dependency.
+No extra runtime dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import urllib.error
+import urllib.request
+from typing import Any
+
+API_ROOT = "https://api.github.com"
+_USER_AGENT = "dev10x-github-app-setup"
+_REQUEST_TIMEOUT_SECONDS = 15
+
+
+class GitHubAPIError(Exception):
+    """Raised when a GitHub API call fails."""
+
+
+def mint_app_jwt(*, app_id: str, private_key: str) -> str:
+    """Mint a short-lived App-level JWT for the GitHub API."""
+    import jwt
+
+    now = int(time.time())
+    token = jwt.encode(
+        {"iat": now - 60, "exp": now + 300, "iss": app_id},
+        private_key,
+        algorithm="RS256",
+    )
+    return token if isinstance(token, str) else token.decode()
+
+
+def _bearer_headers(value: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {value}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": _USER_AGENT,
+    }
+
+
+def _request(
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str],
+    body: dict[str, Any] | None = None,
+) -> Any:
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url=url, method=method, headers=headers, data=data)
+    try:
+        with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT_SECONDS) as resp:
+            payload = resp.read().decode()
+            return json.loads(payload) if payload else None
+    except urllib.error.HTTPError as exc:
+        detail = ""
+        try:
+            detail = exc.read().decode(errors="replace")
+        except Exception:  # noqa: BLE001 — best-effort detail extraction
+            detail = ""
+        raise GitHubAPIError(
+            f"{method} {url} → {exc.code} {exc.reason}: {detail}".strip()
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise GitHubAPIError(f"{method} {url} failed: {exc.reason}") from exc
+
+
+def get_app(*, jwt_token: str) -> dict[str, Any]:
+    """Return the authenticated App's metadata (id, slug, owner, ...)."""
+    return _request("GET", f"{API_ROOT}/app", headers=_bearer_headers(jwt_token))
+
+
+def list_installations(*, jwt_token: str) -> list[dict[str, Any]]:
+    """Return all installations of the authenticated App."""
+    return _request(
+        "GET",
+        f"{API_ROOT}/app/installations",
+        headers=_bearer_headers(jwt_token),
+    )
+
+
+def create_installation_token(*, jwt_token: str, installation_id: int) -> str:
+    """Exchange the App JWT for a short-lived installation access token."""
+    result = _request(
+        "POST",
+        f"{API_ROOT}/app/installations/{installation_id}/access_tokens",
+        headers=_bearer_headers(jwt_token),
+        body={},
+    )
+    return result["token"]
+
+
+def list_installation_repositories(*, token: str) -> list[dict[str, Any]]:
+    """List repos the current installation can access."""
+    result = _request(
+        "GET",
+        f"{API_ROOT}/installation/repositories",
+        headers=_bearer_headers(token),
+    )
+    return result.get("repositories", []) if isinstance(result, dict) else []
+
+
+def get_repo(*, token: str, owner: str, repo: str) -> dict[str, Any]:
+    """Read a single repo via installation token."""
+    return _request(
+        "GET",
+        f"{API_ROOT}/repos/{owner}/{repo}",
+        headers=_bearer_headers(token),
+    )

--- a/src/dev10x/skills/audit/privacy.py
+++ b/src/dev10x/skills/audit/privacy.py
@@ -142,6 +142,10 @@ _NET_IMPORT_EXEMPT_PATHS: tuple[str, ...] = (
     # outbound integrations. They are exempt from the no-outbound rule
     # because the policy explicitly covers them.
     "skills/qa-self/scripts/upload-screenshots.py",
+    # `dev10x github-app setup` wizard module: explicitly verifies App
+    # credentials against api.github.com before writing config. Covered
+    # by the GitHub row in PRIVACY_POLICY.md.
+    "src/dev10x/commands/github_app_api.py",
 )
 
 # Files exempt from service detection. The scanner defines the

--- a/tests/commands/test_github_app.py
+++ b/tests/commands/test_github_app.py
@@ -11,6 +11,7 @@ import pytest
 from click.testing import CliRunner
 
 from dev10x.commands import github_app as gha
+from dev10x.commands.github_app import InstallationInfo, VerificationResult
 
 
 @pytest.fixture
@@ -21,63 +22,162 @@ def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return tmp_path
 
 
-class TestSetupWritesConfig:
-    @pytest.fixture
-    def fake_key(self) -> str:
-        return "-----BEGIN RSA PRIVATE KEY-----\nFAKEKEY\n-----END RSA PRIVATE KEY-----\n"
+@pytest.fixture
+def fake_pem(tmp_path: Path) -> Path:
+    pem = tmp_path / "downloads" / "dev10x-bot.2026-05-07.private-key.pem"
+    pem.parent.mkdir(parents=True)
+    pem.write_text("-----BEGIN RSA PRIVATE KEY-----\nFAKEKEY\n-----END RSA PRIVATE KEY-----\n")
+    return pem
+
+
+@pytest.fixture
+def successful_verification() -> VerificationResult:
+    return VerificationResult(
+        success=True,
+        app_slug="dev10x-bot",
+        app_id=12345,
+        installations=[
+            InstallationInfo(
+                id=99,
+                account="Dev10x-Guru",
+                verified_repo="Dev10x-Guru/Dev10x-Claude",
+            ),
+        ],
+    )
+
+
+class TestSetupInstallTargetPersonal:
+    """Personal account → personal registration URL + 'Any account' hint."""
 
     @pytest.fixture
-    def stdin_input(self, fake_key: str) -> str:
-        return "\n".join(["", "12345", "67890", *fake_key.splitlines(), ""]) + "\n"
+    def stdin_input(self, fake_pem: Path) -> str:
+        # click.pause is a no-op when stdin is not a TTY, so only the
+        # actual click.prompt calls consume input.
+        return "\n".join(["1", "12345", str(fake_pem)]) + "\n"
 
     @pytest.fixture
     def result(
         self,
         fake_home: Path,
         stdin_input: str,
+        successful_verification: VerificationResult,
     ) -> object:
         runner = CliRunner()
-        with patch.object(gha, "_validate_key_locally", return_value=None):
+        with (
+            patch.object(gha, "_validate_key_locally", return_value=None),
+            patch.object(gha, "_verify_setup", return_value=successful_verification),
+        ):
             return runner.invoke(gha.github_app, ["setup"], input=stdin_input)
 
     def test_exits_successfully(self, result: object) -> None:
         assert result.exit_code == 0, result.output
 
+    def test_uses_personal_url(self, result: object) -> None:
+        assert "https://github.com/settings/apps/new" in result.output
+
+    def test_steers_to_any_account(self, result: object) -> None:
+        assert '"Any account"' in result.output
+
     def test_writes_config_file(self, result: object, fake_home: Path) -> None:
         assert (fake_home / "github-bot" / "github-app.yaml").is_file()
 
-    def test_writes_key_file(self, result: object, fake_home: Path) -> None:
+    def test_omits_installation_id(self, result: object, fake_home: Path) -> None:
+        config = (fake_home / "github-bot" / "github-app.yaml").read_text()
+        assert "installation_id:" not in config
+
+    def test_moves_pem_to_key_path(self, result: object, fake_home: Path, fake_pem: Path) -> None:
         assert (fake_home / "github-bot" / "dev10x-bot.pem").is_file()
-
-    def test_config_contains_app_id(self, result: object, fake_home: Path) -> None:
-        config = (fake_home / "github-bot" / "github-app.yaml").read_text()
-        assert 'app_id: "12345"' in config
-
-    def test_config_contains_installation_id(
-        self,
-        result: object,
-        fake_home: Path,
-    ) -> None:
-        config = (fake_home / "github-bot" / "github-app.yaml").read_text()
-        assert 'installation_id: "67890"' in config
+        assert not fake_pem.exists()
 
     def test_key_file_has_600_perms(self, result: object, fake_home: Path) -> None:
         key_path = fake_home / "github-bot" / "dev10x-bot.pem"
-        mode = stat.S_IMODE(key_path.stat().st_mode)
-        assert mode == 0o600
-
-    def test_config_file_has_600_perms(self, result: object, fake_home: Path) -> None:
-        config_path = fake_home / "github-bot" / "github-app.yaml"
-        mode = stat.S_IMODE(config_path.stat().st_mode)
-        assert mode == 0o600
+        assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
 
 
-class TestSetupValidationFailure:
-    def test_aborts_when_key_invalid(self, fake_home: Path) -> None:
+class TestSetupInstallTargetOrg:
+    """Org → org-specific registration URL."""
+
+    @pytest.fixture
+    def stdin_input(self, fake_pem: Path) -> str:
+        return "\n".join(["2", "tiretutorinc", "12345", str(fake_pem)]) + "\n"
+
+    def test_uses_org_url(
+        self,
+        fake_home: Path,
+        stdin_input: str,
+        successful_verification: VerificationResult,
+    ) -> None:
         runner = CliRunner()
-        stdin_input = (
-            "\n12345\n\n-----BEGIN RSA PRIVATE KEY-----\nBADKEY\n-----END RSA PRIVATE KEY-----\n\n"
+        with (
+            patch.object(gha, "_validate_key_locally", return_value=None),
+            patch.object(gha, "_verify_setup", return_value=successful_verification),
+        ):
+            result = runner.invoke(gha.github_app, ["setup"], input=stdin_input)
+
+        assert result.exit_code == 0, result.output
+        assert "https://github.com/organizations/tiretutorinc/settings/apps/new" in result.output
+
+
+class TestSetupVerificationFailures:
+    """Verification failures must abort BEFORE writing config."""
+
+    def _run(
+        self,
+        fake_home: Path,
+        fake_pem: Path,
+        verification: VerificationResult,
+    ) -> object:
+        stdin_input = "\n".join(["1", "12345", str(fake_pem)]) + "\n"
+        runner = CliRunner()
+        with (
+            patch.object(gha, "_validate_key_locally", return_value=None),
+            patch.object(gha, "_verify_setup", return_value=verification),
+        ):
+            return runner.invoke(gha.github_app, ["setup"], input=stdin_input)
+
+    def test_aborts_on_app_id_mismatch(self, fake_home: Path, fake_pem: Path) -> None:
+        result = self._run(
+            fake_home,
+            fake_pem,
+            VerificationResult(success=False, error="App ID mismatch: belongs to App 99"),
         )
+        assert result.exit_code == 1
+        assert "App ID mismatch" in result.output
+        assert not (fake_home / "github-bot" / "github-app.yaml").exists()
+
+    def test_aborts_on_no_installations(self, fake_home: Path, fake_pem: Path) -> None:
+        result = self._run(
+            fake_home,
+            fake_pem,
+            VerificationResult(success=False, error="App has no installations."),
+        )
+        assert result.exit_code == 1
+        assert "no installations" in result.output
+        assert not (fake_home / "github-bot" / "github-app.yaml").exists()
+
+    def test_aborts_on_repo_read_failure(self, fake_home: Path, fake_pem: Path) -> None:
+        result = self._run(
+            fake_home,
+            fake_pem,
+            VerificationResult(success=False, error="All installations failed: 404 Not Found"),
+        )
+        assert result.exit_code == 1
+        assert "failed" in result.output.lower()
+        assert not (fake_home / "github-bot" / "github-app.yaml").exists()
+
+    def test_pem_not_moved_on_failure(self, fake_home: Path, fake_pem: Path) -> None:
+        self._run(
+            fake_home,
+            fake_pem,
+            VerificationResult(success=False, error="boom"),
+        )
+        assert fake_pem.exists()
+
+
+class TestSetupLocalKeyValidationFailure:
+    def test_aborts_when_key_invalid(self, fake_home: Path, fake_pem: Path) -> None:
+        stdin_input = "\n".join(["1", "12345", str(fake_pem)]) + "\n"
+        runner = CliRunner()
         with patch.object(gha, "_validate_key_locally", return_value="bad signature"):
             result = runner.invoke(gha.github_app, ["setup"], input=stdin_input)
 
@@ -86,17 +186,32 @@ class TestSetupValidationFailure:
         assert not (fake_home / "github-bot" / "github-app.yaml").exists()
 
 
-class TestSetupOptionalInstallationId:
-    def test_omits_installation_id_when_blank(self, fake_home: Path) -> None:
+class TestSetupPasteFlow:
+    """--paste keeps the legacy paste flow for headless setups."""
+
+    def test_paste_flag_writes_key_text(
+        self,
+        fake_home: Path,
+        successful_verification: VerificationResult,
+    ) -> None:
+        fake_key_lines = [
+            "-----BEGIN RSA PRIVATE KEY-----",
+            "FAKEKEY",
+            "-----END RSA PRIVATE KEY-----",
+        ]
+        # install_target=1, pause, pause, app_id, paste lines, blank
+        stdin_input = "\n".join(["1", "12345", *fake_key_lines, ""]) + "\n"
         runner = CliRunner()
-        fake_key = "-----BEGIN RSA PRIVATE KEY-----\nKEY\n-----END RSA PRIVATE KEY-----\n"
-        stdin_input = "\n".join(["", "12345", "", *fake_key.splitlines(), ""]) + "\n"
-        with patch.object(gha, "_validate_key_locally", return_value=None):
-            result = runner.invoke(gha.github_app, ["setup"], input=stdin_input)
+        with (
+            patch.object(gha, "_validate_key_locally", return_value=None),
+            patch.object(gha, "_verify_setup", return_value=successful_verification),
+        ):
+            result = runner.invoke(gha.github_app, ["setup", "--paste"], input=stdin_input)
 
         assert result.exit_code == 0, result.output
-        config = (fake_home / "github-bot" / "github-app.yaml").read_text()
-        assert "  installation_id:" not in config
+        key_path = fake_home / "github-bot" / "dev10x-bot.pem"
+        assert key_path.is_file()
+        assert "BEGIN RSA PRIVATE KEY" in key_path.read_text()
 
 
 class TestSetupRejectsExistingWithoutForce:
@@ -111,6 +226,162 @@ class TestSetupRejectsExistingWithoutForce:
         result = runner.invoke(gha.github_app, ["setup"], input="\nN\n")
 
         assert result.exit_code == 1
+
+
+class TestPromptInstallTarget:
+    def test_personal_choice(self) -> None:
+        runner = CliRunner()
+        with runner.isolation(input="1\n"):
+            target = gha._prompt_install_target()
+        assert target == {"kind": "personal"}
+
+    def test_org_choice(self) -> None:
+        runner = CliRunner()
+        with runner.isolation(input="2\nDev10x-Guru\n"):
+            target = gha._prompt_install_target()
+        assert target == {"kind": "org", "org": "Dev10x-Guru"}
+
+    def test_manual_choice(self) -> None:
+        runner = CliRunner()
+        with runner.isolation(input="3\n"):
+            target = gha._prompt_install_target()
+        assert target == {"kind": "manual"}
+
+    def test_retries_on_invalid_choice(self) -> None:
+        runner = CliRunner()
+        with runner.isolation(input="9\n1\n"):
+            target = gha._prompt_install_target()
+        assert target == {"kind": "personal"}
+
+    def test_retries_on_empty_org(self) -> None:
+        runner = CliRunner()
+        with runner.isolation(input="2\n\nDev10x-Guru\n"):
+            target = gha._prompt_install_target()
+        assert target == {"kind": "org", "org": "Dev10x-Guru"}
+
+
+class TestPromptPrivateKeyPath:
+    def test_retries_when_path_does_not_exist(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "no-home")
+        valid = tmp_path / "key.pem"
+        valid.write_text("KEY")
+
+        runner = CliRunner()
+        with runner.isolation(input=f"/no/such/file\n{valid}\n"):
+            result = gha._prompt_private_key_path()
+
+        assert result == valid
+
+    def test_rejects_blank_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "no-home")
+        valid = tmp_path / "key.pem"
+        valid.write_text("KEY")
+
+        runner = CliRunner()
+        with runner.isolation(input=f"\n{valid}\n"):
+            result = gha._prompt_private_key_path()
+
+        assert result == valid
+
+
+class TestVerifySetupApiErrors:
+    def test_get_app_failure_aborts(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(gha.api, "mint_app_jwt", lambda **_: "JWT")
+
+        def boom(**_: object) -> dict:
+            raise gha.api.GitHubAPIError("401 Unauthorized")
+
+        monkeypatch.setattr(gha.api, "get_app", boom)
+
+        result = gha._verify_setup(app_id="12345", private_key="KEY")
+
+        assert result.success is False
+        assert "GET /app failed" in (result.error or "")
+
+    def test_list_installations_failure_aborts(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(gha.api, "mint_app_jwt", lambda **_: "JWT")
+        monkeypatch.setattr(gha.api, "get_app", lambda **_: {"id": 12345, "slug": "ok"})
+
+        def boom(**_: object) -> list:
+            raise gha.api.GitHubAPIError("500")
+
+        monkeypatch.setattr(gha.api, "list_installations", boom)
+
+        result = gha._verify_setup(app_id="12345", private_key="KEY")
+
+        assert result.success is False
+        assert "/app/installations" in (result.error or "")
+
+    def test_jwt_minting_failure_aborts(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def boom(**_: object) -> str:
+            raise ValueError("malformed key")
+
+        monkeypatch.setattr(gha.api, "mint_app_jwt", boom)
+
+        result = gha._verify_setup(app_id="12345", private_key="KEY")
+
+        assert result.success is False
+        assert "Could not mint JWT" in (result.error or "")
+
+
+class TestRegistrationUrl:
+    def test_personal(self) -> None:
+        assert gha._registration_url({"kind": "personal"}) == gha.PERSONAL_NEW_APP_URL
+
+    def test_org(self) -> None:
+        url = gha._registration_url({"kind": "org", "org": "tiretutorinc"})
+        assert url == "https://github.com/organizations/tiretutorinc/settings/apps/new"
+
+    def test_manual_returns_placeholder(self) -> None:
+        url = gha._registration_url({"kind": "manual"})
+        assert "yourself" in url
+
+
+class TestInstallScopeHint:
+    def test_personal_steers_to_any_account(self) -> None:
+        hint = gha._install_scope_hint({"kind": "personal"})
+        assert '"Any account"' in hint
+
+    def test_org_explains_implicit_scope(self) -> None:
+        hint = gha._install_scope_hint({"kind": "org", "org": "x"})
+        assert "owned by the org" in hint
+
+    def test_manual_covers_both(self) -> None:
+        hint = gha._install_scope_hint({"kind": "manual"})
+        assert "Any account" in hint
+
+
+class TestNewestPemInDownloads:
+    def test_returns_none_when_no_downloads_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        assert gha._newest_pem_in_downloads() is None
+
+    def test_returns_newest_pem(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        downloads = tmp_path / "Downloads"
+        downloads.mkdir()
+        old = downloads / "old.private-key.pem"
+        new = downloads / "new.private-key.pem"
+        old.write_text("old")
+        new.write_text("new")
+        os.utime(old, (1000, 1000))
+        os.utime(new, (2000, 2000))
+
+        assert gha._newest_pem_in_downloads() == new
+
+    def test_ignores_non_private_key_pems(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        downloads = tmp_path / "Downloads"
+        downloads.mkdir()
+        (downloads / "cert.pem").write_text("not-a-key")
+        assert gha._newest_pem_in_downloads() is None
 
 
 class TestStatus:
@@ -132,3 +403,72 @@ class TestStatus:
 
         assert result.exit_code == 0
         assert str(gha.CONFIG_PATH) in result.output
+
+
+class TestVerifySetup:
+    """Unit-level coverage of the verification orchestrator."""
+
+    def test_app_id_mismatch_aborts(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(gha.api, "mint_app_jwt", lambda **_: "JWT")
+        monkeypatch.setattr(gha.api, "get_app", lambda **_: {"id": 999, "slug": "wrong-app"})
+
+        result = gha._verify_setup(app_id="12345", private_key="KEY")
+
+        assert result.success is False
+        assert "App ID mismatch" in (result.error or "")
+
+    def test_no_installations_aborts(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(gha.api, "mint_app_jwt", lambda **_: "JWT")
+        monkeypatch.setattr(gha.api, "get_app", lambda **_: {"id": 12345, "slug": "ok"})
+        monkeypatch.setattr(gha.api, "list_installations", lambda **_: [])
+
+        result = gha._verify_setup(app_id="12345", private_key="KEY")
+
+        assert result.success is False
+        assert "no installations" in (result.error or "").lower()
+
+    def test_happy_path_reports_verified_repos(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(gha.api, "mint_app_jwt", lambda **_: "JWT")
+        monkeypatch.setattr(gha.api, "get_app", lambda **_: {"id": 12345, "slug": "dev10x-bot"})
+        monkeypatch.setattr(
+            gha.api,
+            "list_installations",
+            lambda **_: [{"id": 99, "account": {"login": "Dev10x-Guru"}}],
+        )
+        monkeypatch.setattr(
+            gha.api,
+            "create_installation_token",
+            lambda **_: "INSTALL_TOKEN",
+        )
+        monkeypatch.setattr(
+            gha.api,
+            "list_installation_repositories",
+            lambda **_: [{"name": "Dev10x-Claude", "owner": {"login": "Dev10x-Guru"}}],
+        )
+        monkeypatch.setattr(gha.api, "get_repo", lambda **_: {"id": 1})
+
+        result = gha._verify_setup(app_id="12345", private_key="KEY")
+
+        assert result.success is True
+        assert result.app_slug == "dev10x-bot"
+        assert len(result.installations) == 1
+        assert result.installations[0].verified_repo == "Dev10x-Guru/Dev10x-Claude"
+
+    def test_all_installations_failing_aborts(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(gha.api, "mint_app_jwt", lambda **_: "JWT")
+        monkeypatch.setattr(gha.api, "get_app", lambda **_: {"id": 12345, "slug": "ok"})
+        monkeypatch.setattr(
+            gha.api,
+            "list_installations",
+            lambda **_: [{"id": 99, "account": {"login": "Dev10x-Guru"}}],
+        )
+
+        def boom(**_: object) -> str:
+            raise gha.api.GitHubAPIError("403 Forbidden")
+
+        monkeypatch.setattr(gha.api, "create_installation_token", boom)
+
+        result = gha._verify_setup(app_id="12345", private_key="KEY")
+
+        assert result.success is False
+        assert "403" in (result.error or "")

--- a/tests/commands/test_github_app_api.py
+++ b/tests/commands/test_github_app_api.py
@@ -1,0 +1,119 @@
+"""Tests for the GitHub API helpers used by the setup wizard."""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from dev10x.commands import github_app_api as api
+
+
+@pytest.fixture
+def fake_pem() -> str:
+    # A real RSA key generated for tests — verifying the JWT path requires
+    # a parseable key, so we generate one inline.
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return pem.decode()
+
+
+def _fake_response(payload: Any, status: int = 200) -> io.BytesIO:
+    body = io.BytesIO(json.dumps(payload).encode())
+    body.status = status  # type: ignore[attr-defined]
+    body.__enter__ = lambda self: self  # type: ignore[assignment]
+    body.__exit__ = lambda self, *args: None  # type: ignore[assignment]
+    return body
+
+
+class TestMintAppJwt:
+    def test_returns_string(self, fake_pem: str) -> None:
+        token = api.mint_app_jwt(app_id="12345", private_key=fake_pem)
+        assert isinstance(token, str)
+        # Three dot-separated segments
+        assert token.count(".") == 2
+
+
+class TestGetApp:
+    def test_parses_response(self) -> None:
+        with patch.object(api.urllib.request, "urlopen") as mocked:
+            mocked.return_value = _fake_response({"id": 12345, "slug": "dev10x-bot"})
+            result = api.get_app(jwt_token="JWT")
+
+        assert result == {"id": 12345, "slug": "dev10x-bot"}
+        called_request = mocked.call_args[0][0]
+        assert called_request.full_url == f"{api.API_ROOT}/app"
+        assert called_request.headers["Authorization"] == "Bearer JWT"
+
+    def test_raises_on_http_error(self) -> None:
+        http_error = urllib.error.HTTPError(
+            url="https://api.github.com/app",
+            code=401,
+            msg="Unauthorized",
+            hdrs={},  # type: ignore[arg-type]
+            fp=io.BytesIO(b'{"message":"Bad credentials"}'),
+        )
+        with patch.object(api.urllib.request, "urlopen", side_effect=http_error):
+            with pytest.raises(api.GitHubAPIError) as excinfo:
+                api.get_app(jwt_token="JWT")
+
+        assert "401" in str(excinfo.value)
+        assert "Bad credentials" in str(excinfo.value)
+
+
+class TestListInstallations:
+    def test_returns_list(self) -> None:
+        installations = [
+            {"id": 1, "account": {"login": "Dev10x-Guru"}},
+            {"id": 2, "account": {"login": "tiretutorinc"}},
+        ]
+        with patch.object(api.urllib.request, "urlopen") as mocked:
+            mocked.return_value = _fake_response(installations)
+            result = api.list_installations(jwt_token="JWT")
+
+        assert result == installations
+
+
+class TestCreateInstallationToken:
+    def test_returns_token_field(self) -> None:
+        with patch.object(api.urllib.request, "urlopen") as mocked:
+            mocked.return_value = _fake_response({"token": "ghs_xyz", "expires_at": "..."})
+            result = api.create_installation_token(jwt_token="JWT", installation_id=99)
+
+        assert result == "ghs_xyz"
+        called_request = mocked.call_args[0][0]
+        assert called_request.method == "POST"
+        assert called_request.full_url == f"{api.API_ROOT}/app/installations/99/access_tokens"
+
+
+class TestListInstallationRepositories:
+    def test_unwraps_repositories_key(self) -> None:
+        payload = {
+            "total_count": 1,
+            "repositories": [{"name": "Dev10x-Claude", "owner": {"login": "Dev10x-Guru"}}],
+        }
+        with patch.object(api.urllib.request, "urlopen") as mocked:
+            mocked.return_value = _fake_response(payload)
+            result = api.list_installation_repositories(token="TOK")
+
+        assert result == payload["repositories"]
+
+
+class TestGetRepo:
+    def test_returns_repo_payload(self) -> None:
+        with patch.object(api.urllib.request, "urlopen") as mocked:
+            mocked.return_value = _fake_response({"id": 1, "name": "Dev10x-Claude"})
+            result = api.get_repo(token="TOK", owner="Dev10x-Guru", repo="Dev10x-Claude")
+
+        assert result == {"id": 1, "name": "Dev10x-Claude"}


### PR DESCRIPTION
**When** running `dev10x github-app setup` after registering and installing the GitHub App on one or more accounts, **I want to** finish the wizard with credentials proven end-to-end (App JWT → installation token → repo read) against the target repos, **so I can** trust that the next agent-generated PR reply will post under the bot identity instead of silently falling back to my personal account because the pasted key was mangled, the installation was pinned to the wrong scope, or the App was registered where it cannot be installed.

---

[`164987b0`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/74/commits/164987b06d1b5c720c0ca444e2311bf8717ef92e) ✨ GH-72 Prove github-app setup credentials end-to-end
Fixes: https://github.com/Dev10x-Guru/dev10x-claude/issues/72

---