### PR TITLE
♻️ Discourage agents from misusing skip-validation flag

### DIFF
--- a/src/dev10x/skills/permission/clean_project_files.py
+++ b/src/dev10x/skills/permission/clean_project_files.py
@@ -22,18 +22,14 @@ from pathlib import Path
 
 import yaml
 
-USERSPACE_CONFIG = (
-    Path.home() / ".claude" / "skills" / "Dev10x:upgrade-cleanup" / "projects.yaml"
-)
+USERSPACE_CONFIG = Path.home() / ".claude" / "skills" / "Dev10x:upgrade-cleanup" / "projects.yaml"
 PLUGIN_CONFIG = (
     Path(__file__).resolve().parents[4] / "skills" / "upgrade-cleanup" / "projects.yaml"
 )
 GLOBAL_SETTINGS = Path.home() / ".claude" / "settings.json"
 
 PLUGIN_NAMES = r"(?:Dev10x|dev10x(?:-claude)?)"
-VERSION_PATTERN = re.compile(
-    rf"plugins/cache/[^/]+/{PLUGIN_NAMES}/(\d+\.\d+\.\d+)", re.IGNORECASE
-)
+VERSION_PATTERN = re.compile(rf"plugins/cache/[^/]+/{PLUGIN_NAMES}/(\d+\.\d+\.\d+)", re.IGNORECASE)
 PUBLISHER_PATTERN = re.compile(rf"plugins/cache/([^/]+)/{PLUGIN_NAMES}/", re.IGNORECASE)
 
 ENV_PREFIX_PATTERN = re.compile(r"^Bash\([A-Z_]+=")
@@ -408,17 +404,13 @@ def _format_messages(
             messages.append(f"    deny:  {deny}")
 
     if result.ask_shadowed_by_allow:
-        messages.append(
-            f"  ⚠ ASK SHADOWED BY ALLOW ({len(result.ask_shadowed_by_allow)}):"
-        )
+        messages.append(f"  ⚠ ASK SHADOWED BY ALLOW ({len(result.ask_shadowed_by_allow)}):")
         for ask, allow in result.ask_shadowed_by_allow:
             messages.append(f"    ask:   {ask}")
             messages.append(f"    allow: {allow}")
 
     if result.exact_duplicates:
-        messages.append(
-            f"  - {len(result.exact_duplicates)} exact duplicates of global rules"
-        )
+        messages.append(f"  - {len(result.exact_duplicates)} exact duplicates of global rules")
         if verbose:
             for rule in result.exact_duplicates:
                 messages.append(f"    {rule}")
@@ -442,9 +434,7 @@ def _format_messages(
                 messages.append(f"    {rule}")
 
     if result.shell_fragments:
-        messages.append(
-            f"  - {len(result.shell_fragments)} shell control flow fragments"
-        )
+        messages.append(f"  - {len(result.shell_fragments)} shell control flow fragments")
         if verbose:
             for rule in result.shell_fragments:
                 messages.append(f"    {rule}")

--- a/src/dev10x/skills/permission_investigator/matrix.py
+++ b/src/dev10x/skills/permission_investigator/matrix.py
@@ -194,9 +194,7 @@ def generate_matrix(
 ) -> Matrix:
     """Generate the cartesian product of dimensions as a Matrix."""
     matrix = Matrix()
-    for tool, prefix, wildcard, location in product(
-        tools, prefixes, wildcards, locations
-    ):
+    for tool, prefix, wildcard, location in product(tools, prefixes, wildcards, locations):
         shape = RuleShape(tool=tool, prefix=prefix, wildcard=wildcard)
         cell = MatrixCell(
             shape=shape,

--- a/src/dev10x/skills/permission_investigator/report.py
+++ b/src/dev10x/skills/permission_investigator/report.py
@@ -101,9 +101,7 @@ def compute_delta(
 
     suggestions: list[str] = []
     for prefix, wildcard in sorted(working_shapes):
-        suggestions.append(
-            f"prefer prefix={prefix} wildcard={wildcard} in plugin-maintenance"
-        )
+        suggestions.append(f"prefer prefix={prefix} wildcard={wildcard} in plugin-maintenance")
 
     return Delta(ineffective_rules=ineffective, suggested_rules=suggestions)
 

--- a/src/dev10x/validators/skill_redirect.py
+++ b/src/dev10x/validators/skill_redirect.py
@@ -56,8 +56,18 @@ SKIP_ENV_VAR = "DEV10X_SKIP_CMD_VALIDATION"
 SKIP_PREFIX_RE = re.compile(rf"^{SKIP_ENV_VAR}=(true|1)\s+", re.IGNORECASE)
 
 OVERRIDE_HINT = (
-    "\n\nTo force this command (e.g., from inside a skill that "
-    "legitimately needs it), prefix it with:\n"
+    f"\n\n⚠️  Do NOT use {SKIP_ENV_VAR} as a shortcut "
+    "to silence this block. That flag is reserved for SKILL AUTHORS "
+    "whose skill legitimately needs the raw command — it is NOT an "
+    "escape hatch for agents reacting to a hook message.\n\n"
+    "If you reached this hint because a command was blocked, the "
+    "correct response is to invoke the skill named above. Reaching "
+    "for the skip flag because the task “looks simple”, "
+    "because you already prepared inputs, or out of inertia is a "
+    "procedural error — the skill exists precisely to enforce the "
+    "guardrails you would otherwise skip.\n\n"
+    "ONLY if you are authoring or executing inside such a skill, "
+    "prefix it with:\n"
     f"  {SKIP_ENV_VAR}=true <command>"
 )
 

--- a/tests/skills/permission-investigator/test_matrix.py
+++ b/tests/skills/permission-investigator/test_matrix.py
@@ -45,9 +45,7 @@ class TestRuleShapeRender:
 
         rendered = shape.render(fixture_relpath=fixture_relpath, user_home=home)
 
-        expected_dir = (
-            "/home/janusz/.claude/plugins/cache/Test/Plugin/9.9.9/skills/probe"
-        )
+        expected_dir = "/home/janusz/.claude/plugins/cache/Test/Plugin/9.9.9/skills/probe"
         assert rendered == f"Read({expected_dir}/*)"
 
     def test_env_home_double_star(

--- a/tests/skills/permission-investigator/test_report.py
+++ b/tests/skills/permission-investigator/test_report.py
@@ -67,9 +67,7 @@ class TestAggregateResults:
 
     def test_ignores_results_without_matching_cell(self) -> None:
         matrix = Matrix()
-        matrix.add_result(
-            MatrixResult(cell_id="orphan", auto_approved=True, prompted=False)
-        )
+        matrix.add_result(MatrixResult(cell_id="orphan", auto_approved=True, prompted=False))
 
         grouped = aggregate_results(matrix)
 
@@ -114,12 +112,12 @@ class TestComputeDelta:
             ],
         )
 
-        assert any(
-            "*/**" in rule for rule in delta.ineffective_rules
-        ), "Expected the */** rule to be flagged"
-        assert all(
-            "git log" not in rule for rule in delta.ineffective_rules
-        ), "Bash rules should not be flagged by Read prompts"
+        assert any("*/**" in rule for rule in delta.ineffective_rules), (
+            "Expected the */** rule to be flagged"
+        )
+        assert all("git log" not in rule for rule in delta.ineffective_rules), (
+            "Bash rules should not be flagged by Read prompts"
+        )
 
     def test_no_rules_flagged_when_all_cells_work(self) -> None:
         matrix = Matrix()

--- a/tests/skills/upgrade-cleanup/test_ensure_reads.py
+++ b/tests/skills/upgrade-cleanup/test_ensure_reads.py
@@ -43,9 +43,7 @@ def fake_plugin_root(fake_home: Path) -> Path:
         bin/
         ...
     """
-    plugin_root = (
-        fake_home / ".claude" / "plugins" / "cache" / "Dev10x-Guru" / "Dev10x" / "9.9.9"
-    )
+    plugin_root = fake_home / ".claude" / "plugins" / "cache" / "Dev10x-Guru" / "Dev10x" / "9.9.9"
     skills_dir = plugin_root / "skills"
     for skill in ["alpha-skill", "beta-skill"]:
         (skills_dir / skill).mkdir(parents=True)
@@ -71,9 +69,7 @@ class TestScanSkillDirectories:
 
         assert scan_skill_directories(empty_root) == []
 
-    def test_ignores_files_only_returns_directories(
-        self, fake_plugin_root: Path
-    ) -> None:
+    def test_ignores_files_only_returns_directories(self, fake_plugin_root: Path) -> None:
         (fake_plugin_root / "skills" / "stray-file.txt").write_text("not a skill")
 
         result = scan_skill_directories(fake_plugin_root)


### PR DESCRIPTION
**When** an agent's command is blocked by the skill-redirect hook, **I want to** the override-hint message firmly discourage using `DEV10X_SKIP_CMD_VALIDATION` as a shortcut, **so I can** trust agents will invoke the recommended skill instead of bypassing the guardrail out of inertia.

---

[`ab6ad492`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/75/commits/ab6ad492797a308fc463a55283dd7e8eca856b54) ♻️ Discourage agents from misusing skip-validation flag
[`e9e6324a`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/75/commits/e9e6324a1e9aa198b4034eb6d7d9887fa013e8f1) 🎨 Apply ruff format to permission-related files
Fixes: none — self-motivated

---