### PR TITLE
🐛 GH-89 Stabilize subprocess error contract for missing scripts

### DIFF
--- a/src/dev10x/subprocess_utils.py
+++ b/src/dev10x/subprocess_utils.py
@@ -88,7 +88,16 @@ def run_script(
     full_path = resolve_script_path(script_path)
 
     if not full_path.exists():
-        raise FileNotFoundError(f"Script not found: {full_path}")
+        # Mirror async_run's timeout sentinel so MCP modules can map the
+        # missing-script case onto their existing returncode-based error
+        # handling instead of leaking FileNotFoundError through the MCP
+        # boundary as an unstructured server error (GH-89).
+        return subprocess.CompletedProcess(
+            args=[str(full_path), *args],
+            returncode=-1,
+            stdout="",
+            stderr=f"Script not found: {full_path}",
+        )
 
     env = os.environ.copy()
     if env_vars:
@@ -149,7 +158,13 @@ async def async_run_script(
     full_path = resolve_script_path(script_path)
 
     if not full_path.exists():
-        raise FileNotFoundError(f"Script not found: {full_path}")
+        # See run_script for rationale (GH-89).
+        return subprocess.CompletedProcess(
+            args=[str(full_path), *[str(a) for a in args]],
+            returncode=-1,
+            stdout="",
+            stderr=f"Script not found: {full_path}",
+        )
 
     env = os.environ.copy()
     if env_vars:

--- a/tests/test_subprocess_utils.py
+++ b/tests/test_subprocess_utils.py
@@ -93,9 +93,13 @@ class TestResolveScriptPath:
 
 
 class TestRunScript:
-    def test_raises_file_not_found_for_missing_script(self) -> None:
-        with pytest.raises(FileNotFoundError, match="Script not found"):
-            run_script("nonexistent/script.sh")
+    def test_returns_sentinel_for_missing_script(self) -> None:
+        result = run_script("nonexistent/script.sh")
+
+        assert result.returncode == -1
+        assert result.stdout == ""
+        assert "Script not found" in result.stderr
+        assert "nonexistent/script.sh" in result.stderr
 
     @patch("dev10x.subprocess_utils.subprocess.run")
     def test_calls_subprocess_with_full_path(
@@ -258,9 +262,13 @@ class TestAsyncRunScript:
         return async_run_script
 
     @pytest.mark.asyncio
-    async def test_raises_file_not_found_for_missing_script(self, sut) -> None:
-        with pytest.raises(FileNotFoundError, match="Script not found"):
-            await sut("nonexistent/script.sh")
+    async def test_returns_sentinel_for_missing_script(self, sut) -> None:
+        result = await sut("nonexistent/script.sh")
+
+        assert result.returncode == -1
+        assert result.stdout == ""
+        assert "Script not found" in result.stderr
+        assert "nonexistent/script.sh" in result.stderr
 
     @pytest.mark.asyncio
     async def test_runs_existing_script(self, sut) -> None:


### PR DESCRIPTION
**When** a dev10x MCP tool invokes a script that has been moved, deleted, or never shipped to the cache, **I want to** receive a structured error from the MCP boundary, **so I can** surface a meaningful failure to the caller instead of an opaque server exception that masks the real cause.

---

[`e1f130a3`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/95/commits/e1f130a396add512df9e8f0c41edbf81a20f6746) 🐛 GH-89 Stabilize subprocess error contract for missing scripts
Fixes: https://github.com/Dev10x-Guru/dev10x-claude/issues/89

---