### PR TITLE
🔒 GH-77 Prevent state file corruption under concurrent writers

### DIFF
--- a/src/dev10x/config/loader.py
+++ b/src/dev10x/config/loader.py
@@ -9,6 +9,7 @@ import msgpack
 import yaml
 
 from dev10x.domain.config_loader import ConfigLoader
+from dev10x.domain.file_locks import atomic_write_bytes
 from dev10x.domain.validation_rule import Compensation, Config, Rule
 
 DEFAULT_TTL_SECONDS = 1800
@@ -66,7 +67,7 @@ def _read_cache(
 def _write_cache(*, cache_path: Path, config: Config) -> None:
     try:
         data = asdict(config)
-        cache_path.write_bytes(msgpack.packb(data, use_bin_type=True))
+        atomic_write_bytes(cache_path, msgpack.packb(data, use_bin_type=True))
     except (msgpack.PackException, OSError):
         pass
 

--- a/src/dev10x/domain/file_locks.py
+++ b/src/dev10x/domain/file_locks.py
@@ -1,0 +1,153 @@
+"""Concurrency-safe file primitives: exclusive locks + atomic writes.
+
+Background: shared state files under ``~/.claude/`` and
+``<repo>/.claude/session/`` are written by multiple worktrees and
+parallel agents. Plain ``Path.write_text()`` truncate-writes lose
+data when two writers race; load→mutate→save cycles also lose data
+even with atomic writes because the second writer reads stale state.
+
+This module exposes three layers:
+
+1. ``file_lock(path)`` — bare exclusive flock on a ``.lock`` sidecar
+2. ``atomic_write_text`` / ``atomic_write_bytes`` — durable writes
+   via ``mkstemp`` + ``os.rename`` (no lock; safe for non-mutating
+   overwrites such as cache files)
+3. ``locked_json_update`` / ``locked_yaml_update`` — full
+   load→mutate→save cycle under a lock, with atomic durable write
+
+Sidecar naming convention:
+
+* ``file_lock`` and ``locked_yaml_update`` **append** ``.lock`` to the
+  target's full name via :func:`_lock_path_for` — e.g. ``plan.yaml``
+  → ``plan.yaml.lock``. New code should follow this convention.
+* ``locked_json_update`` **replaces** the target's suffix with
+  ``.lock`` — e.g. ``settings.local.json`` → ``settings.local.lock``.
+  This is preserved deliberately for backward compatibility with the
+  existing :mod:`dev10x.skills.permission` call sites and the test
+  in ``tests/skills/upgrade-cleanup/test_file_lock.py``; switching
+  it now would orphan on-disk sidecars across the upgrade boundary.
+
+The two functions must not be used against the same target path
+because their sidecars resolve to different files.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import tempfile
+from collections.abc import Generator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def _lock_path_for(path: Path) -> Path:
+    return path.with_suffix(path.suffix + ".lock") if path.suffix else path.with_suffix(".lock")
+
+
+@contextmanager
+def file_lock(path: Path) -> Generator[None, None, None]:
+    """Acquire exclusive ``flock`` on ``<path>.lock`` for the duration.
+
+    Sidecar naming follows the module convention: ``.lock`` is
+    *appended* to the full target name via :func:`_lock_path_for`
+    (e.g. ``plan.yaml`` → ``plan.yaml.lock``). See the module docstring
+    for the reason this differs from :func:`locked_json_update`.
+
+    The sidecar lock file is deliberately not unlinked on release.
+    Unlinking is unsafe: a third writer arriving between ``unlink`` and
+    the next ``open(O_CREAT)`` would get a fresh inode and acquire its
+    own independent flock, breaking mutual exclusion.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_fd = os.open(str(_lock_path_for(path)), os.O_CREAT | os.O_RDWR)
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        os.close(lock_fd)
+
+
+def atomic_write_bytes(path: Path, content: bytes) -> None:
+    """Write ``content`` to ``path`` via ``mkstemp`` + ``os.rename``."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        os.write(fd, content)
+        os.fsync(fd)
+        os.close(fd)
+        os.rename(tmp, str(path))
+    except BaseException:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def atomic_write_text(path: Path, content: str) -> None:
+    """Write ``content`` (UTF-8) to ``path`` atomically."""
+    atomic_write_bytes(path, content.encode("utf-8"))
+
+
+@contextmanager
+def locked_json_update(path: Path) -> Generator[dict[str, Any], None, None]:
+    """Lock ``path``, yield its JSON content as a dict, atomically write back.
+
+    Uses a ``.lock`` sidecar that replaces the path's suffix (e.g.
+    ``settings.local.json`` → ``settings.local.lock``), preserving
+    the historical naming used by the permission-skill call sites.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_fd = os.open(str(path.with_suffix(".lock")), os.O_CREAT | os.O_RDWR)
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        if path.exists():
+            data = json.loads(path.read_text())
+        else:
+            data = {}
+        yield data
+        atomic_write_text(path, json.dumps(data, indent=2) + "\n")
+    finally:
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        os.close(lock_fd)
+
+
+@contextmanager
+def locked_yaml_update(path: Path) -> Generator[dict[str, Any], None, None]:
+    """Lock ``path``, yield its YAML content as a dict, atomically write back.
+
+    Sidecar naming follows the module convention: ``.lock`` is
+    *appended* to the full target name via :func:`_lock_path_for`
+    (e.g. ``plan.yaml`` → ``plan.yaml.lock``). See the module
+    docstring for the reason this differs from
+    :func:`locked_json_update`.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_fd = os.open(str(_lock_path_for(path)), os.O_CREAT | os.O_RDWR)
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        if path.exists():
+            try:
+                data = yaml.safe_load(path.read_text()) or {}
+            except yaml.YAMLError:
+                data = {}
+        else:
+            data = {}
+        yield data
+        atomic_write_text(
+            path,
+            yaml.safe_dump(data, default_flow_style=False, sort_keys=False, allow_unicode=True),
+        )
+    finally:
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        os.close(lock_fd)

--- a/src/dev10x/hooks/session.py
+++ b/src/dev10x/hooks/session.py
@@ -19,6 +19,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from dev10x.domain.file_locks import atomic_write_text, file_lock
 from dev10x.domain.git_context import GitContext
 
 _git = GitContext()
@@ -428,29 +429,26 @@ def session_migrate_permissions() -> None:
 
     for settings_file in settings_files:
         try:
-            settings = json.loads(settings_file.read_text())
+            with file_lock(settings_file):
+                settings = json.loads(settings_file.read_text())
+                permissions = settings.get("permissions", {})
+                changed = False
+                for key in ("allow", "deny"):
+                    raw = permissions.get(key, [])
+                    if not raw:
+                        continue
+                    new_rules, count = _migrate_rules(rules=raw, replacements=replacements)
+                    new_rules = _deduplicate_rules(rules=new_rules)
+                    total_migrated += count
+                    if count:
+                        permissions[key] = new_rules
+                        changed = True
+                if not changed:
+                    continue
+                atomic_write_text(settings_file, json.dumps(settings, indent=2) + "\n")
+            files_changed.append(settings_file.name)
         except (json.JSONDecodeError, OSError):
             continue
-
-        permissions = settings.get("permissions", {})
-        changed = False
-        for key in ("allow", "deny"):
-            raw = permissions.get(key, [])
-            if not raw:
-                continue
-            new_rules, count = _migrate_rules(rules=raw, replacements=replacements)
-            new_rules = _deduplicate_rules(rules=new_rules)
-            total_migrated += count
-            if count:
-                permissions[key] = new_rules
-                changed = True
-
-        if changed:
-            try:
-                settings_file.write_text(json.dumps(settings, indent=2) + "\n")
-            except OSError:
-                continue
-            files_changed.append(settings_file.name)
 
     if total_migrated > 0:
         files_str = ", ".join(files_changed)

--- a/src/dev10x/hooks/task_plan_sync.py
+++ b/src/dev10x/hooks/task_plan_sync.py
@@ -15,6 +15,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from dev10x.domain.file_locks import file_lock
 from dev10x.domain.git_context import GitContext
 from dev10x.domain.plan import Plan
 
@@ -121,24 +122,28 @@ def cmd_hook() -> None:
         sys.exit(0)
 
     plan_path = get_plan_path(toplevel=toplevel)
-    plan = Plan.load(path=plan_path)
-    is_new_plan = plan.is_new
-    plan.ensure_metadata()
+    # Lock spans the full load→mutate→save cycle: without it, two
+    # concurrent TaskCreate hooks both read the same baseline plan
+    # and the second save clobbers the first task entry.
+    with file_lock(plan_path):
+        plan = Plan.load(path=plan_path)
+        is_new_plan = plan.is_new
+        plan.ensure_metadata()
 
-    changed = False
-    if tool_name == "TaskCreate":
-        changed = plan.handle_task_create(
-            tool_input=tool_input,
-            tool_result=tool_result,
-        )
-    elif tool_name == "TaskUpdate":
-        plan.handle_task_update(tool_input=tool_input)
-        changed = True
-    else:
-        sys.exit(0)
+        changed = False
+        if tool_name == "TaskCreate":
+            changed = plan.handle_task_create(
+                tool_input=tool_input,
+                tool_result=tool_result,
+            )
+        elif tool_name == "TaskUpdate":
+            plan.handle_task_update(tool_input=tool_input)
+            changed = True
+        else:
+            sys.exit(0)
 
-    if is_new_plan and not changed:
-        sys.exit(0)
+        if is_new_plan and not changed:
+            sys.exit(0)
 
-    plan.check_all_completed()
-    plan.save(path=plan_path)
+        plan.check_all_completed()
+        plan.save(path=plan_path)

--- a/src/dev10x/platform/registry.py
+++ b/src/dev10x/platform/registry.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 import yaml
 
+from dev10x.domain.file_locks import atomic_write_text
+
 REGISTRY_FILE = Path.home() / ".claude" / "memory" / "Dev10x" / "platforms.yaml"
 
 
@@ -105,9 +107,8 @@ class Registry:
         return {entry["name"]: PlatformConfig.from_dict(entry) for entry in entries}
 
     def save(self, platforms: dict[str, PlatformConfig]) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
         serialised = {"platforms": [platforms[name].to_dict() for name in sorted(platforms)]}
-        self.path.write_text(yaml.safe_dump(serialised, sort_keys=False))
+        atomic_write_text(self.path, yaml.safe_dump(serialised, sort_keys=False))
 
     def add(
         self,

--- a/src/dev10x/skills/permission/file_lock.py
+++ b/src/dev10x/skills/permission/file_lock.py
@@ -1,44 +1,12 @@
+"""Backwards-compatible re-export.
+
+Canonical primitives live in :mod:`dev10x.domain.file_locks`. This
+shim preserves the existing import path for permission-skill call
+sites.
+"""
+
 from __future__ import annotations
 
-import fcntl
-import json
-import os
-import tempfile
-from collections.abc import Generator
-from contextlib import contextmanager
-from pathlib import Path
-from typing import Any
+from dev10x.domain.file_locks import locked_json_update
 
-
-@contextmanager
-def locked_json_update(path: Path) -> Generator[dict[str, Any], None, None]:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    lock_path = path.with_suffix(".lock")
-    lock_fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR)
-    try:
-        fcntl.flock(lock_fd, fcntl.LOCK_EX)
-        if path.exists():
-            data = json.loads(path.read_text())
-        else:
-            data = {}
-        yield data
-        fd, tmp = tempfile.mkstemp(
-            dir=str(path.parent),
-            suffix=".tmp",
-        )
-        try:
-            os.write(fd, (json.dumps(data, indent=2) + "\n").encode())
-            os.fsync(fd)
-            os.close(fd)
-            os.rename(tmp, str(path))
-        except BaseException:
-            os.close(fd)
-            os.unlink(tmp)
-            raise
-    finally:
-        fcntl.flock(lock_fd, fcntl.LOCK_UN)
-        os.close(lock_fd)
-        try:
-            os.unlink(str(lock_path))
-        except FileNotFoundError:
-            pass
+__all__ = ["locked_json_update"]

--- a/tests/domain/test_file_locks.py
+++ b/tests/domain/test_file_locks.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+import multiprocessing as mp
+from pathlib import Path
+
+import pytest
+import yaml
+
+from dev10x.domain.file_locks import (
+    atomic_write_bytes,
+    atomic_write_text,
+    file_lock,
+    locked_json_update,
+    locked_yaml_update,
+)
+
+
+class TestAtomicWriteText:
+    def test_creates_file(self, tmp_path: Path) -> None:
+        target = tmp_path / "subdir" / "out.txt"
+        atomic_write_text(target, "hello")
+        assert target.read_text() == "hello"
+
+    def test_overwrites_existing(self, tmp_path: Path) -> None:
+        target = tmp_path / "out.txt"
+        target.write_text("old")
+        atomic_write_text(target, "new")
+        assert target.read_text() == "new"
+
+    def test_no_stale_tmp_after_success(self, tmp_path: Path) -> None:
+        target = tmp_path / "out.txt"
+        atomic_write_text(target, "hello")
+        leftovers = [p for p in tmp_path.iterdir() if p.suffix == ".tmp"]
+        assert leftovers == []
+
+
+class TestAtomicWriteBytes:
+    def test_writes_binary(self, tmp_path: Path) -> None:
+        target = tmp_path / "out.bin"
+        atomic_write_bytes(target, b"\x00\x01\x02")
+        assert target.read_bytes() == b"\x00\x01\x02"
+
+
+class TestFileLock:
+    def test_creates_sidecar(self, tmp_path: Path) -> None:
+        target = tmp_path / "data.json"
+        with file_lock(target):
+            assert (tmp_path / "data.json.lock").exists()
+        # Sidecar is intentionally left in place after release to avoid
+        # the unlink-race that breaks mutual exclusion under contention.
+        assert (tmp_path / "data.json.lock").exists()
+
+    def test_no_suffix_path(self, tmp_path: Path) -> None:
+        target = tmp_path / "data"
+        with file_lock(target):
+            assert (tmp_path / "data.lock").exists()
+
+
+class TestLockedJsonUpdate:
+    def test_load_mutate_save_cycle(self, tmp_path: Path) -> None:
+        target = tmp_path / "settings.json"
+        target.write_text(json.dumps({"count": 1}))
+        with locked_json_update(target) as data:
+            data["count"] += 1
+        assert json.loads(target.read_text())["count"] == 2
+
+
+class TestLockedYamlUpdate:
+    def test_load_mutate_save_cycle(self, tmp_path: Path) -> None:
+        target = tmp_path / "plan.yaml"
+        target.write_text(yaml.safe_dump({"tasks": [1]}))
+        with locked_yaml_update(target) as data:
+            data["tasks"].append(2)
+        result = yaml.safe_load(target.read_text())
+        assert result["tasks"] == [1, 2]
+
+    def test_creates_when_missing(self, tmp_path: Path) -> None:
+        target = tmp_path / "plan.yaml"
+        with locked_yaml_update(target) as data:
+            data["fresh"] = True
+        assert yaml.safe_load(target.read_text()) == {"fresh": True}
+
+
+def _concurrent_increment(path_str: str, key: str) -> None:
+    path = Path(path_str)
+    with locked_json_update(path) as data:
+        data[key] = data.get(key, 0) + 1
+
+
+class TestConcurrency:
+    @pytest.mark.parametrize("workers", [4, 8])
+    def test_locked_json_update_serializes_writers(self, tmp_path: Path, workers: int) -> None:
+        target = tmp_path / "counter.json"
+        target.write_text(json.dumps({"n": 0}))
+
+        ctx = mp.get_context("fork")
+        processes = [
+            ctx.Process(target=_concurrent_increment, args=(str(target), "n"))
+            for _ in range(workers)
+        ]
+        for p in processes:
+            p.start()
+        for p in processes:
+            p.join(timeout=10)
+            assert p.exitcode == 0, f"worker failed with {p.exitcode}"
+
+        assert json.loads(target.read_text())["n"] == workers

--- a/tests/hooks/test_concurrency.py
+++ b/tests/hooks/test_concurrency.py
@@ -1,0 +1,92 @@
+"""Concurrency tests for shared state file writers (GH-77).
+
+Exercises two or more simulated concurrent writers against the
+task-plan-sync hook to verify the file_lock around the
+load→mutate→save cycle prevents data loss when worktrees or
+parallel agents fire TaskCreate hooks simultaneously.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+HOOK = _REPO_ROOT / "hooks" / "scripts" / "task-plan-sync.py"
+
+
+def _plan_path() -> Path:
+    toplevel = subprocess.check_output(
+        ["git", "rev-parse", "--show-toplevel"],
+        text=True,
+    ).strip()
+    return Path(toplevel) / ".claude" / "session" / "plan.yaml"
+
+
+def _cleanup_plan() -> None:
+    plan = _plan_path()
+    if plan.exists():
+        plan.unlink()
+    lock = plan.with_suffix(plan.suffix + ".lock")
+    if lock.exists():
+        lock.unlink()
+    session_dir = plan.parent
+    if session_dir.exists():
+        try:
+            session_dir.rmdir()
+        except OSError:
+            pass
+
+
+@pytest.fixture(autouse=True)
+def _clean_plan():
+    _cleanup_plan()
+    yield
+    _cleanup_plan()
+
+
+class TestParallelTaskCreate:
+    def test_concurrent_writers_preserve_all_tasks(self) -> None:
+        writers = list(range(1, 9))
+        processes: list[tuple[int, subprocess.Popen[str]]] = []
+        for task_id in writers:
+            payload = json.dumps(
+                {
+                    "tool_name": "TaskCreate",
+                    "tool_input": {"subject": f"Task {task_id}"},
+                    "tool_result": (f"Task #{task_id} created successfully: Task {task_id}"),
+                }
+            )
+            proc = subprocess.Popen(
+                [str(HOOK)],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env={**os.environ},
+            )
+            proc.stdin.write(payload)
+            proc.stdin.close()
+            processes.append((task_id, proc))
+
+        for task_id, proc in processes:
+            proc.wait(timeout=15)
+            assert proc.returncode == 0, (
+                f"writer {task_id} exited {proc.returncode}; stderr={proc.stderr.read()}"
+            )
+
+        summary = subprocess.run(
+            [str(HOOK), "--json-summary"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        plan = json.loads(summary.stdout)
+        ids = sorted(int(t["id"]) for t in plan["tasks"])
+        assert ids == writers, (
+            f"expected all {len(writers)} tasks to survive concurrent writes, got {ids}"
+        )

--- a/tests/skills/upgrade-cleanup/test_file_lock.py
+++ b/tests/skills/upgrade-cleanup/test_file_lock.py
@@ -51,12 +51,16 @@ class TestLockedJsonUpdate:
 
         assert path.exists()
 
-    def test_cleans_up_lock_file(self, settings_file: Path) -> None:
+    def test_leaves_sidecar_in_place(self, settings_file: Path) -> None:
+        # GH-77: lock sidecar is intentionally NOT unlinked on release.
+        # Unlinking races: a third writer between unlink and the next
+        # open(O_CREAT) gets a fresh inode and an independent flock,
+        # breaking mutual exclusion.
         with locked_json_update(path=settings_file) as data:
             data["test"] = True
 
         lock_path = settings_file.with_suffix(".lock")
-        assert not lock_path.exists()
+        assert lock_path.exists()
 
     def test_no_temp_files_left(self, settings_file: Path) -> None:
         parent = settings_file.parent


### PR DESCRIPTION
**When** multiple worktrees or parallel agents write the same shared state file (`~/.claude/settings.json`, `<repo>/.claude/session/plan.yaml`, the platform registry, or the config cache), **I want to** know my write will not be silently clobbered by a racing writer that loaded an older copy, **so I can** trust the on-disk state across concurrent Claude Code sessions without losing TaskCreate entries, permission migrations, or registry updates to a last-write-wins race.

---

[`33efd6ca`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/96/commits/33efd6ca7fa48c8a6e8f7fa6c6c055d87442c1ce) 🔒 GH-77 Prevent state file corruption under concurrent writers
Fixes: https://github.com/Dev10x-Guru/dev10x-claude/issues/77

---