### PR TITLE
✨ GH-98 Enable multi-workspace Slack posting

### DIFF
--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -40,7 +40,34 @@ script resolves user group mentions automatically from your config.
 If no Slack token is found, walk the user through setup using
 AskUserQuestion:
 
-**Step 1 — Token storage method:**
+**Step 1 — Bot Token Scopes.** Configure the full scope set at
+`api.slack.com/apps → <your app> → OAuth & Permissions` **before**
+clicking *Install to Workspace*. Each *Reinstall to Workspace* drops
+the bot's channel memberships, so install once with everything.
+
+| Scope | Skill feature it enables |
+|-------|--------------------------|
+| `chat:write` | Post messages (`--message`, `--update`). |
+| `chat:write.public` | Post to public channels without being a member. |
+| `files:write` | Upload files (`--files`), delete files (`--delete-file`). |
+| `reactions:write` | Add emoji reactions (`--reactions`). |
+| `channels:read` | Diagnose `channel_not_found`, look up channels by name. |
+| `groups:read` | Same as above for private channels. |
+| `mpim:read`, `im:read` | Same for multi-party and direct messages. |
+| `channels:history` | Read thread replies (post-and-read workflows). |
+| `groups:history` | Same for private channel threads. |
+| `mpim:history`, `im:history` | Same for MPIM / DM threads. |
+
+> **Why all of these?** The narrow `chat:write` set lets the skill
+> *send* messages but not *recover* from failures. Without
+> `channels:read`, the skill cannot tell the user *which* channels
+> the bot is actually in when `channel_not_found` returns. Without
+> `*:history`, post-and-read flows are impossible.
+
+After adding scopes, click **Reinstall to Workspace** and re-invite
+the bot to channels you want it to post in.
+
+**Step 2 — Token storage method:**
 
 | Option | Pros | Cons |
 |--------|------|------|
@@ -55,7 +82,7 @@ secret-tool store --label="Slack Bot Token" service slack key bot_token
 
 For **env var**: add `export SLACK_TOKEN=xoxb-...` to shell profile.
 
-**Step 2 — User token vs bot token:**
+**Step 3 — User token vs bot token:**
 
 - `xoxb-` (bot token): Posts as a named bot. Requires the app to be
   added to each channel. Set `bot_username` in config.
@@ -63,6 +90,35 @@ For **env var**: add `export SLACK_TOKEN=xoxb-...` to shell profile.
   Broader permissions but tied to your account.
 
 The script auto-detects the token type from its prefix.
+
+## Multi-Workspace Support
+
+The skill supports posting to multiple Slack workspaces from one
+machine via the `--workspace NAME` flag:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/skills/slack/slack-notify.py \
+  --workspace aperture \
+  --channel C_APERTURE_CHAN \
+  --message "hi"
+# Reads bot token from: secret-tool lookup service slack-aperture key bot_token
+```
+
+Token resolution order:
+
+1. `--workspace NAME` → keyring `service=slack-<NAME>` (or the
+   `workspaces.<name>.keyring_service` override). Raises if missing —
+   the workspace was explicitly requested.
+2. `SLACK_TOKEN` env var (wins over the default keyring; use this for
+   ad-hoc workspace switching without persistent config).
+3. Default keyring `service=slack`.
+
+Store each workspace's bot token under its own keyring service:
+
+```bash
+secret-tool store --label="Slack Tyrell"    service slack            key bot_token
+secret-tool store --label="Slack Aperture"  service slack-aperture   key bot_token
+```
 
 ## Configuration
 
@@ -79,10 +135,22 @@ bot_username: Claude AI
 user_groups:
   "@dev-team": "<!subteam^S0123456789>"
   "@qa-team": "<!subteam^S9876543210>"
+
+# Optional: per-workspace overrides for --workspace NAME
+workspaces:
+  aperture:
+    self_user_id: U0B3EXAMPLE
+    bot_username: Aperture Bot
+    # Defaults to "slack-<name>" if omitted
+    keyring_service: slack-aperture
+    user_groups:
+      "@aperture-team": "<!subteam^S1111111111>"
 ```
 
 All fields are optional. The script works without a config file —
-user group mentions and self-DMs just won't resolve.
+user group mentions and self-DMs just won't resolve. When
+`--workspace NAME` is set, values under `workspaces.<name>` override
+the top-level keys.
 
 ## Usage
 
@@ -157,6 +225,7 @@ Requires `self_user_id` in config or `SLACK_SELF_USER_ID` env var.
 
 | Flag | Effect |
 |------|--------|
+| `--workspace NAME` | Select non-default workspace (see Multi-Workspace Support) |
 | `--broadcast` | Also post thread reply to channel |
 | `--reactions emoji1 emoji2` | Add emoji reactions after posting |
 | `--unfurl` | Enable link previews |
@@ -192,7 +261,8 @@ To discover user IDs, use MCP `slack_search_users` tool.
 | `not_in_channel` | Bot not added to channel | Add bot via channel settings → Integrations |
 | `channel_not_found` | Wrong channel ID | Verify ID in Slack |
 | `No Slack token found` | No token configured | Run first-time setup above |
-| `missing_scope` | Token lacks required permissions | Add scope in Slack app settings |
+| `missing_scope` | Token lacks required permissions | Add scope in Slack app settings, then **Reinstall to Workspace** (see First-Time Setup scope table) |
+| `channel_not_found` (multi-workspace) | Token belongs to a different workspace than the channel | Pass `--workspace NAME` or unset `SLACK_TOKEN` to fall through to default keyring |
 | `cant_delete_message` | Trying to delete another user's msg | Bot can only delete its own messages |
 
 ## Integration with Other Skills

--- a/skills/slack/slack-notify.py
+++ b/skills/slack/slack-notify.py
@@ -451,13 +451,13 @@ def main() -> None:
             sys.exit(1)
 
     if args.files:
-        upload_slack_files(
+        file_id = upload_slack_files(
             channel=args.channel,
             file_paths=args.files,
             message=message,
             thread_ts=args.thread_ts,
         )
-        sys.exit(0)
+        sys.exit(0 if file_id else 1)
 
     if not message:
         print("❌ --message or --message-file required", file=sys.stderr)

--- a/skills/slack/slack-notify.py
+++ b/skills/slack/slack-notify.py
@@ -14,11 +14,13 @@ Usage:
     slack-notify.py --delete-file F0ALXGBAAUC
 
 Token resolution order:
-    1. System keyring (Linux: secret-tool, macOS: Keychain)
+    1. --workspace <name> flag → keyring at service=slack-<name>
     2. SLACK_TOKEN environment variable
+    3. Default keyring at service=slack
 
 Configuration:
-    ~/.claude/memory/Dev10x/slack-config.yaml — user groups, self_user_id, bot_username
+    ~/.claude/memory/Dev10x/slack-config.yaml — user groups, self_user_id,
+    bot_username, and optional `workspaces:` map for multi-workspace setups.
 """
 
 from __future__ import annotations
@@ -35,6 +37,8 @@ if TYPE_CHECKING:
 
 CONFIG_PATH = pathlib.Path.home() / ".claude" / "memory" / "slack-config.yaml"
 
+_active_workspace: str | None = None
+
 
 def _load_config() -> dict:
     if CONFIG_PATH.exists():
@@ -46,13 +50,45 @@ def _load_config() -> dict:
 
 _config = _load_config()
 
-SELF_USER_ID = os.environ.get("SLACK_SELF_USER_ID", _config.get("self_user_id", ""))
-BOT_USERNAME = _config.get("bot_username", "Claude AI")
-USER_GROUPS: dict[str, str] = _config.get("user_groups", {})
+
+def _workspace_config() -> dict:
+    if _active_workspace is None:
+        return {}
+    workspaces = _config.get("workspaces", {}) or {}
+    return workspaces.get(_active_workspace, {}) or {}
+
+
+def set_workspace(name: str | None) -> None:
+    """Select an active workspace. Affects keyring service and per-workspace config."""
+    global _active_workspace
+    _active_workspace = name
+
+
+def _resolve(key: str, default: str = "") -> str:
+    """Read a config key, preferring the active workspace's override."""
+    ws = _workspace_config()
+    if key in ws:
+        return ws[key] or default
+    return _config.get(key, default) or default
+
+
+def _self_user_id() -> str:
+    return os.environ.get("SLACK_SELF_USER_ID") or _resolve("self_user_id", "")
+
+
+def _bot_username() -> str:
+    return _resolve("bot_username", "Claude AI")
+
+
+def _user_groups() -> dict[str, str]:
+    ws = _workspace_config()
+    if "user_groups" in ws:
+        return ws.get("user_groups") or {}
+    return _config.get("user_groups", {}) or {}
 
 
 def resolve_mentions(message: str) -> str:
-    for mention, group_id in USER_GROUPS.items():
+    for mention, group_id in _user_groups().items():
         message = message.replace(mention, group_id)
     return message
 
@@ -69,14 +105,49 @@ def _keyring_lookup(*, service: str, key: str) -> str | None:
         return None
 
 
+def _keyring_service() -> str:
+    """Resolve keyring service name for the active workspace.
+
+    Honors `keyring_service:` override in the workspace config; otherwise
+    falls back to `slack-<workspace>`.
+    """
+    if _active_workspace is None:
+        return "slack"
+    ws = _workspace_config()
+    override = ws.get("keyring_service")
+    if override:
+        return override
+    return f"slack-{_active_workspace}"
+
+
 def get_token() -> str:
-    token = _keyring_lookup(service="slack", key="bot_token")
-    if token:
-        return token
+    """Resolve the Slack bot token.
+
+    Resolution order:
+      1. If --workspace was set: keyring at the workspace's service name.
+         Raise if missing — workspace was explicitly requested.
+      2. SLACK_TOKEN environment variable.
+      3. Default keyring at service=slack.
+    """
+    if _active_workspace is not None:
+        service = _keyring_service()
+        token = _keyring_lookup(service=service, key="bot_token")
+        if token:
+            return token
+        raise RuntimeError(
+            f"No Slack token found in keyring for workspace "
+            f"'{_active_workspace}' (service={service})"
+        )
     env_token = os.environ.get("SLACK_TOKEN")
     if env_token:
         return env_token
-    raise RuntimeError("No Slack token found in system keyring or SLACK_TOKEN env")
+    token = _keyring_lookup(service="slack", key="bot_token")
+    if token:
+        return token
+    raise RuntimeError(
+        "No Slack token found. Set SLACK_TOKEN env, configure the default "
+        "keyring (service=slack, key=bot_token), or pass --workspace NAME."
+    )
 
 
 def send_slack_message(
@@ -97,7 +168,7 @@ def send_slack_message(
         result = client.chat_postMessage(
             channel=channel,
             text=resolved_message,
-            username=None if is_user_token else BOT_USERNAME,
+            username=None if is_user_token else _bot_username(),
             thread_ts=thread_ts,
             reply_broadcast=broadcast if thread_ts else None,
             unfurl_links=unfurl,
@@ -190,7 +261,8 @@ def _files_upload_v2(
 
 
 def send_reminder(message: str) -> str | None:
-    if not SELF_USER_ID:
+    self_user_id = _self_user_id()
+    if not self_user_id:
         print(
             "❌ self_user_id not configured. Set it in "
             f"{CONFIG_PATH} or SLACK_SELF_USER_ID env var.",
@@ -202,7 +274,7 @@ def send_reminder(message: str) -> str | None:
 
         token = get_token()
         client = WebClient(token=token)
-        dm = client.conversations_open(users=SELF_USER_ID)
+        dm = client.conversations_open(users=self_user_id)
         channel = dm["channel"]["id"]
         return send_slack_message(channel=channel, message=message)
     except Exception as ex:
@@ -313,12 +385,26 @@ def main() -> None:
         help="Send a DM reminder to yourself (requires self_user_id in config)",
     )
     parser.add_argument(
+        "--workspace",
+        metavar="NAME",
+        help=(
+            "Select a Slack workspace by name. Reads the bot token from "
+            "keyring service=slack-<name> (override via "
+            "workspaces.<name>.keyring_service in config) and applies "
+            "per-workspace overrides for bot_username / self_user_id / "
+            "user_groups."
+        ),
+    )
+    parser.add_argument(
         "--verbose",
         action="store_true",
         help="Show verbose output",
     )
 
     args = parser.parse_args()
+
+    if args.workspace:
+        set_workspace(args.workspace)
 
     if args.remind:
         ts = send_reminder(message=args.remind)

--- a/tests/skills/slack/test_slack_notify.py
+++ b/tests/skills/slack/test_slack_notify.py
@@ -1,0 +1,196 @@
+"""Tests for slack-notify.py token resolution and workspace config (GH-98)."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_repo_root = Path(__file__).resolve().parent.parent.parent.parent
+_spec = importlib.util.spec_from_file_location(
+    "slack_notify",
+    _repo_root / "skills" / "slack" / "slack-notify.py",
+)
+assert _spec is not None and _spec.loader is not None
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+
+@pytest.fixture(autouse=True)
+def reset_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure each test starts with no active workspace and empty config."""
+    monkeypatch.setattr(_mod, "_config", {})
+    monkeypatch.setattr(_mod, "_active_workspace", None)
+    monkeypatch.delenv("SLACK_TOKEN", raising=False)
+    monkeypatch.delenv("SLACK_SELF_USER_ID", raising=False)
+
+
+class TestGetToken:
+    def test_default_keyring_used_when_no_env_and_no_workspace(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        calls: list[dict] = []
+
+        def fake_lookup(*, service: str, key: str) -> str | None:
+            calls.append({"service": service, "key": key})
+            return "xoxb-from-default-keyring"
+
+        monkeypatch.setattr(_mod, "_keyring_lookup", fake_lookup)
+        assert _mod.get_token() == "xoxb-from-default-keyring"
+        assert calls == [{"service": "slack", "key": "bot_token"}]
+
+    def test_env_var_wins_over_default_keyring(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("SLACK_TOKEN", "xoxb-from-env")
+        monkeypatch.setattr(
+            _mod,
+            "_keyring_lookup",
+            lambda *, service, key: "xoxb-from-default-keyring",
+        )
+        assert _mod.get_token() == "xoxb-from-env"
+
+    def test_workspace_uses_namespaced_keyring(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        looked_up: list[str] = []
+
+        def fake_lookup(*, service: str, key: str) -> str | None:
+            looked_up.append(service)
+            return "xoxb-aperture" if service == "slack-aperture" else None
+
+        monkeypatch.setattr(_mod, "_keyring_lookup", fake_lookup)
+        _mod.set_workspace("aperture")
+        assert _mod.get_token() == "xoxb-aperture"
+        assert looked_up == ["slack-aperture"]
+
+    def test_workspace_ignores_env_token(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("SLACK_TOKEN", "xoxb-from-env")
+        monkeypatch.setattr(
+            _mod,
+            "_keyring_lookup",
+            lambda *, service, key: "xoxb-aperture",
+        )
+        _mod.set_workspace("aperture")
+        assert _mod.get_token() == "xoxb-aperture"
+
+    def test_workspace_missing_token_raises(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(_mod, "_keyring_lookup", lambda *, service, key: None)
+        _mod.set_workspace("aperture")
+        with pytest.raises(RuntimeError, match="aperture"):
+            _mod.get_token()
+
+    def test_no_sources_raises(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(_mod, "_keyring_lookup", lambda *, service, key: None)
+        with pytest.raises(RuntimeError, match="No Slack token found"):
+            _mod.get_token()
+
+    def test_workspace_keyring_service_override(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            _mod,
+            "_config",
+            {"workspaces": {"aperture": {"keyring_service": "custom-aperture"}}},
+        )
+        looked_up: list[str] = []
+
+        def fake_lookup(*, service: str, key: str) -> str | None:
+            looked_up.append(service)
+            return "xoxb-aperture"
+
+        monkeypatch.setattr(_mod, "_keyring_lookup", fake_lookup)
+        _mod.set_workspace("aperture")
+        assert _mod.get_token() == "xoxb-aperture"
+        assert looked_up == ["custom-aperture"]
+
+
+class TestWorkspaceConfigResolution:
+    @pytest.fixture()
+    def config(self) -> dict:
+        return {
+            "self_user_id": "U_DEFAULT",
+            "bot_username": "Default Bot",
+            "user_groups": {"@default-team": "<!subteam^S_DEFAULT>"},
+            "workspaces": {
+                "aperture": {
+                    "self_user_id": "U_APERTURE",
+                    "bot_username": "Aperture Bot",
+                    "user_groups": {"@aperture-team": "<!subteam^S_APERTURE>"},
+                },
+            },
+        }
+
+    def test_defaults_when_no_workspace(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        config: dict,
+    ) -> None:
+        monkeypatch.setattr(_mod, "_config", config)
+        assert _mod._self_user_id() == "U_DEFAULT"
+        assert _mod._bot_username() == "Default Bot"
+        assert _mod._user_groups() == {"@default-team": "<!subteam^S_DEFAULT>"}
+
+    def test_workspace_overrides_defaults(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        config: dict,
+    ) -> None:
+        monkeypatch.setattr(_mod, "_config", config)
+        _mod.set_workspace("aperture")
+        assert _mod._self_user_id() == "U_APERTURE"
+        assert _mod._bot_username() == "Aperture Bot"
+        assert _mod._user_groups() == {"@aperture-team": "<!subteam^S_APERTURE>"}
+
+    def test_unknown_workspace_falls_back_to_defaults(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        config: dict,
+    ) -> None:
+        monkeypatch.setattr(_mod, "_config", config)
+        _mod.set_workspace("ghost")
+        assert _mod._bot_username() == "Default Bot"
+        assert _mod._self_user_id() == "U_DEFAULT"
+
+    def test_self_user_id_env_overrides_all(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        config: dict,
+    ) -> None:
+        monkeypatch.setattr(_mod, "_config", config)
+        monkeypatch.setenv("SLACK_SELF_USER_ID", "U_FROM_ENV")
+        _mod.set_workspace("aperture")
+        assert _mod._self_user_id() == "U_FROM_ENV"
+
+
+class TestResolveMentions:
+    def test_uses_active_workspace_user_groups(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            _mod,
+            "_config",
+            {
+                "user_groups": {"@default": "<!subteam^S_DEF>"},
+                "workspaces": {
+                    "aperture": {"user_groups": {"@aperture": "<!subteam^S_APE>"}},
+                },
+            },
+        )
+        _mod.set_workspace("aperture")
+        assert _mod.resolve_mentions("ping @aperture") == "ping <!subteam^S_APE>"
+        # default group not active when workspace is set
+        assert _mod.resolve_mentions("ping @default") == "ping @default"


### PR DESCRIPTION
**When** I have one Slack workspace already configured in the system keyring and need to post to a second workspace, **I want to** select the target workspace at invocation time **so** I can use the Dev10x:slack skill across all my workspaces without overwriting the keyring entry or losing channel memberships from `Reinstall to Workspace` cycles.

---

[`5e00607e`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/100/commits/5e00607e6874a25b08a74720240c6a905c0a308c) ✨ GH-98 Enable multi-workspace Slack posting
Fixes: https://github.com/Dev10x-Guru/dev10x-claude/issues/98

---