### PR TITLE
🐛 GH-76 Authenticate GitHub App via Bearer scheme

### DIFF
--- a/src/dev10x/github/__init__.py
+++ b/src/dev10x/github/__init__.py
@@ -8,6 +8,7 @@ All public functions are async to avoid blocking the MCP event loop.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import subprocess
 from pathlib import Path
@@ -15,7 +16,9 @@ from typing import Any
 
 from dev10x.domain.repository_ref import RepositoryRef
 from dev10x.domain.result import ErrorResult, Result, err, ok
-from dev10x.github.app_auth import get_bot_token
+from dev10x.github.app_auth import AppConfig, get_bot_token
+
+logger = logging.getLogger(__name__)
 from dev10x.subprocess_utils import (
     async_run,
     async_run_script,
@@ -65,6 +68,13 @@ async def _gh_api(
 async def _bot_env(*, repo: str) -> dict[str, str] | None:
     token = await get_bot_token(repo=repo)
     if token is None:
+        if AppConfig.load() is not None:
+            logger.warning(
+                "GitHub App auth configured but bot token exchange failed for %s — "
+                "falling back to engineer credentials. Verify the App is installed "
+                "on the repo and the private key matches the app_id.",
+                repo,
+            )
         return None
     return {**os.environ, "GH_TOKEN": token, "GITHUB_TOKEN": token}
 

--- a/src/dev10x/github/app_auth.py
+++ b/src/dev10x/github/app_auth.py
@@ -86,6 +86,14 @@ def _parse_expires_at(raw: str | None) -> float:
         return time.time() + 3600
 
 
+def _bearer_env() -> dict[str, str]:
+    # GH_TOKEN/GITHUB_TOKEN must be unset before invoking gh with an App
+    # JWT; otherwise gh sends `Authorization: token <jwt>`, but the App
+    # endpoints (`/repos/{repo}/installation`, `/app/installations/...`)
+    # require the `Bearer` scheme and return 401 for `token`.
+    return {k: v for k, v in os.environ.items() if k not in {"GH_TOKEN", "GITHUB_TOKEN"}}
+
+
 async def _resolve_installation_id(
     *,
     repo: str,
@@ -96,10 +104,12 @@ async def _resolve_installation_id(
             "gh",
             "api",
             "-H",
+            f"Authorization: Bearer {app_jwt}",
+            "-H",
             "Accept: application/vnd.github+json",
             f"/repos/{repo}/installation",
         ],
-        env={**os.environ, "GH_TOKEN": app_jwt, "GITHUB_TOKEN": app_jwt},
+        env=_bearer_env(),
     )
     if result.returncode != 0:
         return None
@@ -120,9 +130,13 @@ async def _exchange_for_installation_token(
             "api",
             "-X",
             "POST",
+            "-H",
+            f"Authorization: Bearer {app_jwt}",
+            "-H",
+            "Accept: application/vnd.github+json",
             f"/app/installations/{installation_id}/access_tokens",
         ],
-        env={**os.environ, "GH_TOKEN": app_jwt, "GITHUB_TOKEN": app_jwt},
+        env=_bearer_env(),
     )
     if result.returncode != 0:
         return None

--- a/tests/github/test_app_auth.py
+++ b/tests/github/test_app_auth.py
@@ -201,6 +201,48 @@ class TestGetBotToken:
         assert token == "fresh"
 
     @pytest.mark.asyncio
+    async def test_resolve_installation_uses_bearer_header_and_strips_gh_token(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("GH_TOKEN", "engineer-token")
+        monkeypatch.setenv("GITHUB_TOKEN", "engineer-token")
+        key_path = tmp_path / "bot.pem"
+        key_path.write_text("KEY")
+        config = auth.AppConfig(app_id="1", private_key_path=key_path)
+
+        responses = [
+            _completed(stdout=json.dumps({"id": 99})),
+            _completed(
+                stdout=json.dumps({"token": "ghs_x", "expires_at": "2099-01-01T00:00:00Z"})
+            ),
+        ]
+        with (
+            patch.object(auth, "_create_app_jwt", return_value="jwt"),
+            patch(
+                "dev10x.github.app_auth.async_run",
+                new_callable=AsyncMock,
+                side_effect=responses,
+            ) as mock_run,
+        ):
+            await auth.get_bot_token(repo="owner/repo", config=config)
+
+        resolve_call = mock_run.call_args_list[0]
+        exchange_call = mock_run.call_args_list[1]
+
+        for call in (resolve_call, exchange_call):
+            args = call.kwargs["args"]
+            assert "Authorization: Bearer jwt" in args, (
+                f"App-auth call must include Bearer header; got args={args}"
+            )
+            env = call.kwargs["env"]
+            assert "GH_TOKEN" not in env, (
+                "GH_TOKEN must be stripped — gh would send 'token' scheme instead of Bearer"
+            )
+            assert "GITHUB_TOKEN" not in env, "GITHUB_TOKEN must be stripped for same reason"
+
+    @pytest.mark.asyncio
     async def test_falls_back_when_response_missing_token(
         self,
         app_config: auth.AppConfig,

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -1022,6 +1022,56 @@ class TestGhApiBotIdentity:
 
     @pytest.mark.asyncio
     @patch("dev10x.github.async_run", new_callable=AsyncMock)
+    @patch("dev10x.github.AppConfig.load")
+    @patch("dev10x.github.get_bot_token", new_callable=AsyncMock)
+    async def test_warns_when_app_configured_but_token_exchange_fails(
+        self,
+        mock_token: AsyncMock,
+        mock_load: AsyncMock,
+        mock_run: AsyncMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        mock_token.return_value = None
+        mock_load.return_value = object()
+        mock_run.return_value = _completed(stdout="{}")
+
+        with caplog.at_level("WARNING", logger="dev10x.github"):
+            await gh._gh_api(
+                "repos/x/y/pulls/1/comments",
+                repo="x/y",
+                as_bot=True,
+            )
+
+        assert any("bot token exchange failed" in r.message for r in caplog.records), (
+            f"Expected warning when App configured but exchange fails; got {caplog.records}"
+        )
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run", new_callable=AsyncMock)
+    @patch("dev10x.github.AppConfig.load")
+    @patch("dev10x.github.get_bot_token", new_callable=AsyncMock)
+    async def test_silent_when_app_not_configured(
+        self,
+        mock_token: AsyncMock,
+        mock_load: AsyncMock,
+        mock_run: AsyncMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        mock_token.return_value = None
+        mock_load.return_value = None
+        mock_run.return_value = _completed(stdout="{}")
+
+        with caplog.at_level("WARNING", logger="dev10x.github"):
+            await gh._gh_api(
+                "repos/x/y/pulls/1/comments",
+                repo="x/y",
+                as_bot=True,
+            )
+
+        assert not any("bot token exchange failed" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run", new_callable=AsyncMock)
     @patch("dev10x.github.get_bot_token", new_callable=AsyncMock)
     async def test_does_not_call_token_resolver_when_not_as_bot(
         self,


### PR DESCRIPTION
**When** the GitHub App is configured and installed for posting bot replies via `mcp__plugin_Dev10x_cli__pr_comment_reply` (and any other `as_bot=True` path), **I want** the App JWT to actually authenticate against GitHub's App-auth endpoints, **so I can** have agent-generated comments posted under the `<app-name>[bot]` identity instead of silently falling back to my personal `gh auth` credentials.

---

[`651e8601`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/101/commits/651e86012f6b8bc2ec051444f6e36f5b2b42cf2f) 🐛 GH-76 Authenticate GitHub App via Bearer scheme
Fixes: https://github.com/Dev10x-Guru/dev10x-claude/issues/76

---