### PR TITLE
📝 Fictionalize private identifiers in audit-report scrubbing

### DIFF
--- a/skills/audit-report/SKILL.md
+++ b/skills/audit-report/SKILL.md
@@ -73,7 +73,7 @@ ls ~/.claude/plugins/cache/Dev10x-Guru/dev10x-claude/
 Use the version directory name (e.g., `0.19.0.dev0`). If the
 cache directory is not found, use `unknown`.
 
-### Step 3: Scrub proprietary information (REQUIRED)
+### Step 3: Fictionalize proprietary information (REQUIRED)
 
 **Treat the source session as private by default.** The upstream
 issue is a public artifact at `Dev10x-Guru/Dev10x-Claude` and MUST
@@ -81,52 +81,66 @@ NOT disclose any identifier from a non-public repository, project,
 branch, ticket tracker, file path, person, or service that is not
 part of the public Dev10x plugin.
 
-Apply the replacement table, allow-list, and 5-step algorithm in
+Instead of redacting private identifiers with bracketed
+placeholders (`<private-repo>`, `TICKET-NN`), **replace them with
+similar-sounding fictional counterparts drawn from pop culture** —
+movies, books, TV, cartoons, video games. The resulting issue
+reads as a coherent story while leaking nothing. Real precedents:
+issue #68 used `initech/initech-pos` + reviewer `skywalker`;
+issue #98 used Tyrell Corp + Aperture Labs.
+
+Apply the vibe-matching guide, consistency rule, and 6-step
+algorithm in
 [`references/privacy-scrub.md`](references/privacy-scrub.md) to
 the verbatim findings text **before** assembling the issue body.
 
-**REQUIRED: Call `AskUserQuestion`** when a finding cannot be
-reported without a private identifier (do NOT use plain text).
-Options:
+**REQUIRED: Call `AskUserQuestion`** when a finding is
+fundamentally about a private codebase pattern that cannot be
+retold through fictional stand-ins without losing the technical
+point (do NOT use plain text). Options:
 
-- Scrub aggressively and file (Recommended) — abstract the
-  identifier even at the cost of specificity
+- Fictionalize aggressively and file (Recommended) — pick the
+  closest pop-culture stand-in even at the cost of some
+  specificity
 - Skip this finding — exclude from upstream, keep in local notes
 
-Never auto-include unscrubbed text. Re-read the assembled body
-and verify no disallowed identifier remains before continuing
-to Step 4.
+Never auto-include unfictionalized text. Re-read the assembled
+body and verify every named entity is fictional (pop-culture
+sourced, not a real company / person / product) before
+continuing to Step 4.
 
 ### Step 4: Generate issue body
 
-Build the issue body from the **scrubbed** findings:
+Build the issue body from the **fictionalized** findings:
 
 ```markdown
 ## Audit Findings
 
 **Plugin version**: Dev10x {version}
-**Session context**: <private-project> / <private-branch>
+**Session context**: {fictional-org}/{fictional-repo} / {fictional-branch}
 **Audit date**: {date}
 
 ### Findings
 
 | # | Phase | Classification | Skill | Description |
 |---|-------|---------------|-------|-------------|
-{scrubbed rows}
+{fictionalized rows}
 
 ### Proposed Fixes
 
-{scrubbed fixes, grouped by skill}
+{fictionalized fixes, grouped by skill}
 
 ### Evidence
 
-{scrubbed transcript excerpts — 2-3 lines per finding, no
-private file paths or identifiers}
+{fictionalized transcript excerpts — 2-3 lines per finding, no
+real file paths, real handles, or real product names}
 ```
 
-The "Session context" line is intentionally generic — the
-upstream maintainer does not need the original repo or branch
-to act on a Dev10x plugin finding.
+The "Session context" line uses fictional stand-ins (e.g.,
+`initech/initech-pos / skywalker/CORE-401/death-star-3/...`) so
+the report reads as a coherent narrative — the upstream
+maintainer does not need the real repo or branch to act on a
+Dev10x plugin finding.
 
 ### Step 5: Derive issue title
 
@@ -175,9 +189,12 @@ and the temp file path so the user can file manually.
 - **One issue per audit**: Batch all findings into a single
   issue per audit session to avoid issue spam.
 - **Privacy by default (Step 3)**: The source session may belong
-  to a private codebase. Scrub repo names, owners, branches,
-  tracker IDs, file paths, hostnames, and personal identifiers
-  before assembling the issue body. Only the public Dev10x
-  plugin context — skill names, plugin file paths, and
-  `Dev10x-Guru/Dev10x-Claude` issue/PR numbers — is allowed
-  verbatim. Re-verify the body is clean before filing.
+  to a private codebase. Fictionalize repo names, owners,
+  branches, tracker IDs, file paths, hostnames, and personal
+  identifiers using pop-culture stand-ins (movies, books,
+  cartoons, games) before assembling the issue body. Never use
+  real company, product, or person names — even ones that *sound*
+  fictional. Only the public Dev10x plugin context — skill names,
+  plugin file paths, and `Dev10x-Guru/Dev10x-Claude` issue/PR
+  numbers — is allowed verbatim. Re-verify every named entity is
+  fictional before filing.

--- a/skills/audit-report/references/privacy-scrub.md
+++ b/skills/audit-report/references/privacy-scrub.md
@@ -6,21 +6,90 @@ NOT disclose any identifier from a non-public repository, project,
 branch, ticket tracker, file path, person, or service that is not
 part of the public Dev10x plugin.
 
-## Replacement Table
+## Principle: Fictionalize, Don't Redact
 
-| Source value | Replace with |
+Replace every private identifier with a **similar-sounding fictional
+counterpart drawn from pop culture** — movies, books, TV, cartoons,
+video games. Do NOT use generic placeholders like `<private-repo>`
+or `TICKET-NN`; they break narrative flow and make the issue body
+read like a leak instead of a story.
+
+Real examples of this pattern already in the wild — issue
+[#68](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/68) uses
+`initech/initech-pos` (Office Space), reviewer handle `skywalker`
+(Star Wars), and keeps `PAY-` as a plausible-looking fictional
+tracker prefix. Issue
+[#98](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/98) uses
+Tyrell Corp (Blade Runner) and Aperture Labs (Portal) as the two
+example workspaces.
+
+**Source pool — pop culture only.** Movies, novels, TV series,
+cartoons, comics, video games. NEVER use the names of real
+companies, real competitors, real products, or real people — even
+if those names *sound* fictional. "Initech" is fine (Office Space);
+"Initrode" is fine (Office Space sequel-joke); a real but obscure
+company name is not.
+
+**Forbidden sources:** real corporations, real tradenames, real
+product names, real public figures, real internal customers, real
+vendors, real internal codenames. When in doubt, pick something
+unambiguously from a movie or book.
+
+## Replacement Strategy
+
+Pick fictional names freely per finding — there is no fixed
+catalog. Choose names that evoke a **similar vibe or domain** to
+the original where it helps the reader follow the story:
+
+| Source flavor | Pick from pop-culture set evoking… |
 |---|---|
-| Non-Dev10x repo name (e.g., `acme/billing`) | `<private-repo>` |
-| Non-Dev10x org/user owner | `<private-owner>` |
-| Branch name not on the public PR branch | `<private-branch>` |
-| Ticket IDs from non-Dev10x trackers (`PAY-133`, Linear/JIRA URLs) | `TICKET-NN` |
-| File paths under `/work/<project>/` or other non-plugin paths | `<project>/path/to/file` |
-| Internal hostnames, DB names, customer names, domains | `<internal-host>`, `<internal-db>` |
-| Person names, emails, Slack handles | `<user>` |
-| Free-text excerpts from private commits, comments, or messages | summarize abstractly |
-| Sentry/observability project slugs that are not public | `<observability-project>` |
+| Big-corporate / megacorp | Tyrell Corp, Weyland-Yutani, Cyberdyne, Omni Consumer Products, Soylent, Vault-Tec, Buy n Large |
+| Defense / aerospace / industrial | Stark Industries, Wayne Enterprises, Massive Dynamic, Yoyodyne, Rekall |
+| Consumer tech / startups | Hooli, Pied Piper, Aperture Science, Wonka Industries, Acme Corp, MomCorp |
+| Quirky / cartoon-coded SMB | Krusty Krab, Los Pollos Hermanos, Bluth Company, Dunder Mifflin, Planet Express, Vandelay Industries |
+| Retail / payments / e-commerce | Initech, Initrode, Pizza Planet, Hot Dog on a Stick, Big Kahuna Burger |
+| Biotech / medical / lab | Umbrella Corp, InGen, Oscorp, Spacely Sprockets, Veridian Dynamics |
+
+For **people**: use first names from the same fictional universe
+or generic literary names — `skywalker`, `vader`, `gandalf`,
+`hermione`, `arya`, `neo`, `morpheus`. Never use a real Slack
+handle or real first+last name even if it "looks generic."
+
+For **branches**: keep the structural pattern
+(`<user>/<TICKET>/<worktree>/<slug>`) but fictionalize each
+segment — `skywalker/CORE-401/death-star-3/align-targeting-computer`.
+
+For **ticket trackers**: invent a fictional 3-4 letter prefix
+that evokes a fictional team or product (`CORE`, `WONKA`, `DUFF`,
+`MOMCORP`, `KRAB`, `INGEN`) and a small integer. Keep the
+prefix consistent within one issue.
+
+For **hostnames / domains**: fictional planets, cities, or
+in-universe locations (`tatooine.internal`, `gotham-db-01`,
+`mos-eisley-staging`).
+
+For **file paths**: keep the directory structure shape but
+fictionalize the project root and any product-revealing
+segment — `wayne-enterprises/payments/src/refund_calculator.py`
+not `/work/acme/billing/...`.
+
+## Consistency Rule
+
+Use a **deterministic per-session mapping** — the same private
+value gets the same fictional name throughout one issue body so
+cross-references stay readable. If the original mentions
+`acme/billing` four times and a reviewer `j.smith` twice, pick
+one fictional repo and one fictional handle on first sight and
+reuse them every time.
+
+When the source has TWO related private orgs (e.g., user's
+company + a side project), pick two fictional companies that
+read as clearly distinct universes — Tyrell Corp + Aperture
+Labs, not Tyrell Corp + Tyrell Subsidiary.
 
 ## Allowed Verbatim (public Dev10x context)
+
+The following CAN appear unchanged — they are already public:
 
 - Skill names with the `Dev10x:` prefix (`Dev10x:git`,
   `Dev10x:git-commit`, …)
@@ -29,35 +98,66 @@ part of the public Dev10x plugin.
   `hooks/...`, `references/...`)
 - The plugin version and the public repo URL
 - GitHub issue / PR numbers from `Dev10x-Guru/Dev10x-Claude`
+- Generic tool names (`git`, `gh`, `pytest`, `ruff`)
+
+## What Must Be Fictionalized
+
+Anything that could let a reader trace the report back to a
+private codebase, customer, employer, or person — and anything
+where management might reasonably claim "internal information
+leaked." When unsure, fictionalize.
+
+- Repository / package names from non-Dev10x repos
+- Org or user owner names (GitHub, Linear, JIRA, internal git)
+- Branch names beyond the public PR branch
+- Ticket IDs / tracker URLs from non-Dev10x trackers
+- File paths under `/work/<project>/` or any non-plugin path
+- Internal hostnames, database names, service names, cluster names
+- Customer names, vendor names, partner names
+- Product names, internal codenames, project codenames
+- Person names, email addresses, Slack handles, GitHub handles
+- Free-text excerpts from private commits, comments, or Slack
+  messages — summarize abstractly OR rewrite with fictional
+  details, do not quote verbatim
+- Sentry / observability project slugs
+- Domain names, URLs pointing at internal systems
 
 ## Algorithm
 
 1. Extract the verbatim findings text.
-2. Apply the replacement table above using a deterministic
-   per-session mapping — the same private value gets the same
-   generic placeholder throughout the body so cross-references
-   stay readable (e.g., `TICKET-01` for the first private ticket
-   seen, `<private-repo-A>` for the first repo).
-3. Replace transcript turn references that point at private
+2. Walk the text once, building a session mapping: each unique
+   private identifier → a fictional counterpart. Pick the
+   fictional name with the vibe-matching guide above; keep a
+   running list so the second mention of a value gets the same
+   replacement as the first.
+3. Apply the mapping. Rewrite quoted excerpts from private
+   sources so the surrounding prose still makes sense with the
+   fictional names substituted in.
+4. Replace transcript turn references that point at private
    session files (`session 529d497f`,
    `~/.claude/projects/-work-...`) with `<source session>`.
    Keep in-session turn numbers ("turn 75", "turns 59–73") —
    they are anonymous within the upstream issue.
-4. Strip any "Local fixes" / "Notes for triage" sections — by
+5. Strip any "Local fixes" / "Notes for triage" sections — by
    definition these are private context.
-5. Re-read the assembled body and verify no identifier from the
-   disallowed list above remains. If any slips through, scrub
-   again. Do not file the issue until the body is clean.
+6. Re-read the assembled body. For every named entity, ask:
+   "could this be googled back to a real company, product, or
+   person?" If yes, fictionalize again. Do not file the issue
+   until every named entity passes this check.
 
-## Decision Gate: Unscrubbable Findings
+## Decision Gate: Unfictionalizable Findings
 
-**STOP and ask the user** if a finding cannot be reported
-without a private identifier (e.g., the finding is fundamentally
-about a private codebase pattern). Use `AskUserQuestion`:
+**STOP and ask the user** if a finding is fundamentally about
+a private codebase pattern that cannot be retold through
+fictional stand-ins without losing the technical point. Use
+`AskUserQuestion`:
 
-- **Scrub aggressively and file (Recommended)** — abstract the
-  identifier even at the cost of some specificity
+- **Fictionalize aggressively and file (Recommended)** — pick
+  the closest pop-culture stand-in even at the cost of some
+  specificity; the technical finding is what matters upstream
 - **Skip this finding** — exclude it from the upstream issue
   and keep it in local notes only
 
-Never auto-include unscrubbed text.
+Never auto-include unfictionalized text. A finding that still
+contains a real org, real person, or real product name is not
+ready to file.


### PR DESCRIPTION
**When** I file skill-audit findings upstream from a private project, **I want to** see private repos, orgs, people, and branches replaced with similar-sounding pop-culture stand-ins instead of bracketed placeholders, **so I can** ship a coherent, readable bug report upstream without leaking internal company information.

---

[`2c7c4315`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/102/commits/2c7c4315f90f503c36d8b57723b2c889185bf28f) 📝 Fictionalize private identifiers in audit-report
Fixes: none — self-motivated

---