### PR TITLE
✨ GH-86 Enable bundled-fixup replies and post-groom SHA refresh

### DIFF
--- a/hooks/scripts/session-guidance.md
+++ b/hooks/scripts/session-guidance.md
@@ -25,6 +25,7 @@ prompts or brittle command matching.
 | `# comment` as first line | Leading `#` can break prefix matching and parser expectations | Use Bash tool `description` parameter |
 | `uv run --script` on executable scripts | Redundant wrapper can miss direct path-based allow rules | Call script directly (shebang handles uv) |
 | `cd /worktree/path && command` | Redundant when CWD is already the worktree; can trigger chaining checks | Run command directly — session switched on worktree creation |
+| `git -C /worktree/path command` | Symmetric to the `cd` form: `-C` shifts the effective command prefix and breaks allow-rule matching when the path is already the CWD (GH-97 caught this 20× in one session) | Drop `-C` — git already operates on the current worktree |
 | `--jq '"\(.x): \(.y)"'` (jq interpolation) | Escaped quotes trigger "consecutive quote characters" obfuscation check | Use jq concatenation: `-q '.x + ": " + .y'` |
 
 ## Preferred Patterns

--- a/skills/gh-pr-respond/instructions.md
+++ b/skills/gh-pr-respond/instructions.md
@@ -160,6 +160,108 @@ sessions caught this exact pattern — the agent says it will
 delegate, then does the work itself. Stating intent is not
 execution. Only a `Skill()` tool call counts as delegation.
 
+**Pre-push TaskList self-check (GH-97):** Before any `git push`
+or `Skill(Dev10x:git)` invocation that ships fixup commits,
+call `TaskList` and verify that every comment marked
+"completed" with verdict VALID has an associated
+`Skill(Dev10x:gh-pr-fixup)` call recorded in the task
+metadata or a sibling subtask. If a VALID comment is marked
+completed but no `Skill()` invocation is recorded for it, STOP
+and re-run that comment through `Skill(Dev10x:gh-pr-fixup)`.
+This guardrail exists because at `adaptive` friction, three
+audit sessions in a row bypassed the delegation under context
+pressure (~42% compliance). The REQUIRED markers above are
+necessary but not sufficient — the TaskList evidence check is
+the trailing audit that catches the bypass before it ships.
+
+## Bundled Fixup Mode (GH-86, GH-97)
+
+Default behavior is one `fixup!` commit per comment. The bundled
+mode is the explicit carve-out for refactors that naturally
+address several review threads at once — e.g., a single rename
+that closes three comments, or a helper extraction that closes
+two threads on the same file region.
+
+### Trigger criteria
+
+Enter bundled mode when ALL of the following are true:
+
+1. Two or more VALID comments target the same file/region or
+   share the same underlying issue.
+2. The fix is a single coherent change — splitting it into one
+   fixup per comment would produce duplicate diffs or
+   semantically identical commits.
+3. The user has not explicitly asked for separate fixups.
+
+When in doubt, default to one fixup per comment. Bundling is
+opt-in for the agent: offer it via `AskUserQuestion` rather
+than auto-bundling silently.
+
+### Bundled-reply template
+
+When a single `fixup!` addresses N comments, every reply MUST
+include the same template, hyperlinked. Plain-text SHA tails
+(e.g., `` (fixup `<sha>`) ``) are PROHIBITED — they become
+orphan references the moment `Dev10x:git-groom` rewrites
+history.
+
+```markdown
+{contextual response to the reviewer's point}
+
+**Fix commit:** [`<short-sha>`](https://github.com/{repo}/pull/{pr}/commits/<sha>)
+**Code change:** [`<file>:<lines>`](https://github.com/{repo}/blob/<branch-head-sha>/<path>#L<start>-L<end>)
+
+Note: this fix is bundled with {N-1} other thread(s) into a single
+`fixup!` commit and will be squashed into its parent during
+`Dev10x:git-groom`.
+```
+
+Rules:
+
+- The `Fix commit:` URL uses the `/pull/{N}/commits/<sha>` form,
+  which GitHub resolves in the PR commits tab even after force
+  push (the bare `/commit/<sha>` form does not).
+- The blob URL pins to the **current branch HEAD SHA**, not the
+  fixup SHA. The fixup SHA disappears at squash time; the
+  branch-head SHA stays valid until the next force push (and
+  the post-groom refresh step below re-pins it then).
+- Every bundled reply explicitly states it is bundled. Reviewers
+  must be able to tell from any single thread that the same fix
+  resolves siblings.
+- Track the comment IDs grouped under each fixup in skill state
+  so the post-groom refresh phase can locate them.
+
+### Post-Groom SHA Refresh (sub-phase of shipping pipeline)
+
+After `Skill(Dev10x:git-groom)` rewrites history (fixups
+squashed, force push complete), any reply posted earlier in
+this session that references a pre-groom SHA is now stale.
+Refresh those replies before the merge gate.
+
+Sequence (runs between groom and push-monitor steps):
+
+1. Collect every reply this skill posted in the current session
+   that referenced a `fixup!` SHA or its pre-rebase parent. The
+   bundled-mode grouping (above) is the authoritative source.
+2. For each tracked reply:
+   a. Resolve the new parent SHA (the squashed-into commit).
+   b. Rewrite the reply body using the bundled-reply template,
+      substituting the new parent SHA for `Fix commit:` and the
+      new branch-head SHA for the blob URL.
+   c. PATCH the reply via
+      `mcp__plugin_Dev10x_cli__pr_comments(action="edit", ...)`.
+      Never drop to raw `gh api -X PATCH` — the `edit` action
+      exists precisely so the post-groom refresh stays inside
+      the structured tool surface.
+3. Mark the refresh task complete only after every tracked
+   reply was successfully PATCHed. A 404 (comment deleted by
+   reviewer) is acceptable; any other failure must abort the
+   refresh and surface the error.
+
+Skip this sub-phase when no replies were posted in the current
+session (e.g., resumed from a different process) OR when no
+fixup commits exist on the branch.
+
 ## Preamble: Branch Location Check
 
 Before processing comments, verify the PR branch is accessible
@@ -467,8 +569,13 @@ For each approved comment:
   wait for user input between comments. The triage-to-fixup
   transition is atomic: verdict received → `Skill()` invoked,
   no pause. Never manually implement fixes or post replies via
-  raw commands. The fixup skill handles the entire lifecycle
-  (one fixup commit per comment).
+  raw commands. The fixup skill handles the entire lifecycle.
+
+  **Default cardinality is one fixup commit per comment.** When
+  several VALID comments share a coherent fix, see the **Bundled
+  Fixup Mode** section above — bundling is opt-in and requires
+  every affected reply to use the hyperlinked bundled-reply
+  template plus the post-groom SHA refresh sub-phase.
 - **INVALID / QUESTION / OUT_OF_SCOPE** → post reply using MCP tool:
   ```
   mcp__plugin_Dev10x_cli__pr_comment_reply(
@@ -647,15 +754,21 @@ Options:
   post-response shipping sequence. **REQUIRED: Use `Skill()` for
   each step** — never run raw git/gh commands directly:
   1. `Skill(Dev10x:git-groom)` — squash fixup commits
-  2. `Skill(Dev10x:git)` — push with `--force-with-lease`
-  3. `Skill(Dev10x:gh-pr-monitor)` — watch CI after force push
-  4. **CI guard (GH-684):** Only after CI passes, run
+  2. **Post-Groom SHA Refresh** — PATCH any session-posted
+     replies that referenced pre-groom SHAs. See the
+     **Bundled Fixup Mode → Post-Groom SHA Refresh** section
+     above. Use `mcp__plugin_Dev10x_cli__pr_comments(action="edit")`,
+     never raw `gh api -X PATCH`. Skip when no replies were
+     posted this session.
+  3. `Skill(Dev10x:git)` — push with `--force-with-lease`
+  4. `Skill(Dev10x:gh-pr-monitor)` — watch CI after force push
+  5. **CI guard (GH-684):** Only after CI passes, run
      `gh pr ready` to mark the PR ready for review. Do NOT
      run `gh pr ready` before CI is green — this was the #1
      bypass pattern: marking ready then discovering CI failures.
      Also verify no unresolved review threads remain before
      marking ready.
-  5. If CI passes and no new comments → merge via
+  6. If CI passes and no new comments → merge via
      `Skill(Dev10x:gh-pr-merge)` — NEVER raw `gh pr merge`
      (GH-759 F3). The skill validates 8 pre-merge conditions
      including unaddressed review comments that raw merge

--- a/skills/gh-pr-triage/SKILL.md
+++ b/skills/gh-pr-triage/SKILL.md
@@ -42,6 +42,33 @@ verify the triage decisions without searching through hidden threads.
 - Called by `Dev10x:gh-pr-respond` before delegating to `Dev10x:gh-pr-fixup`
 - Standalone when you want to validate a comment without committing to a fix
 
+## NEVER inline triage (GH-463, GH-97)
+
+This is a `Skill()`-only entry point. The verdicts above
+(`VALID`/`INVALID`/`QUESTION`/`OUT_OF_SCOPE`) are this skill's
+output contract — they MUST NOT appear in narrative text as a
+substitute for invoking the skill.
+
+If you find yourself writing:
+
+> "Comment 3 is VALID — the test does need a fixture."
+
+without a preceding `Skill(Dev10x:gh-pr-triage)` tool call, you
+have bypassed the delegation. The bypass typically happens under
+context pressure when the verdict feels obvious. It is exactly
+the regression GH-463 and GH-97 caught (~42% compliance in the
+audited session) — the agent classified five comments inline
+across one PR cycle, all without a single `Skill()` call. The
+verdict feeling obvious is precisely the rationalization that
+triggers the bypass.
+
+**Detection hint for parent skills:** When `Dev10x:gh-pr-respond`
+or another caller observes inline classification language
+without a preceding `Skill(Dev10x:gh-pr-triage)` call in the
+same turn, the caller MUST abort the current comment and
+re-enter via this skill. See `Dev10x:gh-pr-respond/instructions.md`
+§ Critical: Delegation is Mandatory.
+
 ## Orchestration
 
 This skill follows `references/task-orchestration.md` patterns.

--- a/skills/git-groom/SKILL.md
+++ b/skills/git-groom/SKILL.md
@@ -38,3 +38,18 @@ in [`instructions.md`](instructions.md).
 When this skill is invoked, Read `instructions.md` now and
 follow it end-to-end. The strategy `AskUserQuestion` gate
 documented there is REQUIRED.
+
+## Legacy script path warning (GH-97)
+
+This skill MUST be invoked via `Skill('Dev10x:git-groom')`.
+Direct script invocation is unsupported and the historical
+path `~/.claude/skills/dx:git/scripts/git-rebase-groom.sh`
+no longer exists (it predates the current plugin layout).
+Audit sessions show agents reaching for that path from
+muscle memory, then falling back to raw
+`git -c sequence.editor=... rebase -i --autosquash` when it
+ENOENTs. Neither path is correct — both bypass the safety
+checks this skill wraps around `git rebase` (protected-branch
+guard, autosquash sanity, force-push-with-lease). If you see
+the ENOENT, the corrective action is to invoke the skill,
+not to retry the script.

--- a/src/dev10x/github/__init__.py
+++ b/src/dev10x/github/__init__.py
@@ -309,6 +309,31 @@ async def _pr_comment_reply(
     return _parse_gh_api_result(result)
 
 
+async def _pr_comment_edit(
+    *,
+    resolved_repo: str,
+    comment_id: int | str | None = None,
+    body: str | None = None,
+    **_: Any,
+) -> Result[dict[str, Any]]:
+    if comment_id is None or body is None:
+        return err("comment_id and body required for 'edit' action")
+    try:
+        comment_id_int = int(comment_id)
+    except (TypeError, ValueError):
+        return err(
+            f"comment_id must be an integer for 'edit' (REST comment id). Got: {comment_id!r}"
+        )
+    result = await _gh_api(
+        f"repos/{resolved_repo}/pulls/comments/{comment_id_int}",
+        method="PATCH",
+        fields={"body": body},
+        repo=str(resolved_repo),
+        as_bot=True,
+    )
+    return _parse_gh_api_result(result)
+
+
 async def _pr_comment_resolve(
     *,
     resolved_repo: str,
@@ -378,6 +403,7 @@ _PR_COMMENT_ACTIONS: dict[str, Any] = {
     "get": _pr_comment_get,
     "list": _pr_comment_list,
     "reply": _pr_comment_reply,
+    "edit": _pr_comment_edit,
     "resolve": _pr_comment_resolve,
 }
 

--- a/src/dev10x/mcp/server_cli.py
+++ b/src/dev10x/mcp/server_cli.py
@@ -149,7 +149,7 @@ async def pr_comments(
     """Manage GitHub PR review comments and threads.
 
     Args:
-        action: One of: list, get, reply, resolve
+        action: One of: list, get, reply, edit, resolve
         pr_number: PR number (required for list, reply)
         comment_id: Comment ID (required for get, reply, resolve single)
         comment_ids: List of GraphQL node_ids for batch resolve

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -727,6 +727,73 @@ class TestPrCommentsActionReply:
         assert "must be an integer" in result.error
 
 
+class TestPrCommentsActionEdit:
+    @pytest.mark.asyncio
+    @patch("dev10x.github._gh_api", new_callable=AsyncMock)
+    async def test_patches_comment_body(
+        self,
+        mock_api: AsyncMock,
+        mock_resolve_repo: AsyncMock,
+    ) -> None:
+        mock_api.return_value = _completed(
+            stdout=json.dumps({"id": 3130499018, "body": "refreshed"}),
+        )
+
+        result = await gh.pr_comments(
+            action="edit",
+            comment_id=3130499018,
+            body="refreshed",
+        )
+
+        assert isinstance(result, SuccessResult)
+        assert mock_api.call_args.args[0] == ("repos/owner/repo/pulls/comments/3130499018")
+        assert mock_api.call_args.kwargs["method"] == "PATCH"
+        assert mock_api.call_args.kwargs["fields"] == {"body": "refreshed"}
+        assert mock_api.call_args.kwargs["as_bot"] is True
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github._gh_api", new_callable=AsyncMock)
+    async def test_coerces_numeric_string_to_int(
+        self,
+        mock_api: AsyncMock,
+        mock_resolve_repo: AsyncMock,
+    ) -> None:
+        mock_api.return_value = _completed(stdout=json.dumps({"id": 1}))
+
+        result = await gh.pr_comments(
+            action="edit",
+            comment_id="3130499018",
+            body="refreshed",
+        )
+
+        assert isinstance(result, SuccessResult)
+        assert mock_api.call_args.args[0] == ("repos/owner/repo/pulls/comments/3130499018")
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_numeric_comment_id(
+        self,
+        mock_resolve_repo: AsyncMock,
+    ) -> None:
+        result = await gh.pr_comments(
+            action="edit",
+            comment_id="PRRC_abc",
+            body="refreshed",
+        )
+
+        assert isinstance(result, ErrorResult)
+        assert "must be an integer" in result.error
+
+    @pytest.mark.asyncio
+    async def test_requires_comment_id_and_body(
+        self,
+        mock_resolve_repo: AsyncMock,
+    ) -> None:
+        result = await gh.pr_comments(action="edit")
+
+        assert isinstance(result, ErrorResult)
+        assert "comment_id and body required" in result.error
+
+
 class TestRequestReview:
     @pytest.mark.asyncio
     @patch("dev10x.github._gh_api", new_callable=AsyncMock)
@@ -780,7 +847,7 @@ class TestPrCommentsStrategyDispatch:
 
         assert isinstance(result, ErrorResult)
         assert "Unknown action" in result.error
-        assert "get, list, reply, resolve" in result.error
+        assert "get, list, reply, edit, resolve" in result.error
 
     @pytest.mark.asyncio
     @patch("dev10x.github._gh_api", new_callable=AsyncMock)


### PR DESCRIPTION
**When** a refactor naturally addresses several review threads at once, **I want to** ship one `fixup!` commit that closes them all with hyperlinked replies that survive a force-push, **so** reviewers don't see orphan SHAs after `Dev10x:git-groom` rewrites history **and** the agent doesn't drop to raw `gh api -X PATCH` to patch the mess.

## Summary

Bundles GH-86 and GH-97 audit findings on `Dev10x:gh-pr-respond` into one fix:

- **`Dev10x:gh-pr-respond`** — new **Bundled Fixup Mode** section: trigger criteria, hyperlinked reply template (`Fix commit:` + `Code change:` blob URL pinned to current branch HEAD), and the **Post-Groom SHA Refresh** sub-phase that PATCHes session-posted replies between `git-groom` and the merge gate. Soften the absolute "one fixup per comment" wording. Add a pre-push `TaskList` self-check that catches "stated-but-not-executed" `Skill(gh-pr-fixup)` bypasses before they ship (GH-97 finding 3).
- **`Dev10x:gh-pr-triage`** — re-emphasize the NEVER-inline contract so verdict labels stop appearing in narrative text without a preceding `Skill()` call (GH-97 finding 5).
- **`Dev10x:git-groom`** — flag the dead legacy script path that agents reach for from muscle memory, and warn against the raw `git rebase -i --autosquash` fallback (GH-97 finding 6).
- **`session-guidance.md`** — add `git -C /worktree/path` anti-pattern row symmetric to `cd /worktree/path && command` (20× prefix poisoning observed in the audited session, GH-97 finding 7).
- **`pr_comments` MCP** — add `action="edit"` so the post-groom refresh can PATCH stale SHA references via the structured tool surface, never raw `gh api -X PATCH` (GH-86 finding 3). Four tests cover happy path, numeric-string coercion, non-numeric rejection, and required-fields validation.

## Commits

[`4c64dece`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/105/commits/4c64decea99aafed3871bf931fc96647ffd2bfe2) ✨ GH-86 Enable bundled-fixup replies and post-groom SHA refresh

## Tests

`uv run --extra dev pytest tests/github/test_github.py` — 57 passed (4 new for `pr_comments action="edit"`). Full suite: 1769 passed, 1 pre-existing benchmark gate failure on `origin/develop` (mcp_server_import baseline stale), 2 skipped.

Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/86
Refs: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/97
