### PR TITLE
🔒 GH-78 Harden MCP error contracts and cwd enforcement

### DIFF
--- a/src/dev10x/github/__init__.py
+++ b/src/dev10x/github/__init__.py
@@ -17,13 +17,13 @@ from typing import Any
 from dev10x.domain.repository_ref import RepositoryRef
 from dev10x.domain.result import ErrorResult, Result, err, ok
 from dev10x.github.app_auth import AppConfig, get_bot_token
-
-logger = logging.getLogger(__name__)
 from dev10x.subprocess_utils import (
     async_run,
     async_run_script,
     parse_key_value_output,
 )
+
+logger = logging.getLogger(__name__)
 
 
 async def _detect_repo() -> str | None:

--- a/src/dev10x/mcp/server_cli.py
+++ b/src/dev10x/mcp/server_cli.py
@@ -758,7 +758,8 @@ async def plan_sync_json_summary(cwd: str | None = None) -> dict:
 
     Returns:
         Dictionary with plan metadata, context, and task list.
-        Empty dict if no plan exists.
+        Empty dict if a plan file exists but holds no metadata.
+        `{"error": "Not in a git repository"}` when run outside a repo.
     """
     from dev10x import plan as plan_tools
     from dev10x.subprocess_utils import use_cwd

--- a/src/dev10x/plan/__init__.py
+++ b/src/dev10x/plan/__init__.py
@@ -45,7 +45,7 @@ async def json_summary() -> dict[str, Any]:
 
     toplevel = get_toplevel()
     if not toplevel:
-        return {}
+        return {"error": "Not in a git repository"}
 
     plan_path = get_plan_path(toplevel=toplevel)
     plan = Plan.load(path=plan_path)

--- a/src/dev10x/subprocess_utils.py
+++ b/src/dev10x/subprocess_utils.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import functools
 import json
 import os
 import subprocess
+from collections.abc import Awaitable, Callable
 from contextvars import ContextVar
 from pathlib import Path
 from typing import Any
@@ -41,6 +43,33 @@ def use_cwd(cwd: str | None):
 def effective_cwd() -> str | None:
     """Return the bound effective CWD or None if unbound."""
     return _effective_cwd.get()
+
+
+def requires_cwd[R](
+    func: Callable[..., Awaitable[R]],
+) -> Callable[..., Awaitable[R]]:
+    """Decorator: bind `cwd=` kwarg to the effective-CWD ContextVar.
+
+    Applied to async MCP tool handlers that accept a `cwd: str | None`
+    keyword argument. The decorator extracts `cwd` from kwargs and
+    invokes the wrapped function inside a `use_cwd(cwd)` block so
+    subprocess calls automatically route to the caller's working
+    directory (GH-979).
+
+    Enforces the contract at handler-definition time: the wrapped
+    function MUST declare a `cwd` keyword parameter. New MCP handlers
+    that forget the wrapper are caught by `tests/test_cwd_enforcement.py`
+    which fails CI when a `@server.tool()` handler with a `cwd`
+    parameter is missing `with use_cwd(...)` or `@requires_cwd`.
+    """
+
+    @functools.wraps(func)
+    async def wrapper(*args: Any, **kwargs: Any) -> R:
+        cwd = kwargs.get("cwd")
+        with use_cwd(cwd):
+            return await func(*args, **kwargs)
+
+    return wrapper
 
 
 def get_plugin_root() -> Path:

--- a/src/dev10x/validators/commit_jtbd.py
+++ b/src/dev10x/validators/commit_jtbd.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from dev10x.domain import HookInput, HookResult
+from dev10x.domain.result import ErrorResult, Result, err, ok
 
 _VERB_BASES = [
     "Add",
@@ -154,12 +155,12 @@ def _strip_prefix(title: str) -> str:
     return desc
 
 
-def _check_jtbd(title: str) -> tuple[bool, str]:
+def _check_jtbd(title: str) -> Result[str]:
     desc = _strip_prefix(title)
     match = VERB_RE.match(desc)
     if match:
-        return False, match.group(1)
-    return True, ""
+        return err(match.group(1))
+    return ok("")
 
 
 @dataclass
@@ -187,12 +188,12 @@ class CommitJtbdValidator:
         if gitmoji in self.bypass_gitmoji:
             return None
 
-        is_ok, verb = _check_jtbd(title)
-        if not is_ok:
+        result = _check_jtbd(title)
+        if isinstance(result, ErrorResult):
             return HookResult(
                 message=BLOCK_MSG.format(
                     title=title,
-                    verb=verb,
+                    verb=result.error,
                     jtbd_verbs=JTBD_VERBS,
                 )
             )

--- a/src/dev10x/validators/sql_safety.py
+++ b/src/dev10x/validators/sql_safety.py
@@ -14,6 +14,7 @@ import shlex
 from dataclasses import dataclass
 
 from dev10x.domain import HookInput, HookResult
+from dev10x.domain.result import ErrorResult, Result, err, ok
 
 POSTGRES_CONN_RE = re.compile(r"postgres(?:ql)?://[^'\"\s]+:[^@'\"\s]+@[a-zA-Z0-9._-]+")
 
@@ -129,22 +130,22 @@ def _extract_sql_from_command(command: str) -> str | None:
 _SINGLE_QUOTED_RE = re.compile(r"'[^']*'")
 
 
-def _validate_sql(sql: str) -> tuple[bool, str]:
+def _validate_sql(sql: str) -> Result[str]:
     stripped = sql.strip().rstrip(";").strip()
 
     if not stripped:
-        return True, ""
+        return ok("")
 
     without_strings = _SINGLE_QUOTED_RE.sub("", stripped)
     if ";" in without_strings:
-        return False, (
+        return err(
             "Multi-statement SQL is not allowed.\n"
             "Submit one statement at a time.\n\n"
             f"Blocked SQL:\n{sql}"
         )
 
     if not SAFE_PREFIXES.match(stripped):
-        return False, (
+        return err(
             "Query does not start with SELECT/WITH/EXPLAIN/SHOW.\n"
             "Only read-only queries are allowed.\n\n"
             f"Blocked SQL:\n{sql}"
@@ -153,13 +154,13 @@ def _validate_sql(sql: str) -> tuple[bool, str]:
     match = BLOCKED_KEYWORDS.search(stripped)
     if match:
         keyword = match.group(0).upper()
-        return False, (
+        return err(
             f"Query contains blocked keyword: {keyword}\n"
             "Only read-only queries are allowed.\n\n"
             f"Blocked SQL:\n{sql}"
         )
 
-    return True, ""
+    return ok("")
 
 
 @dataclass
@@ -239,13 +240,13 @@ class SqlSafetyValidator:
         if sql is None:
             return None
 
-        ok, err = _validate_sql(sql)
-        if ok:
+        result = _validate_sql(sql)
+        if not isinstance(result, ErrorResult):
             return None
 
         return HookResult(
             message=(
-                f"BLOCKED by db safety hook: {err}\n\n"
+                f"BLOCKED by db safety hook: {result.error}\n\n"
                 "This query modifies data and cannot be run through the "
                 "read-only tool. Print the SQL for the user to run manually."
             )

--- a/tests/plan/test_plan.py
+++ b/tests/plan/test_plan.py
@@ -56,12 +56,12 @@ class TestSetContext:
 class TestJsonSummary:
     @pytest.mark.asyncio
     @patch(f"{TASK_PLAN_SYNC}.get_toplevel", return_value=None)
-    async def test_returns_empty_when_not_in_git_repo(
+    async def test_returns_error_when_not_in_git_repo(
         self,
         mock_toplevel: MagicMock,
     ) -> None:
         result = await plan_mod.json_summary()
-        assert result == {}
+        assert result == {"error": "Not in a git repository"}
 
     @pytest.mark.asyncio
     @patch(f"{TASK_PLAN_SYNC}.get_toplevel", return_value="/tmp/repo")

--- a/tests/test_cwd_enforcement.py
+++ b/tests/test_cwd_enforcement.py
@@ -1,0 +1,122 @@
+"""Lint test: MCP tool handlers with `cwd` parameter must bind it.
+
+Every `@server.tool()`-decorated async function in `server_cli.py` that
+accepts a `cwd: str | None` parameter must either:
+
+1. Apply `@requires_cwd` (binds `cwd` to the effective-CWD ContextVar), or
+2. Manually wrap its body with `with use_cwd(cwd):`.
+
+Handlers that forget the binding silently fall back to the MCP server's
+startup CWD — the root-cause class of GH-979.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from dev10x.subprocess_utils import get_plugin_root
+
+
+def _server_cli_path() -> Path:
+    return get_plugin_root() / "src" / "dev10x" / "mcp" / "server_cli.py"
+
+
+def _is_server_tool(decorator: ast.expr) -> bool:
+    if isinstance(decorator, ast.Call):
+        decorator = decorator.func
+    if isinstance(decorator, ast.Attribute):
+        return decorator.attr == "tool"
+    if isinstance(decorator, ast.Name):
+        return decorator.id == "tool"
+    return False
+
+
+def _has_requires_cwd(node: ast.AsyncFunctionDef) -> bool:
+    for dec in node.decorator_list:
+        target = dec.func if isinstance(dec, ast.Call) else dec
+        if isinstance(target, ast.Name) and target.id == "requires_cwd":
+            return True
+        if isinstance(target, ast.Attribute) and target.attr == "requires_cwd":
+            return True
+    return False
+
+
+def _accepts_cwd_kwarg(node: ast.AsyncFunctionDef) -> bool:
+    all_args = [*node.args.args, *node.args.kwonlyargs]
+    return any(arg.arg == "cwd" for arg in all_args)
+
+
+def _body_uses_use_cwd(node: ast.AsyncFunctionDef) -> bool:
+    for sub in ast.walk(node):
+        if not isinstance(sub, ast.With):
+            continue
+        for item in sub.items:
+            call = item.context_expr
+            if not isinstance(call, ast.Call):
+                continue
+            target = call.func
+            if isinstance(target, ast.Name) and target.id == "use_cwd":
+                return True
+            if isinstance(target, ast.Attribute) and target.attr == "use_cwd":
+                return True
+    return False
+
+
+def _server_tool_handlers() -> list[ast.AsyncFunctionDef]:
+    tree = ast.parse(_server_cli_path().read_text())
+    handlers: list[ast.AsyncFunctionDef] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AsyncFunctionDef):
+            continue
+        if any(_is_server_tool(dec) for dec in node.decorator_list):
+            handlers.append(node)
+    return handlers
+
+
+def test_server_cli_handlers_with_cwd_bind_it() -> None:
+    offenders: list[str] = []
+    for handler in _server_tool_handlers():
+        if not _accepts_cwd_kwarg(handler):
+            continue
+        if _has_requires_cwd(handler) or _body_uses_use_cwd(handler):
+            continue
+        offenders.append(f"{handler.name} (line {handler.lineno})")
+
+    assert not offenders, (
+        "MCP handlers declare a `cwd` parameter but neither apply "
+        "@requires_cwd nor wrap the body with `use_cwd(cwd)`. "
+        "Without one of these, subprocess calls leak to the server's "
+        "startup CWD (GH-979). Offenders:\n  - " + "\n  - ".join(offenders)
+    )
+
+
+@pytest.mark.asyncio
+async def test_requires_cwd_binds_effective_cwd(tmp_path: Path) -> None:
+    from dev10x.subprocess_utils import effective_cwd, requires_cwd
+
+    captured: dict[str, str | None] = {}
+
+    @requires_cwd
+    async def handler(*, cwd: str | None = None) -> dict[str, str | None]:
+        captured["bound"] = effective_cwd()
+        return {"ok": "1"}
+
+    await handler(cwd=str(tmp_path))
+    assert captured["bound"] == str(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_requires_cwd_passes_through_when_cwd_none() -> None:
+    from dev10x.subprocess_utils import effective_cwd, requires_cwd
+
+    captured: dict[str, str | None] = {}
+
+    @requires_cwd
+    async def handler(*, cwd: str | None = None) -> None:
+        captured["bound"] = effective_cwd()
+
+    await handler(cwd=None)
+    assert captured["bound"] is None


### PR DESCRIPTION
**When** an MCP tool errors or a handler forgets to bind its working directory, **I want to** receive a uniform, explicit error envelope and have the binding enforced at lint time, **so I can** trust every MCP boundary in the plugin instead of triaging silent `{}` returns and CWD leaks one regression at a time.

---

[`c76cb96f`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/106/commits/c76cb96fd20da1c37fe0b5d17ccc9d3afe499f33) 🐛 GH-78 Surface git-repo errors from plan.json_summary
[`ab69799d`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/106/commits/ab69799de7933039b1264a100591a1f886c240fd) ♻️ GH-78 Unify validator error returns with Result[str]
[`15ab878c`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/106/commits/15ab878cf0610d876b0bd813fa1646b332b62c56) 🔒 GH-78 Enforce cwd binding on MCP handlers via @requires_cwd
[`09f6cf4a`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/106/commits/09f6cf4a0a9c24d824ccbd2584ae4562a0866d4d) 🚨 GH-78 Restore import-block ordering in github/__init__.py
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/78

---