### PR TITLE
🐛 GH-84 Stop blocking mktmp.sh args as git commit

### DIFF
--- a/src/dev10x/domain/validation_rule.py
+++ b/src/dev10x/domain/validation_rule.py
@@ -5,6 +5,26 @@ from dataclasses import dataclass, field
 from functools import cached_property
 from typing import Any
 
+_SUBCOMMAND_BOUNDARY = r"(?![-\w])"
+
+
+def _anchor_subcommand(*, pattern: str) -> str:
+    """Anchor a CLI subcommand pattern at the right edge.
+
+    YAML patterns like ``git commit`` or ``gh pr create`` are
+    command-name prefixes; without a right-edge boundary, ``git commit``
+    matches inside ``git commit-msg`` (an argument value), producing
+    false positives (GH-84). Append a negative lookahead so the
+    pattern's last token cannot be followed by another word or hyphen
+    character.
+
+    Patterns already ending in a regex anchor (``$``, ``\\b``) or an
+    explicit lookaround are left untouched.
+    """
+    if pattern.endswith(("$", r"\b")) or pattern.endswith((")", "]")):
+        return pattern
+    return pattern + _SUBCOMMAND_BOUNDARY
+
 
 @dataclass(frozen=True)
 class Compensation:
@@ -40,7 +60,7 @@ class Rule:
 
     @cached_property
     def compiled_patterns(self) -> list[re.Pattern[str]]:
-        return [re.compile(p) for p in self.patterns]
+        return [re.compile(_anchor_subcommand(pattern=p)) for p in self.patterns]
 
     @cached_property
     def compiled_file_pattern(self) -> re.Pattern[str] | None:

--- a/tests/domain/test_rule_engine.py
+++ b/tests/domain/test_rule_engine.py
@@ -231,3 +231,55 @@ class TestRuleEngineEvaluateCommand:
         result = engine.evaluate_command(command="git push --dry-run")
 
         assert result is None
+
+
+class TestSubcommandBoundary:
+    """Regression coverage for GH-84: `git commit` matching `git commit-msg`."""
+
+    @pytest.fixture()
+    def engine(self) -> RuleEngine:
+        return RuleEngine(
+            command_rules=[
+                Rule(
+                    name="git-commit",
+                    matcher="Bash",
+                    patterns=["git commit"],
+                    compensations=[Compensation(type="use-skill", skill="Dev10x:git-commit")],
+                ),
+                Rule(
+                    name="gh-pr-create",
+                    matcher="Bash",
+                    patterns=["gh pr create"],
+                    compensations=[Compensation(type="use-skill", skill="Dev10x:gh-pr-create")],
+                ),
+            ],
+        )
+
+    def test_real_git_commit_still_blocked(self, engine: RuleEngine) -> None:
+        result = engine.evaluate_command(command="git commit -m 'msg'")
+
+        assert result is not None
+        assert result.name == "git-commit"
+
+    def test_git_commit_msg_argument_passes(self, engine: RuleEngine) -> None:
+        result = engine.evaluate_command(
+            command="/tmp/Dev10x/bin/mktmp.sh git commit-msg .txt",
+        )
+
+        assert result is None
+
+    def test_git_commits_word_extension_passes(self, engine: RuleEngine) -> None:
+        result = engine.evaluate_command(command="echo git commits today")
+
+        assert result is None
+
+    def test_gh_pr_create_real_invocation_blocked(self, engine: RuleEngine) -> None:
+        result = engine.evaluate_command(command="gh pr create --draft")
+
+        assert result is not None
+        assert result.name == "gh-pr-create"
+
+    def test_gh_pr_create_hyphenated_argument_passes(self, engine: RuleEngine) -> None:
+        result = engine.evaluate_command(command="echo gh pr create-something")
+
+        assert result is None


### PR DESCRIPTION
**When** the agent prepares a commit message via the `mktmp.sh` wrapper, **I want to** pass `git commit-msg .txt` as a namespace + prefix + extension argument **so I can** create the temp file without the `validate-bash-command.py` hook substring-matching the literal `git commit` inside my argument list and falsely redirecting me to `Skill(Dev10x:git-commit)`.

---

[`11ca8b81`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/110/commits/11ca8b813ed07c8d7c3338b6d22990fe91ce2635) 🐛 GH-84 Stop blocking mktmp.sh args as git commit
Fixes: https://github.com/Dev10x-Guru/dev10x-claude/issues/84

---