### PR TITLE
✨ GH-99 Enable permission doctor for plugin-cache hygiene

### DIFF
--- a/references/baseline-permissions.yaml
+++ b/references/baseline-permissions.yaml
@@ -1,0 +1,560 @@
+# Dev10x Baseline Permissions (GH-99)
+#
+# Catalog of safe-to-allow tools the plugin's permission doctor should
+# seed by default into every project's allow list. Grouped by application
+# target so maintainers can prune/extend per audience.
+#
+# Conventions:
+#   - Use `${CLAUDE_PLUGIN_ROOT}/...` for plugin-script rules. Never paste
+#     resolved cache paths (e.g. `/plugins/cache/Dev10x-Guru/Dev10x/0.71.0/`)
+#     — those rot on every plugin upgrade. The `~/.claude/plugins/cache/**/`
+#     form is also acceptable; the doctor canonicalizes pinned paths to
+#     that form.
+#   - Trailing wildcard form: prefer `Bash(cmd *)` (space). The `Bash(cmd:*)`
+#     form is equivalent per Claude Code docs but the UI writes the space
+#     form on "always allow", so we standardize on it.
+#   - Built-in read-only commands (`ls`, `cat`, `head`, `tail`, `grep`,
+#     `find`, `wc`, `diff`, `stat`, `du`, `cd`) are NOT listed — they
+#     never prompt for the command itself. Path access still gated by
+#     `additionalDirectories`.
+#
+# Tiers:
+#   tier-1: ship as plugin base permissions (universal — git/gh/skills/scaffold)
+#   tier-2: ship as plugin base permissions (common dev tools — uv, node, docker)
+#   tier-3: ship as opt-in groups (heavier or domain-specific)
+
+version: 1
+last_audited: 2026-05-15
+source_issue: GH-99
+
+groups:
+
+  # ─── TIER 1 ─────────────────────────────────────────────────────────
+
+  git-core:
+    tier: 1
+    description: Day-to-day git porcelain. Universal across every project.
+    rules:
+      - Bash(git status:*)
+      - Bash(git branch:*)
+      - Bash(git checkout:*)
+      - Bash(git switch:*)
+      - Bash(git add:*)
+      - Bash(git commit:*)
+      - Bash(git commit -m:*)
+      - Bash(git log:*)
+      - Bash(git diff:*)
+      - Bash(git fetch:*)
+      - Bash(git push:*)
+      - Bash(git pull:*)
+      - Bash(git rebase:*)
+      - Bash(git rebase -i:*)
+      - Bash(git reset:*)
+      - Bash(git reset --soft:*)
+      - Bash(git reset --hard:*)
+      - Bash(git restore:*)
+      - Bash(git restore --staged:*)
+      - Bash(git stash:*)
+      - Bash(git show:*)
+      - Bash(git symbolic-ref:*)
+      - Bash(git rev-parse:*)
+      - Bash(git rev-list:*)
+      - Bash(git reflog:*)
+      - Bash(git remote:*)
+      - Bash(git merge:*)
+      - Bash(git merge-base:*)
+      - Bash(git merge-tree:*)
+      - Bash(git mv:*)
+      - Bash(git tag:*)
+      - Bash(git cherry-pick:*)
+      - Bash(git cherry:*)
+      - Bash(git blame:*)
+      - Bash(git ls-files:*)
+      - Bash(git ls-remote:*)
+      - Bash(git ls-tree:*)
+      - Bash(git describe:*)
+      - Bash(git shortlog:*)
+      - Bash(git worktree:*)
+      - Bash(git check-ignore:*)
+      - Bash(git grep:*)
+      - Bash(git config --get:*)
+      - Bash(git config --list:*)
+      - Bash(git config --show-origin:*)
+      - Bash(git diff-tree:*)
+
+  git-aliases-dev10x:
+    tier: 1
+    description: Aliases installed by Dev10x:git-alias-setup.
+    rules:
+      - Bash(git develop-log:*)
+      - Bash(git develop-diff:*)
+      - Bash(git develop-rebase:*)
+      - Bash(git autosquash-develop:*)
+      - Bash(git development-log:*)
+      - Bash(git development-diff:*)
+      - Bash(git development-rebase:*)
+      - Bash(git autosquash-development:*)
+      - Bash(git main-log:*)
+      - Bash(git main-diff:*)
+      - Bash(git main-rebase:*)
+      - Bash(git autosquash-main:*)
+      - Bash(git master-log:*)
+      - Bash(git master-diff:*)
+      - Bash(git master-rebase:*)
+      - Bash(git autosquash-master:*)
+      - Bash(git trunk-log:*)
+      - Bash(git trunk-diff:*)
+      - Bash(git trunk-rebase:*)
+      - Bash(git autosquash-trunk:*)
+
+  github-cli:
+    tier: 1
+    description: >
+      GitHub CLI ops for PRs, issues, runs, workflows. Writes flow
+      through gh-pr-create / ticket-create skills.
+    rules:
+      - Bash(gh auth:*)
+      - Bash(gh auth login:*)
+      - Bash(gh auth status:*)
+      - Bash(gh api:*)
+      - Bash(gh browse:*)
+      - Bash(gh repo clone:*)
+      - Bash(gh repo list:*)
+      - Bash(gh repo view:*)
+      - Bash(gh search:*)
+      - Bash(gh pr view:*)
+      - Bash(gh pr list:*)
+      - Bash(gh pr status:*)
+      - Bash(gh pr diff:*)
+      - Bash(gh pr checks:*)
+      - Bash(gh pr edit:*)
+      - Bash(gh pr review:*)
+      - Bash(gh pr ready:*)
+      - Bash(gh pr reopen:*)
+      - Bash(gh pr create:*)
+      - Bash(gh pr comment:*)
+      - Bash(gh pr merge:*)
+      - Bash(gh issue view:*)
+      - Bash(gh issue list:*)
+      - Bash(gh issue status:*)
+      - Bash(gh issue create:*)
+      - Bash(gh issue close:*)
+      - Bash(gh issue edit:*)
+      - Bash(gh issue comment:*)
+      - Bash(gh label list:*)
+      - Bash(gh label create:*)
+      - Bash(gh label edit:*)
+      - Bash(gh milestone:*)
+      - Bash(gh release list:*)
+      - Bash(gh release view:*)
+      - Bash(gh run list:*)
+      - Bash(gh run view:*)
+      - Bash(gh run watch:*)
+      - Bash(gh run download:*)
+      - Bash(gh run rerun:*)
+      - Bash(gh workflow list:*)
+      - Bash(gh workflow view:*)
+
+  dev10x-scaffolding:
+    tier: 1
+    description: >
+      Shared scaffolding for Dev10x skills. Plugin scripts use
+      `${CLAUDE_PLUGIN_ROOT}` so they survive upgrades.
+    rules:
+      - Skill(Dev10x:*)
+      - Read(/tmp/claude/git/**)
+      - Write(/tmp/claude/git/**)
+      - Read(/tmp/Dev10x/**)
+      - Write(/tmp/Dev10x/**)
+      - "Bash(${CLAUDE_PLUGIN_ROOT}/bin/**)"
+      - "Bash(${CLAUDE_PLUGIN_ROOT}/hooks/scripts/**)"
+      - "Bash(${CLAUDE_PLUGIN_ROOT}/skills/**)"
+      - "Bash(${CLAUDE_PLUGIN_ROOT}/lib/**)"
+
+  # ─── TIER 2 ─────────────────────────────────────────────────────────
+
+  shell-helpers:
+    tier: 2
+    description: >
+      Common shell utilities not on Claude Code's built-in read-only
+      list. Built-ins (find, grep, ls, cat, head, tail, wc, diff,
+      stat, du, cd) intentionally absent.
+    rules:
+      - Bash(jq:*)
+      - Bash(yq:*)
+      - Bash(rg *)
+      - Bash(rg --files *)
+      - Bash(sed *)
+      - Bash(awk *)
+      - Bash(awk:*)
+      - Bash(xargs cat:*)
+      - Bash(xargs ls:*)
+      - Bash(xargs rg:*)
+      - Bash(chmod:*)
+      - Bash(chmod +x:*)
+      - Bash(chmod a+x:*)
+      - Bash(chmod u+x:*)
+      - Bash(chmod -x:*)
+      - Bash(mkdir:*)
+      - Bash(cp /tmp:*)
+      - Bash(mv /tmp:*)
+      - Bash(ln:*)
+      - Bash(basename:*)
+      - Bash(printenv:*)
+      - Bash(env:*)
+      - Bash(date:*)
+      - Bash(pwd:*)
+      - Bash(alias:*)
+      - Bash(comm:*)
+      - Bash(source:*)
+      - Bash(tar *)
+      - Bash(gzip *)
+      - Bash(base64:*)
+      - Bash(curl -fsSL:*)
+      - Bash(curl -s*:*)
+      - Bash(curl -si:*)
+      - Bash(curl -sI:*)
+      - Bash(which *)
+      - Bash([ -f .git ])
+
+  python-toolchain:
+    tier: 2
+    description: >
+      Python dev tools. `uv:*` is broad because uv has no destructive
+      subcommands unless `publish` is explicitly invoked.
+    rules:
+      - Bash(uv:*)
+      - Bash(pip list:*)
+      - Bash(pip show:*)
+      - Bash(pip index:*)
+      - Bash(pip install:*)
+      - Bash(pipx list:*)
+      - Bash(python:*)
+      - Bash(python3:*)
+      - Bash(ipython:*)
+      - Bash(ruff check:*)
+      - Bash(ruff format:*)
+      - Bash(black:*)
+      - Bash(isort:*)
+      - Bash(mypy:*)
+      - Bash(python -m pytest *)
+      - Bash(pytest:*)
+
+  node-toolchain:
+    tier: 2
+    description: JavaScript / TypeScript runtime + package managers.
+    rules:
+      - Bash(node *)
+      - Bash(node:*)
+      - Bash(node --version)
+      - Bash(npm:*)
+      - Bash(npm run:*)
+      - Bash(npm test:*)
+      - Bash(npm view:*)
+      - Bash(npm run lint:*)
+      - Bash(npx:*)
+      - Bash(npx eslint:*)
+      - Bash(npx prettier:*)
+      - Bash(npx prettier --write:*)
+      - Bash(npx tsc:*)
+      - Bash(npx jest:*)
+      - Bash(npx vitest:*)
+      - Bash(npx vitest run:*)
+      - Bash(pnpm:*)
+      - Bash(pnpm test:*)
+      - Bash(pnpm lint:*)
+      - Bash(pnpm build:*)
+      - Bash(pnpm check:*)
+      - Bash(pnpm exec:*)
+      - Bash(pnpm remove:*)
+      - Bash(yarn:*)
+      - Bash(yarn test)
+      - Bash(yarn build *)
+      - Bash(yarn install *)
+      - Bash(yarn eslint *)
+      - Bash(yarn prettier *)
+      - Bash(yarn lint:eslint:*)
+      - Bash(yarn lint:tsc)
+
+  docker:
+    tier: 2
+    description: >
+      Docker / docker-compose for local dev environments. Write ops
+      scoped — no broad `docker run *` without `--rm`.
+    rules:
+      - Bash(docker compose:*)
+      - Bash(docker ps:*)
+      - Bash(docker logs:*)
+      - Bash(docker inspect:*)
+      - Bash(docker exec:*)
+      - Bash(docker image:*)
+      - Bash(docker images:*)
+      - Bash(docker network:*)
+      - Bash(docker pull:*)
+      - Bash(docker run --rm:*)
+      - Bash(docker start:*)
+      - Bash(docker stop:*)
+      - Bash(docker rm:*)
+      - Bash(docker info:*)
+      - Bash(docker history:*)
+
+  database-readonly:
+    tier: 2
+    description: >
+      Read-only DB inspection. Writes always require explicit user
+      approval per Dev10x CLAUDE.md rule.
+    rules:
+      - Bash(psql:*)
+      - Bash(pg_dump:*)
+
+  apt-and-system:
+    tier: 2
+    description: System inspection (read-only). Package install excluded.
+    rules:
+      - Bash(apt list:*)
+      - Bash(apt-cache policy:*)
+      - Bash(dpkg:*)
+      - Bash(flatpak list:*)
+      - Bash(pgrep:*)
+      - Bash(lsmod)
+      - Bash(lspci)
+
+  # ─── TIER 3 ─────────────────────────────────────────────────────────
+
+  media-and-format:
+    tier: 3
+    description: Image/video/PDF tooling. Opt-in for content/design workflows.
+    rules:
+      - Bash(ffmpeg:*)
+      - Bash(ffprobe:*)
+      - Bash(convert:*)
+      - Bash(java -jar ~/.local/bin/plantuml.jar:*)
+
+  aws-readonly:
+    tier: 3
+    description: >
+      AWS CLI read-only ops via aws-vault. Writes blocked at the skill
+      level.
+    rules:
+      - Bash(aws ecr describe-images:*)
+      - Bash(aws ecr describe-repositories:*)
+
+  bigquery-readonly:
+    tier: 3
+    description: BigQuery inspection.
+    rules:
+      - Bash(bq ls:*)
+      - Bash(bq show:*)
+
+  kubernetes-readonly:
+    tier: 3
+    description: >
+      kubectl read-only inspection. Namespace-scoped wildcards because
+      real-world usage always passes `-n <namespace>`. Excludes
+      apply/delete/patch/exec/scale/rollout/edit/create — those mutate
+      cluster state and must stay prompted. `port-forward`, `proxy`,
+      `exec`, and `cp` intentionally excluded (escape hatches / arbitrary
+      code).
+    rules:
+      - Bash(kubectl get:*)
+      - Bash(kubectl -n * get:*)
+      - Bash(kubectl describe:*)
+      - Bash(kubectl -n * describe:*)
+      - Bash(kubectl logs:*)
+      - Bash(kubectl -n * logs:*)
+      - Bash(kubectl top:*)
+      - Bash(kubectl -n * top:*)
+      - Bash(kubectl explain:*)
+      - Bash(kubectl api-resources:*)
+      - Bash(kubectl api-versions:*)
+      - Bash(kubectl version:*)
+      - Bash(kubectl cluster-info:*)
+      - Bash(kubectl config get-contexts:*)
+      - Bash(kubectl config current-context:*)
+      - Bash(kubectl config view:*)
+
+  network-diagnostics:
+    tier: 3
+    description: >
+      Read-only network/VPN/system inspection. Opt-in. Write forms
+      (ip route add, nmcli connection modify, iptables -A/-D/-I)
+      intentionally excluded — they change system state.
+    rules:
+      - Bash(ip route:*)
+      - Bash(ip addr:*)
+      - Bash(ip -4 addr:*)
+      - Bash(ip -6 addr:*)
+      - Bash(ip link:*)
+      - Bash(resolvectl:*)
+      - Bash(nmcli:*)
+      - Bash(nmcli -t:*)
+      - Bash(nmcli connection show:*)
+      - Bash(nmcli device:*)
+      - Bash(ss:*)
+      - Bash(ss -tlnp:*)
+      - Bash(netstat:*)
+      - Bash(dig:*)
+      - Bash(nslookup:*)
+      - Bash(host:*)
+      - Bash(traceroute:*)
+      - Bash(ping -c:*)
+      - Bash(ps -ef:*)
+      - Bash(ps aux:*)
+      - Bash(pgrep:*)
+
+  build-tools:
+    tier: 3
+    description: Make and language-agnostic build runners.
+    rules:
+      - Bash(make:*)
+      - Bash(pre-commit run:*)
+      - Bash(gitlint:*)
+      - Bash(bump-my-version:*)
+
+  webfetch-public-docs:
+    tier: 3
+    description: Public documentation domains used by tooling skills.
+    rules:
+      - WebFetch(domain:docs.docker.com)
+      - WebFetch(domain:docs.gunicorn.org)
+      - WebFetch(domain:gunicorn.org)
+      - WebFetch(domain:health.aws.amazon.com)
+
+  obsidian-cli:
+    tier: 3
+    description: >
+      Obsidian CLI (v1.12+) for vault automation via IPC to a running
+      Obsidian desktop. Read + safe-write ops only. Destructive or
+      arbitrary-code commands (`delete`, `eval`, `dev:*`,
+      `plugin:install`, `plugin:uninstall`, `theme:install`,
+      `theme:uninstall`, `reload`, `restart`) intentionally excluded.
+      Known gotcha: snap-installed Obsidian may hang silently on
+      multi-line `daily:append` content; fall back to direct vault-file
+      Write.
+    rules:
+      - Bash(obsidian read:*)
+      - Bash(obsidian create:*)
+      - Bash(obsidian append:*)
+      - Bash(obsidian prepend:*)
+      - Bash(obsidian move:*)
+      - Bash(obsidian rename:*)
+      - Bash(obsidian files:*)
+      - Bash(obsidian folders:*)
+      - Bash(obsidian file:*)
+      - Bash(obsidian random:*)
+      - Bash(obsidian daily:*)
+      - Bash(obsidian search:*)
+      - Bash(obsidian properties:*)
+      - Bash(obsidian property:*)
+      - Bash(obsidian aliases:*)
+      - Bash(obsidian tags:*)
+      - Bash(obsidian tag:*)
+      - Bash(obsidian tasks:*)
+      - Bash(obsidian task:*)
+      - Bash(obsidian backlinks:*)
+      - Bash(obsidian links:*)
+      - Bash(obsidian unresolved:*)
+      - Bash(obsidian orphans:*)
+      - Bash(obsidian deadends:*)
+      - Bash(obsidian bookmarks:*)
+      - Bash(obsidian bookmark:*)
+      - Bash(obsidian templates:*)
+      - Bash(obsidian template:read:*)
+      - Bash(obsidian template:insert:*)
+      - Bash(obsidian plugins:*)
+      - Bash(obsidian plugin:enable:*)
+      - Bash(obsidian plugin:disable:*)
+      - Bash(obsidian sync:status:*)
+      - Bash(obsidian sync:history:*)
+      - Bash(obsidian sync:read:*)
+      - Bash(obsidian sync:deleted:*)
+      - Bash(obsidian themes:*)
+      - Bash(obsidian theme:set:*)
+      - Bash(obsidian snippets:*)
+      - Bash(obsidian snippet:enable:*)
+      - Bash(obsidian snippet:disable:*)
+      - Bash(obsidian commands:*)
+      - Bash(obsidian command:*)
+      - Bash(obsidian hotkeys:*)
+      - Bash(obsidian hotkey:*)
+      - Bash(obsidian bases:*)
+      - Bash(obsidian base:query:*)
+      - Bash(obsidian base:views:*)
+      - Bash(obsidian history:list:*)
+      - Bash(obsidian history:read:*)
+      - Bash(obsidian workspace:*)
+      - Bash(obsidian tabs:*)
+      - Bash(obsidian tab:open:*)
+      - Bash(obsidian diff:*)
+      - Bash(obsidian vault:*)
+      - Bash(obsidian vaults:*)
+      - Bash(obsidian version:*)
+      - Bash(obsidian outline:*)
+      - Bash(obsidian wordcount:*)
+      - Bash(obsidian recents:*)
+      - Skill(obsidian-cli:*)
+
+# ─── DEPRECATIONS ─────────────────────────────────────────────────────
+# Rules the doctor should rewrite or remove on sweep.
+
+deprecations:
+  - pattern: 'Bash\(/home/[^/]+/\.claude/plugins/cache/Dev10x-Guru/Dev10x/\d+\.\d+\.\d+/'
+    reason: >
+      Version-pinned plugin path with resolved username. Rotted on every
+      `claude plugin update` — the version segment becomes orphan.
+    action: canonicalize
+    canonical_replacement: '~/.claude/plugins/cache/Dev10x-Guru/Dev10x/**/'
+
+  - pattern: 'Bash\(~/\.claude/plugins/cache/Dev10x-Guru/Dev10x/\d+\.\d+\.\d+/'
+    reason: >
+      Version-pinned plugin path. Already uses `~/` but still rots on
+      upgrade because the version segment is hardcoded.
+    action: canonicalize
+    canonical_replacement: '~/.claude/plugins/cache/Dev10x-Guru/Dev10x/**/'
+
+  - pattern: '^Bash\(/tmp/claude/bin/mktmp\.sh:\*\)$'
+    reason: >
+      Legacy mktmp shell helper. Superseded by MCP tool
+      `mcp__plugin_Dev10x_cli__mktmp`.
+    action: remove
+
+# ─── INVARIANTS THE DOCTOR ENFORCES ───────────────────────────────────
+
+invariants:
+  - id: no-resolved-plugin-cache
+    description: >
+      No allow rule may reference a resolved plugin cache path. Use
+      `${CLAUDE_PLUGIN_ROOT}` or `~/.claude/plugins/cache/**/`.
+  - id: no-cross-project-paths
+    description: >
+      No allow rule may reference another project's absolute path
+      (cross-contamination from copy-pasted settings).
+  - id: no-worktree-source-paths
+    description: >
+      When CWD is a worktree, allow rules must not reference the source
+      repository by absolute path — the same files exist inside the
+      worktree at relative paths. Detect via `git rev-parse --git-common-dir`.
+  - id: additional-directories-not-bash
+    description: >
+      Bash allow rules cannot substitute for `additionalDirectories`.
+      When a prompt persists with a matching Bash rule, diagnose path
+      scope first.
+  - id: no-redundant-readonly-builtins
+    description: >
+      Built-in read-only commands (find, grep, ls, cat, head, tail, wc,
+      diff, stat, du, cd) must NOT be added as allow rules — they're
+      redundant and clutter the list.
+
+# ─── DOCTOR CONSUMPTION ───────────────────────────────────────────────
+# How `Dev10x:plugin-maintenance` consumes this catalog:
+#
+# 1. Tier 1 + Tier 2 groups: merged into the active base_permissions
+#    set during `ensure-base`. Missing rules are added.
+# 2. Tier 3 groups: opt-in via `dev10x permission doctor
+#    --enable-group=<name>`. Not added by default.
+# 3. Deprecations:
+#    - `action: canonicalize` → rewrite rule string to
+#      `canonical_replacement`.
+#    - `action: remove` → drop the rule entirely.
+# 4. Invariants: surfaced as warnings during `dev10x permission doctor`;
+#    not auto-applied (require user confirmation).

--- a/skills/permission-investigator/SKILL.md
+++ b/skills/permission-investigator/SKILL.md
@@ -174,6 +174,36 @@ overwrites it.
 Adaptive friction auto-selects the recommended option. Strict
 and guided friction prompt for confirmation.
 
+## additionalDirectories Diagnostic (GH-99)
+
+When a permission prompt persists **despite a matching Bash allow
+rule**, the friction is almost always path scope, not the Bash command.
+The prompt's third option ("Yes, allow reading from `<dir>` from this
+project") is the only UI signal that the issue is
+`additionalDirectories`. Without it, agents keep widening Bash rules
+that have no effect.
+
+Use `dev10x.skills.permission.doctor.diagnose_additional_directories`
+when investigating such cases:
+
+```python
+from dev10x.skills.permission.doctor import diagnose_additional_directories
+
+msg = diagnose_additional_directories(
+    rule="Bash(rg:*)",
+    path_arguments=["/work/other-repo/src/foo.py"],
+    additional_directories=["/work/this-project"],
+)
+# → "Bash rule 'Bash(rg:*)' matched, but path '...' is outside
+#    registered additionalDirectories. Add /work/other-repo to
+#    additionalDirectories in .claude/settings.local.json —
+#    this is a path-scope issue, not a Bash allow-rule issue."
+```
+
+The investigator should surface this diagnosis explicitly in its
+report when a cell remains `PROMPTED` after the rule was applied AND
+the fixture path lies outside `additionalDirectories`.
+
 ## Notes
 
 - **Workdir:** `/tmp/Dev10x/permission-investigator/` — fixtures,

--- a/skills/plugin-maintenance/SKILL.md
+++ b/skills/plugin-maintenance/SKILL.md
@@ -85,6 +85,7 @@ on the mode. Execute these `TaskCreate` calls at startup:
 9. `TaskCreate(subject="Merge worktree permissions", activeForm="Merging worktree perms")`
 10. `TaskCreate(subject="Audit permissions for friction", activeForm="Auditing permissions")`
 11. `TaskCreate(subject="Clean project files", activeForm="Cleaning project files")`
+12. `TaskCreate(subject="Run permission doctor", activeForm="Running doctor sweep")`
 
 Set sequential dependencies. Mark each step `in_progress` when
 starting and `completed` when done. Steps that produce no
@@ -383,6 +384,53 @@ ${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/scripts/clean-project-files.py
 
 **Leaked secret detection:** Rules containing plaintext
 credentials are flagged with warnings so users can rotate them.
+
+### 12. Run permission doctor *(full only)* (GH-99)
+
+Apply the baseline-permissions catalog and detect cross-project /
+worktree↔source-repo contamination. The doctor handles three classes
+of friction not covered by the other steps:
+
+- **Pinned plugin paths** — version-rotted rules like
+  `Bash(/home/u/.claude/plugins/cache/Dev10x-Guru/Dev10x/0.71.0/...)`
+  are rewritten to the version-wildcard form
+  `Bash(~/.claude/plugins/cache/Dev10x-Guru/Dev10x/**/...)` so they
+  survive `claude plugin update`.
+- **Catalog deprecations** — entries from
+  `references/baseline-permissions.yaml` with
+  `action: canonicalize` are rewritten; `action: remove` entries
+  (e.g., legacy `/tmp/claude/bin/mktmp.sh:*`) are dropped.
+- **Cross-contamination** — rules whose absolute paths point outside
+  the current project, or into the source repo when CWD is a worktree,
+  are flagged so the user can remove them.
+
+1. Canonicalize pinned paths (idempotent, safe to re-run):
+
+```bash
+uv run dev10x permission doctor canonicalize --dry-run
+uv run dev10x permission doctor canonicalize
+```
+
+2. Apply catalog deprecations:
+
+```bash
+uv run dev10x permission doctor apply-deprecations --dry-run
+uv run dev10x permission doctor apply-deprecations
+```
+
+3. Scan for cross-contamination (no auto-fix — surfaces findings only):
+
+```bash
+uv run dev10x permission doctor cross-contamination
+```
+
+4. Enable an opt-in Tier 3 group when needed (e.g., `kubernetes-readonly`,
+   `network-diagnostics`, `obsidian-cli`):
+
+```bash
+uv run dev10x permission doctor enable-group kubernetes-readonly --dry-run
+uv run dev10x permission doctor enable-group kubernetes-readonly
+```
 
 ## Configuration
 

--- a/src/dev10x/commands/permission.py
+++ b/src/dev10x/commands/permission.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -741,3 +742,182 @@ def investigate_delta() -> None:
     click.echo("Suggested replacements:")
     for line in delta.suggested_rules or ["  (none — matrix incomplete or all prompt)"]:
         click.echo(f"  * {line}")
+
+
+@permission.group()
+def doctor() -> None:
+    """Diagnose and fix common allow-rule friction patterns (GH-99)."""
+
+
+@doctor.command(name="canonicalize")
+@click.option("--dry-run", is_flag=True, help="Show changes without modifying files")
+@click.option("--quiet", is_flag=True, help="Suppress per-file details")
+def doctor_canonicalize(*, dry_run: bool, quiet: bool) -> None:
+    """Rewrite version-pinned plugin paths to ~/.claude/plugins/cache/**/ form.
+
+    Rules of the form ``Bash(/home/<user>/.claude/plugins/cache/Dev10x-Guru/
+    Dev10x/0.71.0/...)`` rot on every plugin upgrade. This command rewrites
+    them to the version-wildcard form so they survive future updates.
+    """
+    from dev10x.skills.permission import doctor as mod
+    from dev10x.skills.permission import update_paths as paths_mod
+
+    config_path = paths_mod.find_config()
+    config = paths_mod.load_config(config_path)
+    settings_files = paths_mod.find_settings_files(
+        roots=config.get("roots", []),
+        include_user=config.get("include_user_settings", True),
+    )
+    if not settings_files:
+        click.echo("No settings files found.")
+        return
+
+    if dry_run and not quiet:
+        click.echo("(dry run — no files will be modified)\n")
+
+    total_rewrites = 0
+    files_changed = 0
+    for path in sorted(settings_files):
+        result = mod.canonicalize_settings_file(path, dry_run=dry_run)
+        if result.changed:
+            files_changed += 1
+            total_rewrites += result.changed
+            if not quiet:
+                click.echo(f"\n{path} — {result.changed} rewrites")
+                for original, rewritten in result.rewrites:
+                    click.echo(f"  - {original}")
+                    click.echo(f"  + {rewritten}")
+    verb = "Would rewrite" if dry_run else "Rewrote"
+    click.echo(f"\n{verb} {total_rewrites} pinned paths across {files_changed} files.")
+
+
+@doctor.command(name="cross-contamination")
+@click.option(
+    "--cwd", type=click.Path(exists=True), default=None, help="Project root (default: $PWD)"
+)
+@click.option("--quiet", is_flag=True, help="Suppress per-rule details")
+def doctor_cross_contamination(*, cwd: str | None, quiet: bool) -> None:
+    """Flag allow rules whose paths point outside the current project.
+
+    Detects two contamination patterns:
+      1. Foreign-project paths (copy-pasted settings).
+      2. Source-repo paths when CWD is a worktree (use relative paths
+         inside the worktree instead).
+    """
+    from dev10x.skills.permission import doctor as mod
+
+    root = Path(cwd) if cwd else Path.cwd()
+    workspace = mod.detect_workspace(root)
+    settings_path = workspace.project_root / ".claude" / "settings.local.json"
+    if not settings_path.is_file():
+        click.echo(f"No settings file at {settings_path}")
+        return
+    data = json.loads(settings_path.read_text())
+    rules: list[str] = []
+    perms = data.get("permissions", {})
+    for bucket in ("allow", "deny", "ask"):
+        rules.extend(perms.get(bucket, []) or [])
+    findings = mod.detect_cross_contamination(rules, workspace=workspace)
+    if not findings:
+        click.echo(f"{settings_path} — no cross-contamination findings.")
+        return
+    click.echo(f"\n{settings_path} — {len(findings)} findings")
+    for finding in findings:
+        click.echo(f"  ! {finding.rule}")
+        if not quiet:
+            click.echo(f"      reason: {finding.reason}")
+            click.echo(f"      suggestion: {finding.suggestion}")
+
+
+@doctor.command(name="apply-deprecations")
+@click.option("--dry-run", is_flag=True, help="Show changes without modifying files")
+def doctor_apply_deprecations(*, dry_run: bool) -> None:
+    """Apply catalog deprecations (canonicalize / remove) to settings files."""
+    from dev10x.skills.permission import doctor as mod
+    from dev10x.skills.permission import update_paths as paths_mod
+
+    catalog = mod.load_catalog()
+    config_path = paths_mod.find_config()
+    config = paths_mod.load_config(config_path)
+    settings_files = paths_mod.find_settings_files(
+        roots=config.get("roots", []),
+        include_user=config.get("include_user_settings", True),
+    )
+    if not settings_files:
+        click.echo("No settings files found.")
+        return
+
+    if dry_run:
+        click.echo("(dry run — no files will be modified)\n")
+
+    total_actions = 0
+    for path in sorted(settings_files):
+        data = json.loads(path.read_text())
+        perms = data.get("permissions", {})
+        changes_in_file = 0
+        for bucket in ("allow", "deny", "ask"):
+            rules = perms.get(bucket)
+            if not isinstance(rules, list):
+                continue
+            new_rules, outcomes = mod.apply_deprecations(rules, catalog=catalog)
+            if outcomes:
+                changes_in_file += len(outcomes)
+                click.echo(f"\n{path} [{bucket}] — {len(outcomes)} actions")
+                for outcome in outcomes:
+                    if outcome.action == "remove":
+                        click.echo(f"  - REMOVE: {outcome.rule}  # {outcome.reason}")
+                    elif outcome.action == "canonicalize":
+                        click.echo(f"  ~ CANON:  {outcome.rule}")
+                        click.echo(f"           → {outcome.replacement}")
+                    else:
+                        click.echo(f"  ? {outcome.action.upper()}: {outcome.rule}")
+            perms[bucket] = new_rules
+        if changes_in_file and not dry_run:
+            data["permissions"] = perms
+            path.write_text(json.dumps(data, indent=2) + "\n")
+        total_actions += changes_in_file
+    verb = "Would apply" if dry_run else "Applied"
+    click.echo(f"\n{verb} {total_actions} deprecation actions.")
+
+
+@doctor.command(name="enable-group")
+@click.argument("group_name")
+@click.option("--dry-run", is_flag=True, help="Show changes without modifying files")
+def doctor_enable_group(*, group_name: str, dry_run: bool) -> None:
+    """Add a Tier 3 group's rules from the baseline-permissions catalog."""
+    from dev10x.skills.permission import doctor as mod
+    from dev10x.skills.permission import update_paths as paths_mod
+
+    catalog = mod.load_catalog()
+    rules = catalog.group_rules(group_name)
+    if not rules:
+        click.echo(f"ERROR: unknown group {group_name!r}")
+        sys.exit(1)
+    config_path = paths_mod.find_config()
+    config = paths_mod.load_config(config_path)
+    settings_files = paths_mod.find_settings_files(
+        roots=config.get("roots", []),
+        include_user=config.get("include_user_settings", True),
+    )
+    if not settings_files:
+        click.echo("No settings files found.")
+        return
+    if dry_run:
+        click.echo("(dry run — no files will be modified)\n")
+    total_added = 0
+    for path in sorted(settings_files):
+        data = json.loads(path.read_text())
+        perms = data.setdefault("permissions", {})
+        allow = perms.setdefault("allow", [])
+        added_here = [rule for rule in rules if rule not in allow]
+        if not added_here:
+            continue
+        click.echo(f"\n{path} — adding {len(added_here)} rules from {group_name!r}")
+        for rule in added_here:
+            click.echo(f"  + {rule}")
+        if not dry_run:
+            allow.extend(added_here)
+            path.write_text(json.dumps(data, indent=2) + "\n")
+        total_added += len(added_here)
+    verb = "Would add" if dry_run else "Added"
+    click.echo(f"\n{verb} {total_added} rules from group {group_name!r}.")

--- a/src/dev10x/skills/permission/doctor.py
+++ b/src/dev10x/skills/permission/doctor.py
@@ -1,0 +1,416 @@
+"""Permission doctor — diagnose and fix common allow-rule friction (GH-99).
+
+Three concerns this module addresses:
+
+1. **Pinned plugin paths** — rules of the form
+   ``Bash(/home/<user>/.claude/plugins/cache/Dev10x-Guru/Dev10x/0.71.0/...)``
+   rot on every ``claude plugin update`` because the resolved version
+   segment becomes orphan. The fix is to canonicalize them to the
+   version-wildcard form ``Bash(~/.claude/plugins/cache/Dev10x-Guru/Dev10x/**/...)``.
+
+2. **Cross-contamination** — rules referencing another project's
+   absolute path (copy-paste leakage) and, in worktree CWDs, rules
+   referencing the source repo by absolute path when a relative path
+   inside the worktree would work.
+
+3. **Catalog application** — load the baseline-permissions catalog
+   (``references/baseline-permissions.yaml``) and apply deprecation
+   actions (canonicalize / remove) plus invariant checks.
+
+CLI entry points live under ``dev10x permission doctor``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+PLUGIN_NAMES = r"(?:Dev10x|dev10x-claude)"
+
+PINNED_VERSION_RE = re.compile(
+    rf"(?P<prefix>/home/[^/]+/|~/)"
+    rf"\.claude/plugins/cache/(?P<publisher>[^/]+)/(?P<plugin>{PLUGIN_NAMES})/"
+    rf"(?P<version>\d+\.\d+\.\d+)/"
+)
+
+CATALOG_PATH = Path(__file__).resolve().parents[4] / "references" / "baseline-permissions.yaml"
+
+
+def canonicalize_rule(rule: str) -> str | None:
+    """Rewrite a single allow-rule string to canonical form.
+
+    Returns the rewritten rule, or ``None`` when no rewrite applies.
+
+    Rewrites:
+      - ``/home/<user>/.claude/plugins/cache/<pub>/<plugin>/<version>/``
+        → ``~/.claude/plugins/cache/<pub>/<plugin>/**/``
+      - ``~/.claude/plugins/cache/<pub>/<plugin>/<version>/``
+        → ``~/.claude/plugins/cache/<pub>/<plugin>/**/``
+    """
+    match = PINNED_VERSION_RE.search(rule)
+    if match is None:
+        return None
+    canonical = f"~/.claude/plugins/cache/{match['publisher']}/{match['plugin']}/**/"
+    rewritten = rule[: match.start()] + canonical + rule[match.end() :]
+    if rewritten == rule:
+        return None
+    return rewritten
+
+
+@dataclass
+class CanonicalizeResult:
+    rewrites: list[tuple[str, str]] = field(default_factory=list)
+    unchanged: int = 0
+
+    @property
+    def changed(self) -> int:
+        return len(self.rewrites)
+
+
+def canonicalize_rules(rules: Iterable[str]) -> CanonicalizeResult:
+    """Apply ``canonicalize_rule`` across an iterable, deduping the output."""
+    result = CanonicalizeResult()
+    seen: set[str] = set()
+    for rule in rules:
+        rewritten = canonicalize_rule(rule)
+        target = rewritten if rewritten is not None else rule
+        if rewritten is not None:
+            result.rewrites.append((rule, rewritten))
+        else:
+            result.unchanged += 1
+        seen.add(target)
+    return result
+
+
+def canonicalize_settings_file(
+    settings_path: Path,
+    *,
+    dry_run: bool = False,
+) -> CanonicalizeResult:
+    """Rewrite pinned plugin paths in a settings.json file.
+
+    Operates on ``permissions.allow`` and ``permissions.deny`` lists.
+    Dedupes after rewriting — collisions with already-canonical rules
+    collapse silently.
+    """
+    data = json.loads(settings_path.read_text())
+    perms = data.get("permissions", {})
+    result = CanonicalizeResult()
+    for bucket in ("allow", "deny", "ask"):
+        rules = perms.get(bucket)
+        if not isinstance(rules, list):
+            continue
+        new_rules: list[str] = []
+        seen: set[str] = set()
+        for rule in rules:
+            if not isinstance(rule, str):
+                new_rules.append(rule)
+                continue
+            rewritten = canonicalize_rule(rule)
+            final = rewritten if rewritten is not None else rule
+            if rewritten is not None:
+                result.rewrites.append((rule, rewritten))
+            else:
+                result.unchanged += 1
+            if final in seen:
+                continue
+            seen.add(final)
+            new_rules.append(final)
+        perms[bucket] = new_rules
+    if not dry_run and result.changed:
+        data["permissions"] = perms
+        settings_path.write_text(json.dumps(data, indent=2) + "\n")
+    return result
+
+
+@dataclass
+class CrossContaminationFinding:
+    rule: str
+    reason: str
+    suggestion: str
+
+
+@dataclass
+class WorkspaceContext:
+    project_root: Path
+    git_common_dir: Path | None = None
+
+    @property
+    def is_worktree(self) -> bool:
+        if self.git_common_dir is None:
+            return False
+        return self.git_common_dir.resolve().parent != self.project_root.resolve()
+
+    @property
+    def source_repo(self) -> Path | None:
+        if not self.is_worktree or self.git_common_dir is None:
+            return None
+        return self.git_common_dir.resolve().parent
+
+
+def detect_workspace(cwd: Path) -> WorkspaceContext:
+    """Detect project root and (if worktree) source repo via git."""
+    try:
+        toplevel = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return WorkspaceContext(project_root=cwd)
+    try:
+        common_dir = subprocess.run(
+            ["git", "rev-parse", "--git-common-dir"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return WorkspaceContext(project_root=Path(toplevel))
+    common_path = Path(common_dir)
+    if not common_path.is_absolute():
+        common_path = (Path(toplevel) / common_path).resolve()
+    return WorkspaceContext(
+        project_root=Path(toplevel),
+        git_common_dir=common_path,
+    )
+
+
+_ABSOLUTE_PATH_RE = re.compile(r"\((?:[A-Za-z]+:\s*)?(?P<path>/[^):*\s]+)")
+
+
+SYSTEM_PATH_PREFIXES = ("/usr/", "/etc/", "/var/", "/opt/")
+
+
+def _extract_absolute_path(rule: str) -> str | None:
+    """Pull the first absolute filesystem path out of a rule string."""
+    match = _ABSOLUTE_PATH_RE.search(rule)
+    if match is None:
+        return None
+    return match["path"]
+
+
+def _is_system_path(path_str: str) -> bool:
+    """Heuristic: paths under /usr, /etc, /var, /opt are system tooling.
+
+    ``/tmp`` is intentionally excluded — Dev10x uses ``/tmp/Dev10x/...``
+    extensively and pytest fixtures live under ``/tmp/pytest-...``. The
+    caller decides whether to skip /tmp paths after checking project
+    membership.
+    """
+    return path_str.startswith(SYSTEM_PATH_PREFIXES)
+
+
+def detect_cross_contamination(
+    rules: Iterable[str],
+    *,
+    workspace: WorkspaceContext,
+) -> list[CrossContaminationFinding]:
+    """Flag rules whose absolute paths leak across projects or into the source repo."""
+    findings: list[CrossContaminationFinding] = []
+    project_resolved = workspace.project_root.resolve()
+    source_resolved = workspace.source_repo.resolve() if workspace.source_repo else None
+    for rule in rules:
+        if not isinstance(rule, str):
+            continue
+        path_str = _extract_absolute_path(rule)
+        if path_str is None:
+            continue
+        path = Path(path_str)
+        if str(path).startswith(str(Path.home())):
+            continue
+        try:
+            resolved = path.resolve()
+        except OSError:
+            continue
+        if _is_within(resolved, project_resolved):
+            continue
+        if _is_system_path(path_str) and not (
+            source_resolved is not None and _is_within(resolved, source_resolved)
+        ):
+            continue
+        if path_str.startswith("/tmp/") and not (
+            source_resolved is not None and _is_within(resolved, source_resolved)
+        ):
+            continue
+        if source_resolved is not None and _is_within(resolved, source_resolved):
+            findings.append(
+                CrossContaminationFinding(
+                    rule=rule,
+                    reason=(
+                        "Path points into the source repository while CWD is "
+                        "a worktree. The same files exist relative to the "
+                        "worktree — use a relative path instead."
+                    ),
+                    suggestion=(
+                        f"Rewrite to a relative path or remove the rule. Source: {source_resolved}"
+                    ),
+                )
+            )
+            continue
+        findings.append(
+            CrossContaminationFinding(
+                rule=rule,
+                reason=(
+                    "Absolute path is outside this project root — likely "
+                    "copy-pasted from another repo's settings."
+                ),
+                suggestion=(
+                    f"Remove the rule or move it to the owning project. "
+                    f"Project: {project_resolved}"
+                ),
+            )
+        )
+    return findings
+
+
+def _is_within(child: Path, parent: Path) -> bool:
+    try:
+        child.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+@dataclass
+class Catalog:
+    version: int
+    last_audited: str
+    groups: dict[str, dict]
+    deprecations: list[dict]
+    invariants: list[dict]
+
+    def tier_rules(self, *, tiers: Iterable[int]) -> list[str]:
+        tier_set = set(tiers)
+        rules: list[str] = []
+        for group in self.groups.values():
+            if group.get("tier") in tier_set:
+                rules.extend(group.get("rules", []))
+        return rules
+
+    def group_rules(self, name: str) -> list[str]:
+        return list(self.groups.get(name, {}).get("rules", []))
+
+
+def load_catalog(path: Path = CATALOG_PATH) -> Catalog:
+    """Load the baseline-permissions catalog from YAML."""
+    raw = yaml.safe_load(path.read_text())
+    return Catalog(
+        version=int(raw.get("version", 0)),
+        last_audited=str(raw.get("last_audited", "")),
+        groups=raw.get("groups", {}),
+        deprecations=raw.get("deprecations", []),
+        invariants=raw.get("invariants", []),
+    )
+
+
+@dataclass
+class DeprecationOutcome:
+    rule: str
+    action: str
+    replacement: str | None = None
+    reason: str = ""
+
+
+def apply_deprecations(
+    rules: Iterable[str],
+    *,
+    catalog: Catalog,
+) -> tuple[list[str], list[DeprecationOutcome]]:
+    """Apply catalog deprecations to a list of rules.
+
+    Returns the rewritten rule list (with removals dropped) and a list of
+    outcomes describing what changed.
+    """
+    outcomes: list[DeprecationOutcome] = []
+    output: list[str] = []
+    seen: set[str] = set()
+    compiled = [
+        (re.compile(entry["pattern"]), entry)
+        for entry in catalog.deprecations
+        if entry.get("pattern")
+    ]
+    for rule in rules:
+        if not isinstance(rule, str):
+            output.append(rule)
+            continue
+        matched_entry = None
+        for pattern, entry in compiled:
+            if pattern.search(rule):
+                matched_entry = entry
+                break
+        if matched_entry is None:
+            if rule not in seen:
+                output.append(rule)
+                seen.add(rule)
+            continue
+        action = matched_entry.get("action", "remove")
+        reason = matched_entry.get("reason", "")
+        if action == "remove":
+            outcomes.append(DeprecationOutcome(rule=rule, action="remove", reason=reason))
+            continue
+        if action == "canonicalize":
+            replacement = canonicalize_rule(rule) or rule
+            outcomes.append(
+                DeprecationOutcome(
+                    rule=rule,
+                    action="canonicalize",
+                    replacement=replacement,
+                    reason=reason,
+                )
+            )
+            if replacement not in seen:
+                output.append(replacement)
+                seen.add(replacement)
+            continue
+        # Unknown action — keep the rule, flag the outcome.
+        outcomes.append(DeprecationOutcome(rule=rule, action=action, reason=reason))
+        if rule not in seen:
+            output.append(rule)
+            seen.add(rule)
+    return output, outcomes
+
+
+def diagnose_additional_directories(
+    rule: str,
+    *,
+    path_arguments: Iterable[str],
+    additional_directories: Iterable[str],
+) -> str | None:
+    """Return a diagnostic message when a Bash rule is fine but the path is out of scope.
+
+    A persistent prompt despite a matching Bash allow rule almost always
+    indicates the command's path arguments fall outside the registered
+    ``additionalDirectories``. This returns the directory the user should
+    add, or ``None`` when no diagnosis applies.
+
+    The caller is expected to know which Bash rule fired (``rule``), what
+    path arguments the command carried (``path_arguments``), and which
+    directories are currently registered (``additional_directories``).
+    """
+    additional = [Path(d).expanduser().resolve() for d in additional_directories]
+    for arg in path_arguments:
+        try:
+            resolved = Path(arg).expanduser().resolve()
+        except OSError:
+            continue
+        if any(_is_within(resolved, parent) for parent in additional):
+            continue
+        if resolved.exists() or resolved.parent.exists():
+            return (
+                f"Bash rule {rule!r} matched, but path {arg!r} is outside "
+                f"registered additionalDirectories. Add "
+                f"{resolved.parent if resolved.is_file() else resolved} to "
+                f"additionalDirectories in .claude/settings.local.json — "
+                f"this is a path-scope issue, not a Bash allow-rule issue."
+            )
+    return None

--- a/tests/permission/test_doctor.py
+++ b/tests/permission/test_doctor.py
@@ -1,0 +1,234 @@
+"""Tests for dev10x.skills.permission.doctor (GH-99)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+doctor = pytest.importorskip("dev10x.skills.permission.doctor")
+
+
+class TestCanonicalizeRule:
+    def test_rewrites_resolved_username_and_version(self) -> None:
+        rule = (
+            "Bash(/home/janusz/.claude/plugins/cache/Dev10x-Guru/Dev10x/0.71.0"
+            "/skills/foo/scripts/bar.sh:*)"
+        )
+        assert doctor.canonicalize_rule(rule) == (
+            "Bash(~/.claude/plugins/cache/Dev10x-Guru/Dev10x/**/skills/foo/scripts/bar.sh:*)"
+        )
+
+    def test_rewrites_tilde_version(self) -> None:
+        rule = "Bash(~/.claude/plugins/cache/Dev10x-Guru/Dev10x/0.5.0/bin/release.sh:*)"
+        assert doctor.canonicalize_rule(rule) == (
+            "Bash(~/.claude/plugins/cache/Dev10x-Guru/Dev10x/**/bin/release.sh:*)"
+        )
+
+    def test_rewrites_dev10x_claude_plugin_name(self) -> None:
+        rule = "Bash(/home/u/.claude/plugins/cache/Other/dev10x-claude/1.2.3/skills/x/y.sh:*)"
+        assert doctor.canonicalize_rule(rule) == (
+            "Bash(~/.claude/plugins/cache/Other/dev10x-claude/**/skills/x/y.sh:*)"
+        )
+
+    def test_returns_none_when_already_canonical(self) -> None:
+        rule = "Bash(~/.claude/plugins/cache/Dev10x-Guru/Dev10x/**/bin/release.sh:*)"
+        assert doctor.canonicalize_rule(rule) is None
+
+    def test_returns_none_when_unrelated(self) -> None:
+        assert doctor.canonicalize_rule("Bash(git status:*)") is None
+        assert doctor.canonicalize_rule("Read(/tmp/Dev10x/**)") is None
+
+
+class TestCanonicalizeRulesIterable:
+    def test_collects_rewrites(self) -> None:
+        result = doctor.canonicalize_rules(
+            [
+                "Bash(/home/a/.claude/plugins/cache/Dev10x-Guru/Dev10x/0.1.0/x.sh:*)",
+                "Bash(git status:*)",
+                "Bash(~/.claude/plugins/cache/Dev10x-Guru/Dev10x/0.2.0/y.sh:*)",
+            ]
+        )
+        assert result.changed == 2
+        assert result.unchanged == 1
+
+    def test_handles_empty_iterable(self) -> None:
+        result = doctor.canonicalize_rules([])
+        assert result.changed == 0
+        assert result.unchanged == 0
+
+
+class TestCanonicalizeSettingsFile:
+    def test_rewrites_allow_and_deny_blocks(self, tmp_path: Path) -> None:
+        settings = tmp_path / "settings.local.json"
+        settings.write_text(
+            json.dumps(
+                {
+                    "permissions": {
+                        "allow": [
+                            "Bash(/home/u/.claude/plugins/cache/Dev10x-Guru/Dev10x/0.71.0/skills/a.sh:*)",
+                            "Bash(git status:*)",
+                        ],
+                        "deny": [
+                            "Bash(~/.claude/plugins/cache/Dev10x-Guru/Dev10x/0.5.0/dangerous.sh:*)",
+                        ],
+                    }
+                }
+            )
+        )
+        result = doctor.canonicalize_settings_file(settings)
+        assert result.changed == 2
+        data = json.loads(settings.read_text())
+        assert (
+            "Bash(~/.claude/plugins/cache/Dev10x-Guru/Dev10x/**/skills/a.sh:*)"
+            in data["permissions"]["allow"]
+        )
+        assert (
+            "Bash(~/.claude/plugins/cache/Dev10x-Guru/Dev10x/**/dangerous.sh:*)"
+            in data["permissions"]["deny"]
+        )
+
+    def test_dry_run_does_not_write(self, tmp_path: Path) -> None:
+        settings = tmp_path / "settings.local.json"
+        original = {
+            "permissions": {
+                "allow": [
+                    "Bash(/home/u/.claude/plugins/cache/Dev10x-Guru/Dev10x/0.71.0/x.sh:*)",
+                ]
+            }
+        }
+        settings.write_text(json.dumps(original))
+        result = doctor.canonicalize_settings_file(settings, dry_run=True)
+        assert result.changed == 1
+        assert json.loads(settings.read_text()) == original
+
+    def test_dedupes_collisions(self, tmp_path: Path) -> None:
+        settings = tmp_path / "settings.local.json"
+        settings.write_text(
+            json.dumps(
+                {
+                    "permissions": {
+                        "allow": [
+                            "Bash(/home/u/.claude/plugins/cache/Dev10x-Guru/Dev10x/0.71.0/x.sh:*)",
+                            "Bash(~/.claude/plugins/cache/Dev10x-Guru/Dev10x/**/x.sh:*)",
+                        ]
+                    }
+                }
+            )
+        )
+        doctor.canonicalize_settings_file(settings)
+        data = json.loads(settings.read_text())
+        assert data["permissions"]["allow"] == [
+            "Bash(~/.claude/plugins/cache/Dev10x-Guru/Dev10x/**/x.sh:*)"
+        ]
+
+
+class TestCrossContamination:
+    def test_flags_foreign_project_path(self, tmp_path: Path) -> None:
+        project = tmp_path / "my-project"
+        project.mkdir()
+        workspace = doctor.WorkspaceContext(project_root=project)
+        rule = "Bash(/work/other-project/script.sh:*)"
+        findings = doctor.detect_cross_contamination([rule], workspace=workspace)
+        assert len(findings) == 1
+        assert "outside this project root" in findings[0].reason
+
+    def test_flags_source_repo_path_from_worktree(self, tmp_path: Path) -> None:
+        source = tmp_path / "source-repo"
+        source.mkdir()
+        worktree = tmp_path / "wt-1"
+        worktree.mkdir()
+        common = source / ".git"
+        common.mkdir()
+        workspace = doctor.WorkspaceContext(
+            project_root=worktree,
+            git_common_dir=common,
+        )
+        assert workspace.is_worktree
+        rule = f"Bash({source}/script.sh:*)"
+        findings = doctor.detect_cross_contamination([rule], workspace=workspace)
+        assert len(findings) == 1
+        assert "worktree" in findings[0].reason.lower()
+
+    def test_skips_paths_under_project_root(self, tmp_path: Path) -> None:
+        project = tmp_path / "p"
+        project.mkdir()
+        (project / "script.sh").write_text("")
+        workspace = doctor.WorkspaceContext(project_root=project)
+        rule = f"Bash({project}/script.sh:*)"
+        findings = doctor.detect_cross_contamination([rule], workspace=workspace)
+        assert findings == []
+
+    def test_skips_tmp_and_system_paths(self, tmp_path: Path) -> None:
+        project = tmp_path / "p"
+        project.mkdir()
+        workspace = doctor.WorkspaceContext(project_root=project)
+        rules = [
+            "Bash(/tmp/Dev10x/x.sh:*)",
+            "Bash(/usr/bin/jq:*)",
+        ]
+        assert doctor.detect_cross_contamination(rules, workspace=workspace) == []
+
+
+class TestCatalogAndDeprecations:
+    def test_load_catalog_finds_yaml(self) -> None:
+        catalog = doctor.load_catalog()
+        assert catalog.version >= 1
+        assert "git-core" in catalog.groups
+        assert any(d.get("action") == "canonicalize" for d in catalog.deprecations)
+
+    def test_tier_rules_filters_by_tier(self) -> None:
+        catalog = doctor.load_catalog()
+        tier1 = catalog.tier_rules(tiers=[1])
+        assert any("git status" in r for r in tier1)
+        tier3 = catalog.tier_rules(tiers=[3])
+        assert any("kubectl" in r for r in tier3)
+
+    def test_apply_deprecations_canonicalizes(self) -> None:
+        catalog = doctor.load_catalog()
+        rules = [
+            "Bash(/home/u/.claude/plugins/cache/Dev10x-Guru/Dev10x/0.71.0/x.sh:*)",
+        ]
+        new_rules, outcomes = doctor.apply_deprecations(rules, catalog=catalog)
+        assert len(outcomes) == 1
+        assert outcomes[0].action == "canonicalize"
+        assert new_rules == ["Bash(~/.claude/plugins/cache/Dev10x-Guru/Dev10x/**/x.sh:*)"]
+
+    def test_apply_deprecations_removes(self) -> None:
+        catalog = doctor.load_catalog()
+        new_rules, outcomes = doctor.apply_deprecations(
+            ["Bash(/tmp/claude/bin/mktmp.sh:*)"],
+            catalog=catalog,
+        )
+        assert new_rules == []
+        assert outcomes[0].action == "remove"
+
+
+class TestAdditionalDirectoriesDiagnosis:
+    def test_returns_diagnostic_for_out_of_scope_path(self, tmp_path: Path) -> None:
+        in_scope = tmp_path / "in-scope"
+        in_scope.mkdir()
+        out_of_scope = tmp_path / "out"
+        out_of_scope.mkdir()
+        target = out_of_scope / "file.txt"
+        target.write_text("x")
+        msg = doctor.diagnose_additional_directories(
+            "Bash(cat:*)",
+            path_arguments=[str(target)],
+            additional_directories=[str(in_scope)],
+        )
+        assert msg is not None
+        assert "additionalDirectories" in msg
+
+    def test_returns_none_when_path_in_scope(self, tmp_path: Path) -> None:
+        in_scope = tmp_path / "in-scope"
+        in_scope.mkdir()
+        target = in_scope / "file.txt"
+        target.write_text("x")
+        msg = doctor.diagnose_additional_directories(
+            "Bash(cat:*)",
+            path_arguments=[str(target)],
+            additional_directories=[str(in_scope)],
+        )
+        assert msg is None


### PR DESCRIPTION
**When** maintaining a Dev10x install across multiple worktrees and projects after `claude plugin update`, **I want to** rewrite version-pinned plugin paths to a canonical wildcard form, apply a shared baseline-permissions catalog, and detect cross-project contamination, **so** rule rot stops compounding and post-upgrade permission prompts go away without me hand-editing 48 `.claude/settings*.json` files.

## What ships

- **`references/baseline-permissions.yaml`** — 3-tier catalog (universal git/gh/scaffolding, common dev tools, opt-in groups including `kubernetes-readonly`, `network-diagnostics`, `obsidian-cli`) plus regex-based `deprecations:` and enforceable `invariants:`.
- **`src/dev10x/skills/permission/doctor.py`** — `canonicalize_rule` / `canonicalize_settings_file` rewrite `/home/<user>/.../Dev10x/<version>/...` rules to `~/.../Dev10x/**/...` and dedupe collisions; `detect_cross_contamination` (with `git rev-parse --git-common-dir` worktree awareness) flags foreign-project and source-repo paths; `apply_deprecations` executes catalog `canonicalize` / `remove` actions; `diagnose_additional_directories` surfaces path-scope friction when a Bash rule fires but the prompt persists.
- **`dev10x permission doctor`** CLI group: `canonicalize`, `apply-deprecations`, `cross-contamination`, `enable-group <name>` (for opt-in Tier 3 groups).
- **Docs:** `plugin-maintenance` SKILL gains step 12 (doctor sweep); `permission-investigator` SKILL documents the `additionalDirectories` diagnostic.
- **Tests:** 20 cases covering rewrite, dedup, dry-run, cross-contamination (incl. worktree source-repo path), catalog load, deprecation application, and the diagnostic.

## Why this matters

Post-upgrade rule rot was compounding silently — the "always allow" UI writes resolved paths, so each `claude plugin update` orphans ~34/48 settings files in the audited fleet. The catalog is also the single source of truth the doctor diffs against, so future audit runs stop proposing rules that are already covered.

---

[`4ecd7a22`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/111/commits/4ecd7a22cffbbc58941646ed50b5cb5a8e193cf2) ✨ GH-99 Enable permission doctor for plugin-cache hygiene
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/99

---