### PR TITLE
🔒 GH-99 Allow `uv run dev10x` from plugin-maintenance

### DIFF
--- a/skills/plugin-maintenance/SKILL.md
+++ b/skills/plugin-maintenance/SKILL.md
@@ -17,6 +17,7 @@ user-invocable: true
 invocation-name: Dev10x:plugin-maintenance
 allowed-tools:
   - Bash(${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/scripts/:*)
+  - Bash(uv run dev10x:*)
   - mcp__plugin_Dev10x_cli__update_paths
   - Agent(Dev10x:permission-auditor)
   - AskUserQuestion


### PR DESCRIPTION
**When** running `Dev10x:plugin-maintenance` full mode after the GH-99 doctor steps landed (PR #111), **I want** the skill's `allowed-tools` to cover `Bash(uv run dev10x:*)` so step 12 invocations like `uv run dev10x permission doctor canonicalize` execute without a permission prompt every time, **so** the doctor sweep stays unattended in adaptive sessions.

## What changed

- `skills/plugin-maintenance/SKILL.md` adds `- Bash(uv run dev10x:*)` to the `allowed-tools` block, mirroring the entry already present in `skills/permission-investigator/SKILL.md` (which uses the same CLI surface).

## Why this matters

Step 12 of `plugin-maintenance` (added in PR #111) is the new permission-doctor sweep — `canonicalize`, `apply-deprecations`, `cross-contamination`, `enable-group`. Each subcommand is documented as `uv run dev10x permission doctor ...`, but the skill's tool declaration didn't list `Bash(uv run dev10x:*)`. Without it, every doctor invocation surfaces a permission prompt and the unattended sweep stalls.

Addresses post-merge review comment `r3246856249` on #111. The original PR was already merged when the review fired, so this is a follow-up rather than a fixup.

## Verification

- `Dev10x:permission-investigator/SKILL.md` already declares the same entry (line 17), confirming the rule shape.
- Cross-checked against `.claude/rules/skill-patterns.md` item 2 and `reviewer-skill.md` items 8–8f: external Bash tools invoked inside the skill body MUST be declared in `allowed-tools`.

---

[`d849b1a2`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/114/commits/d849b1a292121afab873fcb023ff6611ed726f99) 🔒 GH-99 Allow `uv run dev10x` from plugin-maintenance
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/99

---