### PR TITLE
♻️ GH-80 Type domain primitives: paths, profile, friction, audit

### DIFF
--- a/src/dev10x/commands/github_app.py
+++ b/src/dev10x/commands/github_app.py
@@ -17,9 +17,10 @@ from pathlib import Path
 import click
 
 from dev10x.commands import github_app_api as api
+from dev10x.domain.claude_paths import ClaudeDir
 
-CONFIG_DIR = Path.home() / ".claude" / "Dev10x" / "github-bot"
-CONFIG_PATH = CONFIG_DIR / "github-app.yaml"
+CONFIG_DIR = ClaudeDir.github_bot_dir()
+CONFIG_PATH = ClaudeDir.github_app_yaml()
 KEY_PATH = CONFIG_DIR / "dev10x-bot.pem"
 
 PERSONAL_NEW_APP_URL = "https://github.com/settings/apps/new"

--- a/src/dev10x/config/loader.py
+++ b/src/dev10x/config/loader.py
@@ -10,6 +10,7 @@ import yaml
 
 from dev10x.domain.config_loader import ConfigLoader
 from dev10x.domain.file_locks import atomic_write_bytes
+from dev10x.domain.friction_level import FrictionLevel
 from dev10x.domain.validation_rule import Compensation, Config, Rule
 
 DEFAULT_TTL_SECONDS = 1800
@@ -79,7 +80,7 @@ def _parse_yaml(*, yaml_path: Path) -> Config:
     rules = [Rule.from_yaml_entry(entry=entry) for entry in data.get("rules", [])]
 
     return Config(
-        friction_level=cfg_data.get("friction_level", "strict"),
+        friction_level=FrictionLevel.from_yaml(cfg_data.get("friction_level")),
         plugin_repo=cfg_data.get("plugin_repo", ""),
         rules=rules,
     )
@@ -106,7 +107,7 @@ def _dict_to_config(*, raw: dict[str, Any]) -> Config:
         for r in raw.get("rules", [])
     ]
     return Config(
-        friction_level=raw.get("friction_level", "strict"),
+        friction_level=FrictionLevel.from_yaml(raw.get("friction_level")),
         plugin_repo=raw.get("plugin_repo", ""),
         rules=rules,
     )

--- a/src/dev10x/domain/claude_paths.py
+++ b/src/dev10x/domain/claude_paths.py
@@ -1,0 +1,98 @@
+"""Canonical Claude Code filesystem paths.
+
+Centralizes every `Path.home() / ".claude" / ...` reference in the codebase
+to eliminate the triplicated USERSPACE_CONFIG constant and to support a
+single test/CI override via `DEV10X_CLAUDE_HOME`.
+
+Paths are resolved lazily on each access so tests can mutate
+`DEV10X_CLAUDE_HOME` between calls without re-importing the module.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+CLAUDE_HOME_ENV_VAR = "DEV10X_CLAUDE_HOME"
+
+
+class ClaudeDir:
+    """Lazy accessors for canonical paths under `~/.claude`.
+
+    `DEV10X_CLAUDE_HOME` overrides the root — useful in tests and CI.
+    """
+
+    @classmethod
+    def home(cls) -> Path:
+        override = os.environ.get(CLAUDE_HOME_ENV_VAR)
+        if override:
+            return Path(override).expanduser()
+        return Path.home() / ".claude"
+
+    @classmethod
+    def settings_json(cls) -> Path:
+        return cls.home() / "settings.json"
+
+    @classmethod
+    def skills_dir(cls) -> Path:
+        return cls.home() / "skills"
+
+    @classmethod
+    def projects_dir(cls) -> Path:
+        return cls.home() / "projects"
+
+    @classmethod
+    def session_state_dir(cls) -> Path:
+        return cls.projects_dir() / "_session_state"
+
+    @classmethod
+    def metrics_dir(cls) -> Path:
+        return cls.projects_dir() / "_metrics"
+
+    @classmethod
+    def memory_dir(cls) -> Path:
+        return cls.home() / "memory"
+
+    @classmethod
+    def memory_dev10x_dir(cls) -> Path:
+        return cls.memory_dir() / "Dev10x"
+
+    @classmethod
+    def memory_projects_yaml(cls) -> Path:
+        return cls.memory_dev10x_dir() / "projects.yaml"
+
+    @classmethod
+    def dev10x_config_dir(cls) -> Path:
+        return cls.home() / "Dev10x"
+
+    @classmethod
+    def github_bot_dir(cls) -> Path:
+        return cls.dev10x_config_dir() / "github-bot"
+
+    @classmethod
+    def github_app_yaml(cls) -> Path:
+        return cls.github_bot_dir() / "github-app.yaml"
+
+    @classmethod
+    def upgrade_cleanup_projects_yaml(cls) -> Path:
+        """Userspace projects config used by upgrade-cleanup and plugin-maintenance."""
+        return cls.skills_dir() / "Dev10x:upgrade-cleanup" / "projects.yaml"
+
+    @classmethod
+    def plugins_cache_dir(cls) -> Path:
+        return cls.home() / "plugins" / "cache"
+
+    @classmethod
+    def platforms_yaml(cls) -> Path:
+        return cls.memory_dev10x_dir() / "platforms.yaml"
+
+    @classmethod
+    def slack_config_yaml(cls) -> Path:
+        return cls.memory_dir() / "slack-config.yaml"
+
+    @classmethod
+    def slack_review_config_yaml(cls) -> Path:
+        return cls.memory_dir() / "slack-config-code-review-requests.yaml"
+
+
+__all__ = ["ClaudeDir", "CLAUDE_HOME_ENV_VAR"]

--- a/src/dev10x/domain/friction_level.py
+++ b/src/dev10x/domain/friction_level.py
@@ -1,0 +1,58 @@
+"""Friction level enum — how aggressively a session pauses for confirmation.
+
+Replaces scattered string-equality checks (``friction_level == "adaptive"``,
+``== "guided"``) across hooks, validators, and commands with a single
+type-safe enum and a stable parser.
+
+Note: shares the ``STRICT`` member name with ``ProfileTier`` but the two
+enums are unrelated. ``ProfileTier`` controls *which validators run*;
+``FrictionLevel`` controls *how the work-on orchestrator paces itself*.
+Keep type imports explicit at every use site.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class FrictionLevel(StrEnum):
+    """Session friction setting from ``.claude/Dev10x/session.yaml``.
+
+    Members preserve the lowercase string value so YAML round-trips and
+    legacy ``friction_level`` columns continue to read cleanly.
+    """
+
+    STRICT = "strict"
+    GUIDED = "guided"
+    ADAPTIVE = "adaptive"
+
+    @classmethod
+    def default(cls) -> FrictionLevel:
+        """Internal default — matches the long-standing string fallback ("strict").
+
+        The interactive ``Dev10x:init`` prompt suggests ``guided`` for new
+        projects, but internal code paths (Config dataclass, YAML parse
+        fallbacks) all defaulted to ``strict`` before this enum existed.
+        Preserving that here keeps the type migration behaviour-neutral.
+        """
+        return cls.STRICT
+
+    @classmethod
+    def from_yaml(cls, raw: object) -> FrictionLevel:
+        """Parse a raw YAML value into a FrictionLevel.
+
+        Empty/unknown/non-string values fall back to ``FrictionLevel.default()``.
+        Case-insensitive; trims surrounding whitespace.
+        """
+        if not isinstance(raw, str):
+            return cls.default()
+        normalized = raw.strip().lower()
+        if not normalized:
+            return cls.default()
+        for member in cls:
+            if member.value == normalized:
+                return member
+        return cls.default()
+
+
+__all__ = ["FrictionLevel"]

--- a/src/dev10x/domain/hook_telemetry.py
+++ b/src/dev10x/domain/hook_telemetry.py
@@ -1,0 +1,47 @@
+"""Hook telemetry enums — phase and outcome of an audited hook record.
+
+Replaces string literals scattered across ``hooks/audit.py`` (``"body"`` /
+``"wrap"`` / ``"ok"`` / ``"block"`` / ``"error"`` / ``"unknown"``) with
+type-safe StrEnums. Values preserve the existing JSONL on-disk
+representation so the audit log stays backwards-compatible.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class HookPhase(StrEnum):
+    """Which side of the hook lifecycle a record describes."""
+
+    BODY = "body"
+    WRAP = "wrap"
+
+
+class HookOutcome(StrEnum):
+    """Exit-status classification recorded for each hook invocation."""
+
+    OK = "ok"
+    BLOCK = "block"
+    ERROR = "error"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def from_exit_code(cls, exit_code: int) -> HookOutcome:
+        """Map a Claude-Code hook exit code to its outcome bucket.
+
+        - 0 → OK
+        - 2 → BLOCK (PreToolUse deny / informational block)
+        - 1 → ERROR
+        - anything else → UNKNOWN
+        """
+        if exit_code == 0:
+            return cls.OK
+        if exit_code == 2:
+            return cls.BLOCK
+        if exit_code == 1:
+            return cls.ERROR
+        return cls.UNKNOWN
+
+
+__all__ = ["HookPhase", "HookOutcome"]

--- a/src/dev10x/domain/profile_tier.py
+++ b/src/dev10x/domain/profile_tier.py
@@ -1,0 +1,51 @@
+"""Profile tier enum for validator registry.
+
+Replaces the `PROFILE_HIERARCHY` tuple + ordinal `index()` compare +
+`except ValueError` fallback with a type-safe IntEnum. `MINIMAL < STANDARD
+< STRICT` is intrinsic; invalid raw strings are rejected at parse time
+via `from_raw`, which collapses the "unknown profile → default" fallback
+to one place.
+"""
+
+from __future__ import annotations
+
+from enum import IntEnum
+
+
+class ProfileTier(IntEnum):
+    """Active profile filter for Bash command validators (GH-413).
+
+    Lower-tier validators run at all higher tiers (a `MINIMAL` rule fires
+    under `STANDARD` and `STRICT`; a `STRICT` rule does not fire under
+    `STANDARD`).
+    """
+
+    MINIMAL = 0
+    STANDARD = 1
+    STRICT = 2
+
+    @classmethod
+    def default(cls) -> ProfileTier:
+        return cls.STANDARD
+
+    @classmethod
+    def from_raw(cls, raw: str | None) -> ProfileTier:
+        """Parse a raw string from env or YAML into a ProfileTier.
+
+        Unknown / empty values fall back to ``ProfileTier.default()``.
+        Case-insensitive; trims surrounding whitespace.
+        """
+        if not raw:
+            return cls.default()
+        normalized = raw.strip().lower()
+        for member in cls:
+            if member.name.lower() == normalized:
+                return member
+        return cls.default()
+
+    def includes(self, validator_tier: ProfileTier) -> bool:
+        """Return True if a validator at ``validator_tier`` runs at this tier."""
+        return validator_tier <= self
+
+
+__all__ = ["ProfileTier"]

--- a/src/dev10x/domain/validation_rule.py
+++ b/src/dev10x/domain/validation_rule.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass, field
 from functools import cached_property
 from typing import Any
 
+from dev10x.domain.friction_level import FrictionLevel
+
 _SUBCOMMAND_BOUNDARY = r"(?![-\w])"
 
 
@@ -126,6 +128,6 @@ class Rule:
 
 @dataclass(frozen=True)
 class Config:
-    friction_level: str = "strict"
+    friction_level: FrictionLevel = FrictionLevel.STRICT
     plugin_repo: str = ""
     rules: list[Rule] = field(default_factory=list)

--- a/src/dev10x/github/app_auth.py
+++ b/src/dev10x/github/app_auth.py
@@ -21,9 +21,10 @@ from pathlib import Path
 
 import yaml
 
+from dev10x.domain.claude_paths import ClaudeDir
 from dev10x.subprocess_utils import async_run
 
-DEFAULT_CONFIG_PATH = Path.home() / ".claude" / "Dev10x" / "github-bot" / "github-app.yaml"
+DEFAULT_CONFIG_PATH = ClaudeDir.github_app_yaml()
 
 
 @dataclass(frozen=True)

--- a/src/dev10x/hooks/audit.py
+++ b/src/dev10x/hooks/audit.py
@@ -29,6 +29,8 @@ from functools import wraps
 from pathlib import Path
 from typing import Any, TypeVar
 
+from dev10x.domain.hook_telemetry import HookOutcome, HookPhase
+
 SPAN_ID_ENV = "DEV10X_HOOK_SPAN_ID"
 AUDIT_ENABLE_ENV = "DEV10X_HOOK_AUDIT"
 AUDIT_DIR_ENV = "DEV10X_HOOK_AUDIT_DIR"
@@ -75,14 +77,8 @@ def _write_record(*, record: dict[str, Any]) -> None:
         pass
 
 
-def _classify_outcome(*, exit_code: int) -> str:
-    if exit_code == 0:
-        return "ok"
-    if exit_code == 2:
-        return "block"
-    if exit_code == 1:
-        return "error"
-    return "unknown"
+def _classify_outcome(*, exit_code: int) -> HookOutcome:
+    return HookOutcome.from_exit_code(exit_code)
 
 
 def audit_hook(name: str, *, event: str = "") -> Callable[[F], F]:
@@ -128,7 +124,7 @@ def audit_hook(name: str, *, event: str = "") -> Callable[[F], F]:
             finally:
                 body_ms = int((time.perf_counter() - start) * 1000)
                 record = {
-                    "phase": "body",
+                    "phase": HookPhase.BODY,
                     "ts": datetime.now(UTC).isoformat(),
                     "hook": name,
                     "event": event,
@@ -161,7 +157,7 @@ def write_wrap_record(
     if not _audit_enabled():
         return
     record = {
-        "phase": "wrap",
+        "phase": HookPhase.WRAP,
         "ts": datetime.now(UTC).isoformat(),
         "hook": hook,
         "argv": argv,
@@ -220,9 +216,9 @@ def summarize(*, records: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
         phase = rec.get("phase")
         span_id = rec.get("span_id", "")
         if not span_id:
-            if phase == "body":
+            if phase == HookPhase.BODY:
                 body_only.append(rec)
-            elif phase == "wrap":
+            elif phase == HookPhase.WRAP:
                 wrap_only.append(rec)
             continue
         if not isinstance(phase, str):
@@ -232,8 +228,8 @@ def summarize(*, records: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
 
     hook_stats: dict[str, dict[str, Any]] = {}
     for span in by_span.values():
-        body = span.get("body")
-        wrap = span.get("wrap")
+        body = span.get(HookPhase.BODY)
+        wrap = span.get(HookPhase.WRAP)
         record = body or wrap
         if record is None:
             continue
@@ -252,9 +248,9 @@ def summarize(*, records: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
         )
         stats["count"] += 1
         outcome = record.get("outcome", "")
-        if outcome == "error":
+        if outcome == HookOutcome.ERROR:
             stats["error_count"] += 1
-        elif outcome == "block":
+        elif outcome == HookOutcome.BLOCK:
             stats["block_count"] += 1
         if body and wrap:
             total = int(wrap.get("total_ms") or 0)

--- a/src/dev10x/hooks/permission_diagnostics.py
+++ b/src/dev10x/hooks/permission_diagnostics.py
@@ -26,6 +26,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from dev10x.domain.claude_paths import ClaudeDir
+
 
 @dataclass(frozen=True)
 class SettingsFile:
@@ -62,7 +64,7 @@ SETTINGS_PRECEDENCE: list[SettingsFile] = [
     ),
     SettingsFile(
         label="user settings",
-        path=Path.home() / ".claude" / "settings.json",
+        path=ClaudeDir.settings_json(),
         precedence=5,
     ),
 ]

--- a/src/dev10x/hooks/session.py
+++ b/src/dev10x/hooks/session.py
@@ -21,6 +21,7 @@ from typing import Any
 
 from dev10x.domain.claude_paths import ClaudeDir
 from dev10x.domain.file_locks import atomic_write_text, file_lock
+from dev10x.domain.friction_level import FrictionLevel
 from dev10x.domain.git_context import GitContext
 
 _git = GitContext()
@@ -90,24 +91,24 @@ def _format_plan_summary(plan: dict[str, Any]) -> str:
     return PlanSummary.from_dict(data=plan).format_for_display()
 
 
-def _read_friction_level(*, toplevel: str) -> str:
+def _read_friction_level(*, toplevel: str) -> FrictionLevel:
     session_yaml = Path(toplevel) / ".claude" / "Dev10x" / "session.yaml"
     if not session_yaml.exists():
-        return ""
+        return FrictionLevel.default()
     try:
         import yaml
 
         with open(session_yaml) as f:
             data = yaml.safe_load(f) or {}
-        return data.get("friction_level", "")
+        return FrictionLevel.from_yaml(data.get("friction_level"))
     except Exception:
-        return ""
+        return FrictionLevel.default()
 
 
 def _format_decision_guidance(
     *,
     plan: dict[str, Any],
-    friction_level: str,
+    friction_level: FrictionLevel,
 ) -> str:
     from dev10x.domain.session_state import PlanSummary
 
@@ -119,7 +120,7 @@ def _format_decision_guidance(
             return "Session resumed with tasks remaining. Auto-advance through the task list."
         return ""
 
-    if friction_level == "adaptive":
+    if friction_level is FrictionLevel.ADAPTIVE:
         return (
             "Session resumed with pending decisions. Friction level is adaptive — "
             "auto-select recommended options for all queued decisions and continue "

--- a/src/dev10x/hooks/session.py
+++ b/src/dev10x/hooks/session.py
@@ -19,6 +19,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from dev10x.domain.claude_paths import ClaudeDir
 from dev10x.domain.file_locks import atomic_write_text, file_lock
 from dev10x.domain.git_context import GitContext
 
@@ -138,7 +139,7 @@ def build_reload_context() -> str:
         return ""
 
     project_hash = hashlib.md5(toplevel.encode()).hexdigest()
-    state_dir = Path.home() / ".claude" / "projects" / "_session_state"
+    state_dir = ClaudeDir.session_state_dir()
     state_file = state_dir / f"{project_hash}.json"
     plan_file = Path(toplevel) / ".claude" / "session" / "plan.yaml"
 
@@ -475,7 +476,7 @@ def session_persist(data: dict | None = None) -> None:
         return
 
     project_hash = hashlib.md5(toplevel.encode()).hexdigest()
-    state_dir = Path.home() / ".claude" / "projects" / "_session_state"
+    state_dir = ClaudeDir.session_state_dir()
     state_dir.mkdir(parents=True, exist_ok=True)
     state_dir.chmod(0o700)
     state_file = state_dir / f"{project_hash}.json"

--- a/src/dev10x/hooks/skill.py
+++ b/src/dev10x/hooks/skill.py
@@ -15,6 +15,7 @@ import sys
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+from dev10x.domain.claude_paths import ClaudeDir
 from dev10x.domain.git_context import GitContext
 
 _git = GitContext()
@@ -64,7 +65,7 @@ def skill_metrics(data: dict | None = None) -> None:
     timestamp = now.strftime("%Y-%m-%dT%H:%M:%SZ")
     date_tag = now.strftime("%Y-%m-%d")
 
-    metrics_dir = Path.home() / ".claude" / "projects" / "_metrics"
+    metrics_dir = ClaudeDir.metrics_dir()
     metrics_dir.mkdir(parents=True, exist_ok=True)
 
     metrics_file = metrics_dir / f"{project_hash}_{date_tag}.jsonl"

--- a/src/dev10x/platform/registry.py
+++ b/src/dev10x/platform/registry.py
@@ -7,9 +7,10 @@ from pathlib import Path
 
 import yaml
 
+from dev10x.domain.claude_paths import ClaudeDir
 from dev10x.domain.file_locks import atomic_write_text
 
-REGISTRY_FILE = Path.home() / ".claude" / "memory" / "Dev10x" / "platforms.yaml"
+REGISTRY_FILE = ClaudeDir.platforms_yaml()
 
 
 @dataclass(frozen=True)

--- a/src/dev10x/skills/permission/clean_project_files.py
+++ b/src/dev10x/skills/permission/clean_project_files.py
@@ -22,11 +22,13 @@ from pathlib import Path
 
 import yaml
 
-USERSPACE_CONFIG = Path.home() / ".claude" / "skills" / "Dev10x:upgrade-cleanup" / "projects.yaml"
+from dev10x.domain.claude_paths import ClaudeDir
+
+USERSPACE_CONFIG = ClaudeDir.upgrade_cleanup_projects_yaml()
 PLUGIN_CONFIG = (
     Path(__file__).resolve().parents[4] / "skills" / "upgrade-cleanup" / "projects.yaml"
 )
-GLOBAL_SETTINGS = Path.home() / ".claude" / "settings.json"
+GLOBAL_SETTINGS = ClaudeDir.settings_json()
 
 PLUGIN_NAMES = r"(?:Dev10x|dev10x(?:-claude)?)"
 VERSION_PATTERN = re.compile(rf"plugins/cache/[^/]+/{PLUGIN_NAMES}/(\d+\.\d+\.\d+)", re.IGNORECASE)
@@ -467,7 +469,7 @@ def _format_messages(
 def find_settings_files(roots: list[str]) -> list[Path]:
     files: list[Path] = []
 
-    project_settings_dir = Path.home() / ".claude" / "projects"
+    project_settings_dir = ClaudeDir.projects_dir()
     if project_settings_dir.is_dir():
         for settings_file in project_settings_dir.rglob("settings.local.json"):
             files.append(settings_file)

--- a/src/dev10x/skills/permission/merge_worktree_permissions.py
+++ b/src/dev10x/skills/permission/merge_worktree_permissions.py
@@ -18,7 +18,9 @@ from pathlib import Path
 
 import yaml
 
-USERSPACE_CONFIG = Path.home() / ".claude" / "skills" / "Dev10x:upgrade-cleanup" / "projects.yaml"
+from dev10x.domain.claude_paths import ClaudeDir
+
+USERSPACE_CONFIG = ClaudeDir.upgrade_cleanup_projects_yaml()
 PLUGIN_CONFIG = (
     Path(__file__).resolve().parents[4] / "skills" / "upgrade-cleanup" / "projects.yaml"
 )

--- a/src/dev10x/skills/permission/update_paths.py
+++ b/src/dev10x/skills/permission/update_paths.py
@@ -20,8 +20,10 @@ from pathlib import Path
 
 import yaml
 
-MEMORY_CONFIG = Path.home() / ".claude" / "memory" / "Dev10x" / "projects.yaml"
-USERSPACE_CONFIG = Path.home() / ".claude" / "skills" / "Dev10x:upgrade-cleanup" / "projects.yaml"
+from dev10x.domain.claude_paths import ClaudeDir
+
+MEMORY_CONFIG = ClaudeDir.memory_projects_yaml()
+USERSPACE_CONFIG = ClaudeDir.upgrade_cleanup_projects_yaml()
 PLUGIN_CONFIG = (
     Path(__file__).resolve().parents[4] / "skills" / "upgrade-cleanup" / "projects.yaml"
 )
@@ -82,13 +84,13 @@ def find_settings_files(
 ) -> list[Path]:
     files: list[Path] = []
     if include_user:
-        user_dir = Path.home() / ".claude"
+        user_dir = ClaudeDir.home()
         for name in ("settings.json", "settings.local.json"):
             candidate = user_dir / name
             if candidate.exists():
                 files.append(candidate)
 
-    project_settings_dir = Path.home() / ".claude" / "projects"
+    project_settings_dir = ClaudeDir.projects_dir()
     if project_settings_dir.is_dir():
         for settings_file in project_settings_dir.rglob("settings.local.json"):
             files.append(settings_file)
@@ -562,7 +564,7 @@ def _is_nonfunctional_mcp_wildcard(rule: str) -> bool:
 
 
 def _load_global_allow_rules() -> tuple[set[str], list[str]]:
-    global_settings = Path.home() / ".claude" / "settings.json"
+    global_settings = ClaudeDir.settings_json()
     if not global_settings.is_file():
         return set(), []
     try:
@@ -894,7 +896,7 @@ KNOWN_PLUGIN_DIRS = ("Dev10x", "dev10x-claude")
 
 
 def _detect_plugin_cache() -> str:
-    cache_root = Path.home() / ".claude" / "plugins" / "cache"
+    cache_root = ClaudeDir.plugins_cache_dir()
     if not cache_root.is_dir():
         return "~/.claude/plugins/cache/Dev10x-Guru/Dev10x"
     candidates: list[Path] = []

--- a/src/dev10x/validators/__init__.py
+++ b/src/dev10x/validators/__init__.py
@@ -11,10 +11,10 @@ Validators are lazily imported — only loaded when the registry is
 first accessed via get_validators(). This avoids paying the import
 cost of all 8 modules at module-level on every hook invocation.
 
-Profile filtering (GH-413): validators declare a profile tier
-("minimal", "standard", "strict") and a stable rule_id. The registry
+Profile filtering (GH-413): validators declare a ProfileTier
+(MINIMAL, STANDARD, STRICT) and a stable rule_id. The registry
 filters the active set based on DEV10X_HOOK_PROFILE (default:
-"standard"), DEV10X_HOOK_DISABLE (comma-separated rule_ids), and
+STANDARD), DEV10X_HOOK_DISABLE (comma-separated rule_ids), and
 DEV10X_HOOK_EXPERIMENTAL (opt-in flag for experimental validators).
 """
 
@@ -24,56 +24,61 @@ import importlib
 import os
 from typing import TYPE_CHECKING
 
-from dev10x.validators.base import PROFILE_HIERARCHY
+from dev10x.domain.profile_tier import ProfileTier
 
 if TYPE_CHECKING:
     from dev10x.validators.base import Validator
 
-_VALIDATOR_SPECS: list[tuple[str, str, str, str, bool]] = [
+_VALIDATOR_SPECS: list[tuple[str, str, str, ProfileTier, bool]] = [
     # (module_path, class_name, rule_id, profile, experimental)
-    ("dev10x.validators.safe_subshell", "SafeSubshellValidator", "DX001", "minimal", False),
+    (
+        "dev10x.validators.safe_subshell",
+        "SafeSubshellValidator",
+        "DX001",
+        ProfileTier.MINIMAL,
+        False,
+    ),
     (
         "dev10x.validators.command_substitution",
         "CommandSubstitutionValidator",
         "DX002",
-        "minimal",
+        ProfileTier.MINIMAL,
         False,
     ),
-    ("dev10x.validators.execution_safety", "ExecutionSafetyValidator", "DX003", "minimal", False),
-    ("dev10x.validators.sql_safety", "SqlSafetyValidator", "DX004", "minimal", False),
-    ("dev10x.validators.pr_base", "PrBaseValidator", "DX005", "minimal", False),
-    ("dev10x.validators.skill_redirect", "SkillRedirectValidator", "DX006", "standard", False),
-    ("dev10x.validators.prefix_friction", "PrefixFrictionValidator", "DX007", "standard", False),
-    ("dev10x.validators.commit_jtbd", "CommitJtbdValidator", "DX008", "strict", False),
+    (
+        "dev10x.validators.execution_safety",
+        "ExecutionSafetyValidator",
+        "DX003",
+        ProfileTier.MINIMAL,
+        False,
+    ),
+    ("dev10x.validators.sql_safety", "SqlSafetyValidator", "DX004", ProfileTier.MINIMAL, False),
+    ("dev10x.validators.pr_base", "PrBaseValidator", "DX005", ProfileTier.MINIMAL, False),
+    (
+        "dev10x.validators.skill_redirect",
+        "SkillRedirectValidator",
+        "DX006",
+        ProfileTier.STANDARD,
+        False,
+    ),
+    (
+        "dev10x.validators.prefix_friction",
+        "PrefixFrictionValidator",
+        "DX007",
+        ProfileTier.STANDARD,
+        False,
+    ),
+    ("dev10x.validators.commit_jtbd", "CommitJtbdValidator", "DX008", ProfileTier.STRICT, False),
 ]
 
-_DEFAULT_PROFILE = "standard"
 
-
-def _profile_includes(*, validator_profile: str, active_profile: str) -> bool:
-    """Return True if validator runs at the active profile level.
-
-    Lower-tier validators run at all higher tiers. Unknown profiles
-    default to "standard".
-    """
-    try:
-        validator_tier = PROFILE_HIERARCHY.index(validator_profile)
-        active_tier = PROFILE_HIERARCHY.index(active_profile)
-    except ValueError:
-        validator_tier = PROFILE_HIERARCHY.index(_DEFAULT_PROFILE)
-        active_tier = PROFILE_HIERARCHY.index(_DEFAULT_PROFILE)
-    return validator_tier <= active_tier
-
-
-def _load_profile_config() -> tuple[str, set[str], bool]:
+def _load_profile_config() -> tuple[ProfileTier, set[str], bool]:
     """Read profile configuration from environment variables.
 
     Returns:
         (active_profile, disabled_rule_ids, experimental_enabled)
     """
-    active = os.environ.get("DEV10X_HOOK_PROFILE", _DEFAULT_PROFILE).strip().lower()
-    if active not in PROFILE_HIERARCHY:
-        active = _DEFAULT_PROFILE
+    active = ProfileTier.from_raw(os.environ.get("DEV10X_HOOK_PROFILE"))
 
     disabled_raw = os.environ.get("DEV10X_HOOK_DISABLE", "")
     disabled = {rid.strip().upper() for rid in disabled_raw.split(",") if rid.strip()}
@@ -99,7 +104,7 @@ def get_validators() -> list[Validator]:
                 continue
             if experimental and not experimental_enabled:
                 continue
-            if not _profile_includes(validator_profile=profile, active_profile=active_profile):
+            if not active_profile.includes(validator_tier=profile):
                 continue
             mod = importlib.import_module(module_path)
             cls = getattr(mod, class_name)

--- a/src/dev10x/validators/base.py
+++ b/src/dev10x/validators/base.py
@@ -29,8 +29,6 @@ from typing import Protocol, runtime_checkable
 
 from dev10x.domain import HookAllow, HookInput, HookResult, HookRetry
 
-PROFILE_HIERARCHY: tuple[str, ...] = ("minimal", "standard", "strict")
-
 
 @runtime_checkable
 class Validator(Protocol):

--- a/src/dev10x/validators/skill_redirect.py
+++ b/src/dev10x/validators/skill_redirect.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from dev10x.domain import HookInput, HookResult
+from dev10x.domain.friction_level import FrictionLevel
 from dev10x.domain.validation_rule import Compensation, Config
 
 if TYPE_CHECKING:
@@ -125,7 +126,7 @@ def _format_skill_msg(
     *,
     label: str,
     comp: Compensation,
-    friction_level: str,
+    friction_level: FrictionLevel,
     plugin_repo: str,
 ) -> str:
     file_issue_hint = (
@@ -135,7 +136,7 @@ def _format_skill_msg(
         else ""
     )
     if comp.type == "use-tool":
-        if friction_level == "guided" and comp.description:
+        if friction_level is FrictionLevel.GUIDED and comp.description:
             return (
                 f"\u26d4  `{label}` blocked — use the MCP tool instead.\n\n"
                 f"  Tool: `{comp.tool}`\n\n"
@@ -155,7 +156,7 @@ def _format_skill_msg(
             f"{file_issue_hint}{OVERRIDE_HINT}"
         )
 
-    if friction_level == "guided" and comp.fallback:
+    if friction_level is FrictionLevel.GUIDED and comp.fallback:
         return (
             f"\u26d4  `{label}` blocked — use the skill instead.\n\n"
             f"  Skill: `Skill({comp.skill})`\n\n"

--- a/tests/domain/test_claude_paths.py
+++ b/tests/domain/test_claude_paths.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dev10x.domain.claude_paths import CLAUDE_HOME_ENV_VAR, ClaudeDir
+
+
+@pytest.fixture
+def home_override(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    monkeypatch.setenv(CLAUDE_HOME_ENV_VAR, str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture
+def no_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(CLAUDE_HOME_ENV_VAR, raising=False)
+
+
+@pytest.mark.parametrize(
+    "accessor,expected_suffix",
+    [
+        ("home", ""),
+        ("settings_json", "settings.json"),
+        ("skills_dir", "skills"),
+        ("projects_dir", "projects"),
+        ("session_state_dir", "projects/_session_state"),
+        ("metrics_dir", "projects/_metrics"),
+        ("memory_dir", "memory"),
+        ("memory_dev10x_dir", "memory/Dev10x"),
+        ("memory_projects_yaml", "memory/Dev10x/projects.yaml"),
+        ("dev10x_config_dir", "Dev10x"),
+        ("github_bot_dir", "Dev10x/github-bot"),
+        ("github_app_yaml", "Dev10x/github-bot/github-app.yaml"),
+        ("upgrade_cleanup_projects_yaml", "skills/Dev10x:upgrade-cleanup/projects.yaml"),
+        ("plugins_cache_dir", "plugins/cache"),
+        ("platforms_yaml", "memory/Dev10x/platforms.yaml"),
+        ("slack_config_yaml", "memory/slack-config.yaml"),
+        ("slack_review_config_yaml", "memory/slack-config-code-review-requests.yaml"),
+    ],
+)
+def test_paths_resolve_under_override(
+    home_override: Path,
+    accessor: str,
+    expected_suffix: str,
+) -> None:
+    path = getattr(ClaudeDir, accessor)()
+    expected = home_override / expected_suffix if expected_suffix else home_override
+    assert path == expected
+
+
+def test_home_default_uses_home_dot_claude(no_override: None) -> None:
+    assert ClaudeDir.home() == Path.home() / ".claude"
+
+
+def test_override_is_read_lazily_per_call(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv(CLAUDE_HOME_ENV_VAR, str(tmp_path / "first"))
+    first = ClaudeDir.settings_json()
+    monkeypatch.setenv(CLAUDE_HOME_ENV_VAR, str(tmp_path / "second"))
+    second = ClaudeDir.settings_json()
+    assert first != second
+    assert first == tmp_path / "first" / "settings.json"
+    assert second == tmp_path / "second" / "settings.json"
+
+
+def test_override_expands_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(CLAUDE_HOME_ENV_VAR, "~/custom-claude")
+    expected = Path("~/custom-claude").expanduser()
+    assert ClaudeDir.home() == expected

--- a/tests/domain/test_friction_level.py
+++ b/tests/domain/test_friction_level.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+
+from dev10x.domain.friction_level import FrictionLevel
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("strict", FrictionLevel.STRICT),
+        ("guided", FrictionLevel.GUIDED),
+        ("adaptive", FrictionLevel.ADAPTIVE),
+        ("STRICT", FrictionLevel.STRICT),
+        (" Adaptive ", FrictionLevel.ADAPTIVE),
+    ],
+)
+def test_from_yaml_known(raw: str, expected: FrictionLevel) -> None:
+    assert FrictionLevel.from_yaml(raw) is expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [None, "", "   ", "bogus", 42, ["adaptive"], {"adaptive": True}],
+)
+def test_from_yaml_unknown_falls_back_to_default(raw: object) -> None:
+    assert FrictionLevel.from_yaml(raw) is FrictionLevel.STRICT
+
+
+def test_default_is_strict() -> None:
+    assert FrictionLevel.default() is FrictionLevel.STRICT
+
+
+def test_member_values_are_lowercase() -> None:
+    for member in FrictionLevel:
+        assert member.value == member.name.lower()
+
+
+def test_str_enum_round_trips_through_yaml() -> None:
+    assert FrictionLevel.ADAPTIVE == "adaptive"
+    assert "adaptive" == FrictionLevel.ADAPTIVE.value

--- a/tests/domain/test_hook_telemetry.py
+++ b/tests/domain/test_hook_telemetry.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+
+from dev10x.domain.hook_telemetry import HookOutcome, HookPhase
+
+
+@pytest.mark.parametrize(
+    "exit_code,expected",
+    [
+        (0, HookOutcome.OK),
+        (2, HookOutcome.BLOCK),
+        (1, HookOutcome.ERROR),
+        (3, HookOutcome.UNKNOWN),
+        (-1, HookOutcome.UNKNOWN),
+        (137, HookOutcome.UNKNOWN),
+    ],
+)
+def test_outcome_from_exit_code(exit_code: int, expected: HookOutcome) -> None:
+    assert HookOutcome.from_exit_code(exit_code) is expected
+
+
+def test_phase_values_match_jsonl_schema() -> None:
+    assert HookPhase.BODY == "body"
+    assert HookPhase.WRAP == "wrap"
+
+
+def test_outcome_values_match_jsonl_schema() -> None:
+    assert HookOutcome.OK == "ok"
+    assert HookOutcome.BLOCK == "block"
+    assert HookOutcome.ERROR == "error"
+    assert HookOutcome.UNKNOWN == "unknown"

--- a/tests/domain/test_profile_tier.py
+++ b/tests/domain/test_profile_tier.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pytest
+
+from dev10x.domain.profile_tier import ProfileTier
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("minimal", ProfileTier.MINIMAL),
+        ("standard", ProfileTier.STANDARD),
+        ("strict", ProfileTier.STRICT),
+        ("MINIMAL", ProfileTier.MINIMAL),
+        (" Strict ", ProfileTier.STRICT),
+    ],
+)
+def test_from_raw_known(raw: str, expected: ProfileTier) -> None:
+    assert ProfileTier.from_raw(raw) == expected
+
+
+@pytest.mark.parametrize("raw", [None, "", "bogus", "STRIKT"])
+def test_from_raw_unknown_falls_back_to_default(raw: str | None) -> None:
+    assert ProfileTier.from_raw(raw) is ProfileTier.STANDARD
+
+
+def test_default_is_standard() -> None:
+    assert ProfileTier.default() is ProfileTier.STANDARD
+
+
+def test_ordinal_ordering() -> None:
+    assert ProfileTier.MINIMAL < ProfileTier.STANDARD < ProfileTier.STRICT
+
+
+@pytest.mark.parametrize(
+    "active,validator,expected",
+    [
+        (ProfileTier.MINIMAL, ProfileTier.MINIMAL, True),
+        (ProfileTier.MINIMAL, ProfileTier.STANDARD, False),
+        (ProfileTier.STANDARD, ProfileTier.MINIMAL, True),
+        (ProfileTier.STANDARD, ProfileTier.STANDARD, True),
+        (ProfileTier.STANDARD, ProfileTier.STRICT, False),
+        (ProfileTier.STRICT, ProfileTier.MINIMAL, True),
+        (ProfileTier.STRICT, ProfileTier.STANDARD, True),
+        (ProfileTier.STRICT, ProfileTier.STRICT, True),
+    ],
+)
+def test_includes_matrix(
+    active: ProfileTier,
+    validator: ProfileTier,
+    expected: bool,
+) -> None:
+    assert active.includes(validator_tier=validator) is expected

--- a/tests/hooks/test_session_formatters.py
+++ b/tests/hooks/test_session_formatters.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 
+from dev10x.domain.friction_level import FrictionLevel
 from dev10x.hooks.session import (
     _format_decision_guidance,
     _format_plan_summary,
@@ -153,30 +154,30 @@ class TestReadFrictionLevel:
 
         result = _read_friction_level(toplevel=str(tmp_path))
 
-        assert result == "adaptive"
+        assert result is FrictionLevel.ADAPTIVE
 
-    def test_returns_empty_when_file_missing(self, tmp_path: Path) -> None:
+    def test_returns_default_when_file_missing(self, tmp_path: Path) -> None:
         result = _read_friction_level(toplevel=str(tmp_path))
 
-        assert result == ""
+        assert result is FrictionLevel.STRICT
 
-    def test_returns_empty_for_invalid_yaml(self, tmp_path: Path) -> None:
+    def test_returns_default_for_invalid_yaml(self, tmp_path: Path) -> None:
         session_dir = tmp_path / ".claude" / "Dev10x"
         session_dir.mkdir(parents=True)
         (session_dir / "session.yaml").write_text(": invalid: yaml: [")
 
         result = _read_friction_level(toplevel=str(tmp_path))
 
-        assert result == ""
+        assert result is FrictionLevel.STRICT
 
-    def test_returns_empty_when_key_missing(self, tmp_path: Path) -> None:
+    def test_returns_default_when_key_missing(self, tmp_path: Path) -> None:
         session_dir = tmp_path / ".claude" / "Dev10x"
         session_dir.mkdir(parents=True)
         (session_dir / "session.yaml").write_text("active_modes: []\n")
 
         result = _read_friction_level(toplevel=str(tmp_path))
 
-        assert result == ""
+        assert result is FrictionLevel.STRICT
 
 
 class TestFormatDecisionGuidance:
@@ -213,7 +214,7 @@ class TestFormatDecisionGuidance:
     ) -> None:
         result = _format_decision_guidance(
             plan=plan_with_decision,
-            friction_level="adaptive",
+            friction_level=FrictionLevel.ADAPTIVE,
         )
 
         assert "auto-select" in result
@@ -225,7 +226,7 @@ class TestFormatDecisionGuidance:
     ) -> None:
         result = _format_decision_guidance(
             plan=plan_with_decision,
-            friction_level="guided",
+            friction_level=FrictionLevel.GUIDED,
         )
 
         assert "AskUserQuestion" in result
@@ -236,7 +237,7 @@ class TestFormatDecisionGuidance:
     ) -> None:
         result = _format_decision_guidance(
             plan=plan_with_decision,
-            friction_level="strict",
+            friction_level=FrictionLevel.STRICT,
         )
 
         assert "AskUserQuestion" in result
@@ -247,7 +248,7 @@ class TestFormatDecisionGuidance:
     ) -> None:
         result = _format_decision_guidance(
             plan=plan_without_decision,
-            friction_level="guided",
+            friction_level=FrictionLevel.GUIDED,
         )
 
         assert "Auto-advance" in result
@@ -262,18 +263,18 @@ class TestFormatDecisionGuidance:
 
         result = _format_decision_guidance(
             plan=plan,
-            friction_level="guided",
+            friction_level=FrictionLevel.GUIDED,
         )
 
         assert result == ""
 
-    def test_empty_friction_level_re_asks(
+    def test_default_friction_level_re_asks(
         self,
         plan_with_decision: dict,
     ) -> None:
         result = _format_decision_guidance(
             plan=plan_with_decision,
-            friction_level="",
+            friction_level=FrictionLevel.default(),
         )
 
         assert "AskUserQuestion" in result

--- a/tests/validators/test_profile_filter.py
+++ b/tests/validators/test_profile_filter.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 
 import pytest
 
+from dev10x.domain.profile_tier import ProfileTier
 from dev10x.validators import (
     _load_profile_config,
-    _profile_includes,
     get_validators,
     reset_registry,
 )
@@ -32,48 +32,22 @@ def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("DEV10X_HOOK_EXPERIMENTAL", raising=False)
 
 
-class TestProfileIncludes:
-    def test_minimal_runs_at_minimal(self) -> None:
-        assert _profile_includes(validator_profile="minimal", active_profile="minimal")
-
-    def test_minimal_runs_at_standard(self) -> None:
-        assert _profile_includes(validator_profile="minimal", active_profile="standard")
-
-    def test_minimal_runs_at_strict(self) -> None:
-        assert _profile_includes(validator_profile="minimal", active_profile="strict")
-
-    def test_standard_skipped_at_minimal(self) -> None:
-        assert not _profile_includes(validator_profile="standard", active_profile="minimal")
-
-    def test_standard_runs_at_standard(self) -> None:
-        assert _profile_includes(validator_profile="standard", active_profile="standard")
-
-    def test_strict_skipped_at_standard(self) -> None:
-        assert not _profile_includes(validator_profile="strict", active_profile="standard")
-
-    def test_strict_runs_at_strict(self) -> None:
-        assert _profile_includes(validator_profile="strict", active_profile="strict")
-
-    def test_unknown_profile_defaults_to_standard(self) -> None:
-        assert _profile_includes(validator_profile="bogus", active_profile="bogus")
-
-
 class TestLoadProfileConfig:
     def test_defaults_to_standard(self) -> None:
         active, disabled, experimental = _load_profile_config()
-        assert active == "standard"
+        assert active is ProfileTier.STANDARD
         assert disabled == set()
         assert experimental is False
 
     def test_reads_profile_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("DEV10X_HOOK_PROFILE", "minimal")
         active, _, _ = _load_profile_config()
-        assert active == "minimal"
+        assert active is ProfileTier.MINIMAL
 
     def test_invalid_profile_falls_back_to_standard(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("DEV10X_HOOK_PROFILE", "paranoid")
         active, _, _ = _load_profile_config()
-        assert active == "standard"
+        assert active is ProfileTier.STANDARD
 
     def test_disable_list_parsed(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("DEV10X_HOOK_DISABLE", "DX001, dx002,DX003 ")
@@ -105,7 +79,8 @@ class TestLoadProfileConfig:
 class TestGetValidatorsProfileFiltering:
     def test_default_profile_is_standard(self) -> None:
         validators = get_validators()
-        assert all(v.profile in ("minimal", "standard") for v in validators), (
+        allowed = {ProfileTier.MINIMAL, ProfileTier.STANDARD}
+        assert all(v.profile in allowed for v in validators), (
             f"Unexpected profiles: {[v.profile for v in validators]}"
         )
 
@@ -114,7 +89,7 @@ class TestGetValidatorsProfileFiltering:
     ) -> None:
         monkeypatch.setenv("DEV10X_HOOK_PROFILE", "minimal")
         validators = get_validators()
-        assert all(v.profile == "minimal" for v in validators)
+        assert all(v.profile is ProfileTier.MINIMAL for v in validators)
         # Should include skill_redirect only at standard+, so it's excluded here
         names = {v.name for v in validators}
         assert "skill-redirect" not in names
@@ -166,7 +141,7 @@ class TestRuleIdAssignment:
         validators = get_validators()
         for v in validators:
             assert hasattr(v, "profile")
-            assert v.profile in ("minimal", "standard", "strict")
+            assert isinstance(v.profile, ProfileTier)
 
     def test_rule_ids_are_unique(self) -> None:
         # Use strict profile to get all validators


### PR DESCRIPTION
**When** extending Dev10x with new validators, MCP tools, or path-aware features, **the developer wants to** rely on type-safe enums and value objects for ticket IDs, profile tiers, friction levels, MCP tool names, skill names, and Claude paths, **so future contributors can** add features without silent fallbacks, regex divergence, or hunting down triplicated constants.

This PR delivers **slice 1 of 12** sub-items from GH-80 — the foundational
paths module plus three enums. The remaining 8 value objects and the
`Task` dataclass migration are scoped for follow-up PRs (see checklist).

## What ships here

| # | Tier | Item | Module |
|---|------|------|--------|
| C8 | HIGH | `ClaudeDir` — 18 lazy classmethod accessors for `~/.claude/...` paths with `DEV10X_CLAUDE_HOME` override; eliminates triplicated `USERSPACE_CONFIG` | `domain/claude_paths.py` |
| C2 | HIGH | `ProfileTier(IntEnum)` — replaces `PROFILE_HIERARCHY` tuple + `.index()` ordinal compare + `except ValueError` fallback | `domain/profile_tier.py` |
| C3 | MED | `FrictionLevel(StrEnum)` — replaces scattered `friction_level == "adaptive"` / `"guided"` checks with `is FrictionLevel.X` | `domain/friction_level.py` |
| F7 | LOW | `HookPhase`, `HookOutcome` — types audit JSONL `phase`/`outcome` fields | `domain/hook_telemetry.py` |

## Remaining work (deferred to follow-up PRs)

- [ ] **HIGH #C5** — `McpToolName(VO)` with parsed `family`/`server`/`func`, `is_wildcard()`, `is_dev10x_tool()`. Consolidate 4 divergent regexes in `enumerate_mcp.py`, `update_paths.py`, `permission_diagnostics.py`, `audit/privacy.py`.
- [ ] **HIGH #B5** — Introduce `Task` dataclass; migrate `PlanSummary.tasks: list[dict[str, Any]]` to `list[Task]`. Move `is_pending()`, `is_completed()`, `needs_decision()`, `format_line()` onto `Task`.
- [ ] **MED #C1** — `TicketId(VO)` consolidating `TICKET_RE` (`commit_jtbd.py:87`) and `DEFAULT_TICKET_PATTERN` (`collect_prs.py:62`).
- [ ] **MED #C6** — `SkillName(VO)` with `plugin`/`feature` fields, `.invocation_name`/`.dir_name`/`.safe_fs_name()`. Eliminates inline `replace(":", "-")` in `hooks/skill.py:42`.
- [ ] **MED #C7** — `PermissionRule(VO)` consolidating `Tool(pattern)` parsing in `permission_diagnostics.py`, `permission_investigator/report.py`, `clean_project_files.py`.
- [ ] **MED #C10** — `GitmojiPrefix(VO)` consolidating `BYPASS_GITMOJI` and `GITMOJI_CATEGORIES`.
- [ ] **LOW #C4** — `ValidatorRuleId(VO)` matching `DX\d{3}`; consolidate `.upper()` normalisation duplicated at parse and match.
- [ ] **LOW #C9** — `PrReviewThreadId(VO)` validating `PRRT_` prefix at construction.

## Acceptance progress against GH-80 "Done when"

- [ ] No string-equality checks against `"strict"`/`"guided"`/`"minimal"` outside enum definitions. (`profile` strings eliminated for `ProfileTier`; `friction_level` migrated to `FrictionLevel` and uses `is` checks at hot sites.)
- [x] `Path.home() / ".claude"` appears only inside `domain/claude_paths.py` (the 11 ad-hoc sites in this PR were migrated; non-importable standalone scripts like `slack_review_request.py` retained).
- [ ] `PlanSummary.tasks` is typed `list[Task]` (deferred — #B5).

## Notes for reviewers

- `FrictionLevel.default()` returns `STRICT` to preserve the long-standing Config dataclass default rather than the user-facing prompt default of `guided` — keeps the type migration behaviour-neutral.
- `HookPhase`/`HookOutcome` are `StrEnum`s so the audit JSONL on-disk schema is unchanged.
- `ClaudeDir` exposes classmethod accessors (not module constants) so `DEV10X_CLAUDE_HOME` overrides are honored per-call, which matters for tests and CI.

[`1f5beea0`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/125/commits/1f5beea0f21d741ce3049c83de9d282c6240182e) ♻️ GH-80 Centralize Claude Code filesystem paths via ClaudeDir
[`743dd87d`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/125/commits/743dd87d903786be1829a96ccd98c50f6660c832) ♻️ GH-80 Replace PROFILE_HIERARCHY tuple with ProfileTier enum
[`55c7d52a`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/125/commits/55c7d52afb5453223ab7aeb70f8e3745805ebccd) ♻️ GH-80 Replace friction_level strings with FrictionLevel enum
[`66f060a0`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/125/commits/66f060a0e2837e95b975d71248e0bbae64fb95db) ♻️ GH-80 Type hook phase/outcome via HookPhase + HookOutcome

Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/80
