### PR TITLE
♻️ GH-92 Promote permission helpers, drop stdout-capture hack

### DIFF
--- a/src/dev10x/commands/permission.py
+++ b/src/dev10x/commands/permission.py
@@ -12,6 +12,15 @@ def permission() -> None:
     """Maintain Dev10x plugin permission settings."""
 
 
+def _emit_result(result: dict) -> int:
+    """Print messages/errors from a public-API result dict and return its exit_code."""
+    for msg in result.get("messages", []):
+        click.echo(msg)
+    for err in result.get("errors", []):
+        click.echo(err, err=True)
+    return int(result.get("exit_code", 0))
+
+
 @permission.command(name="update-paths")
 @click.option("--dry-run", is_flag=True, help="Show changes without modifying files")
 @click.option(
@@ -116,11 +125,13 @@ def ensure_base(*, dry_run: bool, quiet: bool) -> None:
         return
 
     sys.exit(
-        mod._ensure_base(
-            config=config,
-            settings_files=settings_files,
-            dry_run=dry_run,
-            quiet=quiet,
+        _emit_result(
+            mod.ensure_base(
+                config=config,
+                settings_files=settings_files,
+                dry_run=dry_run,
+                quiet=quiet,
+            )
         )
     )
 
@@ -144,10 +155,12 @@ def generalize(*, dry_run: bool, quiet: bool) -> None:
         return
 
     sys.exit(
-        mod._generalize(
-            settings_files=settings_files,
-            dry_run=dry_run,
-            quiet=quiet,
+        _emit_result(
+            mod.generalize(
+                settings_files=settings_files,
+                dry_run=dry_run,
+                quiet=quiet,
+            )
         )
     )
 
@@ -176,11 +189,13 @@ def ensure_workspace(*, dry_run: bool, quiet: bool) -> None:
         return
 
     sys.exit(
-        mod._ensure_workspace(
-            config=config,
-            settings_files=settings_files,
-            dry_run=dry_run,
-            quiet=quiet,
+        _emit_result(
+            mod.ensure_workspace(
+                config=config,
+                settings_files=settings_files,
+                dry_run=dry_run,
+                quiet=quiet,
+            )
         )
     )
 
@@ -204,11 +219,13 @@ def ensure_scripts(*, dry_run: bool, quiet: bool) -> None:
         return
 
     sys.exit(
-        mod._ensure_scripts(
-            config=config,
-            settings_files=settings_files,
-            dry_run=dry_run,
-            quiet=quiet,
+        _emit_result(
+            mod.ensure_scripts(
+                config=config,
+                settings_files=settings_files,
+                dry_run=dry_run,
+                quiet=quiet,
+            )
         )
     )
 
@@ -232,11 +249,13 @@ def ensure_reads(*, dry_run: bool, quiet: bool) -> None:
         return
 
     sys.exit(
-        mod._ensure_reads(
-            config=config,
-            settings_files=settings_files,
-            dry_run=dry_run,
-            quiet=quiet,
+        _emit_result(
+            mod.ensure_reads(
+                config=config,
+                settings_files=settings_files,
+                dry_run=dry_run,
+                quiet=quiet,
+            )
         )
     )
 
@@ -244,9 +263,9 @@ def ensure_reads(*, dry_run: bool, quiet: bool) -> None:
 @permission.command()
 def init() -> None:
     """Create userspace config from plugin default."""
-    from dev10x.skills.permission.update_paths import _init_userspace_config
+    from dev10x.skills.permission.update_paths import init_userspace_config
 
-    sys.exit(_init_userspace_config())
+    sys.exit(_emit_result(init_userspace_config()))
 
 
 @permission.command()

--- a/src/dev10x/permission/__init__.py
+++ b/src/dev10x/permission/__init__.py
@@ -2,13 +2,16 @@
 
 Wraps permission sub-commands as an MCP tool so skills can update
 plugin permission settings without Bash allow-rule friction.
+
+Calls the public ``ensure_*`` / ``generalize`` helpers in
+``dev10x.skills.permission.update_paths``, which return structured
+result dicts (``exit_code``, ``messages``, ``errors``, stats). No
+``redirect_stdout`` capture — the helpers do not print to stdout.
 """
 
 from __future__ import annotations
 
 import asyncio
-import io
-from contextlib import redirect_stdout
 from typing import Any
 
 from dev10x.subprocess_utils import async_run, get_plugin_root
@@ -35,49 +38,85 @@ def _run_sub_command(
     if not settings_files:
         return {"error": "No settings files found."}
 
-    buf = io.StringIO()
-    rc = 0
+    combined_messages: list[str] = []
+    combined_errors: list[str] = []
+    exit_code = 0
 
-    with redirect_stdout(buf):
-        if ensure_workspace:
-            rc = mod._ensure_workspace(
-                config=config,
-                settings_files=settings_files,
-                dry_run=dry_run,
-                quiet=quiet,
-            )
-        if ensure_base and rc == 0:
-            rc = mod._ensure_base(
-                config=config,
-                settings_files=settings_files,
-                dry_run=dry_run,
-                quiet=quiet,
-            )
-        if generalize and rc == 0:
-            rc = mod._generalize(
-                settings_files=settings_files,
-                dry_run=dry_run,
-                quiet=quiet,
-            )
-        if ensure_scripts and rc == 0:
-            rc = mod._ensure_scripts(
-                config=config,
-                settings_files=settings_files,
-                dry_run=dry_run,
-                quiet=quiet,
-            )
-        if ensure_reads and rc == 0:
-            rc = mod._ensure_reads(
-                config=config,
-                settings_files=settings_files,
-                dry_run=dry_run,
-                quiet=quiet,
-            )
+    def _run(result: dict[str, Any]) -> bool:
+        """Append result's messages/errors and return True if it succeeded."""
+        nonlocal exit_code
+        combined_messages.extend(result.get("messages", []))
+        combined_errors.extend(result.get("errors", []))
+        rc = int(result.get("exit_code", 0))
+        if rc != 0:
+            exit_code = rc
+            return False
+        return True
 
-    output = buf.getvalue().strip()
-    if rc != 0:
-        return {"error": output or f"Sub-command failed with exit code {rc}"}
-    return {"success": True, "output": output}
+    if ensure_workspace:
+        if not _run(
+            mod.ensure_workspace(
+                config=config,
+                settings_files=settings_files,
+                dry_run=dry_run,
+                quiet=quiet,
+            )
+        ):
+            return _format_failure(combined_messages, combined_errors, exit_code)
+    if ensure_base:
+        if not _run(
+            mod.ensure_base(
+                config=config,
+                settings_files=settings_files,
+                dry_run=dry_run,
+                quiet=quiet,
+            )
+        ):
+            return _format_failure(combined_messages, combined_errors, exit_code)
+    if generalize:
+        if not _run(
+            mod.generalize(
+                settings_files=settings_files,
+                dry_run=dry_run,
+                quiet=quiet,
+            )
+        ):
+            return _format_failure(combined_messages, combined_errors, exit_code)
+    if ensure_scripts:
+        if not _run(
+            mod.ensure_scripts(
+                config=config,
+                settings_files=settings_files,
+                dry_run=dry_run,
+                quiet=quiet,
+            )
+        ):
+            return _format_failure(combined_messages, combined_errors, exit_code)
+    if ensure_reads:
+        if not _run(
+            mod.ensure_reads(
+                config=config,
+                settings_files=settings_files,
+                dry_run=dry_run,
+                quiet=quiet,
+            )
+        ):
+            return _format_failure(combined_messages, combined_errors, exit_code)
+
+    output = "\n".join(combined_messages).strip()
+    return {"success": True, "output": output, "messages": combined_messages}
+
+
+def _format_failure(
+    messages: list[str],
+    errors: list[str],
+    exit_code: int,
+) -> dict[str, Any]:
+    error_text = "\n".join(errors).strip()
+    if not error_text:
+        body = "\n".join(messages).strip()
+        error_text = body or f"Sub-command failed with exit code {exit_code}"
+    return {"error": error_text, "messages": messages, "errors": errors}
 
 
 async def update_paths(

--- a/src/dev10x/skills/permission/update_paths.py
+++ b/src/dev10x/skills/permission/update_paths.py
@@ -621,89 +621,128 @@ def ensure_workspace_directories(
     return len(missing), messages
 
 
-def _ensure_workspace(
+def _result(
+    *,
+    exit_code: int,
+    messages: list[str],
+    errors: list[str],
+    total_added: int = 0,
+    files_changed: int = 0,
+) -> dict[str, object]:
+    return {
+        "exit_code": exit_code,
+        "messages": messages,
+        "errors": errors,
+        "total_added": total_added,
+        "files_changed": files_changed,
+    }
+
+
+def ensure_workspace(
     *,
     config: dict,
     settings_files: list[Path],
     dry_run: bool,
     quiet: bool = False,
-) -> int:
+) -> dict[str, object]:
+    """Add workspace directory registrations to settings files.
+
+    Returns a result dict: ``{exit_code, messages, errors, total_added,
+    files_changed}``. Callers print ``messages`` (stdout) and ``errors``
+    (stderr) and act on ``exit_code``. No print() side effects.
+    """
+    messages: list[str] = []
+    errors: list[str] = []
+
     workspace_dirs = config.get("workspace_directories", [])
     if not workspace_dirs:
         if not quiet:
-            print("No workspace_directories defined in config.")
-        return 0
+            messages.append("No workspace_directories defined in config.")
+        return _result(
+            exit_code=0,
+            messages=messages,
+            errors=errors,
+            total_added=0,
+            files_changed=0,
+        )
 
     if not quiet:
-        print(f"Workspace directories: {len(workspace_dirs)} entr(ies)")
+        messages.append(f"Workspace directories: {len(workspace_dirs)} entr(ies)")
         for d in workspace_dirs:
-            print(f"  - {d}")
+            messages.append(f"  - {d}")
         if dry_run:
-            print("(dry run — no files will be modified)\n")
+            messages.append("(dry run — no files will be modified)\n")
 
     total_added = 0
     files_changed = 0
 
     for path in sorted(settings_files):
-        count, messages = ensure_workspace_directories(
+        count, file_messages = ensure_workspace_directories(
             path,
             workspace_dirs,
             dry_run=dry_run,
         )
         if count > 0:
             if not quiet:
-                print(f"\n{path}")
-                for msg in messages:
-                    print(msg)
+                messages.append(f"\n{path}")
+                messages.extend(file_messages)
             total_added += count
             files_changed += 1
 
     if total_added == 0:
-        print("All settings files already register the workspace directories.")
+        messages.append("All settings files already register the workspace directories.")
     else:
         verb = "Would add" if dry_run else "Added"
-        print(f"{verb} {total_added} workspace entries across {files_changed} files.")
+        messages.append(f"{verb} {total_added} workspace entries across {files_changed} files.")
 
-    return 0
+    return _result(
+        exit_code=0,
+        messages=messages,
+        errors=errors,
+        total_added=total_added,
+        files_changed=files_changed,
+    )
 
 
-def _ensure_base(
+def ensure_base(
     *,
     config: dict,
     settings_files: list[Path],
     dry_run: bool,
     quiet: bool = False,
-) -> int:
+) -> dict[str, object]:
+    """Add missing base permissions to each settings file. Returns result dict."""
+    messages: list[str] = []
+    errors: list[str] = []
+
     base_permissions = config.get("base_permissions", [])
     if not base_permissions:
-        print("No base_permissions defined in config.")
-        return 0
+        messages.append("No base_permissions defined in config.")
+        return _result(exit_code=0, messages=messages, errors=errors)
 
     global_rules, stale_wildcards = _load_global_allow_rules()
     filtered = [p for p in base_permissions if p not in global_rules]
     skipped = len(base_permissions) - len(filtered)
 
     if not quiet:
-        print(f"Base permissions: {len(base_permissions)} rules")
+        messages.append(f"Base permissions: {len(base_permissions)} rules")
         if stale_wildcards:
-            print(
+            messages.append(
                 f"  WARNING: {len(stale_wildcards)} non-functional MCP wildcard(s)"
                 " in global settings.json:"
             )
             for wc in stale_wildcards:
-                print(f"    - {wc}  (Claude Code ignores MCP wildcards)")
+                messages.append(f"    - {wc}  (Claude Code ignores MCP wildcards)")
         if skipped > 0:
-            print(f"  Skipping {skipped} already in global settings.json")
+            messages.append(f"  Skipping {skipped} already in global settings.json")
         if dry_run:
-            print("(dry run — no files will be modified)\n")
+            messages.append("(dry run — no files will be modified)\n")
 
     if not filtered:
         if not quiet:
-            print("All base permissions already covered by global settings.")
-        return 0
+            messages.append("All base permissions already covered by global settings.")
+        return _result(exit_code=0, messages=messages, errors=errors)
 
-    # Discover MCP catalog once — reused across all settings files
-    # so we don't re-parse the AST per file.
     from dev10x.skills.permission.enumerate_mcp import discover_mcp_tools
 
     mcp_catalog = discover_mcp_tools()
@@ -712,7 +751,7 @@ def _ensure_base(
     files_changed = 0
 
     for path in sorted(settings_files):
-        count, messages = ensure_base_permissions(
+        count, file_messages = ensure_base_permissions(
             path,
             filtered,
             dry_run=dry_run,
@@ -720,70 +759,88 @@ def _ensure_base(
         )
         if count > 0:
             if not quiet:
-                print(f"\n{path}")
-                for msg in messages:
-                    print(msg)
+                messages.append(f"\n{path}")
+                messages.extend(file_messages)
             total_added += count
             files_changed += 1
 
     if total_added == 0:
-        print("All files already have base permissions.")
+        messages.append("All files already have base permissions.")
     else:
         verb = "Would add" if dry_run else "Added"
-        print(f"{verb} {total_added} permissions across {files_changed} files.")
+        messages.append(f"{verb} {total_added} permissions across {files_changed} files.")
 
-    return 0
+    return _result(
+        exit_code=0,
+        messages=messages,
+        errors=errors,
+        total_added=total_added,
+        files_changed=files_changed,
+    )
 
 
-def _generalize(
+def generalize(
     *,
     settings_files: list[Path],
     dry_run: bool,
     quiet: bool = False,
-) -> int:
+) -> dict[str, object]:
+    """Replace session-specific permission args with wildcards. Returns result dict."""
+    messages: list[str] = []
+    errors: list[str] = []
+
     if dry_run and not quiet:
-        print("(dry run — no files will be modified)\n")
+        messages.append("(dry run — no files will be modified)\n")
 
     total_generalized = 0
     files_changed = 0
 
     for path in sorted(settings_files):
-        count, messages = generalize_permissions(path, dry_run=dry_run)
+        count, file_messages = generalize_permissions(path, dry_run=dry_run)
         if count > 0:
             if not quiet:
-                print(f"\n{path}")
-                for msg in messages:
-                    print(msg)
+                messages.append(f"\n{path}")
+                messages.extend(file_messages)
             total_generalized += count
             files_changed += 1
 
     if total_generalized == 0:
-        print("No session-specific permissions found.")
+        messages.append("No session-specific permissions found.")
     else:
         verb = "Would generalize" if dry_run else "Generalized"
-        print(f"{verb} {total_generalized} permissions in {files_changed} files.")
+        messages.append(f"{verb} {total_generalized} permissions in {files_changed} files.")
 
-    return 0
+    return _result(
+        exit_code=0,
+        messages=messages,
+        errors=errors,
+        total_added=total_generalized,
+        files_changed=files_changed,
+    )
 
 
-def _ensure_scripts(
+def ensure_scripts(
     *,
     config: dict,
     settings_files: list[Path],
     dry_run: bool,
     quiet: bool = False,
-) -> int:
+) -> dict[str, object]:
+    """Add missing per-script allow rules for plugin scripts. Returns result dict."""
+    messages: list[str] = []
+    errors: list[str] = []
+
     cache_dir = Path(config["plugin_cache"]).expanduser()
     target_version = detect_latest_version(cache_dir)
     if not target_version:
-        print(f"ERROR: No versions found in {cache_dir}", file=sys.stderr)
-        return 1
+        errors.append(f"ERROR: No versions found in {cache_dir}")
+        return _result(exit_code=1, messages=messages, errors=errors)
 
     plugin_root = cache_dir / target_version
     scripts = scan_plugin_scripts(plugin_root)
     if not scripts:
-        print(f"No callable scripts found in {plugin_root}")
-        return 0
+        messages.append(f"No callable scripts found in {plugin_root}")
+        return _result(exit_code=0, messages=messages, errors=errors)
 
     expected_rules = build_script_allow_rules(
         scripts,
@@ -791,10 +848,10 @@ def _ensure_scripts(
     )
 
     if not quiet:
-        print(f"Plugin root: {plugin_root}")
-        print(f"Scripts found: {len(scripts)}")
+        messages.append(f"Plugin root: {plugin_root}")
+        messages.append(f"Scripts found: {len(scripts)}")
         if dry_run:
-            print("(dry run — no files will be modified)\n")
+            messages.append("(dry run — no files will be modified)\n")
 
     total_added = 0
     files_changed = 0
@@ -807,40 +864,49 @@ def _ensure_scripts(
         if not missing:
             continue
 
-        count, messages = ensure_script_rules(
+        count, file_messages = ensure_script_rules(
             settings_path=path,
             missing_rules=missing,
             dry_run=dry_run,
         )
         if count > 0:
             if not quiet:
-                print(f"\n{path}")
-                for msg in messages:
-                    print(msg)
+                messages.append(f"\n{path}")
+                messages.extend(file_messages)
             total_added += count
             files_changed += 1
 
     if total_added == 0:
-        print("All settings files have complete script coverage.")
+        messages.append("All settings files have complete script coverage.")
     else:
         verb = "Would add" if dry_run else "Added"
-        print(f"{verb} {total_added} script rules across {files_changed} files.")
+        messages.append(f"{verb} {total_added} script rules across {files_changed} files.")
 
-    return 0
+    return _result(
+        exit_code=0,
+        messages=messages,
+        errors=errors,
+        total_added=total_added,
+        files_changed=files_changed,
+    )
 
 
-def _ensure_reads(
+def ensure_reads(
     *,
     config: dict,
     settings_files: list[Path],
     dry_run: bool,
     quiet: bool = False,
-) -> int:
+) -> dict[str, object]:
+    """Emit per-skill folder Read rules with ~/ + /home/<user>/ twins. Returns result dict."""
+    messages: list[str] = []
+    errors: list[str] = []
+
     cache_dir = Path(config["plugin_cache"]).expanduser()
     target_version = detect_latest_version(cache_dir)
     if not target_version:
-        print(f"ERROR: No versions found in {cache_dir}", file=sys.stderr)
-        return 1
+        errors.append(f"ERROR: No versions found in {cache_dir}")
+        return _result(exit_code=1, messages=messages, errors=errors)
 
     plugin_root = cache_dir / target_version
     expected_rules = build_read_allow_rules(
@@ -848,14 +914,14 @@ def _ensure_reads(
         user_home=Path.home(),
     )
     if not expected_rules:
-        print(f"No Read rules to emit for {plugin_root}")
-        return 0
+        messages.append(f"No Read rules to emit for {plugin_root}")
+        return _result(exit_code=0, messages=messages, errors=errors)
 
     if not quiet:
-        print(f"Plugin root: {plugin_root}")
-        print(f"Read rules expected: {len(expected_rules)} (twins included)")
+        messages.append(f"Plugin root: {plugin_root}")
+        messages.append(f"Read rules expected: {len(expected_rules)} (twins included)")
         if dry_run:
-            print("(dry run — no files will be modified)\n")
+            messages.append("(dry run — no files will be modified)\n")
 
     total_added = 0
     files_changed = 0
@@ -868,26 +934,31 @@ def _ensure_reads(
         if not missing:
             continue
 
-        count, messages = ensure_read_rules(
+        count, file_messages = ensure_read_rules(
             settings_path=path,
             missing_rules=missing,
             dry_run=dry_run,
         )
         if count > 0:
             if not quiet:
-                print(f"\n{path}")
-                for msg in messages:
-                    print(msg)
+                messages.append(f"\n{path}")
+                messages.extend(file_messages)
             total_added += count
             files_changed += 1
 
     if total_added == 0:
-        print("All settings files have complete Read coverage.")
+        messages.append("All settings files have complete Read coverage.")
     else:
         verb = "Would add" if dry_run else "Added"
-        print(f"{verb} {total_added} Read rules across {files_changed} files.")
+        messages.append(f"{verb} {total_added} Read rules across {files_changed} files.")
 
-    return 0
+    return _result(
+        exit_code=0,
+        messages=messages,
+        errors=errors,
+        total_added=total_added,
+        files_changed=files_changed,
+    )
 
 
 KNOWN_PLUGIN_DIRS = ("Dev10x", "dev10x-claude")
@@ -916,16 +987,20 @@ def _detect_plugin_cache() -> str:
     return "~/.claude/plugins/cache/Dev10x-Guru/Dev10x"
 
 
-def _init_userspace_config() -> int:
+def init_userspace_config() -> dict[str, object]:
+    """Create userspace config from plugin default. Returns result dict."""
+    messages: list[str] = []
+    errors: list[str] = []
+
     if MEMORY_CONFIG.is_file():
-        print(f"Config already exists: {MEMORY_CONFIG}")
-        return 0
+        messages.append(f"Config already exists: {MEMORY_CONFIG}")
+        return _result(exit_code=0, messages=messages, errors=errors)
     if USERSPACE_CONFIG.is_file():
-        print(f"Config already exists: {USERSPACE_CONFIG}")
-        return 0
+        messages.append(f"Config already exists: {USERSPACE_CONFIG}")
+        return _result(exit_code=0, messages=messages, errors=errors)
     if not PLUGIN_CONFIG.is_file():
-        print(f"ERROR: Plugin default config not found: {PLUGIN_CONFIG}", file=sys.stderr)
-        return 1
+        errors.append(f"ERROR: Plugin default config not found: {PLUGIN_CONFIG}")
+        return _result(exit_code=1, messages=messages, errors=errors)
     USERSPACE_CONFIG.parent.mkdir(parents=True, exist_ok=True)
     content = PLUGIN_CONFIG.read_text()
     detected_cache = _detect_plugin_cache()
@@ -934,7 +1009,7 @@ def _init_userspace_config() -> int:
         detected_cache,
     )
     USERSPACE_CONFIG.write_text(content)
-    print(f"Created: {USERSPACE_CONFIG}")
-    print(f"Plugin cache: {detected_cache}")
-    print("Edit this file to add your project roots.")
-    return 0
+    messages.append(f"Created: {USERSPACE_CONFIG}")
+    messages.append(f"Plugin cache: {detected_cache}")
+    messages.append("Edit this file to add your project roots.")
+    return _result(exit_code=0, messages=messages, errors=errors)

--- a/tests/permission/test_permission.py
+++ b/tests/permission/test_permission.py
@@ -175,7 +175,10 @@ class TestRunSubCommand:
                 "find_settings_files": find_sf,
             }
 
-    @patch(f"{MOD_PATH}._ensure_base", return_value=0)
+    @patch(
+        f"{MOD_PATH}.ensure_base",
+        return_value={"exit_code": 0, "messages": ["ok"], "errors": []},
+    )
     def test_ensure_base_calls_underlying_function(
         self,
         mock_ensure: AsyncMock,
@@ -185,7 +188,10 @@ class TestRunSubCommand:
         assert result["success"] is True
         mock_ensure.assert_called_once()
 
-    @patch(f"{MOD_PATH}._generalize", return_value=0)
+    @patch(
+        f"{MOD_PATH}.generalize",
+        return_value={"exit_code": 0, "messages": [], "errors": []},
+    )
     def test_generalize_calls_underlying_function(
         self,
         mock_gen: AsyncMock,
@@ -195,7 +201,10 @@ class TestRunSubCommand:
         assert result["success"] is True
         mock_gen.assert_called_once()
 
-    @patch(f"{MOD_PATH}._ensure_scripts", return_value=0)
+    @patch(
+        f"{MOD_PATH}.ensure_scripts",
+        return_value={"exit_code": 0, "messages": [], "errors": []},
+    )
     def test_ensure_scripts_calls_underlying_function(
         self,
         mock_scripts: AsyncMock,
@@ -205,7 +214,10 @@ class TestRunSubCommand:
         assert result["success"] is True
         mock_scripts.assert_called_once()
 
-    @patch(f"{MOD_PATH}._ensure_reads", return_value=0)
+    @patch(
+        f"{MOD_PATH}.ensure_reads",
+        return_value={"exit_code": 0, "messages": [], "errors": []},
+    )
     def test_ensure_reads_calls_underlying_function(
         self,
         mock_reads: AsyncMock,
@@ -215,7 +227,14 @@ class TestRunSubCommand:
         assert result["success"] is True
         mock_reads.assert_called_once()
 
-    @patch(f"{MOD_PATH}._ensure_base", return_value=1)
+    @patch(
+        f"{MOD_PATH}.ensure_base",
+        return_value={
+            "exit_code": 1,
+            "messages": [],
+            "errors": ["boom"],
+        },
+    )
     def test_returns_error_on_nonzero_exit(
         self,
         mock_ensure: AsyncMock,
@@ -223,9 +242,16 @@ class TestRunSubCommand:
     ) -> None:
         result = perm_mod._run_sub_command(ensure_base=True)
         assert "error" in result
+        assert result["error"] == "boom"
 
-    @patch(f"{MOD_PATH}._generalize", return_value=0)
-    @patch(f"{MOD_PATH}._ensure_base", return_value=1)
+    @patch(
+        f"{MOD_PATH}.generalize",
+        return_value={"exit_code": 0, "messages": [], "errors": []},
+    )
+    @patch(
+        f"{MOD_PATH}.ensure_base",
+        return_value={"exit_code": 1, "messages": [], "errors": ["boom"]},
+    )
     def test_skips_generalize_when_ensure_base_fails(
         self,
         mock_ensure: AsyncMock,
@@ -235,6 +261,52 @@ class TestRunSubCommand:
         result = perm_mod._run_sub_command(ensure_base=True, generalize=True)
         assert "error" in result
         mock_gen.assert_not_called()
+
+    def test_does_not_capture_stdout(
+        self,
+        mock_mod: dict,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """MCP service must not redirect_stdout — helpers return structured data."""
+        with patch(
+            f"{MOD_PATH}.ensure_base",
+            return_value={
+                "exit_code": 0,
+                "messages": ["Added 2 base permissions"],
+                "errors": [],
+            },
+        ):
+            result = perm_mod._run_sub_command(ensure_base=True)
+
+        assert result["success"] is True
+        assert "Added 2 base permissions" in result["output"]
+        # Helper did not print to real stdout — capsys captures nothing.
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert captured.err == ""
+
+    def test_error_path_surfaces_helper_errors(
+        self,
+        mock_mod: dict,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Error envelope carries structured errors list — no stdout capture."""
+        with patch(
+            f"{MOD_PATH}.ensure_scripts",
+            return_value={
+                "exit_code": 1,
+                "messages": [],
+                "errors": ["ERROR: No versions found in /fake/cache"],
+            },
+        ):
+            result = perm_mod._run_sub_command(ensure_scripts=True)
+
+        assert "error" in result
+        assert "No versions found" in result["error"]
+        assert result["errors"] == ["ERROR: No versions found in /fake/cache"]
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert captured.err == ""
 
     def test_returns_error_when_no_settings_files(self) -> None:
         with (

--- a/tests/skills/upgrade-cleanup/test_ensure_workspace.py
+++ b/tests/skills/upgrade-cleanup/test_ensure_workspace.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from dev10x.skills.permission.update_paths import (
-    _ensure_workspace,
+    ensure_workspace,
     ensure_workspace_directories,
 )
 
@@ -122,14 +122,16 @@ class TestEnsureWorkspaceOrchestrator:
         two_files: list[Path],
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        rc = _ensure_workspace(
+        result = ensure_workspace(
             config={"workspace_directories": ["/tmp/Dev10x"]},
             settings_files=two_files,
             dry_run=False,
             quiet=True,
         )
 
-        assert rc == 0
+        assert result["exit_code"] == 0
+        assert result["files_changed"] == 2
+        assert capsys.readouterr().out == ""
         for path in two_files:
             data = json.loads(path.read_text())
             assert data["permissions"]["additionalDirectories"] == ["/tmp/Dev10x"]
@@ -138,14 +140,14 @@ class TestEnsureWorkspaceOrchestrator:
         self,
         two_files: list[Path],
     ) -> None:
-        rc = _ensure_workspace(
+        result = ensure_workspace(
             config={},
             settings_files=two_files,
             dry_run=False,
             quiet=True,
         )
 
-        assert rc == 0
+        assert result["exit_code"] == 0
         for path in two_files:
             data = json.loads(path.read_text())
             assert "additionalDirectories" not in data.get("permissions", {})


### PR DESCRIPTION
**When** the `permission` MCP service exposes `update-paths` sub-commands, **I want to** call public helpers that return structured data **so** the MCP tool can drop its `redirect_stdout` hack and surface uniform stdout/stderr/exit_code envelopes to callers.

---

[`c48ba1d1`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/126/commits/c48ba1d1648d8fd9b50f605f9648c640bfaccf77) ♻️ GH-92 Promote permission helpers to public, drop stdout-capture hack
Fixes: https://github.com/Dev10x-Guru/dev10x-claude/issues/92

---