### PR TITLE
♻️ GH-82 Promote validator registry and capability dispatch

### DIFF
--- a/src/dev10x/commands/hook.py
+++ b/src/dev10x/commands/hook.py
@@ -32,7 +32,7 @@ def validate_bash() -> None:
 
 def _validate_bash_body() -> None:
     from dev10x.domain import HookInput
-    from dev10x.validators import get_validators
+    from dev10x.validators import get_chain
 
     inp = HookInput.from_stdin()
     if inp.tool_name != "Bash":
@@ -40,20 +40,8 @@ def _validate_bash_body() -> None:
     if not inp.command:
         sys.exit(0)
 
-    for validator in get_validators():
-        try:
-            if validator.should_run(inp=inp):
-                result = validator.validate(inp=inp)
-                if result is not None:
-                    result.emit()
-        except Exception:
-            if _DEBUG:
-                print(
-                    f"[HOOK_DEBUG] {validator.name} raised:",
-                    file=sys.stderr,
-                )
-                traceback.print_exc(file=sys.stderr)
-            continue
+    for result in get_chain().run(inp=inp):
+        result.emit()
 
     sys.exit(0)
 
@@ -109,29 +97,14 @@ def permission_denied() -> None:
     Exit codes: 0 always (retry decision is in JSON output).
     """
     from dev10x.domain import HookInput
-    from dev10x.validators import get_validators
-    from dev10x.validators.base import Corrector
+    from dev10x.validators import get_chain
 
     inp = HookInput.from_stdin()
 
     if inp.command:
-        for validator in get_validators():
-            try:
-                if not validator.should_run(inp=inp):
-                    continue
-                if not isinstance(validator, Corrector):
-                    continue
-                result = validator.correct(inp=inp)
-                if result is not None:
-                    result.emit()
-            except Exception:
-                if _DEBUG:
-                    print(
-                        f"[HOOK_DEBUG] {validator.name} correct() raised:",
-                        file=sys.stderr,
-                    )
-                    traceback.print_exc(file=sys.stderr)
-                continue
+        result = get_chain().correct(inp=inp)
+        if result is not None:
+            result.emit()
 
     _run_permission_diagnostics(raw=inp.raw, cwd=inp.cwd)
     sys.exit(0)

--- a/src/dev10x/validators/__init__.py
+++ b/src/dev10x/validators/__init__.py
@@ -1,74 +1,93 @@
 """Bash command validators for Claude Code PreToolUse hooks.
 
 Single-dispatcher architecture: one Python process validates all Bash
-commands by iterating a registry of Validator implementations. Each
-validator has a fast `should_run` predicate and a `validate` method.
+commands by iterating a :class:`ValidatorRegistry`. Each validator
+declares its profile tier, rule_id, and capabilities as class
+attributes (see :mod:`dev10x.validators.base`).
 
 Ordering matters: allow-validators run before deny-validators so safe
 patterns get auto-approved before a deny-validator would block them.
 
-Validators are lazily imported — only loaded when the registry is
-first accessed via get_validators(). This avoids paying the import
+Validators are lazily imported — the registry only loads modules for
+specs surviving the active filter set. This avoids paying the import
 cost of all 8 modules at module-level on every hook invocation.
 
-Profile filtering (GH-413): validators declare a ProfileTier
-(MINIMAL, STANDARD, STRICT) and a stable rule_id. The registry
-filters the active set based on DEV10X_HOOK_PROFILE (default:
-STANDARD), DEV10X_HOOK_DISABLE (comma-separated rule_ids), and
-DEV10X_HOOK_EXPERIMENTAL (opt-in flag for experimental validators).
+Profile filtering (GH-413): each :class:`ValidatorSpec` carries a
+:class:`ProfileTier` and a rule_id. The registry composes three
+filters built from environment variables:
+
+  DEV10X_HOOK_PROFILE        — active tier (default ``STANDARD``)
+  DEV10X_HOOK_DISABLE        — comma-separated rule_ids to drop
+  DEV10X_HOOK_EXPERIMENTAL   — opt-in flag for experimental validators
 """
 
 from __future__ import annotations
 
-import importlib
 import os
 from typing import TYPE_CHECKING
 
 from dev10x.domain.profile_tier import ProfileTier
+from dev10x.validators.registry import (
+    DisableListFilter,
+    ExperimentalFilter,
+    ProfileFilter,
+    ValidatorChain,
+    ValidatorRegistry,
+    ValidatorSpec,
+)
 
 if TYPE_CHECKING:
     from dev10x.validators.base import Validator
 
-_VALIDATOR_SPECS: list[tuple[str, str, str, ProfileTier, bool]] = [
-    # (module_path, class_name, rule_id, profile, experimental)
-    (
-        "dev10x.validators.safe_subshell",
-        "SafeSubshellValidator",
-        "DX001",
-        ProfileTier.MINIMAL,
-        False,
+_SPECS: list[ValidatorSpec] = [
+    ValidatorSpec(
+        module_path="dev10x.validators.safe_subshell",
+        class_name="SafeSubshellValidator",
+        rule_id="DX001",
+        profile=ProfileTier.MINIMAL,
     ),
-    (
-        "dev10x.validators.command_substitution",
-        "CommandSubstitutionValidator",
-        "DX002",
-        ProfileTier.MINIMAL,
-        False,
+    ValidatorSpec(
+        module_path="dev10x.validators.command_substitution",
+        class_name="CommandSubstitutionValidator",
+        rule_id="DX002",
+        profile=ProfileTier.MINIMAL,
     ),
-    (
-        "dev10x.validators.execution_safety",
-        "ExecutionSafetyValidator",
-        "DX003",
-        ProfileTier.MINIMAL,
-        False,
+    ValidatorSpec(
+        module_path="dev10x.validators.execution_safety",
+        class_name="ExecutionSafetyValidator",
+        rule_id="DX003",
+        profile=ProfileTier.MINIMAL,
     ),
-    ("dev10x.validators.sql_safety", "SqlSafetyValidator", "DX004", ProfileTier.MINIMAL, False),
-    ("dev10x.validators.pr_base", "PrBaseValidator", "DX005", ProfileTier.MINIMAL, False),
-    (
-        "dev10x.validators.skill_redirect",
-        "SkillRedirectValidator",
-        "DX006",
-        ProfileTier.STANDARD,
-        False,
+    ValidatorSpec(
+        module_path="dev10x.validators.sql_safety",
+        class_name="SqlSafetyValidator",
+        rule_id="DX004",
+        profile=ProfileTier.MINIMAL,
     ),
-    (
-        "dev10x.validators.prefix_friction",
-        "PrefixFrictionValidator",
-        "DX007",
-        ProfileTier.STANDARD,
-        False,
+    ValidatorSpec(
+        module_path="dev10x.validators.pr_base",
+        class_name="PrBaseValidator",
+        rule_id="DX005",
+        profile=ProfileTier.MINIMAL,
     ),
-    ("dev10x.validators.commit_jtbd", "CommitJtbdValidator", "DX008", ProfileTier.STRICT, False),
+    ValidatorSpec(
+        module_path="dev10x.validators.skill_redirect",
+        class_name="SkillRedirectValidator",
+        rule_id="DX006",
+        profile=ProfileTier.STANDARD,
+    ),
+    ValidatorSpec(
+        module_path="dev10x.validators.prefix_friction",
+        class_name="PrefixFrictionValidator",
+        rule_id="DX007",
+        profile=ProfileTier.STANDARD,
+    ),
+    ValidatorSpec(
+        module_path="dev10x.validators.commit_jtbd",
+        class_name="CommitJtbdValidator",
+        rule_id="DX008",
+        profile=ProfileTier.STRICT,
+    ),
 ]
 
 
@@ -89,41 +108,55 @@ def _load_profile_config() -> tuple[ProfileTier, set[str], bool]:
     return active, disabled, experimental_enabled
 
 
-_validators: list[Validator] | None = None
+def _build_registry() -> ValidatorRegistry:
+    """Construct a registry seeded with module specs and env-driven filters."""
+    active, disabled, experimental = _load_profile_config()
+    return ValidatorRegistry(
+        specs=list(_SPECS),
+        filters=[
+            ProfileFilter(active=active),
+            DisableListFilter(disabled=frozenset(disabled)),
+            ExperimentalFilter(enabled=experimental),
+        ],
+    )
+
+
+_registry: ValidatorRegistry | None = None
+
+
+def get_registry() -> ValidatorRegistry:
+    """Return the process-wide registry, building it on first access."""
+    global _registry
+    if _registry is None:
+        _registry = _build_registry()
+    return _registry
 
 
 def get_validators() -> list[Validator]:
-    global _validators
-    if _validators is None:
-        from dev10x.validators.base import Validator as V
-
-        active_profile, disabled, experimental_enabled = _load_profile_config()
-        _validators = []
-        for module_path, class_name, rule_id, profile, experimental in _VALIDATOR_SPECS:
-            if rule_id.upper() in disabled:
-                continue
-            if experimental and not experimental_enabled:
-                continue
-            if not active_profile.includes(validator_tier=profile):
-                continue
-            mod = importlib.import_module(module_path)
-            cls = getattr(mod, class_name)
-            instance = cls()
-            if not hasattr(instance, "rule_id"):
-                instance.rule_id = rule_id
-            if not hasattr(instance, "profile"):
-                instance.profile = profile
-            if not hasattr(instance, "experimental"):
-                instance.experimental = experimental
-            assert isinstance(instance, V), f"{class_name} does not implement Validator"
-            _validators.append(instance)
-    return _validators
+    """Return active validator instances (lazy-loaded on first call)."""
+    return get_registry().active()
 
 
 def reset_registry() -> None:
     """Clear the cached validator registry — used by tests."""
-    global _validators
-    _validators = None
+    global _registry
+    _registry = None
 
 
-__all__ = ["get_validators", "reset_registry"]
+def get_chain() -> ValidatorChain:
+    """Return a chain bound to the process-wide registry."""
+    return ValidatorChain(registry=get_registry())
+
+
+__all__ = [
+    "DisableListFilter",
+    "ExperimentalFilter",
+    "ProfileFilter",
+    "ValidatorChain",
+    "ValidatorRegistry",
+    "ValidatorSpec",
+    "get_chain",
+    "get_registry",
+    "get_validators",
+    "reset_registry",
+]

--- a/src/dev10x/validators/base.py
+++ b/src/dev10x/validators/base.py
@@ -1,33 +1,32 @@
-"""Validator protocol for Bash command validation.
+"""Validator protocol and base class for Bash command validation.
 
 Two hook integration points:
 
-  PreToolUse  → should_run() + validate()  — block before execution
-  PermissionDenied → should_run() + correct() — guide after auto-mode denial
+  PreToolUse        → should_run() + validate()  — block before execution
+  PermissionDenied  → should_run() + correct()   — guide after auto-mode denial
 
-The correct() method is optional. Validators that implement it can
-provide retry-with-guidance responses for the PermissionDenied hook.
+Validators declare their capabilities via :attr:`ValidatorBase.capabilities`
+(``"validate"`` always, ``"correct"`` for retry-with-guidance support).
+The dispatcher consults this set instead of runtime ``isinstance`` checks,
+so adding new capabilities (e.g., ``"explain"``) is a one-line change.
 
-Validators also declare profile-tier metadata (GH-413):
+Validators also declare profile-tier metadata as class attributes:
 
-  rule_id       — stable identifier (e.g., "DX001"), used for
-                  DEV10X_HOOK_DISABLE filtering
-  profile       — "minimal" | "standard" | "strict" — which active
-                  profile this validator participates in. Validators
-                  at or below the active profile run; higher-profile
-                  validators are skipped.
-  experimental  — True to opt out unless DEV10X_HOOK_EXPERIMENTAL=1
+  rule_id       — stable identifier (e.g., ``"DX001"``)
+  profile       — which :class:`ProfileTier` this validator participates in
+  experimental  — opt-in flag for DEV10X_HOOK_EXPERIMENTAL=1
 
-All three fields are optional — missing attributes default to
-profile="standard", experimental=False, rule_id="" (never disabled
-by ID).
+The :class:`ValidatorRegistry` verifies these match the corresponding
+:class:`ValidatorSpec` at registration time, replacing the previous
+post-instantiation monkey-patching.
 """
 
 from __future__ import annotations
 
-from typing import Protocol, runtime_checkable
+from typing import ClassVar, Protocol, runtime_checkable
 
 from dev10x.domain import HookAllow, HookInput, HookResult, HookRetry
+from dev10x.domain.profile_tier import ProfileTier
 
 
 @runtime_checkable
@@ -50,3 +49,25 @@ class Corrector(Protocol):
     def correct(self, inp: HookInput) -> HookRetry | None:
         """Return HookRetry to suggest retry with corrective guidance, None otherwise."""
         ...
+
+
+class ValidatorBase:
+    """Mixin declaring registry metadata as class attributes.
+
+    Inherit from this and override the class attributes:
+
+        class FooValidator(ValidatorBase):
+            name = "foo"
+            rule_id = "DX042"
+            profile = ProfileTier.STANDARD
+            capabilities = frozenset({"validate", "correct"})
+
+    Removing the previous ``hasattr`` guarded monkey-patching in
+    :func:`get_validators` — the metadata now lives on the class itself.
+    """
+
+    name: ClassVar[str] = ""
+    rule_id: ClassVar[str] = ""
+    profile: ClassVar[ProfileTier] = ProfileTier.STANDARD
+    experimental: ClassVar[bool] = False
+    capabilities: ClassVar[frozenset[str]] = frozenset({"validate"})

--- a/src/dev10x/validators/command_substitution.py
+++ b/src/dev10x/validators/command_substitution.py
@@ -15,8 +15,11 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from typing import ClassVar
 
 from dev10x.domain import HookInput, HookResult
+from dev10x.domain.profile_tier import ProfileTier
+from dev10x.validators.base import ValidatorBase
 
 CAT_SUBSHELL_RE = re.compile(r"\$\(cat\s+\S+\)")
 
@@ -33,8 +36,10 @@ when the tool supports reading from a file directly."""
 
 
 @dataclass
-class CommandSubstitutionValidator:
-    name: str = "command-substitution"
+class CommandSubstitutionValidator(ValidatorBase):
+    name: ClassVar[str] = "command-substitution"
+    rule_id: ClassVar[str] = "DX002"
+    profile: ClassVar[ProfileTier] = ProfileTier.MINIMAL
 
     def should_run(self, inp: HookInput) -> bool:
         return "$(cat " in inp.command

--- a/src/dev10x/validators/commit_jtbd.py
+++ b/src/dev10x/validators/commit_jtbd.py
@@ -14,9 +14,12 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from pathlib import Path
+from typing import ClassVar
 
 from dev10x.domain import HookInput, HookResult
+from dev10x.domain.profile_tier import ProfileTier
 from dev10x.domain.result import ErrorResult, Result, err, ok
+from dev10x.validators.base import ValidatorBase
 
 _VERB_BASES = [
     "Add",
@@ -164,8 +167,10 @@ def _check_jtbd(title: str) -> Result[str]:
 
 
 @dataclass
-class CommitJtbdValidator:
-    name: str = "commit-jtbd"
+class CommitJtbdValidator(ValidatorBase):
+    name: ClassVar[str] = "commit-jtbd"
+    rule_id: ClassVar[str] = "DX008"
+    profile: ClassVar[ProfileTier] = ProfileTier.STRICT
     bypass_gitmoji: frozenset[str] = BYPASS_GITMOJI
 
     def should_run(self, inp: HookInput) -> bool:

--- a/src/dev10x/validators/execution_safety.py
+++ b/src/dev10x/validators/execution_safety.py
@@ -15,8 +15,11 @@ import os
 import re
 import shlex
 from dataclasses import dataclass
+from typing import ClassVar
 
 from dev10x.domain import HookInput, HookResult
+from dev10x.domain.profile_tier import ProfileTier
+from dev10x.validators.base import ValidatorBase
 
 SHELL_WRITE_RE = re.compile(
     r"\bcat\b\s*(>|<<|>\s*\S)"
@@ -80,8 +83,10 @@ def _is_approved_path(path: str) -> bool:
 
 
 @dataclass
-class ExecutionSafetyValidator:
-    name: str = "execution-safety"
+class ExecutionSafetyValidator(ValidatorBase):
+    name: ClassVar[str] = "execution-safety"
+    rule_id: ClassVar[str] = "DX003"
+    profile: ClassVar[ProfileTier] = ProfileTier.MINIMAL
 
     def should_run(self, inp: HookInput) -> bool:
         return True

--- a/src/dev10x/validators/pr_base.py
+++ b/src/dev10x/validators/pr_base.py
@@ -12,8 +12,11 @@ from __future__ import annotations
 import re
 import subprocess
 from dataclasses import dataclass
+from typing import ClassVar
 
 from dev10x.domain import HookInput, HookResult
+from dev10x.domain.profile_tier import ProfileTier
+from dev10x.validators.base import ValidatorBase
 
 GH_PR_CREATE_RE = re.compile(r"gh\s+pr\s+create")
 
@@ -33,8 +36,10 @@ def _detect_base_branch() -> str | None:
 
 
 @dataclass
-class PrBaseValidator:
-    name: str = "pr-base"
+class PrBaseValidator(ValidatorBase):
+    name: ClassVar[str] = "pr-base"
+    rule_id: ClassVar[str] = "DX005"
+    profile: ClassVar[ProfileTier] = ProfileTier.MINIMAL
 
     def should_run(self, inp: HookInput) -> bool:
         return GH_PR_CREATE_RE.search(inp.command) is not None

--- a/src/dev10x/validators/prefix_friction.py
+++ b/src/dev10x/validators/prefix_friction.py
@@ -15,9 +15,11 @@ import json
 import os
 import re
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from dev10x.domain import HookInput, HookResult
+from dev10x.domain.profile_tier import ProfileTier
+from dev10x.validators.base import ValidatorBase
 
 if TYPE_CHECKING:
     from dev10x.domain import HookRetry
@@ -189,8 +191,11 @@ def _suggest_alias(*, branch: str, subcommand: str | None) -> str:
 
 
 @dataclass
-class PrefixFrictionValidator:
-    name: str = "prefix-friction"
+class PrefixFrictionValidator(ValidatorBase):
+    name: ClassVar[str] = "prefix-friction"
+    rule_id: ClassVar[str] = "DX007"
+    profile: ClassVar[ProfileTier] = ProfileTier.STANDARD
+    capabilities: ClassVar[frozenset[str]] = frozenset({"validate", "correct"})
     _allow_patterns: list[str] | None = field(default=None, repr=False)
 
     def should_run(self, inp: HookInput) -> bool:

--- a/src/dev10x/validators/registry.py
+++ b/src/dev10x/validators/registry.py
@@ -1,0 +1,249 @@
+"""ValidatorRegistry, filters, and chain for Bash command validation.
+
+Separates three concerns previously tangled in ``validators/__init__.py``:
+
+  ValidatorSpec        — typed discovery record (replaces 5-tuple)
+  ValidatorFilter      — composable predicate over specs
+  ValidatorRegistry    — owns specs, applies filters, lazy-imports
+                         validator instances, supports lookup by rule_id
+  ValidatorChain       — iterates active validators for a HookInput,
+                         catches per-validator failures, short-circuits
+                         ``correct()`` at first non-None HookRetry
+
+Specs carry ``rule_id``/``profile``/``experimental`` so filtering can
+happen before any validator module is imported. Each validator class
+declares the same metadata via :class:`ValidatorBase` class attributes;
+the registry verifies the two agree at registration time.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import traceback
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Protocol
+
+from dev10x.domain.profile_tier import ProfileTier
+
+if TYPE_CHECKING:
+    from dev10x.domain import HookAllow, HookInput, HookResult, HookRetry
+    from dev10x.validators.base import Validator
+
+_DEBUG = os.environ.get("HOOK_DEBUG", "") != ""
+
+
+@dataclass(frozen=True)
+class ValidatorSpec:
+    """Typed discovery record for a validator class.
+
+    Carries enough metadata for the registry to filter validators by
+    profile/disable-list/experimental flags before importing the
+    backing module — preserving the lazy-import behavior of the old
+    tuple-based registry.
+    """
+
+    module_path: str
+    class_name: str
+    rule_id: str
+    profile: ProfileTier
+    experimental: bool = False
+
+
+class ValidatorFilter(Protocol):
+    """Composable predicate applied to specs at registry-build time."""
+
+    def keep(self, spec: ValidatorSpec) -> bool:
+        """Return True to retain ``spec`` in the active set."""
+        ...
+
+
+@dataclass(frozen=True)
+class ProfileFilter:
+    """Keep specs at or below the active profile tier."""
+
+    active: ProfileTier
+
+    def keep(self, spec: ValidatorSpec) -> bool:
+        return self.active.includes(validator_tier=spec.profile)
+
+
+@dataclass(frozen=True)
+class DisableListFilter:
+    """Drop specs whose rule_id appears in the disabled set (case-insensitive)."""
+
+    disabled: frozenset[str]
+
+    def keep(self, spec: ValidatorSpec) -> bool:
+        return spec.rule_id.upper() not in self.disabled
+
+
+@dataclass(frozen=True)
+class ExperimentalFilter:
+    """Drop experimental specs unless experimental mode is enabled."""
+
+    enabled: bool
+
+    def keep(self, spec: ValidatorSpec) -> bool:
+        return self.enabled or not spec.experimental
+
+
+@dataclass
+class ValidatorRegistry:
+    """Owns validator specs, applies filters, lazy-loads instances.
+
+    Construction is cheap: only specs are stored. The first call to
+    :meth:`active` imports the surviving modules and instantiates
+    validators. Subsequent calls return the cached list.
+    """
+
+    specs: list[ValidatorSpec] = field(default_factory=list)
+    filters: list[ValidatorFilter] = field(default_factory=list)
+    _instances: list[Validator] | None = field(default=None, init=False, repr=False)
+
+    def register(self, spec: ValidatorSpec) -> None:
+        """Append a spec; invalidates any cached instances."""
+        self.specs.append(spec)
+        self._instances = None
+
+    def active_specs(self) -> list[ValidatorSpec]:
+        """Return specs surviving all filters (no validators imported)."""
+        return [spec for spec in self.specs if all(f.keep(spec) for f in self.filters)]
+
+    def active(self) -> list[Validator]:
+        """Return validator instances for all active specs (lazy import)."""
+        if self._instances is None:
+            self._instances = [self._instantiate(spec=spec) for spec in self.active_specs()]
+        return self._instances
+
+    def find_by_rule_id(self, rule_id: str) -> ValidatorSpec | None:
+        """Return the spec for ``rule_id`` (regardless of filter state)."""
+        rule_id_upper = rule_id.upper()
+        for spec in self.specs:
+            if spec.rule_id.upper() == rule_id_upper:
+                return spec
+        return None
+
+    def lookup(self, rule_id: str) -> Validator | None:
+        """Return the active validator instance for ``rule_id`` or None."""
+        rule_id_upper = rule_id.upper()
+        for validator in self.active():
+            if getattr(validator, "rule_id", "").upper() == rule_id_upper:
+                return validator
+        return None
+
+    def is_active(self, rule_id: str) -> bool:
+        """Return True if a validator with ``rule_id`` would run now."""
+        rule_id_upper = rule_id.upper()
+        return any(spec.rule_id.upper() == rule_id_upper for spec in self.active_specs())
+
+    def reset(self) -> None:
+        """Drop cached instances; next :meth:`active` re-imports."""
+        self._instances = None
+
+    @staticmethod
+    def _instantiate(spec: ValidatorSpec) -> Validator:
+        from dev10x.validators.base import Validator as V
+
+        module = importlib.import_module(spec.module_path)
+        cls = getattr(module, spec.class_name)
+        instance = cls()
+        assert isinstance(instance, V), f"{spec.class_name} does not implement Validator"
+        _assert_metadata_matches(instance=instance, spec=spec)
+        return instance
+
+
+def _assert_metadata_matches(*, instance: Validator, spec: ValidatorSpec) -> None:
+    """Verify class-declared metadata matches the spec — fail fast on drift."""
+    declared_rule_id = getattr(instance, "rule_id", None)
+    declared_profile = getattr(instance, "profile", None)
+    declared_experimental = getattr(instance, "experimental", None)
+    assert declared_rule_id == spec.rule_id, (
+        f"{spec.class_name}.rule_id={declared_rule_id!r} disagrees with "
+        f"spec rule_id={spec.rule_id!r}"
+    )
+    assert declared_profile == spec.profile, (
+        f"{spec.class_name}.profile={declared_profile!r} disagrees with "
+        f"spec profile={spec.profile!r}"
+    )
+    assert declared_experimental == spec.experimental, (
+        f"{spec.class_name}.experimental={declared_experimental!r} disagrees with "
+        f"spec experimental={spec.experimental!r}"
+    )
+
+
+@dataclass
+class ValidatorChain:
+    """Iterates active validators for a single :class:`HookInput`.
+
+    Two entry points:
+
+      :meth:`run` — for PreToolUse: emits every non-None ``validate()``
+        result; iteration continues so multiple validators may speak.
+
+      :meth:`correct` — for PermissionDenied: short-circuits at the
+        first validator returning a :class:`HookRetry`.
+
+    Validators raising during ``should_run``/``validate``/``correct``
+    are swallowed (logged when ``HOOK_DEBUG`` is set) so a single
+    misbehaving validator cannot block the hook.
+    """
+
+    registry: ValidatorRegistry
+
+    def run(self, inp: HookInput) -> list[HookResult | HookAllow]:
+        """Invoke ``validate()`` on every applicable validator.
+
+        Returns the list of non-None results in registration order;
+        callers emit each in turn.
+        """
+        results: list[HookResult | HookAllow] = []
+        for validator in self.registry.active():
+            try:
+                if not validator.should_run(inp=inp):
+                    continue
+                result = validator.validate(inp=inp)
+            except Exception:
+                _log_validator_error(validator=validator, method="validate")
+                continue
+            if result is not None:
+                results.append(result)
+        return results
+
+    def correct(self, inp: HookInput) -> HookRetry | None:
+        """Invoke ``correct()`` on capable validators; first hit wins."""
+        for validator in self.registry.active():
+            if "correct" not in getattr(validator, "capabilities", frozenset()):
+                continue
+            try:
+                if not validator.should_run(inp=inp):
+                    continue
+                result = validator.correct(inp=inp)  # type: ignore[attr-defined]
+            except Exception:
+                _log_validator_error(validator=validator, method="correct")
+                continue
+            if result is not None:
+                return result
+        return None
+
+
+def _log_validator_error(*, validator: Validator, method: str) -> None:
+    if not _DEBUG:
+        return
+    print(
+        f"[HOOK_DEBUG] {validator.name} {method}() raised:",
+        file=sys.stderr,
+    )
+    traceback.print_exc(file=sys.stderr)
+
+
+__all__ = [
+    "DisableListFilter",
+    "ExperimentalFilter",
+    "ProfileFilter",
+    "ValidatorChain",
+    "ValidatorFilter",
+    "ValidatorRegistry",
+    "ValidatorSpec",
+]

--- a/src/dev10x/validators/safe_subshell.py
+++ b/src/dev10x/validators/safe_subshell.py
@@ -15,8 +15,11 @@ command via HookAllow.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import ClassVar
 
 from dev10x.domain import HookAllow, HookInput, HookResult
+from dev10x.domain.profile_tier import ProfileTier
+from dev10x.validators.base import ValidatorBase
 
 SAFE_SUBSHELL_PREFIXES = (
     "git rev-parse",
@@ -109,8 +112,10 @@ def _outer_command_token(command: str) -> str:
 
 
 @dataclass
-class SafeSubshellValidator:
-    name: str = "safe-subshell"
+class SafeSubshellValidator(ValidatorBase):
+    name: ClassVar[str] = "safe-subshell"
+    rule_id: ClassVar[str] = "DX001"
+    profile: ClassVar[ProfileTier] = ProfileTier.MINIMAL
 
     def should_run(self, inp: HookInput) -> bool:
         return "$(" in inp.command

--- a/src/dev10x/validators/skill_redirect.py
+++ b/src/dev10x/validators/skill_redirect.py
@@ -19,11 +19,13 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from dev10x.domain import HookInput, HookResult
 from dev10x.domain.friction_level import FrictionLevel
+from dev10x.domain.profile_tier import ProfileTier
 from dev10x.domain.validation_rule import Compensation, Config
+from dev10x.validators.base import ValidatorBase
 
 if TYPE_CHECKING:
     from dev10x.domain import HookRetry
@@ -174,8 +176,11 @@ def _format_skill_msg(
 
 
 @dataclass
-class SkillRedirectValidator:
-    name: str = "skill-redirect"
+class SkillRedirectValidator(ValidatorBase):
+    name: ClassVar[str] = "skill-redirect"
+    rule_id: ClassVar[str] = "DX006"
+    profile: ClassVar[ProfileTier] = ProfileTier.STANDARD
+    capabilities: ClassVar[frozenset[str]] = frozenset({"validate", "correct"})
 
     def should_run(self, inp: HookInput) -> bool:
         if SKIP_PREFIX_RE.match(inp.command):

--- a/src/dev10x/validators/sql_safety.py
+++ b/src/dev10x/validators/sql_safety.py
@@ -12,9 +12,12 @@ import os
 import re
 import shlex
 from dataclasses import dataclass
+from typing import ClassVar
 
 from dev10x.domain import HookInput, HookResult
+from dev10x.domain.profile_tier import ProfileTier
 from dev10x.domain.result import ErrorResult, Result, err, ok
+from dev10x.validators.base import ValidatorBase
 
 POSTGRES_CONN_RE = re.compile(r"postgres(?:ql)?://[^'\"\s]+:[^@'\"\s]+@[a-zA-Z0-9._-]+")
 
@@ -164,8 +167,10 @@ def _validate_sql(sql: str) -> Result[str]:
 
 
 @dataclass
-class SqlSafetyValidator:
-    name: str = "sql-safety"
+class SqlSafetyValidator(ValidatorBase):
+    name: ClassVar[str] = "sql-safety"
+    rule_id: ClassVar[str] = "DX004"
+    profile: ClassVar[ProfileTier] = ProfileTier.MINIMAL
 
     def should_run(self, inp: HookInput) -> bool:
         cmd = inp.command

--- a/tests/validators/test_registry.py
+++ b/tests/validators/test_registry.py
@@ -1,0 +1,318 @@
+"""Tests for ValidatorRegistry, filters, and ValidatorChain (GH-82 #A1/#A2/#A3/#F5)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+import pytest
+
+from dev10x.domain import HookInput, HookResult, HookRetry
+from dev10x.domain.profile_tier import ProfileTier
+from dev10x.validators.base import ValidatorBase
+from dev10x.validators.registry import (
+    DisableListFilter,
+    ExperimentalFilter,
+    ProfileFilter,
+    ValidatorChain,
+    ValidatorRegistry,
+    ValidatorSpec,
+)
+
+
+@dataclass
+class _StubValidator(ValidatorBase):
+    name: ClassVar[str] = "stub"
+    rule_id: ClassVar[str] = "DX001"
+    profile: ClassVar[ProfileTier] = ProfileTier.MINIMAL
+
+    def should_run(self, inp: HookInput) -> bool:
+        return True
+
+    def validate(self, inp: HookInput) -> HookResult | None:
+        return HookResult(message="stub-blocked")
+
+
+@dataclass
+class _StubCorrector(ValidatorBase):
+    name: ClassVar[str] = "stub-correct"
+    rule_id: ClassVar[str] = "DX002"
+    profile: ClassVar[ProfileTier] = ProfileTier.STANDARD
+    capabilities: ClassVar[frozenset[str]] = frozenset({"validate", "correct"})
+
+    def should_run(self, inp: HookInput) -> bool:
+        return True
+
+    def validate(self, inp: HookInput) -> HookResult | None:
+        return None
+
+    def correct(self, inp: HookInput) -> HookRetry | None:
+        return HookRetry(message="stub-retry")
+
+
+@pytest.fixture
+def stub_input() -> HookInput:
+    return HookInput(raw={}, tool_name="Bash", command="echo hi", cwd="/tmp")
+
+
+class TestProfileFilter:
+    @pytest.mark.parametrize(
+        ("active", "validator_tier", "expected"),
+        [
+            (ProfileTier.MINIMAL, ProfileTier.MINIMAL, True),
+            (ProfileTier.MINIMAL, ProfileTier.STANDARD, False),
+            (ProfileTier.STANDARD, ProfileTier.STANDARD, True),
+            (ProfileTier.STANDARD, ProfileTier.STRICT, False),
+            (ProfileTier.STRICT, ProfileTier.STRICT, True),
+            (ProfileTier.STRICT, ProfileTier.MINIMAL, True),
+        ],
+    )
+    def test_keep(self, active: ProfileTier, validator_tier: ProfileTier, expected: bool) -> None:
+        spec = ValidatorSpec(
+            module_path="m", class_name="C", rule_id="DX001", profile=validator_tier
+        )
+        assert ProfileFilter(active=active).keep(spec=spec) is expected
+
+
+class TestDisableListFilter:
+    def test_drops_disabled_rule(self) -> None:
+        spec = ValidatorSpec(
+            module_path="m", class_name="C", rule_id="DX042", profile=ProfileTier.MINIMAL
+        )
+        f = DisableListFilter(disabled=frozenset({"DX042"}))
+        assert f.keep(spec=spec) is False
+
+    def test_keeps_unlisted_rule(self) -> None:
+        spec = ValidatorSpec(
+            module_path="m", class_name="C", rule_id="DX099", profile=ProfileTier.MINIMAL
+        )
+        f = DisableListFilter(disabled=frozenset({"DX042"}))
+        assert f.keep(spec=spec) is True
+
+    def test_case_insensitive(self) -> None:
+        spec = ValidatorSpec(
+            module_path="m", class_name="C", rule_id="dx042", profile=ProfileTier.MINIMAL
+        )
+        f = DisableListFilter(disabled=frozenset({"DX042"}))
+        assert f.keep(spec=spec) is False
+
+
+class TestExperimentalFilter:
+    def test_drops_experimental_when_disabled(self) -> None:
+        spec = ValidatorSpec(
+            module_path="m",
+            class_name="C",
+            rule_id="DX001",
+            profile=ProfileTier.MINIMAL,
+            experimental=True,
+        )
+        assert ExperimentalFilter(enabled=False).keep(spec=spec) is False
+
+    def test_keeps_experimental_when_enabled(self) -> None:
+        spec = ValidatorSpec(
+            module_path="m",
+            class_name="C",
+            rule_id="DX001",
+            profile=ProfileTier.MINIMAL,
+            experimental=True,
+        )
+        assert ExperimentalFilter(enabled=True).keep(spec=spec) is True
+
+    def test_keeps_non_experimental_always(self) -> None:
+        spec = ValidatorSpec(
+            module_path="m",
+            class_name="C",
+            rule_id="DX001",
+            profile=ProfileTier.MINIMAL,
+            experimental=False,
+        )
+        assert ExperimentalFilter(enabled=False).keep(spec=spec) is True
+
+
+class TestValidatorRegistry:
+    def _stub_spec(self) -> ValidatorSpec:
+        return ValidatorSpec(
+            module_path="tests.validators.test_registry",
+            class_name="_StubValidator",
+            rule_id="DX001",
+            profile=ProfileTier.MINIMAL,
+        )
+
+    def test_register_and_active_specs(self) -> None:
+        spec = self._stub_spec()
+        registry = ValidatorRegistry()
+        registry.register(spec=spec)
+        assert registry.active_specs() == [spec]
+
+    def test_active_instantiates_validator(self) -> None:
+        registry = ValidatorRegistry(specs=[self._stub_spec()])
+        validators = registry.active()
+        assert len(validators) == 1
+        assert isinstance(validators[0], _StubValidator)
+
+    def test_active_is_cached(self) -> None:
+        registry = ValidatorRegistry(specs=[self._stub_spec()])
+        first = registry.active()
+        second = registry.active()
+        assert first is second
+
+    def test_reset_invalidates_cache(self) -> None:
+        registry = ValidatorRegistry(specs=[self._stub_spec()])
+        first = registry.active()
+        registry.reset()
+        second = registry.active()
+        assert first is not second
+
+    def test_register_invalidates_cache(self) -> None:
+        registry = ValidatorRegistry(specs=[self._stub_spec()])
+        registry.active()
+        registry.register(spec=self._stub_spec())
+        assert registry._instances is None  # type: ignore[attr-defined]
+
+    def test_filter_drops_specs(self) -> None:
+        registry = ValidatorRegistry(
+            specs=[self._stub_spec()],
+            filters=[DisableListFilter(disabled=frozenset({"DX001"}))],
+        )
+        assert registry.active_specs() == []
+        assert registry.active() == []
+
+    def test_find_by_rule_id_hits(self) -> None:
+        spec = self._stub_spec()
+        registry = ValidatorRegistry(specs=[spec])
+        assert registry.find_by_rule_id(rule_id="DX001") is spec
+        assert registry.find_by_rule_id(rule_id="dx001") is spec
+
+    def test_find_by_rule_id_missing(self) -> None:
+        registry = ValidatorRegistry(specs=[self._stub_spec()])
+        assert registry.find_by_rule_id(rule_id="DX999") is None
+
+    def test_lookup_returns_active_instance(self) -> None:
+        registry = ValidatorRegistry(specs=[self._stub_spec()])
+        validator = registry.lookup(rule_id="DX001")
+        assert isinstance(validator, _StubValidator)
+
+    def test_lookup_returns_none_when_filtered_out(self) -> None:
+        registry = ValidatorRegistry(
+            specs=[self._stub_spec()],
+            filters=[DisableListFilter(disabled=frozenset({"DX001"}))],
+        )
+        assert registry.lookup(rule_id="DX001") is None
+
+    def test_is_active_true_when_filter_passes(self) -> None:
+        registry = ValidatorRegistry(specs=[self._stub_spec()])
+        assert registry.is_active(rule_id="DX001") is True
+
+    def test_is_active_false_when_filtered_out(self) -> None:
+        registry = ValidatorRegistry(
+            specs=[self._stub_spec()],
+            filters=[ProfileFilter(active=ProfileTier.STRICT)],
+        )
+        # spec is MINIMAL, STRICT includes everything so still active
+        assert registry.is_active(rule_id="DX001") is True
+
+    def test_metadata_mismatch_raises(self) -> None:
+        bad = ValidatorSpec(
+            module_path="tests.validators.test_registry",
+            class_name="_StubValidator",
+            rule_id="DX999",  # disagrees with class attr "DX001"
+            profile=ProfileTier.MINIMAL,
+        )
+        registry = ValidatorRegistry(specs=[bad])
+        with pytest.raises(AssertionError, match="rule_id"):
+            registry.active()
+
+
+class TestValidatorChain:
+    def test_run_collects_validate_results(self, stub_input: HookInput) -> None:
+        registry = ValidatorRegistry(
+            specs=[
+                ValidatorSpec(
+                    module_path="tests.validators.test_registry",
+                    class_name="_StubValidator",
+                    rule_id="DX001",
+                    profile=ProfileTier.MINIMAL,
+                )
+            ]
+        )
+        chain = ValidatorChain(registry=registry)
+        results = chain.run(inp=stub_input)
+        assert len(results) == 1
+        assert isinstance(results[0], HookResult)
+        assert results[0].message == "stub-blocked"
+
+    def test_run_swallows_validator_exceptions(self, stub_input: HookInput) -> None:
+        @dataclass
+        class _Raiser(ValidatorBase):
+            name: ClassVar[str] = "raiser"
+            rule_id: ClassVar[str] = "DX900"
+            profile: ClassVar[ProfileTier] = ProfileTier.MINIMAL
+
+            def should_run(self, inp: HookInput) -> bool:
+                return True
+
+            def validate(self, inp: HookInput) -> HookResult | None:
+                raise RuntimeError("boom")
+
+        registry = ValidatorRegistry()
+        registry._instances = [_Raiser()]  # type: ignore[attr-defined]
+        chain = ValidatorChain(registry=registry)
+        assert chain.run(inp=stub_input) == []
+
+    def test_correct_dispatches_only_to_capable(self, stub_input: HookInput) -> None:
+        registry = ValidatorRegistry(
+            specs=[
+                ValidatorSpec(
+                    module_path="tests.validators.test_registry",
+                    class_name="_StubValidator",
+                    rule_id="DX001",
+                    profile=ProfileTier.MINIMAL,
+                ),
+                ValidatorSpec(
+                    module_path="tests.validators.test_registry",
+                    class_name="_StubCorrector",
+                    rule_id="DX002",
+                    profile=ProfileTier.STANDARD,
+                ),
+            ]
+        )
+        chain = ValidatorChain(registry=registry)
+        result = chain.correct(inp=stub_input)
+        assert isinstance(result, HookRetry)
+        assert result.message == "stub-retry"
+
+    def test_correct_returns_none_when_no_capable_validators(self, stub_input: HookInput) -> None:
+        registry = ValidatorRegistry(
+            specs=[
+                ValidatorSpec(
+                    module_path="tests.validators.test_registry",
+                    class_name="_StubValidator",
+                    rule_id="DX001",
+                    profile=ProfileTier.MINIMAL,
+                )
+            ]
+        )
+        chain = ValidatorChain(registry=registry)
+        assert chain.correct(inp=stub_input) is None
+
+    def test_correct_swallows_exceptions(self, stub_input: HookInput) -> None:
+        @dataclass
+        class _Raiser(ValidatorBase):
+            name: ClassVar[str] = "raiser"
+            rule_id: ClassVar[str] = "DX901"
+            profile: ClassVar[ProfileTier] = ProfileTier.STANDARD
+            capabilities: ClassVar[frozenset[str]] = frozenset({"validate", "correct"})
+
+            def should_run(self, inp: HookInput) -> bool:
+                return True
+
+            def validate(self, inp: HookInput) -> HookResult | None:
+                return None
+
+            def correct(self, inp: HookInput) -> HookRetry | None:
+                raise RuntimeError("boom")
+
+        registry = ValidatorRegistry()
+        registry._instances = [_Raiser()]  # type: ignore[attr-defined]
+        chain = ValidatorChain(registry=registry)
+        assert chain.correct(inp=stub_input) is None


### PR DESCRIPTION
When I extend the Bash validator surface (new rule, new filter, new capability), I want to add an entry to a typed registry instead of editing the central loop, so I can land additive changes without touching shared dispatch code or monkey-patching attributes onto instances.

---

[`48cee6d3`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/129/commits/48cee6d3f25c616bfe53fb8e9cdb34bea5016656) ♻️ GH-82 Promote validator registry and capability dispatch
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/82

---