### PR TITLE
♻️ GH-81 Consolidate Plan domain via service layer + TaskStatus

### DIFF
--- a/src/dev10x/domain/plan.py
+++ b/src/dev10x/domain/plan.py
@@ -13,6 +13,7 @@ import re
 import tempfile
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
@@ -32,6 +33,75 @@ def _get_branch() -> str:
 def _extract_task_id(tool_result: str) -> str | None:
     match = re.search(r"Task #(\d+)", tool_result)
     return match.group(1) if match else None
+
+
+def get_toplevel() -> str | None:
+    """Return the git toplevel for the current CWD, or None outside a repo.
+
+    A fresh GitContext is constructed per call so the MCP server (a
+    long-lived process) sees the caller's effective CWD on every
+    invocation instead of caching the directory the first call hit.
+    """
+    from dev10x.domain.git_context import GitContext
+
+    return GitContext().toplevel
+
+
+def get_plan_path(*, toplevel: str) -> Path:
+    """Resolve the canonical plan file path within a git toplevel."""
+    return Path(toplevel) / ".claude" / "session" / "plan.yaml"
+
+
+class TaskStatus(StrEnum):
+    PENDING = "pending"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    DELETED = "deleted"
+
+
+@dataclass(frozen=True)
+class TaskTransition:
+    timestamp_field: str | None
+    allowed_from: frozenset[TaskStatus | None]
+
+
+# Declarative transition table. `allowed_from` lists the prior statuses
+# that may transition to the target; `None` represents an absent/new
+# status (the task entry has no `status` field yet). DELETED is reachable
+# from any state because the operation removes the task entirely.
+TASK_TRANSITIONS: dict[TaskStatus, TaskTransition] = {
+    TaskStatus.PENDING: TaskTransition(
+        timestamp_field=None,
+        allowed_from=frozenset({None, TaskStatus.PENDING, TaskStatus.IN_PROGRESS}),
+    ),
+    TaskStatus.IN_PROGRESS: TaskTransition(
+        timestamp_field="started_at",
+        allowed_from=frozenset({None, TaskStatus.PENDING, TaskStatus.IN_PROGRESS}),
+    ),
+    TaskStatus.COMPLETED: TaskTransition(
+        timestamp_field="completed_at",
+        allowed_from=frozenset(
+            {
+                None,
+                TaskStatus.PENDING,
+                TaskStatus.IN_PROGRESS,
+                TaskStatus.COMPLETED,
+            }
+        ),
+    ),
+    TaskStatus.DELETED: TaskTransition(
+        timestamp_field=None,
+        allowed_from=frozenset(
+            {
+                None,
+                TaskStatus.PENDING,
+                TaskStatus.IN_PROGRESS,
+                TaskStatus.COMPLETED,
+                TaskStatus.DELETED,
+            }
+        ),
+    ),
+}
 
 
 @dataclass
@@ -87,6 +157,11 @@ class Plan:
             result["tasks"] = self.tasks
         return result
 
+    def archive(self, *, path: Path) -> None:
+        """Stamp `archived_at` on plan metadata and persist to `path`."""
+        self.metadata["archived_at"] = _now_iso()
+        self.save(path=path)
+
     def ensure_metadata(self) -> None:
         if not self.metadata:
             self.metadata = {
@@ -99,6 +174,13 @@ class Plan:
     @property
     def is_new(self) -> bool:
         return not self.metadata
+
+    def context_keys(self) -> list[str]:
+        """Return the top-level keys stored under plan context."""
+        context = self.metadata.get("context", {})
+        if not isinstance(context, dict):
+            return []
+        return list(context.keys())
 
     def handle_task_create(
         self,
@@ -113,7 +195,7 @@ class Plan:
         task_entry: dict[str, Any] = {
             "id": task_id,
             "subject": tool_input.get("subject", ""),
-            "status": "pending",
+            "status": TaskStatus.PENDING.value,
             "created_at": _now_iso(),
         }
         description = tool_input.get("description")
@@ -134,20 +216,28 @@ class Plan:
         if not task_id:
             return
 
-        status = tool_input.get("status")
-        if status == "deleted":
+        raw_status = tool_input.get("status")
+        target_status = _coerce_status(raw_status)
+        if target_status is TaskStatus.DELETED:
             self.tasks = [t for t in self.tasks if t.get("id") != task_id]
             return
 
         for task in self.tasks:
             if task.get("id") != task_id:
                 continue
-            if status:
-                task["status"] = status
-                if status == "completed":
-                    task["completed_at"] = _now_iso()
-                elif status == "in_progress":
-                    task["started_at"] = _now_iso()
+            if target_status is not None and not _is_valid_transition(
+                current=_coerce_status(task.get("status")),
+                target=target_status,
+            ):
+                # Reject invalid transitions silently; the hook must keep
+                # processing other updates rather than crashing on a stale
+                # status flip caused by clock skew or replay.
+                break
+            if target_status is not None:
+                task["status"] = target_status.value
+                transition = TASK_TRANSITIONS[target_status]
+                if transition.timestamp_field is not None:
+                    task[transition.timestamp_field] = _now_iso()
             if "subject" in tool_input:
                 task["subject"] = tool_input["subject"]
             if "description" in tool_input:
@@ -165,13 +255,30 @@ class Plan:
 
     def check_all_completed(self) -> None:
         all_statuses = [t.get("status") for t in self.tasks]
-        if all_statuses and all(s == "completed" for s in all_statuses):
-            self.metadata["status"] = "completed"
+        if all_statuses and all(s == TaskStatus.COMPLETED.value for s in all_statuses):
+            self.metadata["status"] = TaskStatus.COMPLETED.value
             self.metadata["completed_at"] = _now_iso()
 
     def set_context(self, *, key: str, value: str) -> None:
         context = self.metadata.setdefault("context", {})
         _set_nested(d=context, dotpath=key, value=value)
+
+
+def _coerce_status(raw: Any) -> TaskStatus | None:
+    if raw is None:
+        return None
+    try:
+        return TaskStatus(raw)
+    except ValueError:
+        return None
+
+
+def _is_valid_transition(
+    *,
+    current: TaskStatus | None,
+    target: TaskStatus,
+) -> bool:
+    return current in TASK_TRANSITIONS[target].allowed_from
 
 
 def _set_nested(*, d: dict[str, Any], dotpath: str, value: str) -> None:

--- a/src/dev10x/domain/session_state.py
+++ b/src/dev10x/domain/session_state.py
@@ -100,21 +100,19 @@ class PlanSummary:
         )
 
     @property
+    def pending_tasks(self) -> list[dict[str, Any]]:
+        return [t for t in self.tasks if t.get("status") not in ("completed", "deleted")]
+
+    @property
     def pending_decisions(self) -> list[dict[str, Any]]:
-        return [
-            t
-            for t in self.tasks
-            if t.get("status") not in ("completed", "deleted")
-            and t.get("metadata", {}).get("decision_needed")
-        ]
+        return [t for t in self.pending_tasks if t.get("metadata", {}).get("decision_needed")]
 
     def format_for_display(self) -> str:
         completed = sum(1 for t in self.tasks if t.get("status") == "completed")
         total = len(self.tasks)
         pending = [
             f"  - [{t.get('status')}] #{t.get('id')} {t.get('subject')}"
-            for t in self.tasks
-            if t.get("status") not in ("completed", "deleted")
+            for t in self.pending_tasks
         ]
 
         lines = [f"Persisted plan detected ({completed}/{total} tasks completed):"]

--- a/src/dev10x/hooks/task_plan_sync.py
+++ b/src/dev10x/hooks/task_plan_sync.py
@@ -1,7 +1,9 @@
-"""Task plan synchronizer — persists task state to a YAML plan file.
+"""Task plan synchronizer — CLI entry points for plan operations.
 
-Triggered on TaskCreate and TaskUpdate. Maintains a per-project
-plan file that survives context compaction and session restarts.
+Triggered on TaskCreate and TaskUpdate (via `cmd_hook`) or invoked
+directly from `dev10x hook plan ...` commands. The mutation logic
+lives in `dev10x.plan.service`; this module is the thin CLI adapter
+that handles stdin parsing, locking, and stdout/exit-code shaping.
 
 Plan file location:
     <git-toplevel>/.claude/session/plan.yaml
@@ -11,93 +13,57 @@ from __future__ import annotations
 
 import json
 import sys
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 from dev10x.domain.file_locks import file_lock
-from dev10x.domain.git_context import GitContext
-from dev10x.domain.plan import Plan
-
-
-def get_toplevel() -> str | None:
-    # GH-979: Fresh GitContext per call so the MCP server (long-lived
-    # process) sees the caller's effective CWD on every invocation
-    # instead of caching the directory the first call happened to hit.
-    return GitContext().toplevel
-
-
-def get_plan_path(*, toplevel: str) -> Path:
-    return Path(toplevel) / ".claude" / "session" / "plan.yaml"
+from dev10x.domain.plan import Plan, get_plan_path, get_toplevel
+from dev10x.plan.service import (
+    PlanServiceError,
+    archive_plan,
+    plan_summary,
+    set_plan_context,
+)
 
 
 def read_plan(*, plan_path: Path) -> dict[str, Any]:
-    plan = Plan.load(path=plan_path)
-    return plan._to_dict()
+    """Load plan YAML into a dict. Consumed by `dev10x.hooks.session`."""
+    return Plan.load(path=plan_path)._to_dict()
 
 
 def cmd_set_context(*, args: list[str]) -> None:
-    toplevel = get_toplevel()
-    if not toplevel:
-        print("Not in a git repository", file=sys.stderr)
+    try:
+        updated = set_plan_context(args=args)
+    except PlanServiceError as exc:
+        print(str(exc), file=sys.stderr)
         sys.exit(1)
-
-    plan_path = get_plan_path(toplevel=toplevel)
-    plan = Plan.load(path=plan_path)
-    plan.ensure_metadata()
-
-    for arg in args:
-        if "=" not in arg:
-            print(f"Invalid argument (expected K=V): {arg}", file=sys.stderr)
-            sys.exit(1)
-        key, value = arg.split("=", 1)
-        plan.set_context(key=key, value=value)
-
-    plan.save(path=plan_path)
-    context = plan.metadata.get("context", {})
-    print(f"Updated plan context: {list(context.keys())}")
+    print(f"Updated plan context: {updated}")
 
 
 def cmd_archive() -> None:
-    toplevel = get_toplevel()
-    if not toplevel:
-        print("Not in a git repository", file=sys.stderr)
+    try:
+        result = archive_plan()
+    except PlanServiceError as exc:
+        print(str(exc), file=sys.stderr)
         sys.exit(1)
-
-    plan_path = get_plan_path(toplevel=toplevel)
-    if not plan_path.exists():
+    if not result["archived"]:
         print("No plan file to archive")
         sys.exit(0)
-
-    plan = Plan.load(path=plan_path)
-    archive_dir = Path(toplevel) / ".claude" / "session" / "archive"
-    archive_dir.mkdir(parents=True, exist_ok=True)
-
-    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S")
-    branch_slug = plan.metadata.get("branch", "unknown")
-    branch_slug = branch_slug.replace("/", "-")[:50]
-    archive_name = f"plan-{timestamp}-{branch_slug}.yaml"
-    archive_path = archive_dir / archive_name
-
-    plan.metadata["archived_at"] = datetime.now(UTC).isoformat()
-    plan.save(path=archive_path)
-    plan_path.unlink()
-    print(f"Archived plan to {archive_path.name}")
+    print(f"Archived plan to {result['archive_name']}")
 
 
 def cmd_json_summary() -> None:
-    toplevel = get_toplevel()
-    if not toplevel:
+    try:
+        summary = plan_summary()
+    except PlanServiceError:
         json.dump({}, sys.stdout)
         sys.exit(0)
 
-    plan_path = get_plan_path(toplevel=toplevel)
-    plan = Plan.load(path=plan_path)
-    if not plan.metadata:
+    if not summary:
         json.dump({}, sys.stdout)
         sys.exit(0)
 
-    json.dump(plan._to_dict(), sys.stdout, indent=2)
+    json.dump(summary, sys.stdout, indent=2)
 
 
 def cmd_hook() -> None:

--- a/src/dev10x/plan/__init__.py
+++ b/src/dev10x/plan/__init__.py
@@ -1,89 +1,42 @@
 """Plan sync MCP tool implementations.
 
-Wraps task-plan-sync operations as MCP tools so skills can
-update plan context, retrieve summaries, and archive plans
-without Bash allow-rule friction.
+Wraps the `dev10x.plan.service` transaction layer as async MCP
+tools so skills can update plan context, retrieve summaries, and
+archive plans without Bash allow-rule friction.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
+from dev10x.plan.service import (
+    PlanServiceError,
+    archive_plan,
+    plan_summary,
+    set_plan_context,
+)
+
 
 async def set_context(*, args: list[str]) -> dict[str, Any]:
-    from dev10x.hooks.task_plan_sync import (
-        Plan,
-        get_plan_path,
-        get_toplevel,
-    )
-
-    toplevel = get_toplevel()
-    if not toplevel:
-        return {"error": "Not in a git repository"}
-
-    plan_path = get_plan_path(toplevel=toplevel)
-    plan = Plan.load(path=plan_path)
-    plan.ensure_metadata()
-
-    for arg in args:
-        if "=" not in arg:
-            return {"error": f"Invalid argument (expected K=V): {arg}"}
-        key, value = arg.split("=", 1)
-        plan.set_context(key=key, value=value)
-
-    plan.save(path=plan_path)
-    context = plan.metadata.get("context", {})
-    return {"success": True, "updated_keys": list(context.keys())}
+    try:
+        updated = set_plan_context(args=args)
+    except PlanServiceError as exc:
+        return {"error": str(exc)}
+    return {"success": True, "updated_keys": updated}
 
 
 async def json_summary() -> dict[str, Any]:
-    from dev10x.hooks.task_plan_sync import (
-        Plan,
-        get_plan_path,
-        get_toplevel,
-    )
-
-    toplevel = get_toplevel()
-    if not toplevel:
-        return {"error": "Not in a git repository"}
-
-    plan_path = get_plan_path(toplevel=toplevel)
-    plan = Plan.load(path=plan_path)
-    if not plan.metadata:
-        return {}
-
-    return plan._to_dict()
+    try:
+        return plan_summary()
+    except PlanServiceError as exc:
+        return {"error": str(exc)}
 
 
 async def archive() -> dict[str, Any]:
-    from datetime import UTC, datetime
-    from pathlib import Path
-
-    from dev10x.hooks.task_plan_sync import (
-        Plan,
-        get_plan_path,
-        get_toplevel,
-    )
-
-    toplevel = get_toplevel()
-    if not toplevel:
-        return {"error": "Not in a git repository"}
-
-    plan_path = get_plan_path(toplevel=toplevel)
-    if not plan_path.exists():
+    try:
+        result = archive_plan()
+    except PlanServiceError as exc:
+        return {"error": str(exc)}
+    if not result["archived"]:
         return {"success": True, "message": "No plan file to archive"}
-
-    plan = Plan.load(path=plan_path)
-    archive_dir = Path(toplevel) / ".claude" / "session" / "archive"
-    archive_dir.mkdir(parents=True, exist_ok=True)
-
-    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S")
-    branch_slug = plan.metadata.get("branch", "unknown")
-    branch_slug = branch_slug.replace("/", "-")[:50]
-    archive_name = f"plan-{timestamp}-{branch_slug}.yaml"
-    archive_path = archive_dir / archive_name
-
-    plan.metadata["archived_at"] = datetime.now(UTC).isoformat()
-    plan.save(path=archive_path)
-    plan_path.unlink()
-    return {"success": True, "archive_name": archive_name}
+    return {"success": True, "archive_name": result["archive_name"]}

--- a/src/dev10x/plan/service.py
+++ b/src/dev10x/plan/service.py
@@ -1,0 +1,83 @@
+"""Plan transaction layer.
+
+Single canonical implementation of the operations that mutate or
+read a project's plan file. Both the CLI hook
+(`dev10x.hooks.task_plan_sync`) and the MCP wrapper
+(`dev10x.plan`) delegate here, eliminating the previously
+duplicated `archive()` block and inline imports.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from dev10x.domain.plan import Plan, get_plan_path, get_toplevel
+
+
+class PlanServiceError(Exception):
+    """Raised when a plan service operation cannot proceed."""
+
+
+def set_plan_context(*, args: list[str]) -> list[str]:
+    """Apply K=V context updates to the plan; return updated keys."""
+    toplevel = get_toplevel()
+    if not toplevel:
+        raise PlanServiceError("Not in a git repository")
+
+    plan_path = get_plan_path(toplevel=toplevel)
+    plan = Plan.load(path=plan_path)
+    plan.ensure_metadata()
+
+    for arg in args:
+        if "=" not in arg:
+            raise PlanServiceError(f"Invalid argument (expected K=V): {arg}")
+        key, value = arg.split("=", 1)
+        plan.set_context(key=key, value=value)
+
+    plan.save(path=plan_path)
+    return plan.context_keys()
+
+
+def plan_summary() -> dict[str, Any]:
+    """Return the plan as a YAML-shaped dict, or `{}` when not yet started."""
+    toplevel = get_toplevel()
+    if not toplevel:
+        raise PlanServiceError("Not in a git repository")
+
+    plan_path = get_plan_path(toplevel=toplevel)
+    plan = Plan.load(path=plan_path)
+    if plan.is_new:
+        return {}
+    return plan._to_dict()
+
+
+def archive_plan() -> dict[str, Any]:
+    """Move the active plan file into the session archive.
+
+    Returns a dict describing the outcome: `{"archived": False}` when
+    there is no plan to archive, or `{"archived": True, "archive_name": ...}`
+    after a successful move. Callers translate this into a CLI message
+    or MCP response payload.
+    """
+    toplevel = get_toplevel()
+    if not toplevel:
+        raise PlanServiceError("Not in a git repository")
+
+    plan_path = get_plan_path(toplevel=toplevel)
+    if not plan_path.exists():
+        return {"archived": False}
+
+    plan = Plan.load(path=plan_path)
+    archive_dir = plan_path.parent / "archive"
+    archive_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S")
+    branch_slug = plan.metadata.get("branch", "unknown")
+    branch_slug = branch_slug.replace("/", "-")[:50]
+    archive_name = f"plan-{timestamp}-{branch_slug}.yaml"
+    archive_path = archive_dir / archive_name
+
+    plan.archive(path=archive_path)
+    plan_path.unlink()
+    return {"archived": True, "archive_name": archive_name}

--- a/tests/domain/test_plan.py
+++ b/tests/domain/test_plan.py
@@ -6,7 +6,14 @@ from unittest.mock import patch
 import pytest
 import yaml
 
-from dev10x.domain.plan import Plan, _extract_task_id, _set_nested
+from dev10x.domain.plan import (
+    TASK_TRANSITIONS,
+    Plan,
+    TaskStatus,
+    _extract_task_id,
+    _set_nested,
+    get_plan_path,
+)
 
 
 class TestExtractTaskId:
@@ -287,3 +294,70 @@ class TestPlanEnsureMetadata:
 
         assert plan.metadata["branch"] == "old"
         assert "last_synced" in plan.metadata
+
+
+class TestPlanArchive:
+    def test_stamps_archived_at_and_saves(self, tmp_path: Path) -> None:
+        plan = Plan(metadata={"status": "completed"})
+        archive_path = tmp_path / "archive" / "plan.yaml"
+
+        plan.archive(path=archive_path)
+
+        assert archive_path.exists()
+        assert "archived_at" in plan.metadata
+        loaded = Plan.load(path=archive_path)
+        assert "archived_at" in loaded.metadata
+
+
+class TestPlanContextKeys:
+    def test_returns_empty_when_no_context(self) -> None:
+        assert Plan(metadata={"status": "x"}).context_keys() == []
+
+    def test_returns_context_keys(self) -> None:
+        plan = Plan(metadata={"context": {"work_type": "feature", "tickets": []}})
+
+        assert sorted(plan.context_keys()) == ["tickets", "work_type"]
+
+    def test_returns_empty_when_context_not_dict(self) -> None:
+        plan = Plan(metadata={"context": "broken"})
+
+        assert plan.context_keys() == []
+
+
+class TestTaskTransitions:
+    def test_pending_has_no_timestamp(self) -> None:
+        assert TASK_TRANSITIONS[TaskStatus.PENDING].timestamp_field is None
+
+    def test_in_progress_writes_started_at(self) -> None:
+        assert TASK_TRANSITIONS[TaskStatus.IN_PROGRESS].timestamp_field == "started_at"
+
+    def test_completed_writes_completed_at(self) -> None:
+        assert TASK_TRANSITIONS[TaskStatus.COMPLETED].timestamp_field == "completed_at"
+
+    def test_completed_to_in_progress_rejected(self) -> None:
+        plan = Plan(
+            metadata={"status": "in_progress"},
+            tasks=[{"id": "1", "status": "completed", "completed_at": "old"}],
+        )
+
+        plan.handle_task_update(tool_input={"taskId": "1", "status": "in_progress"})
+
+        assert plan.tasks[0]["status"] == "completed"
+        assert "started_at" not in plan.tasks[0]
+
+    def test_unknown_status_silently_skipped(self) -> None:
+        plan = Plan(
+            metadata={"status": "in_progress"},
+            tasks=[{"id": "1", "status": "pending"}],
+        )
+
+        plan.handle_task_update(tool_input={"taskId": "1", "status": "bogus"})
+
+        assert plan.tasks[0]["status"] == "pending"
+
+
+class TestGetPlanPath:
+    def test_joins_toplevel_with_session_plan(self, tmp_path: Path) -> None:
+        path = get_plan_path(toplevel=str(tmp_path))
+
+        assert path == tmp_path / ".claude" / "session" / "plan.yaml"

--- a/tests/domain/test_session_state.py
+++ b/tests/domain/test_session_state.py
@@ -159,6 +159,25 @@ class TestPlanSummaryFormatForDisplay:
         assert "can be archived" in summary.format_for_display()
 
 
+class TestPlanSummaryPendingTasks:
+    def test_excludes_completed_and_deleted(self) -> None:
+        summary = PlanSummary(
+            tasks=[
+                {"id": "1", "subject": "A", "status": "pending"},
+                {"id": "2", "subject": "B", "status": "in_progress"},
+                {"id": "3", "subject": "C", "status": "completed"},
+                {"id": "4", "subject": "D", "status": "deleted"},
+            ],
+        )
+
+        ids = [t["id"] for t in summary.pending_tasks]
+
+        assert ids == ["1", "2"]
+
+    def test_empty_when_no_tasks(self) -> None:
+        assert PlanSummary().pending_tasks == []
+
+
 class TestPlanSummaryPendingDecisions:
     def test_returns_tasks_with_decision_needed(self) -> None:
         summary = PlanSummary(

--- a/tests/plan/test_plan.py
+++ b/tests/plan/test_plan.py
@@ -7,12 +7,12 @@ import pytest
 
 plan_mod = pytest.importorskip("dev10x.plan", reason="dev10x not installed")
 
-TASK_PLAN_SYNC = "dev10x.hooks.task_plan_sync"
+SERVICE = "dev10x.plan.service"
 
 
 class TestSetContext:
     @pytest.mark.asyncio
-    @patch(f"{TASK_PLAN_SYNC}.get_toplevel", return_value=None)
+    @patch(f"{SERVICE}.get_toplevel", return_value=None)
     async def test_returns_error_when_not_in_git_repo(
         self,
         mock_toplevel: MagicMock,
@@ -21,9 +21,9 @@ class TestSetContext:
         assert result == {"error": "Not in a git repository"}
 
     @pytest.mark.asyncio
-    @patch(f"{TASK_PLAN_SYNC}.get_toplevel", return_value="/tmp/repo")
-    @patch(f"{TASK_PLAN_SYNC}.get_plan_path")
-    @patch(f"{TASK_PLAN_SYNC}.Plan")
+    @patch(f"{SERVICE}.get_toplevel", return_value="/tmp/repo")
+    @patch(f"{SERVICE}.get_plan_path")
+    @patch(f"{SERVICE}.Plan")
     async def test_returns_error_for_invalid_arg(
         self,
         mock_plan_cls: MagicMock,
@@ -36,9 +36,9 @@ class TestSetContext:
         assert "error" in result
 
     @pytest.mark.asyncio
-    @patch(f"{TASK_PLAN_SYNC}.get_toplevel", return_value="/tmp/repo")
-    @patch(f"{TASK_PLAN_SYNC}.get_plan_path")
-    @patch(f"{TASK_PLAN_SYNC}.Plan")
+    @patch(f"{SERVICE}.get_toplevel", return_value="/tmp/repo")
+    @patch(f"{SERVICE}.get_plan_path")
+    @patch(f"{SERVICE}.Plan")
     async def test_sets_context_successfully(
         self,
         mock_plan_cls: MagicMock,
@@ -46,7 +46,7 @@ class TestSetContext:
         mock_toplevel: MagicMock,
     ) -> None:
         mock_plan = MagicMock()
-        mock_plan.metadata = {"context": {"key": "value"}}
+        mock_plan.context_keys.return_value = ["key"]
         mock_plan_cls.load.return_value = mock_plan
         result = await plan_mod.set_context(args=["key=value"])
         assert result["success"] is True
@@ -55,7 +55,7 @@ class TestSetContext:
 
 class TestJsonSummary:
     @pytest.mark.asyncio
-    @patch(f"{TASK_PLAN_SYNC}.get_toplevel", return_value=None)
+    @patch(f"{SERVICE}.get_toplevel", return_value=None)
     async def test_returns_error_when_not_in_git_repo(
         self,
         mock_toplevel: MagicMock,
@@ -64,9 +64,9 @@ class TestJsonSummary:
         assert result == {"error": "Not in a git repository"}
 
     @pytest.mark.asyncio
-    @patch(f"{TASK_PLAN_SYNC}.get_toplevel", return_value="/tmp/repo")
-    @patch(f"{TASK_PLAN_SYNC}.get_plan_path")
-    @patch(f"{TASK_PLAN_SYNC}.Plan")
+    @patch(f"{SERVICE}.get_toplevel", return_value="/tmp/repo")
+    @patch(f"{SERVICE}.get_plan_path")
+    @patch(f"{SERVICE}.Plan")
     async def test_returns_empty_when_no_metadata(
         self,
         mock_plan_cls: MagicMock,
@@ -74,15 +74,15 @@ class TestJsonSummary:
         mock_toplevel: MagicMock,
     ) -> None:
         mock_plan = MagicMock()
-        mock_plan.metadata = {}
+        mock_plan.is_new = True
         mock_plan_cls.load.return_value = mock_plan
         result = await plan_mod.json_summary()
         assert result == {}
 
     @pytest.mark.asyncio
-    @patch(f"{TASK_PLAN_SYNC}.get_toplevel", return_value="/tmp/repo")
-    @patch(f"{TASK_PLAN_SYNC}.get_plan_path")
-    @patch(f"{TASK_PLAN_SYNC}.Plan")
+    @patch(f"{SERVICE}.get_toplevel", return_value="/tmp/repo")
+    @patch(f"{SERVICE}.get_plan_path")
+    @patch(f"{SERVICE}.Plan")
     async def test_returns_plan_dict(
         self,
         mock_plan_cls: MagicMock,
@@ -90,7 +90,7 @@ class TestJsonSummary:
         mock_toplevel: MagicMock,
     ) -> None:
         mock_plan = MagicMock()
-        mock_plan.metadata = {"branch": "feature"}
+        mock_plan.is_new = False
         mock_plan._to_dict.return_value = {"metadata": {"branch": "feature"}}
         mock_plan_cls.load.return_value = mock_plan
         result = await plan_mod.json_summary()
@@ -99,7 +99,7 @@ class TestJsonSummary:
 
 class TestArchive:
     @pytest.mark.asyncio
-    @patch(f"{TASK_PLAN_SYNC}.get_toplevel", return_value=None)
+    @patch(f"{SERVICE}.get_toplevel", return_value=None)
     async def test_returns_error_when_not_in_git_repo(
         self,
         mock_toplevel: MagicMock,
@@ -108,8 +108,8 @@ class TestArchive:
         assert result == {"error": "Not in a git repository"}
 
     @pytest.mark.asyncio
-    @patch(f"{TASK_PLAN_SYNC}.get_toplevel", return_value="/tmp/repo")
-    @patch(f"{TASK_PLAN_SYNC}.get_plan_path")
+    @patch(f"{SERVICE}.get_toplevel", return_value="/tmp/repo")
+    @patch(f"{SERVICE}.get_plan_path")
     async def test_returns_success_when_no_plan_file(
         self,
         mock_plan_path: MagicMock,

--- a/tests/plan/test_service.py
+++ b/tests/plan/test_service.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from dev10x.plan.service import (
+    PlanServiceError,
+    archive_plan,
+    plan_summary,
+    set_plan_context,
+)
+
+SERVICE = "dev10x.plan.service"
+
+
+class TestSetPlanContext:
+    @patch(f"{SERVICE}.get_toplevel", return_value=None)
+    def test_raises_outside_git_repo(self, _toplevel: object) -> None:
+        with pytest.raises(PlanServiceError, match="git repository"):
+            set_plan_context(args=["k=v"])
+
+    def test_raises_for_invalid_arg(self, tmp_path: Path) -> None:
+        with patch(f"{SERVICE}.get_toplevel", return_value=str(tmp_path)):
+            with pytest.raises(PlanServiceError, match="K=V"):
+                set_plan_context(args=["no-equals"])
+
+    def test_returns_updated_keys(self, tmp_path: Path) -> None:
+        with (
+            patch(f"{SERVICE}.get_toplevel", return_value=str(tmp_path)),
+            patch("dev10x.domain.plan._get_branch", return_value="b"),
+        ):
+            updated = set_plan_context(args=["work_type=feature", 'tickets=["X"]'])
+
+        assert "work_type" in updated
+        assert "tickets" in updated
+
+
+class TestPlanSummary:
+    @patch(f"{SERVICE}.get_toplevel", return_value=None)
+    def test_raises_outside_git_repo(self, _toplevel: object) -> None:
+        with pytest.raises(PlanServiceError):
+            plan_summary()
+
+    def test_returns_empty_when_no_plan(self, tmp_path: Path) -> None:
+        with patch(f"{SERVICE}.get_toplevel", return_value=str(tmp_path)):
+            assert plan_summary() == {}
+
+    def test_returns_dict_when_plan_exists(self, tmp_path: Path) -> None:
+        with (
+            patch(f"{SERVICE}.get_toplevel", return_value=str(tmp_path)),
+            patch("dev10x.domain.plan._get_branch", return_value="b"),
+        ):
+            set_plan_context(args=["work_type=feature"])
+            result = plan_summary()
+
+        assert result["plan"]["context"]["work_type"] == "feature"
+
+
+class TestArchivePlan:
+    @patch(f"{SERVICE}.get_toplevel", return_value=None)
+    def test_raises_outside_git_repo(self, _toplevel: object) -> None:
+        with pytest.raises(PlanServiceError):
+            archive_plan()
+
+    def test_returns_archived_false_when_missing(self, tmp_path: Path) -> None:
+        with patch(f"{SERVICE}.get_toplevel", return_value=str(tmp_path)):
+            assert archive_plan() == {"archived": False}
+
+    def test_archives_existing_plan(self, tmp_path: Path) -> None:
+        with (
+            patch(f"{SERVICE}.get_toplevel", return_value=str(tmp_path)),
+            patch("dev10x.domain.plan._get_branch", return_value="feature/x"),
+        ):
+            set_plan_context(args=["work_type=feature"])
+            result = archive_plan()
+
+        assert result["archived"] is True
+        assert result["archive_name"].startswith("plan-")
+        assert result["archive_name"].endswith(".yaml")
+        archive_dir = tmp_path / ".claude" / "session" / "archive"
+        assert (archive_dir / result["archive_name"]).exists()
+        # Active plan is moved away
+        assert not (tmp_path / ".claude" / "session" / "plan.yaml").exists()


### PR DESCRIPTION
When I need to update plan context, archive a finished plan, or load a summary, **I want** a single transaction layer (`dev10x.plan.service`) that owns those operations and a Plan domain object that owns its own mutations and transition rules, **so I can** stop maintaining duplicated archive logic across the CLI hook and MCP wrapper, stop reaching into `plan.metadata` from callers, and rely on `TaskStatus` + `TASK_TRANSITIONS` to reject invalid state changes declaratively.

---

[`20e66a2a`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/131/commits/20e66a2aa5e2a3c4b62384afaa4c1b8dc3a42c14) ♻️ GH-81 Consolidate Plan domain via service layer + TaskStatus
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/81

---