### PR TITLE
✨ GH-113 Enable early-insight short-circuit in skill-audit

### DIFF
--- a/skills/skill-audit/evals/evals.json
+++ b/skills/skill-audit/evals/evals.json
@@ -20,6 +20,11 @@
       "id": "findings-output",
       "name": "Findings Output",
       "description": "Produces structured skill findings report with counts and recommendations"
+    },
+    {
+      "id": "early-insight-gate",
+      "name": "Early-Insight Gate",
+      "description": "Phase 0 detects narrow, transcript-evident questions, presents inline findings, and routes via AskUserQuestion with three options (select & file, step back, discard) without dispatching wave subagents"
     }
   ],
   "evals": [
@@ -102,6 +107,104 @@
           "check": "tool_not_called",
           "tool": "AskUserQuestion",
           "signal": "AskUserQuestion is not called; audit proceeds directly"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "name": "early-insight-gate-fires",
+      "prompt": "/Dev10x:skill-audit why did you merge with unhandled review https://github.com/Dev10x-Guru/Dev10x-Claude/pull/111",
+      "description": "Tests that Phase 0 fires when the user asks a narrow, transcript-evident question. The gate must present findings inline, call AskUserQuestion with three options, and on 'Select & file now' route to Dev10x:audit-report without dispatching wave subagents.",
+      "setup": {
+        "explicit_path": "not provided",
+        "narrow_question": "why did you merge with unhandled review <PR-URL>",
+        "evidence_in_context": true,
+        "invocation": "/Dev10x:skill-audit why did you merge with unhandled review https://github.com/Dev10x-Guru/Dev10x-Claude/pull/111"
+      },
+      "dimensions": ["early-insight-gate"],
+      "assertions": [
+        {
+          "id": "phase0_gate_uses_tool",
+          "text": "Phase 0 early-insight gate calls AskUserQuestion (not plain text)",
+          "check": "tool_called",
+          "tool": "AskUserQuestion",
+          "signal": "AskUserQuestion is called after inline findings are presented"
+        },
+        {
+          "id": "phase0_option_count",
+          "text": "Gate presents exactly 3 options",
+          "check": "option_count",
+          "count": 3,
+          "signal": "Three options: Select & file now / Step back / Discard"
+        },
+        {
+          "id": "phase0_option_labels",
+          "text": "Options match the documented labels",
+          "check": "output_contains",
+          "signals": [
+            "Select & file now",
+            "Step back and run full audit",
+            "Discard"
+          ]
+        },
+        {
+          "id": "phase0_inline_findings",
+          "text": "Findings are presented inline before the gate fires",
+          "check": "output_contains",
+          "signals": ["violation", "root cause", "lesson"]
+        },
+        {
+          "id": "phase0_no_wave_dispatch_on_select",
+          "text": "When 'Select & file now' is chosen, no wave subagent is dispatched before Phase 7",
+          "check": "tool_not_called_before",
+          "tool": "Agent",
+          "before_tool": "Skill",
+          "before_args_contain": "Dev10x:audit-report",
+          "signal": "Phase 7 reporting fires without prior Wave 1/Wave 2 Agent() calls"
+        },
+        {
+          "id": "phase0_routes_to_audit_report",
+          "text": "Select & file now delegates to Dev10x:audit-report",
+          "check": "tool_called",
+          "tool": "Skill",
+          "args_contain": "Dev10x:audit-report",
+          "signal": "Phase 7 sub-step D invokes Dev10x:audit-report with the inline findings"
+        },
+        {
+          "id": "phase0_multiselect_false",
+          "text": "Gate is single-select",
+          "check": "behavioral",
+          "assertion": "single_option_selection",
+          "signal": "User can select only one disposition option"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "name": "early-insight-gate-skipped-when-broad",
+      "prompt": "/Dev10x:skill-audit",
+      "description": "Tests that Phase 0 is skipped (falls through to Step 0) when no narrow question is provided. Default full-wave behavior must remain unchanged.",
+      "setup": {
+        "explicit_path": "not provided",
+        "narrow_question": "none",
+        "evidence_in_context": false,
+        "invocation": "/Dev10x:skill-audit"
+      },
+      "dimensions": ["early-insight-gate", "audit-execution"],
+      "assertions": [
+        {
+          "id": "phase0_skipped_on_broad",
+          "text": "When no narrow question is provided, Phase 0 does not fire the early-insight AskUserQuestion gate",
+          "check": "behavioral",
+          "assertion": "fall_through_to_step_0",
+          "signal": "Standard task list is created and wave subagents run"
+        },
+        {
+          "id": "step0_tasks_created",
+          "text": "Standard Step 0 task list is created",
+          "check": "tool_called",
+          "tool": "TaskCreate",
+          "signal": "All 10 setup/wave/synthesis tasks are created"
         }
       ]
     }

--- a/skills/skill-audit/instructions.md
+++ b/skills/skill-audit/instructions.md
@@ -10,7 +10,103 @@ This skill follows `references/task-orchestration.md` patterns.
 **Auto-advance:** Complete each phase, immediately start the next.
 Never pause between phases.
 
+### Phase 0: Early-Insight Gate
+
+**Runs before Step 0.** Lets the skill short-circuit the wave
+subagents when the user's question is already answered by the
+visible transcript, while preserving the structured
+select-and-file step that Phase 7 owns.
+
+**The early-insight branch is an optimization, not the new
+default.** When in doubt, fall through to the full wave.
+
+#### Detection heuristic
+
+Pick the early-insight branch ONLY when ALL of the following
+hold:
+
+1. The user's argument names a **specific incident** — a PR
+   URL, a session event, a single observed behavior — and not
+   a generic "audit this session".
+2. The relevant evidence is already in the **current
+   conversation context**. No need to re-extract a transcript
+   from a JSONL file or grep external logs.
+3. The agent can state the violation, root cause, and
+   persistable lesson **without re-reading skill bodies or
+   files**.
+
+If any of the three conditions fails, fall through to Step 0
+and run the standard waves.
+
+#### Branch flow
+
+1. **Read the argument.** If the argument is empty, a directory,
+   or a JSONL path with no accompanying narrow question, the
+   heuristic fails — fall through to Step 0.
+2. **Evaluate the heuristic.** If all three conditions hold,
+   continue; otherwise fall through to Step 0.
+3. **Present early-insight findings inline.** Write 1–3 bullets
+   covering: the violation observed, the root cause, and the
+   persistable lesson. Cite turn numbers or quoted evidence
+   when available. Do NOT modify any files at this point.
+4. **REQUIRED: Call `AskUserQuestion`** (do NOT use plain text,
+   call spec: [`tool-calls/ask-early-insight.md`](tool-calls/ask-early-insight.md)).
+   Options:
+   - **Select & file now (Recommended for clear findings)** —
+     skip to Phase 7 with the inline findings as the
+     pre-formed findings file.
+   - **Step back and run full audit** — fall through to
+     Step 0 and dispatch the standard wave subagents.
+   - **Discard — no action needed** — exit without filing.
+
+**Adaptive friction behavior:** This gate is **ALWAYS_ASK** —
+fires at every friction level, including `adaptive`. The
+choice between filing, stepping back, and discarding is a
+disposition decision that must be explicit. Auto-selecting
+the recommended option would defeat the gate's purpose of
+forcing the supervisor to confirm what gets persisted
+upstream.
+
+#### Disposition handling
+
+| User choice | Next action |
+|-------------|-------------|
+| Select & file now | Create a minimal task list: `TaskCreate(subject="Phase 0: Early-insight findings", activeForm="Presenting findings")` followed by `TaskCreate(subject="Phase 7: Upstream reporting", activeForm="Reporting upstream")`. Skip Steps 0–8 and Phases 1–6 entirely. Jump directly to Phase 7 (Upstream Reporting) using the inline findings as the scrubbed findings file. Phase 7's sub-steps A–D still run — only the wave-driven analysis is skipped. |
+| Step back and run full audit | Fall through to Step 0. Create the full task list and proceed with the standard Wave 1 + Wave 2 orchestration. |
+| Discard | Exit the skill without creating wave tasks and without invoking `Dev10x:audit-report`. |
+
+#### Why this matters
+
+- **Avoids wasted subagent dispatches** when the question is
+  already answered by the visible transcript. The full audit
+  waves are expensive (multiple haiku/sonnet calls); spending
+  them on a question the supervisor already framed precisely
+  is overkill.
+- **Preserves the supervisor selection gate**, which is the
+  part of the skill that has real procedural value — agents
+  are biased toward "file everything I noticed" or "file
+  nothing"; the structured selection step is what makes
+  upstream issues actually useful.
+- **Closes the audit loop reliably.** Without the gate, an
+  agent that answers a narrow audit question conversationally
+  can easily forget the file-upstream step. The
+  `AskUserQuestion` call forces the disposition decision into
+  the conversation.
+
+#### Anti-pattern this prevents
+
+Agent invokes `/Dev10x:skill-audit` with a narrow question,
+answers conversationally, offers to "save memory or file
+upstream", then defers to the supervisor for the choice
+without a structured selection step. The supervisor has to
+remember the workflow and prompt for the missing step.
+
 ### Step 0: Initialize task tracking (MANDATORY)
+
+**Applies when Phase 0 falls through.** If Phase 0 routed to
+"Select & file now" or "Discard", the minimal task list defined
+in Phase 0 is authoritative — do NOT create the wave task list
+below.
 
 **REQUIRED: Create all tasks before ANY other work.**
 Do NOT skip task creation or improvise an ad-hoc workflow.

--- a/skills/skill-audit/tool-calls/ask-early-insight.md
+++ b/skills/skill-audit/tool-calls/ask-early-insight.md
@@ -1,0 +1,40 @@
+# Decision Gate: Early-Insight Disposition
+
+Fired by Phase 0 when the agent has detected a narrow,
+transcript-evident question and prepared findings inline.
+The gate routes the agent to the correct disposition without
+spending wave subagent calls.
+
+```
+AskUserQuestion(questions=[{
+    question: "Findings are ready from the visible transcript "
+              "(see inline summary above). How should we proceed?",
+    header: "Disposition",
+    options: [
+        {label: "Select & file now (Recommended for clear findings)",
+         description: "Skip to Phase 7 and delegate to "
+                      "Dev10x:audit-report with the pre-formed "
+                      "findings — no wave subagents dispatched"},
+        {label: "Step back and run full audit",
+         description: "Proceed to Step 0 and run the standard "
+                      "Wave 1 + Wave 2 subagents before filing"},
+        {label: "Discard — no action needed",
+         description: "Exit without filing; findings remain "
+                      "only in the conversation"}
+    ],
+    multiSelect: false
+}])
+```
+
+## Branching after the gate
+
+| User choice | Next action |
+|-------------|-------------|
+| Select & file now | Create minimal task list (early-insight + select-and-file), skip Steps 0–8 and Phases 1–6, jump directly to Phase 7 with the inline findings as the scrubbed findings file |
+| Step back and run full audit | Fall through to Step 0 (Initialize task tracking) and continue the standard wave orchestration |
+| Discard | Exit the skill; do not create wave tasks, do not delegate to `Dev10x:audit-report` |
+
+The "Select & file now" branch MUST still pass through the
+existing Phase 7 sub-steps (collect → confirm → scrub →
+delegate) — the gate replaces the analysis waves, not the
+upstream reporting pipeline.


### PR DESCRIPTION
**When** debriefing a session with a narrow, transcript-evident question about skill compliance, **I want to** have `/Dev10x:skill-audit` short-circuit the wave subagents and route directly to the structured select-and-file step, **so I can** capture the upstream finding reliably without burning tokens on analysis I already framed.

---

[`b112a6dc`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/132/commits/b112a6dc216358d2360d0e1df0d353a619257c2f) ✨ GH-113 Enable early-insight short-circuit in skill-audit
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/113

---