### PR TITLE
✨ GH-135 Enable grep across plugin cache + memory without prompts

### DIFF
--- a/skills/upgrade-cleanup/projects.yaml
+++ b/skills/upgrade-cleanup/projects.yaml
@@ -109,15 +109,19 @@ base_permissions:
   - "Bash(~/.claude/plugins/cache/**/skills/upgrade-cleanup/scripts/merge-worktree-permissions.py:*)"
   - "Bash(~/.claude/plugins/cache/**/skills/upgrade-cleanup/scripts/update-paths.py:*)"
 
-  # --- Dev10x config file access (GH-878) ---
+  # --- Dev10x config file access (GH-878, GH-135) ---
   # Skills read/write playbook overrides, session config, slack config,
-  # reviewer config, database config under these directories.
+  # reviewer config, database config under these directories. Grep
+  # rules cover skill investigations that scan plugin config and the
+  # plugin cache for allow rules, scripts, and references.
   - "Read(~/.claude/memory/Dev10x/**)"
   - "Write(~/.claude/memory/Dev10x/**)"
   - "Edit(~/.claude/memory/Dev10x/**)"
   - "Read(.claude/Dev10x/**)"
   - "Write(.claude/Dev10x/**)"
   - "Edit(.claude/Dev10x/**)"
+  - "Bash(grep:*~/.claude/memory/Dev10x/**)"
+  - "Bash(grep:*~/.claude/plugins/cache/Dev10x-Guru/**)"
 
   # --- Dev10x MCP tools: cli server (GH-878) ---
   - "mcp__plugin_Dev10x_cli__detect_tracker"


### PR DESCRIPTION
**When** I'm running a Dev10x skill that scans plugin config or the plugin cache (e.g., investigating an allow rule, looking up a reference, or debugging a hook), **I want to** grep under `~/.claude/memory/Dev10x/` and `~/.claude/plugins/cache/Dev10x-Guru/` without per-invocation approval prompts **so I can** investigate the plugin's own configuration protocol without breaking flow on reads that the plugin itself documents.

---

[`db3d96b4`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/138/commits/db3d96b48f17aa3b3923670e118f914e8feece36) ✨ GH-135 Enable grep across plugin cache + memory without prompts
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/135

---