### PR TITLE
✨ GH-69 Adopt subagent status protocol across orchestration skills

### DIFF
--- a/.claude/agents/reviewer-skill-behavior.md
+++ b/.claude/agents/reviewer-skill-behavior.md
@@ -51,6 +51,30 @@ Files matching: `skills/**` (same trigger as `reviewer-skill.md`)
     numbered TaskCreate lists and dependency annotations, verify each
     phase's documented inputs match its dependency list. Skip for
     script-based skills or skills without dependency annotations.
+22. **Subagent status protocol presence (GH-69)** — when a skill section
+    documents an `Agent(...)` dispatch prompt (Phase 2 Gather, Wave 2
+    audit, architect dispatch, fanout sub-agent, etc.), verify the
+    prompt body includes the four-status template from
+    `references/orchestration/subagent-status-protocol.md` (`DONE`,
+    `DONE_WITH_CONCERNS:`, `NEEDS_CONTEXT:`, `BLOCKED:`). Flag missing
+    status-protocol instructions as WARNING — controllers cannot
+    branch deterministically without it and fall back to heuristic
+    parsing of free-form prose.
+    **False-positive prevention**: Do NOT flag dispatch examples in
+    "Anti-pattern" subsections or in pure background-monitor
+    dispatches whose result is a side effect (push notification)
+    rather than a status the controller parses.
+23. **Inline-context vs read-on-demand (GH-69)** — when an `Agent(...)`
+    dispatch is in the Gather, Replicate, or Analyze tier per
+    `.claude/rules/model-selection.md`, prefer the inline-context
+    pattern: the controller pre-reads files and pastes them into the
+    prompt under `<file path="...">...</file>` blocks. Flag prompts
+    that instruct the subagent to Read files dynamically when the
+    file set is known upfront — this is the source of permission-
+    stall failures (mode `dontAsk` does not propagate into the
+    subagent).
+    **False-positive prevention**: Do NOT flag Investigate/Explore
+    tier dispatches where the file set is genuinely unknown.
 
 ## Output Format
 

--- a/skills/adr-evaluate/SKILL.md
+++ b/skills/adr-evaluate/SKILL.md
@@ -79,9 +79,46 @@ Agent(subagent_type="general-purpose",
     - [What goes wrong if NOT chosen]
 
     ## Acknowledged Weaknesses
-    - [Honest downsides]""",
+    - [Honest downsides]
+
+    Report your final status as the LAST line of your output,
+    with exactly one of these prefixes:
+
+    - DONE                           — advocacy complete
+    - DONE_WITH_CONCERNS: <text>     — complete but flagged
+                                       (weak evidence, conflicting
+                                       ADRs, scope creep)
+    - NEEDS_CONTEXT: <what>          — missing input (ADR refs,
+                                       file paths, constraint set)
+    - BLOCKED: <reason>              — permission wall, missing
+                                       tool, unrecoverable error
+
+    Do not write anything after the status line.""",
     run_in_background=true)
 ```
+
+**Parse the trailing status line** per
+`references/orchestration/subagent-status-protocol.md` (GH-69):
+
+- `DONE` / `DONE_WITH_CONCERNS:` → include the advocacy in the
+  Phase 2 synthesis input; surface concerns to the user as part
+  of "Unverified claims flagged" in Phase 3
+- `NEEDS_CONTEXT: <what>` → re-dispatch the affected advocate
+  once with the requested context inlined (do not stall the
+  other advocates)
+- `BLOCKED: <reason>` → drop that advocate, run its advocacy
+  inline from the main session, and surface the reason in the
+  final ADR draft so reviewers know one option received
+  reduced rigor
+
+**Inline-context preference (GH-69):** When the controller has
+already read the relevant source files (e.g., during topic
+scoping), inline them under `<file path="...">...</file>`
+blocks instead of asking each advocate to Read them dynamically.
+Advocates running at Design tier may still Read additional
+files when their advocacy requires it, but the controller-
+provided baseline avoids N advocates duplicating the same
+Reads (and the same permission prompts).
 
 ### Phase 2: Synthesize
 

--- a/skills/gh-pr-review/SKILL.md
+++ b/skills/gh-pr-review/SKILL.md
@@ -47,11 +47,12 @@ Never pause between steps to ask "should I continue?".
 `TaskCreate` calls at startup:
 
 1. `TaskCreate(subject="Fetch PR diff", activeForm="Fetching PR context")`
-2. `TaskCreate(subject="Review changes", activeForm="Reviewing changes")`
-3. `TaskCreate(subject="Post findings", activeForm="Posting review")`
+2. `TaskCreate(subject="Run spec compliance gate", activeForm="Checking spec compliance")`
+3. `TaskCreate(subject="Review changes", activeForm="Reviewing changes")`
+4. `TaskCreate(subject="Post findings", activeForm="Posting review")`
 
-Set sequential dependencies: review blocked by fetch, post blocked
-by review.
+Set sequential dependencies: spec gate blocked by fetch, review
+blocked by spec gate, post blocked by review.
 
 No user decision gates — this skill runs fully automated once
 invoked. All review decisions (what to flag, severity) are made by
@@ -77,6 +78,76 @@ Run in parallel:
 **Why all 5?** Avoids duplicating feedback from previous review cycles
 (per `review-guidelines.md` — "NEVER repeat feedback from previous
 review cycles").
+
+### Step 2b: Phase 0 — Spec Compliance Gate (GH-69)
+
+Before reading per-file context or drafting inline comments,
+dispatch the `spec-reviewer` agent to confirm the PR diff matches
+the linked ticket's acceptance criteria and the PR's Job Story.
+Domain-level review (architecture, style, suggestions) is wasted
+effort when scope is wrong or AC are unmet — surfacing that
+early lets the reviewer post a single short-circuit comment
+instead of a multi-page review against the wrong target.
+
+**Skip Phase 0 when:**
+- The PR has no linked ticket AND no Job Story
+- The diff is purely additive infra (a new agent spec, a new
+  reference doc) where scope is self-evident from the file path
+
+**Pre-read inputs (controller side):** The diff and PR body are
+already loaded in Step 2. Fetch the linked ticket body via the
+appropriate tracker MCP (parse `Fixes: GH-N` / `TEAM-N` /
+`JIRA-N` from the PR body or branch name) and inline it. Do
+NOT instruct the agent to fetch the ticket itself — that
+triggers permission prompts inside the subagent.
+
+**Dispatch:**
+
+```
+Agent(
+    subagent_type="spec-reviewer",
+    description=f"Spec compliance check for PR #{N}",
+    prompt="""Verify the following PR diff matches the linked
+    ticket's acceptance criteria and Job Story.
+
+    <ticket>
+    {inlined ticket body + AC, or "NO_LINKED_TICKET" if none}
+    </ticket>
+
+    <pr_body>
+    {inlined PR body — Job Story is the first paragraph}
+    </pr_body>
+
+    <diff>
+    {inlined output of `gh pr diff N`}
+    </diff>
+
+    Follow the checklist in your spec. Return one paragraph per
+    finding (AC ref / file:line / verdict).
+
+    Report your final status as the LAST line of your output,
+    with exactly one of these prefixes:
+
+    - DONE                       — PASS
+    - DONE_WITH_CONCERNS: <text> — PARTIAL (proceed but flag)
+    - NEEDS_CONTEXT: <what>      — re-dispatch needed
+    - BLOCKED: <verdict>: <reason> — FAIL_SCOPE / FAIL_MISSING /
+                                     FAIL_OVER
+
+    Do not write anything after the status line.""")
+```
+
+**Parse the trailing status line** and branch:
+
+- `DONE` → continue to Step 3 (read changed files)
+- `DONE_WITH_CONCERNS: <text>` → continue; record the concern as
+  a top-of-summary note in the eventual review body
+- `NEEDS_CONTEXT: <what>` → re-dispatch with the requested
+  additional inline context once
+- `BLOCKED: <verdict>: <reason>` → skip Steps 3–6, post a
+  concise review whose body cites the verdict and asks the
+  author to address the spec gap before quality review. Still
+  hide obsolete summaries (Step 7) and post via Step 8.
 
 ### Step 3: Read Changed Files
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -59,9 +59,10 @@ Never pause between steps to ask "should I continue?".
 `TaskCreate` calls at startup:
 
 1. `TaskCreate(subject="Verify branch state", activeForm="Checking branch")`
-2. `TaskCreate(subject="Run automated checks", activeForm="Running checks")`
-3. `TaskCreate(subject="Review changed files", activeForm="Reviewing files")`
-4. `TaskCreate(subject="Present findings", activeForm="Presenting findings")`
+2. `TaskCreate(subject="Run spec compliance gate", activeForm="Checking spec compliance")`
+3. `TaskCreate(subject="Run automated checks", activeForm="Running checks")`
+4. `TaskCreate(subject="Review changed files", activeForm="Reviewing files")`
+5. `TaskCreate(subject="Present findings", activeForm="Presenting findings")`
 
 Set sequential dependencies.
 
@@ -80,6 +81,79 @@ parent provides progress visibility. See
    ahead of develop. If alias fails, fall back to `origin/develop`
 3. Verify branch has commits ahead of base (warn if nothing to review)
 4. Check for uncommitted changes — warn but continue
+
+### Step 1b: Phase 0 — Spec Compliance Gate (GH-69)
+
+Before running automated checks or per-file review, dispatch the
+`spec-reviewer` agent to confirm the diff matches its declared
+specification. Domain-level review is wasted effort when scope is
+wrong or acceptance criteria are unmet — surfacing that early
+short-circuits the rest of the pipeline.
+
+**Skip Phase 0 when:**
+- The branch has no linked ticket and no Job Story (e.g., trivial
+  typo fixes, plugin-maintenance commits)
+- The diff is purely additive infra (e.g., a new agent spec file)
+  where scope is self-evident
+- The caller invoked `Dev10x:review` with `--skip-spec` (reserved
+  flag for explicit opt-out)
+
+**Pre-read inputs (controller side):** Read the linked ticket
+body (via `mcp__plugin_Dev10x_cli__issue_get` or the appropriate
+tracker MCP) and the PR Job Story if present, plus the full
+`git develop-diff` output. Inline both into the dispatch prompt
+under `<ticket>` and `<diff>` blocks — `spec-reviewer` will not
+Read files dynamically (see `agents/spec-reviewer.md`).
+
+**Dispatch:**
+
+```
+Agent(
+    subagent_type="spec-reviewer",
+    description="Spec compliance check for current branch",
+    prompt="""Verify the following diff matches the linked ticket's
+    acceptance criteria and Job Story.
+
+    <ticket>
+    {inlined ticket body + AC}
+    </ticket>
+
+    <job_story>
+    {inlined Job Story from latest commit or PR body}
+    </job_story>
+
+    <diff>
+    {inlined output of `git develop-diff`}
+    </diff>
+
+    Follow the checklist in your spec. Return one paragraph per
+    finding (AC ref / file:line / verdict).
+
+    Report your final status as the LAST line of your output,
+    with exactly one of these prefixes:
+
+    - DONE                       — PASS
+    - DONE_WITH_CONCERNS: <text> — PARTIAL (proceed but flag)
+    - NEEDS_CONTEXT: <what>      — re-dispatch needed
+    - BLOCKED: <verdict>: <reason> — FAIL_SCOPE / FAIL_MISSING /
+                                     FAIL_OVER
+
+    Do not write anything after the status line.""")
+```
+
+**Parse the trailing status line** and branch:
+
+- `DONE` → continue to Step 2 (automated checks)
+- `DONE_WITH_CONCERNS: <text>` → continue, queue the concern for
+  the final findings summary (severity WARNING, source `spec`)
+- `NEEDS_CONTEXT: <what>` → re-dispatch with the requested
+  additional inline context once
+- `BLOCKED: <verdict>: <reason>` → short-circuit the review and
+  call `AskUserQuestion` with options:
+  - **Address spec gap first (Recommended)** — stop and let the
+    user fix scope/missing AC before continuing
+  - **Continue review anyway** — proceed to Step 2; record the
+    verdict as an INFO finding
 
 ### Step 2: Get Branch Diff
 

--- a/skills/skill-audit/instructions.md
+++ b/skills/skill-audit/instructions.md
@@ -439,16 +439,38 @@ that Phases 2, 3, and 5 need.
 they run concurrently. Include the full text of each phase's
 instructions from the Phase Reference section in each prompt.
 
-1. `Agent(subagent_type="general-purpose", model="sonnet", description="Phase 2: Skill coverage", prompt="You are running Phase 2 (Skill Coverage Analysis). Return your complete findings as your response. Also attempt to write them to <PHASE2_OUTPUT> — if the write fails, the main agent will capture your findings from the returned result. Phase 1 action inventory: <PHASE1_OUTPUT>. Skills directory: <SKILLS_DIR>. Read the Phase 1 output, then [include full Phase 2: Skill Coverage Analysis instructions from the Phase Reference section].")`
+**Status protocol (GH-69):** Every Wave 2 prompt MUST append the
+four-line status template from
+`references/orchestration/subagent-status-protocol.md`. Each
+subagent ends its output with one of:
 
-2. `Agent(subagent_type="general-purpose", model="sonnet", description="Phase 3: Compliance check", prompt="You are running Phase 3 (Compliance Check). Return your complete findings as your response. Also attempt to write them to <PHASE3_OUTPUT> — if the write fails, the main agent will capture your findings from the returned result. Phase 1 action inventory: <PHASE1_OUTPUT>. Session transcript: <TRANSCRIPT_PATH>. Skills directory: <SKILLS_DIR>. Session friction context: friction_level=<FRICTION_LEVEL>, active_modes=<ACTIVE_MODES>. When evaluating compliance, treat documented auto-select gates (e.g., `work-on` Phase 3 plan-approval at adaptive — GH-808) as COMPLIANT when the agent auto-selected the recommended option, NOT as SKIPPED_STEP. Read the Phase 1 output, then [include full Phase 3: Compliance Check instructions from the Phase Reference section].")`
+- `DONE` — phase findings complete
+- `DONE_WITH_CONCERNS: <text>` — findings complete but flagged
+  (e.g., transcript truncated, ambiguous compliance call)
+- `NEEDS_CONTEXT: <what>` — missing input the controller can
+  provide (Phase 1 output empty, friction context not set)
+- `BLOCKED: <reason>` — permission wall, missing tool, or
+  unrecoverable error (controller falls back to main-session
+  execution of the phase)
 
-3. `Agent(subagent_type="general-purpose", model="sonnet", description="Phase 5: Lessons learned", prompt="You are running Phase 5 (Lessons Learned Extraction). Return your complete findings as your response. Also attempt to write them to <PHASE5_OUTPUT> — if the write fails, the main agent will capture your findings from the returned result. Phase 1 action inventory: <PHASE1_OUTPUT>. Session transcript: <TRANSCRIPT_PATH>. Memory directory: <MEMORY_DIR>. Read the Phase 1 output, then [include full Phase 5: Lessons Learned Extraction instructions from the Phase Reference section].")`
+The main agent parses the trailing line of each Agent result
+and branches per the protocol before writing the phase output
+file.
+
+1. `Agent(subagent_type="general-purpose", model="sonnet", description="Phase 2: Skill coverage", prompt="You are running Phase 2 (Skill Coverage Analysis). Return your complete findings as your response. Also attempt to write them to <PHASE2_OUTPUT> — if the write fails, the main agent will capture your findings from the returned result. Phase 1 action inventory: <PHASE1_OUTPUT>. Skills directory: <SKILLS_DIR>. Read the Phase 1 output, then [include full Phase 2: Skill Coverage Analysis instructions from the Phase Reference section]. Report your final status as the LAST line of your output, with exactly one of these prefixes: DONE / DONE_WITH_CONCERNS: <text> / NEEDS_CONTEXT: <what> / BLOCKED: <reason>. Do not write anything after the status line.")`
+
+2. `Agent(subagent_type="general-purpose", model="sonnet", description="Phase 3: Compliance check", prompt="You are running Phase 3 (Compliance Check). Return your complete findings as your response. Also attempt to write them to <PHASE3_OUTPUT> — if the write fails, the main agent will capture your findings from the returned result. Phase 1 action inventory: <PHASE1_OUTPUT>. Session transcript: <TRANSCRIPT_PATH>. Skills directory: <SKILLS_DIR>. Session friction context: friction_level=<FRICTION_LEVEL>, active_modes=<ACTIVE_MODES>. When evaluating compliance, treat documented auto-select gates (e.g., `work-on` Phase 3 plan-approval at adaptive — GH-808) as COMPLIANT when the agent auto-selected the recommended option, NOT as SKIPPED_STEP. Read the Phase 1 output, then [include full Phase 3: Compliance Check instructions from the Phase Reference section]. Report your final status as the LAST line of your output, with exactly one of these prefixes: DONE / DONE_WITH_CONCERNS: <text> / NEEDS_CONTEXT: <what> / BLOCKED: <reason>. Do not write anything after the status line.")`
+
+3. `Agent(subagent_type="general-purpose", model="sonnet", description="Phase 5: Lessons learned", prompt="You are running Phase 5 (Lessons Learned Extraction). Return your complete findings as your response. Also attempt to write them to <PHASE5_OUTPUT> — if the write fails, the main agent will capture your findings from the returned result. Phase 1 action inventory: <PHASE1_OUTPUT>. Session transcript: <TRANSCRIPT_PATH>. Memory directory: <MEMORY_DIR>. Read the Phase 1 output, then [include full Phase 5: Lessons Learned Extraction instructions from the Phase Reference section]. Report your final status as the LAST line of your output, with exactly one of these prefixes: DONE / DONE_WITH_CONCERNS: <text> / NEEDS_CONTEXT: <what> / BLOCKED: <reason>. Do not write anything after the status line.")`
 
 Wait for all three subagents to complete. Mark tasks 6, 7, 8
-as `completed` as each returns. If any output file was not written
-by the subagent, use the returned result to write it from the
-main agent.
+as `completed` as each returns AND its status line is `DONE` or
+`DONE_WITH_CONCERNS:`. For `NEEDS_CONTEXT:`, re-dispatch once
+with the requested context inlined. For `BLOCKED:`, fall back
+to running the phase's instructions in the main session and
+surface the reason to the user. If any output file was not
+written by the subagent, use the returned result (minus the
+status line) to write it from the main agent.
 
 ### Step 8: Collect and synthesize
 

--- a/skills/work-on/instructions.md
+++ b/skills/work-on/instructions.md
@@ -312,9 +312,45 @@ Agent(subagent_type=source_agent_type,  # see table above
     - Status (open/closed/merged)
     - Key details (2-3 sentences)
     - Cross-references found (URLs, ticket IDs)
-    Do NOT return full body text — summarize.""",
+    Do NOT return full body text — summarize.
+
+    Report your final status as the LAST line of your output,
+    with exactly one of these prefixes:
+
+    - DONE                           — fetch complete
+    - DONE_WITH_CONCERNS: <text>     — fetched but flagged (e.g.,
+                                       ticket closed, conflicting info)
+    - NEEDS_CONTEXT: <what>          — missing identifier, ambiguous
+                                       slug, etc.
+    - BLOCKED: <reason>              — permission wall, MCP unavailable,
+                                       auth error
+
+    Do not write anything after the status line.""",
     run_in_background=true)
 ```
+
+**Parse the trailing status line** per
+`references/orchestration/subagent-status-protocol.md` (GH-69):
+
+- `DONE` → mark the source's subtask `completed`, fold the summary
+  into the Context Summary
+- `DONE_WITH_CONCERNS: <text>` → mark `completed`, queue the
+  concern for the batched decision presentation in Phase 3
+- `NEEDS_CONTEXT: <what>` → re-dispatch once with the requested
+  context inlined (e.g., a corrected ticket ID)
+- `BLOCKED: <reason>` → run the fetch in the main session as a
+  fallback (`gh issue view`, Linear MCP, etc.) and surface the
+  reason to the user; do not silently drop the source
+
+**Inline-context defaults (GH-69):** When the controller already
+holds file content the subagent needs (e.g., a local PR diff, a
+ticket body fetched earlier in this session), prefer inlining
+it under `<file path="...">...</file>` blocks rather than
+instructing the subagent to Read it. Subagents do not inherit
+the controller's `mode: "dontAsk"` permission, so dynamic Reads
+stall on permission prompts that the user cannot answer.
+Inline-context is the default for Gather, Replicate, and
+Analyze tier dispatches (see `.claude/rules/model-selection.md`).
 
 **Web URLs** (documentation, reference pages) should be fetched
 in the main session via `WebFetch`, not dispatched to subagents.


### PR DESCRIPTION
**When** I orchestrate work that fans out to subagents (Phase 2 Gather in work-on, Wave 2 audits in skill-audit, architect advocates in adr-evaluate, spec gates before domain review), **I want to** rely on a deterministic four-status terminal line (`DONE` / `DONE_WITH_CONCERNS:` / `NEEDS_CONTEXT:` / `BLOCKED:`) that every dispatched agent emits, **so** the controller can branch decisively — re-dispatch, fall back to main-session, or surface a concern via the batched decision queue — instead of guessing intent from free-form prose, and so domain reviewers never burn tokens against a diff that is already failing scope or AC.

---

[`2d1de86c`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/140/commits/2d1de86ca2b6514fa81f1bc658bc5dfa07e289ad) ✨ GH-69 Adopt subagent status protocol across orchestration skills
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/69

---