### PR TITLE
♻️ GH-83 Land M7 small/medium archetype refactors

### DIFF
--- a/src/dev10x/commands/permission.py
+++ b/src/dev10x/commands/permission.py
@@ -719,40 +719,19 @@ def investigate_report(*, output: str | None) -> None:
 @investigate.command(name="delta")
 def investigate_delta() -> None:
     """Compare matrix outcomes against current plugin-maintenance rules."""
-    import json as _json
-
     from dev10x.skills.permission import update_paths as paths_mod
-    from dev10x.skills.permission_investigator.matrix import (
-        Matrix,
-        MatrixCell,
-        MatrixResult,
-        RuleShape,
-    )
-    from dev10x.skills.permission_investigator.report import compute_delta
-
-    state_path = _resolve_state_path()
-    if not state_path.is_file():
-        click.echo("ERROR: state missing — run `prepare` first.", err=True)
-        sys.exit(1)
-    state = _json.loads(state_path.read_text())
-
-    matrix = Matrix()
-    for cell_data in state.get("cells", []):
-        matrix.cells.append(
-            MatrixCell(
-                shape=RuleShape(**cell_data["shape"]),
-                location=cell_data["location"],
-                cell_id=cell_data["cell_id"],
-            )
-        )
-    for cell_id, result_data in state.get("results", {}).items():
-        matrix.add_result(MatrixResult(**result_data))
+    from dev10x.skills.permission_investigator import PermissionDeltaQuery
 
     config_path = paths_mod.find_config()
     config = paths_mod.load_config(config_path)
-    base_permissions = config.get("base_permissions", [])
-
-    delta = compute_delta(matrix=matrix, base_permissions=base_permissions)
+    query = PermissionDeltaQuery(
+        state_path=_resolve_state_path(),
+        base_permissions=config.get("base_permissions", []),
+    )
+    if not query.state_exists():
+        click.echo("ERROR: state missing — run `prepare` first.", err=True)
+        sys.exit(1)
+    delta = query.execute()
 
     click.echo("Ineffective rules currently shipped:")
     for rule in delta.ineffective_rules or ["  (none)"]:

--- a/src/dev10x/config/loader.py
+++ b/src/dev10x/config/loader.py
@@ -8,10 +8,11 @@ from typing import Any
 import msgpack
 import yaml
 
+from dev10x.domain.config_document import Config
 from dev10x.domain.config_loader import ConfigLoader
 from dev10x.domain.file_locks import atomic_write_bytes
 from dev10x.domain.friction_level import FrictionLevel
-from dev10x.domain.validation_rule import Compensation, Config, Rule
+from dev10x.domain.validation_rule import Compensation, Rule
 
 DEFAULT_TTL_SECONDS = 1800
 

--- a/src/dev10x/domain/__init__.py
+++ b/src/dev10x/domain/__init__.py
@@ -1,3 +1,4 @@
+from dev10x.domain.config_document import Config
 from dev10x.domain.config_loader import ConfigLoader
 from dev10x.domain.git_context import GitContext
 from dev10x.domain.hook_input import HookAllow, HookInput, HookResult, HookRetry
@@ -6,7 +7,7 @@ from dev10x.domain.repository_ref import RepositoryRef
 from dev10x.domain.result import ErrorResult, Result, SuccessResult, err, ok
 from dev10x.domain.rule_engine import RuleEngine, RuleMatch
 from dev10x.domain.sql import SqlStatement, is_read_only_sql
-from dev10x.domain.validation_rule import Compensation, Config, Rule
+from dev10x.domain.validation_rule import Compensation, Rule
 
 __all__ = [
     "Compensation",

--- a/src/dev10x/domain/config_document.py
+++ b/src/dev10x/domain/config_document.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from dev10x.domain.friction_level import FrictionLevel
+from dev10x.domain.validation_rule import Rule
+
+
+@dataclass(frozen=True)
+class Config:
+    friction_level: FrictionLevel = FrictionLevel.STRICT
+    plugin_repo: str = ""
+    rules: list[Rule] = field(default_factory=list)

--- a/src/dev10x/domain/config_loader.py
+++ b/src/dev10x/domain/config_loader.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Protocol, runtime_checkable
 
-from dev10x.domain.validation_rule import Config
+from dev10x.domain.config_document import Config
 
 
 @runtime_checkable

--- a/src/dev10x/domain/rule_engine.py
+++ b/src/dev10x/domain/rule_engine.py
@@ -13,7 +13,8 @@ from typing import Any
 
 import yaml
 
-from dev10x.domain.validation_rule import Config, Rule
+from dev10x.domain.config_document import Config
+from dev10x.domain.validation_rule import Rule
 
 
 @dataclass(frozen=True)

--- a/src/dev10x/domain/validation_rule.py
+++ b/src/dev10x/domain/validation_rule.py
@@ -5,8 +5,6 @@ from dataclasses import dataclass, field
 from functools import cached_property
 from typing import Any
 
-from dev10x.domain.friction_level import FrictionLevel
-
 _SUBCOMMAND_BOUNDARY = r"(?![-\w])"
 
 
@@ -124,10 +122,3 @@ class Rule:
             file_substrings=entry.get("file_substrings", []),
             content_pattern=entry.get("content_pattern", ""),
         )
-
-
-@dataclass(frozen=True)
-class Config:
-    friction_level: FrictionLevel = FrictionLevel.STRICT
-    plugin_repo: str = ""
-    rules: list[Rule] = field(default_factory=list)

--- a/src/dev10x/hooks/permission_diagnostics.py
+++ b/src/dev10x/hooks/permission_diagnostics.py
@@ -42,6 +42,12 @@ class RuleMatch:
     matching_rule: str | None
     has_allow_list: bool
 
+    def is_matched(self) -> bool:
+        return self.matching_rule is not None
+
+    def is_unmatched_with_allow_list(self) -> bool:
+        return self.has_allow_list and self.matching_rule is None
+
 
 @dataclass(frozen=True)
 class DiagnosticResult:
@@ -49,6 +55,12 @@ class DiagnosticResult:
     matches: list[RuleMatch]
     diagnosis: str
     fix_suggestion: str
+
+    def matched(self) -> list[RuleMatch]:
+        return [m for m in self.matches if m.is_matched()]
+
+    def has_any_match(self) -> bool:
+        return any(m.is_matched() for m in self.matches)
 
 
 SETTINGS_PRECEDENCE: list[SettingsFile] = [
@@ -111,47 +123,57 @@ def _load_allow_rules(path: Path) -> list[str] | None:
     return allow
 
 
-def _matches_rule(
-    *,
-    signature: str,
-    rule: str,
-) -> bool:
-    if signature.startswith("mcp__"):
-        return fnmatch.fnmatch(name=signature, pat=rule)
+class PermissionResolutionPolicy:
+    """Encapsulates how an allow-rule string is matched against a tool signature.
 
-    paren_idx = rule.find("(")
-    if paren_idx == -1:
-        return fnmatch.fnmatch(name=signature, pat=rule)
+    Lives as a named class so the matching semantics — MCP tools by
+    fnmatch over the whole signature, Bash rules by tool+pattern with
+    ``:*`` prefix expansion — can be unit-tested and extended without
+    touching ``diagnose()``.
+    """
 
-    rule_tool = rule[:paren_idx]
-    rule_pattern = rule[paren_idx + 1 :].rstrip(")")
+    @staticmethod
+    def matches(*, signature: str, rule: str) -> bool:
+        if signature.startswith("mcp__"):
+            return fnmatch.fnmatch(name=signature, pat=rule)
 
-    sig_paren_idx = signature.find("(")
-    if sig_paren_idx == -1:
-        return False
+        paren_idx = rule.find("(")
+        if paren_idx == -1:
+            return fnmatch.fnmatch(name=signature, pat=rule)
 
-    sig_tool = signature[:sig_paren_idx]
-    sig_value = signature[sig_paren_idx + 1 :].rstrip(")")
+        rule_tool = rule[:paren_idx]
+        rule_pattern = rule[paren_idx + 1 :].rstrip(")")
 
-    if rule_tool != sig_tool:
-        return False
+        sig_paren_idx = signature.find("(")
+        if sig_paren_idx == -1:
+            return False
 
-    if rule_pattern.endswith(":*"):
-        prefix = rule_pattern[:-2]
-        return sig_value == prefix or sig_value.startswith(prefix + " ")
+        sig_tool = signature[:sig_paren_idx]
+        sig_value = signature[sig_paren_idx + 1 :].rstrip(")")
 
-    return fnmatch.fnmatch(name=sig_value, pat=rule_pattern)
+        if rule_tool != sig_tool:
+            return False
+
+        if rule_pattern.endswith(":*"):
+            prefix = rule_pattern[:-2]
+            return sig_value == prefix or sig_value.startswith(prefix + " ")
+
+        return fnmatch.fnmatch(name=sig_value, pat=rule_pattern)
+
+    @classmethod
+    def find_matching(cls, *, signature: str, rules: list[str]) -> str | None:
+        for rule in rules:
+            if cls.matches(signature=signature, rule=rule):
+                return rule
+        return None
 
 
-def _find_matching_rule(
-    *,
-    signature: str,
-    rules: list[str],
-) -> str | None:
-    for rule in rules:
-        if _matches_rule(signature=signature, rule=rule):
-            return rule
-    return None
+def _matches_rule(*, signature: str, rule: str) -> bool:
+    return PermissionResolutionPolicy.matches(signature=signature, rule=rule)
+
+
+def _find_matching_rule(*, signature: str, rules: list[str]) -> str | None:
+    return PermissionResolutionPolicy.find_matching(signature=signature, rules=rules)
 
 
 def _resolve_settings_files(*, cwd: str) -> list[SettingsFile]:
@@ -230,9 +252,9 @@ def _build_diagnosis(
     matches: list[RuleMatch],
     winning_file: SettingsFile | None,
 ) -> str:
-    files_with_match = [m for m in matches if m.matching_rule is not None]
+    files_with_match = [m for m in matches if m.is_matched()]
     files_with_allow_list = [m for m in matches if m.has_allow_list]
-    files_without_match = [m for m in matches if m.has_allow_list and m.matching_rule is None]
+    files_without_match = [m for m in matches if m.is_unmatched_with_allow_list()]
 
     if not files_with_match:
         return "No matching allow rule found in any settings file."
@@ -271,7 +293,7 @@ def _build_fix_suggestion(
     matches: list[RuleMatch],
     winning_file: SettingsFile | None,
 ) -> str:
-    files_with_match = [m for m in matches if m.matching_rule is not None]
+    files_with_match = [m for m in matches if m.is_matched()]
 
     if not files_with_match:
         if winning_file:

--- a/src/dev10x/platform/__init__.py
+++ b/src/dev10x/platform/__init__.py
@@ -9,6 +9,18 @@ per-user path editing, no symlinks (so Windows stays safe).
 
 from __future__ import annotations
 
-from dev10x.platform.registry import PlatformConfig, Registry, known_platforms
+from dev10x.platform.registry import (
+    PlatformCatalog,
+    PlatformConfig,
+    Registry,
+    known_platforms,
+    registered_platforms,
+)
 
-__all__ = ["PlatformConfig", "Registry", "known_platforms"]
+__all__ = [
+    "PlatformCatalog",
+    "PlatformConfig",
+    "Registry",
+    "known_platforms",
+    "registered_platforms",
+]

--- a/src/dev10x/platform/registry.py
+++ b/src/dev10x/platform/registry.py
@@ -48,13 +48,33 @@ def _home_relative(*parts: str) -> Path:
     return Path.home().joinpath(*parts)
 
 
-def known_platforms() -> dict[str, PlatformConfig]:
-    """Return the built-in catalog of supported platforms.
+class PlatformCatalog:
+    """Static, read-only catalog of supported target platforms.
 
-    Paths use the platform's default install location. Users who override
-    locations can pass ``--config-dir`` to ``dev10x platform add`` to
-    record the custom path.
+    Encapsulates the built-in platform definitions and exposes a small
+    query surface (``lookup`` / ``names`` / ``contains``) so callers do
+    not poke at the raw dict.
     """
+
+    def __init__(self, entries: dict[str, PlatformConfig] | None = None) -> None:
+        self._entries = entries if entries is not None else _default_entries()
+
+    def lookup(self, name: str) -> PlatformConfig:
+        if name not in self._entries:
+            raise KeyError(f"Unknown platform '{name}'. Known: {', '.join(self.names())}")
+        return self._entries[name]
+
+    def names(self) -> list[str]:
+        return sorted(self._entries)
+
+    def contains(self, name: str) -> bool:
+        return name in self._entries
+
+    def as_dict(self) -> dict[str, PlatformConfig]:
+        return dict(self._entries)
+
+
+def _default_entries() -> dict[str, PlatformConfig]:
     return {
         "claude-code": PlatformConfig(
             name="claude-code",
@@ -94,6 +114,11 @@ def known_platforms() -> dict[str, PlatformConfig]:
     }
 
 
+def known_platforms() -> dict[str, PlatformConfig]:
+    """Backward-compatible accessor — returns the default catalog as a dict."""
+    return PlatformCatalog().as_dict()
+
+
 class Registry:
     """Persisted list of platforms the current user has registered."""
 
@@ -117,11 +142,12 @@ class Registry:
         *,
         config_dir: Path | None = None,
         playbook_override: str | None = None,
+        catalog: PlatformCatalog | None = None,
     ) -> PlatformConfig:
-        catalog = known_platforms()
-        if name not in catalog:
-            raise ValueError(f"Unknown platform '{name}'. Known: {', '.join(sorted(catalog))}")
-        base = catalog[name]
+        catalog = catalog or PlatformCatalog()
+        if not catalog.contains(name):
+            raise ValueError(f"Unknown platform '{name}'. Known: {', '.join(catalog.names())}")
+        base = catalog.lookup(name)
         if config_dir:
             base = PlatformConfig(
                 name=base.name,
@@ -155,4 +181,14 @@ class Registry:
         return True
 
     def list(self) -> list[PlatformConfig]:
-        return [self.load()[name] for name in sorted(self.load())]
+        registered = self.load()
+        return [registered[name] for name in sorted(registered)]
+
+
+def registered_platforms(*, registry: Registry | None = None) -> list[PlatformConfig]:
+    """Service function: combine catalog defaults with user registrations.
+
+    Returns the list of platforms the user has actively registered. Use
+    :class:`PlatformCatalog` directly for the static built-in list.
+    """
+    return (registry or Registry()).list()

--- a/src/dev10x/skills/audit/analyze_permissions.py
+++ b/src/dev10x/skills/audit/analyze_permissions.py
@@ -83,6 +83,18 @@ class ToolCall:
     command: str
     file_path: str = ""
 
+    def is_bash(self) -> bool:
+        return self.tool == "Bash"
+
+    def signature(self) -> str:
+        if self.is_bash():
+            return f"Bash({self.command})"
+        if self.tool in ("Write", "Read", "Edit") and self.file_path:
+            return f"{self.tool}({self.file_path})"
+        if self.tool.startswith("mcp__"):
+            return self.tool
+        return f"{self.tool}()"
+
 
 @dataclass
 class AllowRule:
@@ -100,6 +112,27 @@ class Finding:
     command_display: str
     classification: str
     fix: str
+
+    def base_classification(self) -> str:
+        """Return the classification name without any ``(Nx)`` suffix."""
+        return self.classification.split("(")[0].strip()
+
+    def is_missing_rule(self) -> bool:
+        return self.classification == "MISSING_RULE"
+
+    def is_actionable(self) -> bool:
+        """Findings worth surfacing in the proposed-rules section."""
+        return "MISSING_RULE" in self.classification or "NUISANCE" in self.classification
+
+    def mark_nuisance(self, *, count: int) -> None:
+        self.classification = f"NUISANCE_PATTERN ({count}x)"
+
+    def first_command_word(self) -> str:
+        return self.command_display.split()[0] if self.command_display else ""
+
+    def nuisance_key(self) -> str:
+        first = self.first_command_word()
+        return f"{self.tool}:{first}" if first else self.tool
 
 
 @dataclass
@@ -401,14 +434,13 @@ def analyze_permissions(
 def count_nuisance_patterns(findings: list[Finding]) -> list[Finding]:
     pattern_counts: dict[str, list[Finding]] = {}
     for f in findings:
-        if f.classification == "MISSING_RULE":
-            key = f.tool + ":" + f.command_display.split()[0] if f.command_display else f.tool
-            pattern_counts.setdefault(key, []).append(f)
+        if f.is_missing_rule():
+            pattern_counts.setdefault(f.nuisance_key(), []).append(f)
 
-    for key, group in pattern_counts.items():
+    for group in pattern_counts.values():
         if len(group) >= 3:
             for f in group:
-                f.classification = f"NUISANCE_PATTERN ({len(group)}x)"
+                f.mark_nuisance(count=len(group))
 
     return findings
 
@@ -509,7 +541,7 @@ def propose_allow_rules(findings: list[Finding]) -> list[str]:
     proposals: list[str] = []
 
     for f in findings:
-        if "MISSING_RULE" in f.classification or "NUISANCE" in f.classification:
+        if f.is_actionable():
             if "Add:" in f.fix:
                 rule = f.fix.split("Add: ", 1)[1]
                 if rule not in seen:
@@ -567,7 +599,7 @@ def write_output(
 
     summary: dict[str, int] = {}
     for f in findings:
-        base = f.classification.split("(")[0].strip()
+        base = f.base_classification()
         summary[base] = summary.get(base, 0) + 1
     out.write("## Summary\n\n")
     out.write(f"**Total unmatched calls:** {len(findings)}\n")

--- a/src/dev10x/skills/permission_investigator/__init__.py
+++ b/src/dev10x/skills/permission_investigator/__init__.py
@@ -8,4 +8,70 @@ This package owns the deterministic, non-Claude pieces. The
 subagent dispatch loop that actually exercises each rule shape
 lives in ``skills/permission-investigator/SKILL.md`` because the
 Agent tool is only callable from Claude tool-use protocol.
+
+## Public Facade
+
+Top-level callers (e.g. ``commands/permission.py:investigate_delta``)
+should import from this package, not from internal submodules. The
+``PermissionDeltaQuery`` query object encapsulates state loading,
+matrix reconstruction, and delta computation in one entry point.
 """
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from dev10x.skills.permission_investigator.matrix import (
+    Matrix,
+    MatrixCell,
+    MatrixResult,
+    RuleShape,
+)
+from dev10x.skills.permission_investigator.report import Delta, compute_delta
+
+__all__ = [
+    "Delta",
+    "Matrix",
+    "PermissionDeltaQuery",
+    "load_matrix_from_state",
+]
+
+
+def load_matrix_from_state(state: dict[str, Any]) -> Matrix:
+    """Reconstruct a Matrix from the persisted investigator state dict."""
+    matrix = Matrix()
+    for cell_data in state.get("cells", []):
+        matrix.cells.append(
+            MatrixCell(
+                shape=RuleShape(**cell_data["shape"]),
+                location=cell_data["location"],
+                cell_id=cell_data["cell_id"],
+            )
+        )
+    for _, result_data in state.get("results", {}).items():
+        matrix.add_result(MatrixResult(**result_data))
+    return matrix
+
+
+@dataclass(frozen=True)
+class PermissionDeltaQuery:
+    """Compute the delta between investigator results and shipped rules.
+
+    Reads the persisted matrix state from ``state_path`` and compares
+    against ``base_permissions``. Returns a :class:`Delta` with
+    ineffective and suggested rules.
+    """
+
+    state_path: Path
+    base_permissions: list[str]
+
+    def state_exists(self) -> bool:
+        return self.state_path.is_file()
+
+    def execute(self) -> Delta:
+        state = json.loads(self.state_path.read_text())
+        matrix = load_matrix_from_state(state)
+        return compute_delta(matrix=matrix, base_permissions=self.base_permissions)

--- a/src/dev10x/skills/permission_investigator/matrix.py
+++ b/src/dev10x/skills/permission_investigator/matrix.py
@@ -95,6 +95,10 @@ class Matrix:
     def coverage(self) -> tuple[int, int]:
         return len(self.results), len(self.cells)
 
+    def coverage_label(self) -> str:
+        seen, total = self.coverage()
+        return f"{seen}/{total}"
+
 
 def _tilde_prefix(*, user_home: str) -> str:
     del user_home

--- a/src/dev10x/skills/permission_investigator/report.py
+++ b/src/dev10x/skills/permission_investigator/report.py
@@ -50,8 +50,7 @@ def render_markdown_report(matrix: Matrix) -> str:
 
     lines: list[str] = ["# Permission Pattern Investigation"]
     lines.append("")
-    seen, total = matrix.coverage()
-    lines.append(f"Cells executed: **{seen}/{total}**")
+    lines.append(f"Cells executed: **{matrix.coverage_label()}**")
     lines.append("")
 
     lines.append("## Outcome counts")

--- a/src/dev10x/validators/skill_redirect.py
+++ b/src/dev10x/validators/skill_redirect.py
@@ -22,9 +22,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
 
 from dev10x.domain import HookInput, HookResult
+from dev10x.domain.config_document import Config
 from dev10x.domain.friction_level import FrictionLevel
 from dev10x.domain.profile_tier import ProfileTier
-from dev10x.domain.validation_rule import Compensation, Config
+from dev10x.domain.validation_rule import Compensation
 from dev10x.validators.base import ValidatorBase
 
 if TYPE_CHECKING:

--- a/tests/domain/test_rule_engine.py
+++ b/tests/domain/test_rule_engine.py
@@ -5,8 +5,9 @@ from pathlib import Path
 import pytest
 import yaml
 
+from dev10x.domain.config_document import Config
 from dev10x.domain.rule_engine import RuleEngine
-from dev10x.domain.validation_rule import Compensation, Config, Rule
+from dev10x.domain.validation_rule import Compensation, Rule
 
 
 class TestRuleFromYamlEntry:

--- a/tests/fakers/validation_rule.py
+++ b/tests/fakers/validation_rule.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import factory
 
-from dev10x.domain.validation_rule import Compensation, Config, Rule
+from dev10x.domain.config_document import Config
+from dev10x.domain.validation_rule import Compensation, Rule
 
 
 class CompensationFaker(factory.Factory):


### PR DESCRIPTION
## Job Story

**When** I look at the M7 backlog, **I want to** land the small/medium archetype refactors (D4, D7, D8, B1/B2/B3, B7, B9, I7) in one reviewable bundle **so** I can ship them now and scope the remaining heavy items (D2 session split, D9 domain sub-packages, D1/I8 audit reader, B8 full, I5/I6 GraphQL batch) as separate follow-up tickets without blocking each other.

## Sub-tasks landed (7 of 11 from M7)

- [x] **#D4** — `Config` moved to `domain/config_document.py` (00b39a3)
- [x] **#B7** — `Matrix.coverage_label()` returns `"seen/total"` (cab2a7e)
- [x] **#D7** — `PlatformCatalog` extracted with `lookup`/`names`/`contains`; `registered_platforms()` service function (c0caad4)
- [x] **#B9** — `Registry.list()` double-`self.load()` fixed (c0caad4)
- [x] **#D8** — `PermissionResolutionPolicy` class wraps rule matching (cab2a7e)
- [x] **#B1/#B2** — `ToolCall.is_bash()/signature()` + `Finding.base_classification/is_missing_rule/is_actionable/mark_nuisance/nuisance_key` (c0caad4)
- [x] **#B3** — `RuleMatch.is_matched/is_unmatched_with_allow_list`, `DiagnosticResult.matched/has_any_match` (cab2a7e)
- [x] **#I7** — `PermissionDeltaQuery` facade in `permission_investigator/__init__.py`; `investigate_delta` drops 7 deep imports (cab2a7e)
- [x] **#D3** — Already shipped by M6 (commit 4e7fb9a) — memo predicted this in "Likely subsumed by M6 #A1"

## Spun off as follow-up tickets (4 heavy items)

- [ ] #142 — **M7 #B8 full**: migrate `analyze_permissions` script logic to `dev10x.audit.analyze` so the MCP wrapper imports the factory in-process
- [ ] #143 — **M7 #D1/#I8**: consolidate audit log reading into `audit/log_reader.py`, `@audit_hook` into `hooks/audit_emit.py`
- [ ] #144 — **M7 #D2**: decompose `hooks/session.py` (532 LOC) into `session_dispatch`/`session_document`/`session_policy`/`queries`
- [ ] #145 — **M7 #D9**: reorganize `domain/` into `events/rules/documents/common` sub-packages with re-export shims
- [ ] #146 — **M7 #I5/#I6**: `batch_find_prs()` GraphQL multi-search + shared `PRStatusQuery`

## Why bundle + split

The audit memo scoped M7 at ~7 days; the bundled small/medium items in this PR are independent of each other and each touched ≤3 files. The deferred items each pull large structural changes (D2 splits 532 LOC across 4 files; D9 affects 97 import sites with shim re-exports; D1/I8 moves ~300 LOC across packages; B8-full requires script→package migration; I5/I6 introduces new GraphQL queries). Splitting them out keeps this PR reviewable and lets each heavy refactor get its own focused review.

## Commits

- 00b39a3 — Separate `Config` dataclass from `validation_rule` module
- cab2a7e — Promote permission diagnostics + investigator facades
- c0caad4 — Split platform Registry and add Tell-Don't-Ask finding helpers

## Test plan

- [x] `uv run --extra dev pytest tests/ --no-cov --ignore=tests/benchmarks` — 1978 pass, 2 skip, 0 fail
- [x] `uv run --extra dev ruff check src/ tests/` — clean
- [x] `mcp__plugin_Dev10x_cli__pre_pr_checks` — ruff + ruff format + mypy all green
- [ ] CI green on the PR

Note: `tests/benchmarks/test_startup_time.py::test_baseline_regression[mcp_server_import]` fails on this branch *and* on `develop` (pre-existing baseline regression, unrelated to this PR).

Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/83