### PR TITLE
✨ GH-148 Track skill-audit invocation as cycle-audit task

### DIFF
--- a/skills/skill-audit/evals/evals.json
+++ b/skills/skill-audit/evals/evals.json
@@ -25,6 +25,11 @@
       "id": "early-insight-gate",
       "name": "Early-Insight Gate",
       "description": "Phase 0 detects narrow, transcript-evident questions, presents inline findings, and routes via AskUserQuestion with three options (select & file, step back, discard) without dispatching wave subagents"
+    },
+    {
+      "id": "cycle-audit-task",
+      "name": "Cycle-Audit Task Append (GH-148)",
+      "description": "Step 0a always appends a single 'Audit cycle: diagnose, fix, note in memory, file upstream' task at the end of the current task list before Phase 0 fires, regardless of downstream path. Empty-list edge case: task is created and immediately marked in_progress."
     }
   ],
   "evals": [
@@ -205,6 +210,73 @@
           "check": "tool_called",
           "tool": "TaskCreate",
           "signal": "All 10 setup/wave/synthesis tasks are created"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "name": "cycle-audit-task-appended-empty-list",
+      "prompt": "/Dev10x:skill-audit",
+      "description": "Tests that Step 0a (GH-148) creates a single cycle-audit task at the very start of the invocation, before Phase 0 fires. With an empty task list, the task is marked in_progress immediately and the audit proceeds.",
+      "setup": {
+        "task_list_state": "empty",
+        "invocation": "/Dev10x:skill-audit"
+      },
+      "dimensions": ["cycle-audit-task"],
+      "assertions": [
+        {
+          "id": "cycle_task_created_first",
+          "text": "TaskCreate for the cycle-audit task fires before any Phase 0 / Step 0 task or Agent dispatch",
+          "check": "tool_called_before",
+          "tool": "TaskCreate",
+          "args_contain": "Audit cycle",
+          "before_tool": "AskUserQuestion",
+          "signal": "Cycle-audit task is the first TaskCreate of the invocation"
+        },
+        {
+          "id": "cycle_task_subject_text",
+          "text": "Cycle-audit task subject names the four-stage frame",
+          "check": "output_contains",
+          "signals": [
+            "Audit cycle",
+            "diagnose",
+            "memory",
+            "upstream"
+          ]
+        },
+        {
+          "id": "cycle_task_in_progress_on_empty_list",
+          "text": "When prior task list was empty, the cycle-audit task is set to in_progress before Phase 0 fires",
+          "check": "behavioral",
+          "assertion": "task_in_progress_on_empty_list",
+          "signal": "TaskUpdate with status=in_progress fires on the cycle-audit task immediately after creation"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "name": "cycle-audit-task-appended-non-empty-list",
+      "prompt": "/Dev10x:skill-audit",
+      "description": "Tests that Step 0a (GH-148) appends the cycle-audit task at the end of an existing task list without disrupting prior tasks or wiring any dependencies on them.",
+      "setup": {
+        "task_list_state": "non-empty (prior unrelated tasks present)",
+        "invocation": "/Dev10x:skill-audit"
+      },
+      "dimensions": ["cycle-audit-task"],
+      "assertions": [
+        {
+          "id": "cycle_task_appended_no_dependencies",
+          "text": "Cycle-audit task is created without addBlocks or addBlockedBy wiring to prior tasks",
+          "check": "behavioral",
+          "assertion": "no_dependency_wiring_to_existing_tasks",
+          "signal": "TaskCreate for the cycle-audit task has no blocks/blockedBy targeting existing task IDs"
+        },
+        {
+          "id": "prior_tasks_unchanged",
+          "text": "Prior tasks in the list are not modified, deleted, or reordered",
+          "check": "behavioral",
+          "assertion": "existing_tasks_preserved",
+          "signal": "TaskUpdate is not called on any pre-existing task during Step 0a"
         }
       ]
     }

--- a/skills/skill-audit/instructions.md
+++ b/skills/skill-audit/instructions.md
@@ -10,6 +10,37 @@ This skill follows `references/task-orchestration.md` patterns.
 **Auto-advance:** Complete each phase, immediately start the next.
 Never pause between phases.
 
+### Step 0a: Append cycle-audit task (MANDATORY, GH-148)
+
+**Always runs first — before Phase 0 and Step 0.** Invoking
+`Dev10x:skill-audit` is itself a declaration of supervisor intent:
+"something didn't work out in the last couple of cycles, and I
+want to diagnose the problem, find a solution, note it in memory,
+and file an upstream issue."
+
+Record that intent as a single tracking task at the END of the
+current task list, regardless of which downstream path Phase 0
+selects (early-insight, full wave, or discard):
+
+1. Call `TaskList` to see the existing tasks (if any).
+2. `TaskCreate(subject="Audit cycle: diagnose, fix, note in memory, file upstream", description="Supervisor invoked Dev10x:skill-audit. Frame: something didn't work in the last couple of cycles — diagnose the problem, find a solution, persist the lesson to memory, and file an upstream issue when warranted. This task is the supervisor-facing wrapper for the whole skill-audit invocation; Phase 0 / Step 0 add their own sub-tasks.", activeForm="Auditing cycle")`
+
+**Edge case — empty task list.** If `TaskList` returned no
+tasks (or only completed ones), the cycle-audit task IS the
+work — immediately mark it `in_progress` and proceed to Phase 0
+without waiting for other tasks.
+
+**Edge case — pre-existing task list.** Append at the end with
+no dependency wiring. The cycle-audit task remains visible as
+the supervisor's frame for the whole invocation; Phase 0 and
+Step 0 below add their own task lists alongside it.
+
+**Completion.** Mark the cycle-audit task `completed` only after
+the chosen path terminates:
+- Phase 0 "Discard" → mark completed immediately (no further work)
+- Phase 0 "Select & file now" → mark completed after Phase 7 finishes
+- Phase 0 "Step back" / fall-through → mark completed after Phase 7 finishes
+
 ### Phase 0: Early-Insight Gate
 
 **Runs before Step 0.** Lets the skill short-circuit the wave


### PR DESCRIPTION
**When** the supervisor invokes `Dev10x:skill-audit`, **I want to** record that invocation itself as a task in the current session task list framed as "diagnose problem → find solution → note in memory → file upstream issue", **so I can** see the audit cycle as visible supervisor-facing work alongside the Phase 0 / Step 0 sub-tasks, with the empty-list edge case handled by auto-starting the new task.

---

[`bd55ede8`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/150/commits/bd55ede800b9dbe22183183bbf9586dfcbb3184f) ✨ GH-148 Track skill-audit invocation as cycle-audit task
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/148

---