### PR TITLE
♻️ GH-134 Tighten shipping-pipeline skill guardrails

### DIFF
--- a/skills/gh-pr-merge/instructions.md
+++ b/skills/gh-pr-merge/instructions.md
@@ -26,7 +26,20 @@ The merge strategy is resolved using the config resolution order
 1. **Global with repo matching** — read
    `~/.claude/memory/Dev10x/settings-pr-merge.yaml`, match current
    repo against `projects[].match` globs
-2. **Default** — `squash`
+2. **Default** — `rebase`
+
+Rationale for the `rebase` default: commits authored through this
+plugin already follow gitmoji + ticket + JTBD conventions enforced
+by `Dev10x:git-commit`, and `Dev10x:git-groom` produces a curated
+linear history before merge. Squashing erases that structure and
+breaks per-commit references in PR review threads. Rebase preserves
+the curated commits as-is.
+
+**Migration note for existing users:** If a project previously relied
+on the implicit `squash` default, set `strategy: squash` explicitly
+in `~/.claude/memory/Dev10x/settings-pr-merge.yaml` for that repo's
+`projects[].match` entry. No behavior change for projects that
+already declared `strategy:` explicitly.
 
 ### Config file format
 
@@ -42,10 +55,13 @@ projects:
     strategy: rebase
     delete_branch: true
     solo_maintainer: true
+  - match: "legacy-org/*"
+    strategy: squash   # explicit opt-in to historical default
+    delete_branch: true
 ```
 
 All fields are optional. Defaults:
-- `strategy`: `squash`
+- `strategy`: `rebase`
 - `delete_branch`: `true`
 - `solo_maintainer`: `false`
 
@@ -296,7 +312,7 @@ Extract owner/repo from `gh repo view --json owner,name`.
 ### Step 2: Load merge strategy config
 
 Read the per-project config file. If it does not exist, use
-defaults (`strategy: squash`, `delete_branch: true`,
+defaults (`strategy: rebase`, `delete_branch: true`,
 `solo_maintainer: false`).
 
 ### Step 3: Run all 8 validation checks

--- a/skills/gh-pr-request-review/SKILL.md
+++ b/skills/gh-pr-request-review/SKILL.md
@@ -67,11 +67,13 @@ projects:
 - `default_action: ask` prompts the user for unconfigured projects;
   `skip` silently skips them
 
-### Pre-flight: Approval State Check (GH-993)
+### Pre-flight: Approval State Check (GH-993, GH-128)
 
 Before requesting review, verify the PR is not already approved
-on its current HEAD. Spamming reviewers with redundant requests
-on already-approved PRs is the failure mode this guard prevents.
+on its current HEAD **by a human reviewer**. Spamming reviewers
+with redundant requests on already-approved PRs is the failure
+mode this guard prevents — but bot approvals (e.g., `claude[bot]`,
+automated CI workflows) MUST NOT short-circuit human review.
 
 1. Fetch review state (no MCP wrapper exists for review-decision
    data — `gh pr view` is the supported call site):
@@ -79,22 +81,34 @@ on already-approved PRs is the failure mode this guard prevents.
    gh pr view {pr_number} --repo {repo} \
      --json reviewDecision,reviews,headRefOid
    ```
-2. **If `reviewDecision == "APPROVED"`** and the latest review's
-   `commit.oid` matches `headRefOid`: the PR is approved on the
-   current HEAD. **REQUIRED: Call `AskUserQuestion`** (do NOT use
-   plain text) with options:
+2. **Filter bot approvals first (GH-128).** Before matching reviews
+   against `headRefOid`, drop any review whose `author.login` ends
+   with `[bot]` (e.g., `claude[bot]`, `github-actions[bot]`) or
+   whose `author.type == "Bot"` if that field is available. Bot
+   approvals do not satisfy the "human review" requirement and
+   MUST NOT trigger the short-circuit gate below. If the only
+   approvals on the current HEAD are bot approvals, treat the PR
+   as **unapproved by humans** and proceed normally to Step 4.
+3. **If a HUMAN review with `state == "APPROVED"`** and matching
+   `commit.oid == headRefOid` exists: the PR is approved on the
+   current HEAD by a human. **REQUIRED: Call `AskUserQuestion`**
+   (do NOT use plain text) with options:
    - **Skip — already approved (Recommended)** — short-circuit;
      suggest `Dev10x:gh-pr-merge` instead
    - **Force request anyway** — proceed (e.g., need additional
      reviewers beyond the existing approver)
    - **Cancel** — do nothing
-3. **If `reviewDecision == "APPROVED"`** but newer commits invalidate
-   the approval (latest review `commit.oid` != `headRefOid`): proceed
-   to the re-request flow but **filter out** any reviewer whose latest
-   review on the current HEAD is `APPROVED`. Build the per-reviewer
-   filter from `reviews[]` grouped by `author.login`, taking each
-   author's most recent review.
-4. **Otherwise** (`CHANGES_REQUESTED` or `null`): proceed normally.
+4. **If any HUMAN `APPROVED` review exists** but newer commits
+   invalidate the approval (latest human review `commit.oid` !=
+   `headRefOid`): proceed to the re-request flow but **filter out**
+   any human reviewer whose latest review on the current HEAD is
+   `APPROVED`. Build the per-reviewer filter from `reviews[]`
+   grouped by `author.login` (excluding bots), taking each author's
+   most recent review.
+5. **Otherwise** (only bot approvals, `CHANGES_REQUESTED`, or
+   `null`): proceed normally. When only bot approvals exist on the
+   current HEAD, optionally surface this in the user-facing log
+   line ("PR has only a bot approval — requesting human review").
 
 Skip this precheck when invoked with `--force` flag or when the
 caller passes `bypass_approval_check: true` (e.g., from

--- a/skills/gh-pr-respond/instructions.md
+++ b/skills/gh-pr-respond/instructions.md
@@ -197,6 +197,60 @@ When in doubt, default to one fixup per comment. Bundling is
 opt-in for the agent: offer it via `AskUserQuestion` rather
 than auto-bundling silently.
 
+### Rationalization Watchlist (GH-123)
+
+**Reject bundled mode** when the agent's stated rationale matches
+any of the patterns below. These are well-formed but invalid
+rationalizations that audit session GH-123 caught a 9-comment
+review cycle silently bundling under. The trigger criteria above
+require shared *fix scope*, not shared *commit topology* or
+*implementation efficiency*.
+
+Prohibited rationalizations:
+
+- "Both comments touch the same parent commit"
+- "Autosquash will collapse them anyway"
+- "Fewer stash / checkout / rebase dances"
+- "About the same area of code" (without single-fix coherence)
+- "These are all in the same file"
+- "Easier to land one fixup than three"
+
+These patterns describe convenience or commit topology — neither
+satisfies the "single coherent change" criterion. If the rationale
+for bundling fits any pattern above, STOP and produce one fixup
+per comment. The trigger criteria are about the *fix*, not the
+*workflow*; if splitting produces three distinct diffs, those
+distinct diffs need three distinct fixups.
+
+### Pre-fixup comment-ID checkpoint (GH-123)
+
+Before invoking `Skill(Dev10x:gh-pr-fixup)`, record which review
+comment ID(s) the fixup addresses in the task metadata for that
+step:
+
+```
+TaskUpdate(taskId, metadata={"comment_ids": ["<id1>"], "bundled": false})
+```
+
+For bundled fixups, the metadata MUST list every grouped comment
+ID and the bundle rationale:
+
+```
+TaskUpdate(taskId, metadata={
+    "comment_ids": ["<id1>", "<id2>", "<id3>"],
+    "bundled": true,
+    "bundle_rationale": "<one-sentence shared-fix-scope reason>",
+})
+```
+
+The `bundle_rationale` field is the audit trail. If the rationale
+matches the Rationalization Watchlist above, the task MUST be
+rejected and split into separate fixups before invoking
+`Skill(Dev10x:gh-pr-fixup)`. This makes the "memory-only" rule a
+mechanical guardrail: the metadata records the decision, the
+watchlist filters bad rationales, and `Dev10x:skill-audit` can
+surface patterns of bundling decisions across sessions.
+
 ### Bundled-reply template
 
 When a single `fixup!` addresses N comments, every reply MUST

--- a/skills/request-review/SKILL.md
+++ b/skills/request-review/SKILL.md
@@ -45,32 +45,42 @@ Pass `$ARG` as the skill argument (PR URL, bare number, or empty).
 
 If detection fails, report the error and stop.
 
-### Step 1.5: Approval state precheck (GH-993)
+### Step 1.5: Approval state precheck (GH-993, GH-128)
 
 Before pinging reviewers, check whether the PR is already
-approved on its current HEAD:
+approved on its current HEAD **by a human reviewer**. Bot
+approvals (e.g., `claude[bot]`, `github-actions[bot]`) MUST
+NOT short-circuit the human review request.
 
 ```bash
 gh pr view {PR_NUMBER} --repo {REPO} \
   --json reviewDecision,reviews,headRefOid
 ```
 
-Decision logic:
+**Filter bot approvals first (GH-128).** Before matching reviews
+against `headRefOid`, drop any review whose `author.login` ends
+with `[bot]` (e.g., `claude[bot]`) or whose `author.type == "Bot"`.
+Bot approvals do not satisfy the "human review" requirement.
 
-- `reviewDecision == "APPROVED"` and the latest review's
-  `commit.oid` matches `headRefOid` → PR is approved on the
-  current HEAD. **REQUIRED: Call `AskUserQuestion`** (do NOT
-  use plain text):
+Decision logic (operates on the human-filtered review list):
+
+- A HUMAN review with `state == "APPROVED"` and `commit.oid`
+  matching `headRefOid` → PR is human-approved on the current
+  HEAD. **REQUIRED: Call `AskUserQuestion`** (do NOT use plain
+  text):
   - **Skip — merge instead (Recommended)** — short-circuit
     review request and offer to invoke `Dev10x:gh-pr-merge`
   - **Force request anyway** — proceed to Step 2 with all
     reviewers (e.g., user wants additional eyes)
   - **Cancel** — do nothing
-- `reviewDecision == "APPROVED"` but newer commits have landed
-  since the latest approval → approval is stale; proceed
-  normally to Step 2 (re-review needed)
-- `reviewDecision == "CHANGES_REQUESTED"` or `null` → proceed
-  normally to Step 2
+- HUMAN `APPROVED` reviews exist but newer commits landed since
+  the latest approval → approval is stale; proceed normally to
+  Step 2 (re-review needed)
+- Only bot approvals match the current HEAD, or
+  `reviewDecision == "CHANGES_REQUESTED"`, or no reviews → proceed
+  normally to Step 2. When only bot approvals exist on the current
+  HEAD, log "PR has only a bot approval — requesting human review"
+  so the rationale is visible.
 
 Skip this precheck when invoked with `--force` or when the
 caller is `Dev10x:gh-pr-monitor` Phase 3 with explicit

--- a/skills/slack-review-request/SKILL.md
+++ b/skills/slack-review-request/SKILL.md
@@ -63,23 +63,31 @@ Mentions are resolved against `~/.claude/memory/Dev10x/slack-config.yaml`
 
 ## Flow
 
-### Step 0: Approval state precheck (GH-993)
+### Step 0: Approval state precheck (GH-993, GH-128)
 
 Before posting a Slack ping, verify the PR is not already approved
-on its current HEAD. Re-pinging reviewers on an approved PR is
-noise — the human supervisor's next action is merge, not another
-review pass.
+on its current HEAD **by a human reviewer**. Re-pinging reviewers
+on a human-approved PR is noise — the supervisor's next action is
+merge, not another review pass. Bot approvals (`claude[bot]`,
+`github-actions[bot]`, etc.) MUST NOT short-circuit the Slack ping.
 
-1. Fetch review state:
+1. Fetch review state (no MCP wrapper exists for review-decision
+   data — `gh pr view` is the supported call site):
    ```bash
-   gh pr view {pr_number} --repo {repo} \
-     --json reviewDecision,reviews,headRefOid
+   gh pr view {pr_number} --repo {repo} --json reviewDecision,reviews,headRefOid  # cli-friction: allow raw-gh-pr — review-state precheck
    ```
-2. **If `reviewDecision == "APPROVED"`** and the latest review's
-   `commit.oid` matches `headRefOid`: skip the Slack notification.
+2. **Filter bot approvals first (GH-128).** Drop any review whose
+   `author.login` ends with `[bot]` or whose `author.type == "Bot"`
+   before matching against `headRefOid`. Bot approvals do not
+   satisfy the "human review" requirement.
+3. **If a HUMAN review with `state == "APPROVED"`** and matching
+   `commit.oid == headRefOid` exists: skip the Slack notification.
    Report "Slack notification skipped — PR already approved on
-   current HEAD" and stop.
-3. **Otherwise**: proceed to Step 1.
+   current HEAD by {login}" and stop.
+4. **Otherwise** (only bot approvals, stale approvals, or no
+   approvals): proceed to Step 1. When only bot approvals exist on
+   the current HEAD, log "PR has only a bot approval — posting
+   human review ping" so the rationale is visible.
 
 Skip this precheck when invoked with `--force` flag or when the
 caller passes `bypass_approval_check: true` (e.g., re-review


### PR DESCRIPTION
**When** running the Dev10x shipping pipeline against an active PR,
**I want to** preserve curated commit history by default, route human
review past bot-only approvals, and keep fixup commits 1:1 with
review comments,
**so I can** trust the pipeline's outputs reflect Dev10x conventions
and audit trail without manual cleanup.

Three independent skill-shipping fixes bundled into one PR per the
user's `bundle` directive. Each issue lands as one atomic commit.

---

[`87973b27`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/177/commits/87973b27c2958f88e54d5e3d66c5b67239923208) ✨ GH-134 Default gh-pr-merge to rebase for curated history
[`fa6a734f`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/177/commits/fa6a734f) 🐛 GH-128 Exclude bot approvals from review-state precheck
[`152ab19b`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/177/commits/152ab19b45cff20f11a3f3e67daac7c6561e4d21) ✨ GH-123 Enforce one-fixup-per-comment via mechanical guardrail

Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/134
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/128
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/123
