### PR TITLE
📝 GH-167 Close 14 skill-audit findings across work-on shipping pipeline

### DIFF
--- a/.claude/rules/mcp-tools.md
+++ b/.claude/rules/mcp-tools.md
@@ -44,8 +44,14 @@ its docstring. Examples:
 - `mktmp`: returns `{"path": "/tmp/file"}`
 - Some tools return `{"success": True, "data": result}`
 - Some tools return only tool-specific fields without a `success` flag
+- `push_safe`: returns `{}` on a clean fast-forward push (GH-152) —
+  emptiness is NOT failure; only `{"error": ...}` is failure. Verify
+  the remote with `git ls-remote --heads origin <branch>` if a
+  payload is needed.
 
-Callers must know each tool's specific success response format.
+Callers must know each tool's specific success response format. Branch
+on the presence of an `"error"` key, never on whether the dict is
+empty.
 
 ## Tool Availability by Plugin Version
 

--- a/skills/gh-pr-create/SKILL.md
+++ b/skills/gh-pr-create/SKILL.md
@@ -43,3 +43,12 @@ When this skill is invoked, Read `instructions.md` now and
 follow it end-to-end. `TaskCreate` and `AskUserQuestion` calls
 documented there are REQUIRED (unless invoked with
 `--unattended`, which auto-advances the preview gate).
+
+**End-to-end read enforcement (GH-166):** Consume
+`instructions.md` via a full `Read` of the file. Do NOT use
+`Grep`, partial `Read(offset=...)`, or token-budget skimming
+to locate specific steps — the push-then-create order, the
+ticket-detection fallbacks, the Job Story sourcing rules, and
+the summary-comment side effects are scattered across the
+document. Partial reads that skip later sections routinely
+miss guardrails added after the read window.

--- a/skills/gh-pr-create/instructions.md
+++ b/skills/gh-pr-create/instructions.md
@@ -313,13 +313,37 @@ MCP tool path.
 
 ### Step 6: Push and Create Draft PR
 
+**Strict order: push FIRST, then create PR (GH-159).** The
+push must complete successfully before `create_pr` runs.
+Audit GH-159 caught a session where `create_pr` ran before
+any successful `push_safe`; GitHub accepted the PR but a
+PostToolUse hook had silently rewound HEAD between commits,
+and subsequent `push_safe` calls returned `{}` while the
+remote and local refs diverged. Recovery required
+`git reflog` and `git reset --hard <sha>`.
+
+Verification before `create_pr`:
+
+1. Run `mcp__plugin_Dev10x_cli__push_safe` (or the wrapper
+   script) and confirm a non-error return.
+2. Sanity-check the remote ref with
+   `git ls-remote --heads origin <branch>` — local HEAD SHA
+   must match the remote ref.
+3. ONLY then invoke `create_pr`.
+
+If push verification fails, STOP. Do NOT fall back to a raw
+`git push` (it is hook-blocked) and do NOT call `create_pr`
+on an unpushed branch.
+
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/skills/gh-pr-create/scripts/create-pr.sh "$TITLE" "$JOB_STORY" "$ISSUE" "$FIXES_URL"
 ```
 
 This script:
-1. Pushes the branch with upstream tracking
-2. Creates a draft PR targeting `develop` with plain commit list + checklist template
+1. Pushes the branch with upstream tracking (fails fast if
+   push does not succeed)
+2. Creates a draft PR targeting `develop` with plain commit
+   list + checklist template
 3. Gets the PR number
 4. Updates the body with linked commits (using `generate-commit-list.sh`)
 5. Outputs the PR number

--- a/skills/gh-pr-merge/SKILL.md
+++ b/skills/gh-pr-merge/SKILL.md
@@ -38,3 +38,21 @@ lives in [`instructions.md`](instructions.md).
 When this skill is invoked, Read `instructions.md` now and
 follow it end-to-end. `TaskCreate` and `AskUserQuestion` calls
 documented there are REQUIRED.
+
+## Skill Wrapper is Mandatory (GH-152)
+
+**Hard rule:** Do NOT call `gh pr merge` directly. Every PR
+merge MUST go through `Skill(Dev10x:gh-pr-merge)` so the
+8-check pre-merge gate (unresolved threads, top-level
+comments, inline review comments, CI buckets, draft state,
+mergeability, working copy, review approval) runs. Audit
+GH-152 caught a session where the agent ran
+`gh pr merge <N> --rebase --delete-branch` directly after
+partially reading this SKILL.md — only the CI check was
+performed inline, every other check was skipped.
+
+The PreToolUse hook for raw `gh pr merge` is tracked
+separately (extends the existing blocks on `git commit`,
+`git push`, and `git checkout -b`). Until the hook lands,
+the contract is enforced by convention: agent self-discipline
+plus orchestrator skill-routing tables.

--- a/skills/gh-pr-monitor/SKILL.md
+++ b/skills/gh-pr-monitor/SKILL.md
@@ -41,3 +41,28 @@ handling, team notification, verification — lives in
 When this skill is invoked, Read `instructions.md` now and
 follow it end-to-end. `TaskCreate` and `AskUserQuestion` calls
 documented there are REQUIRED.
+
+## Mandatory Invocation After PR Creation (GH-162)
+
+Audit GH-162 caught a session where work-on task 4.9
+"Monitor CI → delegate to `Dev10x:gh-pr-monitor`" was in the
+plan but never executed; the session ended immediately after
+a single inline `gh pr view` status check (turn 279) and CI
+completion was never confirmed.
+
+**Hard rule:** After `Dev10x:gh-pr-create` succeeds, the very
+next action MUST be `Skill(Dev10x:gh-pr-monitor)` — no
+exceptions. Orchestrators that mark the monitor task
+`completed` without invoking the skill (e.g., via a one-off
+`gh pr view` or inline polling) commit a compliance
+violation. The skill's background-dispatch model is the
+contract; substituting inline polling skips the fixup,
+notification, and verification side effects.
+
+**Solo-maintainer active mode behavior (clarified for GH-152):**
+When `active_modes` contains `solo-maintainer`, the Phase 3
+team notification step is silently skipped — there is no
+Slack channel and no reviewer assignment. The skill still
+runs Phases 1–2 (CI monitoring + fixup handling) and Phase 4
+(verification). The notification gate AskUserQuestion is
+not fired in solo-maintainer mode.

--- a/skills/git-commit-split/SKILL.md
+++ b/skills/git-commit-split/SKILL.md
@@ -34,3 +34,25 @@ steps, per-commit validation, reorder rules — lives in
 When this skill is invoked, Read `instructions.md` now and
 follow it end-to-end. `TaskCreate` calls and the split-plan
 `AskUserQuestion` gate documented there are REQUIRED.
+
+## Invoke First, Not After Manual Steps (GH-160)
+
+**As soon as the user — or the orchestrator — decides a commit
+should be split into multiple atomic commits, this skill is the
+first tool to reach for.** Audit GH-160 caught a session where
+the agent attempted a manual split via 25 sequential
+`git reset HEAD` + selective `git add` + `git commit -F` actions
+across ~50 turns before eventually invoking the skill anyway,
+making the cleanup harder than the original task.
+
+The skill exists specifically to plan the split, run the
+interactive rebase, validate per-commit, and reorder by
+dependency. Do NOT improvise an equivalent manually:
+
+- ❌ `git reset HEAD~N` + selective `git add` + N × `git commit -F`
+- ❌ `git rebase -i HEAD~N` with `edit` directives, hand-edited
+- ✅ `Skill(Dev10x:git-commit-split)` — single entry point
+
+If you catch yourself reaching for `git reset HEAD` to "manually
+group" staged files into separate commits, STOP and invoke this
+skill instead.

--- a/skills/git-commit/SKILL.md
+++ b/skills/git-commit/SKILL.md
@@ -34,3 +34,13 @@ line-length validation, staging, and commit creation — lives in
 When this skill is invoked, Read `instructions.md` now and
 follow it end-to-end. `AskUserQuestion` gates documented there
 are REQUIRED.
+
+**End-to-end read enforcement (GH-166):** Consume
+`instructions.md` via a full `Read` of the file. Do NOT use
+`Grep`, partial `Read(offset=...)`, or token-budget skimming
+to locate specific steps — guardrails (e.g., the Scope
+Invariant, the Pre-staging Gate, the 72-char validation, the
+mktmp-only temp path) are scattered across the document, and
+agents that read only the section they "need" routinely miss
+them. If file size is a concern, request the entire body
+once and rely on the parsed context for subsequent steps.

--- a/skills/git-commit/instructions.md
+++ b/skills/git-commit/instructions.md
@@ -608,6 +608,30 @@ Create this commit? (y/n/edit)
 
 ### Step 10: Stage Files (if needed)
 
+**Pre-staging gate (GH-157):** If the index already contains
+staged files when this skill is invoked (`git diff --cached
+--name-only` returns non-empty), the caller may have staged
+manually and the staged set is now a hidden boundary the skill
+would silently accept.
+
+**Attended mode — REQUIRED: Call `AskUserQuestion`** (do NOT
+use plain text):
+- **Use existing staging (Recommended)** — commit only the
+  currently staged files; do not run `git add -A`
+- **Unstage and re-select** — run `git restore --staged .` and
+  follow the normal staging flow below
+
+**Unattended mode:** Honor pre-existing staging as-is when the
+orchestrator explicitly requested partial staging via pathspec;
+otherwise log a warning and proceed with `git add -A` on the
+union of staged and unstaged changes. Document the decision in
+the commit body if it deviates from the staged set.
+
+Audit GH-157 caught a session where manual `git reset HEAD` +
+selective `git add` set an irreversible boundary that the skill
+inherited without confirmation — remediation required invoking
+`Dev10x:git-commit-split` from scratch.
+
 **Hard rule: NEVER stage individual files by name** (e.g.,
 `git add file1.py file2.py`) to PICK files into a commit.
 Selective staging bypasses the skill contract — all changes

--- a/skills/git-commit/instructions.md
+++ b/skills/git-commit/instructions.md
@@ -123,6 +123,28 @@ points. In unattended mode, these gates are skipped:
   - Edit message — revise before creating
   - Abort — cancel commit
 
+## Scope Invariant (GH-153)
+
+**One commit scope per invocation.** If a second unrelated change
+surfaces mid-flow (e.g., during staging review, the agent spots an
+incidental edit in a different module), finish the current
+invocation first, then re-invoke `Dev10x:git-commit` for the new
+scope. Do NOT extend the in-flight invocation to cover multiple
+scopes.
+
+**Recovery for a blocked raw `git commit`:** When the PreToolUse
+hook denies a raw `git commit -F <path>` you reached for mid-flow
+because a second scope appeared, the correct response is to:
+
+1. Complete the current `Dev10x:git-commit` invocation with the
+   original scope.
+2. Re-invoke `Skill(Dev10x:git-commit)` for the new scope.
+
+**Do NOT use `DEV10X_SKIP_CMD_VALIDATION=true` as a workaround.**
+That flag is reserved for skill-internal exceptions, not caller
+escape hatches. See `references/commit-examples.md` for atomic
+commit guidance.
+
 ## Prerequisites Check
 
 **IMPORTANT:** Verify git state before committing:

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -47,6 +47,32 @@ can consume to create fixup commits.
 **Not for remote PR review** — use `Dev10x:gh-pr-review` to post
 findings to GitHub.
 
+## Solo-Maintainer Auto-Skip Threshold (GH-161)
+
+Audit GH-161 caught a session where `Dev10x:review` and
+`simplify` were auto-completed with the marker
+`Auto-skipped: solo-maintainer` despite the diff touching 8+
+files including domain restructuring and a platform Registry
+split. Blanket auto-skip in `solo-maintainer` mode defeats the
+purpose of the review gate.
+
+**Threshold rule:** When `active_modes` contains
+`solo-maintainer`, auto-skip applies ONLY to small-surface
+changes. Compute the touched-files count from
+`git develop-diff --name-only | wc -l`:
+
+| Files touched | Solo-maintainer behavior |
+|---|---|
+| ≤ 3 files | Auto-skip allowed (Auto-skipped: solo-maintainer) |
+| 4–7 files | Run review in `--unattended` mode (no gate) |
+| ≥ 8 files | Run review in `--unattended` mode; if findings
+exist, emit `AskUserQuestion` so the user retains override |
+
+Orchestrators (e.g., `Dev10x:work-on`) MUST NOT mark the
+review task `completed` with the auto-skip marker when the
+diff exceeds the small-surface threshold. The same rule
+applies to the `simplify` step that follows review.
+
 ## Orchestration
 
 This skill follows `references/task-orchestration.md` patterns

--- a/skills/session-wrap-up/SKILL.md
+++ b/skills/session-wrap-up/SKILL.md
@@ -18,6 +18,32 @@ allowed-tools:
 **Announce:** "Using Dev10x:session-wrap-up to capture open loops
 before closing this session."
 
+## Mandatory Invocation Triggers (GH-163)
+
+Audit GH-163 caught a session that wound down with CI still
+unconfirmed, 5 newly-created follow-up issues unlinked to the
+parent ticket, no plan-sync archive, and no parking note —
+`Dev10x:session-wrap-up` matched every trigger but was never
+invoked, and the parent orchestrator marked its wrap-up task
+`completed` without a `Skill()` call.
+
+**Hard trigger signals that REQUIRE this skill (do not skip):**
+
+- User signals end-of-session: "wrap up", "pause", "done for
+  today", "that's it"
+- CI on a session-created PR is still pending or unconfirmed
+  and the user is stepping away
+- Open loops (PRs awaiting review, deferred tasks, unfiled
+  follow-ups) exist with no plan-sync archive
+- Orchestrators (`Dev10x:work-on`, `Dev10x:fanout`) reach the
+  plan completion gate with non-empty pending tasks
+
+**Anti-pattern (PROHIBITED):** Marking a "Session wrap-up" or
+"Park items" task `completed` in an orchestrator's task list
+without calling `Skill(Dev10x:session-wrap-up)` first. The task
+completion is the side effect of the skill running — not a
+substitute for running it.
+
 ## Overview
 
 Collect all open loops, present them to the user, and help defer

--- a/skills/ticket-create/SKILL.md
+++ b/skills/ticket-create/SKILL.md
@@ -75,6 +75,21 @@ Use this skill when:
 - Documenting an improvement or enhancement
 - Need a properly structured ticket with consistent formatting
 
+### Anti-pattern: Bypassing the wrapper (GH-156)
+
+**Do NOT call `mcp__plugin_Dev10x_cli__issue_create` (or any
+tracker MCP `save_issue` / `gh issue create`) directly when
+creating a new ticket.** Audit GH-156 caught 5 follow-up tickets
+created via raw `issue_create` calls; the resulting tickets
+lacked the Root Cause / Solution / Files Changed scaffolding
+that this skill enforces.
+
+The raw MCP tool is a low-level primitive — this skill is the
+project wrapper that adds structured description formatting,
+label inference, and tracker-detection. Always reach for
+`Skill(Dev10x:ticket-create)` first; the skill's Step 5 will
+dispatch the appropriate MCP tool internally.
+
 ## Input Requirements
 
 This skill requires:

--- a/skills/work-on/instructions.md
+++ b/skills/work-on/instructions.md
@@ -722,14 +722,21 @@ or use Claude Code's built-in plan mode.
 **REQUIRED: Call `AskUserQuestion`** when the plan was
 agent-generated (do NOT use plain text).
 
-**Adaptive friction behavior (GH-808):** At adaptive level,
-auto-select "Approve (Recommended)" — proceed directly to
-Phase 4 without calling `AskUserQuestion`. This means: approve
-the plan and start execution immediately. Do NOT skip the gate
-entirely (which would leave the plan unapproved and execution
-blocked). Auto-select = execute the recommended action.
+**Adaptive friction behavior (GH-808, refined GH-158):** At
+adaptive level, the `AskUserQuestion` tool call MUST still
+emit so the user retains override capability — do not skip
+the gate. The agent auto-selects "Approve (Recommended)" and
+proceeds to Phase 4 only if the user does not override within
+the harness's interactive window. Skipping the gate as plain
+text (audit GH-158: ~45-minute response delay because the A/B
+choice was presented as prose, not a structured widget) is a
+compliance violation regardless of friction level.
 
-**Guided/Strict friction:** Call `AskUserQuestion`:
+Implementation: always call `AskUserQuestion` below; treat
+adaptive as "auto-recommend, but block briefly for override"
+rather than "fire-and-forget approval".
+
+**All friction levels:** Call `AskUserQuestion`:
 
 1. `AskUserQuestion(questions=[{question: "How would you like to proceed with the work plan?", header: "Plan", options: [{label: "Approve (Recommended)", description: "Start execution immediately"}, {label: "Edit", description: "Describe what to change (add/remove/reorder steps)"}], multiSelect: false}])`
 

--- a/skills/work-on/instructions.md
+++ b/skills/work-on/instructions.md
@@ -487,6 +487,25 @@ a playbook file. Call `Read` on the playbook path and verify
 you received YAML content with a `defaults:` key containing
 play definitions. If you cannot confirm this, STOP.
 
+**Resolution probing — DO NOT use `ls` or `cat` (GH-165):**
+
+```bash
+# ❌ FORBIDDEN — chained probes shift the allow-rule prefix
+ls /work/.../playbooks 2>/dev/null; ls ~/.claude/memory/...
+cat ~/.claude/memory/Dev10x/playbooks/work-on.yaml
+
+# ✅ REQUIRED — use Read with absolute paths, one call per tier
+Read(file_path="/abs/path/.claude/Dev10x/playbooks/work-on.yaml")
+Read(file_path="/home/<user>/.claude/memory/Dev10x/playbooks/work-on.yaml")
+Read(file_path="${CLAUDE_PLUGIN_ROOT}/skills/playbook/references/playbook.yaml")
+```
+
+The `ls; ls` pattern triggers `PREFIX_POISONED_CHAIN` friction
+and the bare `cat` triggers `MISSING_RULE` friction (audit
+GH-165). The `Read` tool returns the file content or a clear
+"File does not exist" error, which is the only signal the
+resolution algorithm needs.
+
 **Loading the play:**
 1. Determine the `work_type` from gathered context (see table below)
 2. Resolve the playbook using the 3-tier resolution order above:

--- a/skills/work-on/instructions.md
+++ b/skills/work-on/instructions.md
@@ -1293,6 +1293,23 @@ issue's ticket ID in the message. The shipping pipeline
 runs once — the PR references all bundled issues via
 multiple `Fixes:` lines.
 
+**Commit step positioning (GH-164):** The shipping-pipeline
+`Commit outstanding changes` step (4.7 in the solo-maintainer
+fragment) runs ONCE at the end of all bundle sub-tasks — for
+any residual changes from review/simplify, not as the
+per-issue commit driver. The per-issue commits happen
+*inside* the "Implement changes" epic (step 2c above), not in
+the shipping pipeline. Audit GH-164 caught an agent that
+treated the shipping-pipeline commit step as a sibling of
+the implementation sub-tasks and committed after the very
+first sub-task — prematurely, before later bundle members
+were implemented.
+
+Rule: in bundle mode, every per-issue commit is a child of
+"Implement changes". The shipping-pipeline `Commit outstanding
+changes` step must be positioned strictly AFTER all
+implementation children complete.
+
 **Strategy selection:** When the user explicitly requests
 bundling (e.g., "one PR", "atomic commits", "bundle these"),
 use Strategy B. When the user provides multiple independent

--- a/skills/work-on/instructions.md
+++ b/skills/work-on/instructions.md
@@ -769,8 +769,15 @@ begin Phase 4.
 **REQUIRED after plan approval (GH-760 F2).** Execute these
 calls immediately — do NOT defer or skip:
 
-1. `mcp__plugin_Dev10x_cli__plan_sync_set_context(args=["work_type=<detected_work_type>", "tickets=<JSON array of ticket IDs>", "routing_table={\"commit\":\"Skill(Dev10x:git-commit)\",\"create_pr\":\"Skill(Dev10x:gh-pr-create)\",\"monitor_ci\":\"Skill(Dev10x:gh-pr-monitor)\",\"push\":\"Skill(Dev10x:git)\",\"groom\":\"Skill(Dev10x:git-groom)\",\"branch\":\"Skill(Dev10x:ticket-branch)\",\"verify_acceptance\":\"Skill(Dev10x:verify-acc-dod)\",\"merge_pr\":\"Skill(Dev10x:gh-pr-merge)\"}"])`
+1. `mcp__plugin_Dev10x_cli__plan_sync_set_context(args=["work_type=<detected_work_type>", "tickets=<JSON array of ticket IDs>", "routing_table={\"commit\":\"Skill(Dev10x:git-commit)\",\"create_pr\":\"Skill(Dev10x:gh-pr-create)\",\"monitor_ci\":\"Skill(Dev10x:gh-pr-monitor)\",\"monitor_pr\":\"Skill(Dev10x:gh-pr-monitor)\",\"push\":\"Skill(Dev10x:git)\",\"groom\":\"Skill(Dev10x:git-groom)\",\"branch\":\"Skill(Dev10x:ticket-branch)\",\"verify_acceptance\":\"Skill(Dev10x:verify-acc-dod)\",\"merge_pr\":\"Skill(Dev10x:gh-pr-merge)\",\"work_on\":\"work-on\"}"])`
 2. `mcp__plugin_Dev10x_cli__plan_sync_set_context(args=["gathered_summary=<1-3 sentence summary>"])`
+
+**Attribution keys (GH-152):** The `work_on` key with value
+`"work-on"` is the audit attribution string — skill audits
+match on this exact value to confirm `Dev10x:work-on`
+orchestrated the plan. Include both `monitor_ci` and
+`monitor_pr` keys with the same value so callers can use
+either name without losing the routing.
 
 This ensures the PreCompact hook can inject the routing table
 and work type into the recovery context. Without this, the

--- a/src/dev10x/mcp/server_cli.py
+++ b/src/dev10x/mcp/server_cli.py
@@ -555,6 +555,17 @@ async def push_safe(
 
     Returns:
         Dictionary with keys: success (bool), branch, remote, blocked_reason (if blocked)
+
+    Success semantics (GH-152):
+        An empty dict `{}` IS a successful push — the underlying
+        `git push` script may emit no key/value output on a clean
+        fast-forward. Callers MUST NOT interpret `{}` as failure
+        and MUST NOT fall back to raw `git push` (which is
+        hook-blocked). To verify the remote actually received the
+        push, run `git ls-remote --heads origin <branch>` and
+        compare against the local HEAD SHA. A real failure
+        returns `{"error": "<message>"}` — branch on the `error`
+        key, not on emptiness.
     """
     from dev10x import git as git_tools
     from dev10x.subprocess_utils import use_cwd

--- a/src/dev10x/validators/command-skill-map.yaml
+++ b/src/dev10x/validators/command-skill-map.yaml
@@ -330,13 +330,20 @@ rules:
       - pytest
       - python -m pytest
       - uv run pytest
-    hook_block: false
+    hook_block: true
     compensations:
       - type: use-skill
         skill: test
+        guardrails: 100% coverage gate, concise pass/fail summaries, cwd-aware uv run wrapping
+        fallback: >
+          If the test skill is unavailable, run pytest with coverage
+          (`pytest --cov --cov-report=term-missing`) and verify 100%
+          coverage on changed files manually.
     reason: >
-      The test skill ensures consistent coverage reporting and
-      concise summaries. Use it for standardized test execution.
+      Bare pytest invocations bypass the test skill's coverage gate
+      and concise summary formatting. Audit (GH-155) caught 4 bare
+      pytest calls before commits/PR with no coverage verification.
+      The test skill ensures consistent coverage reporting.
 
   - name: gh-pr-comment-reply
     matcher: Bash


### PR DESCRIPTION
**When** a skill-audit produces 14 findings across the
`Dev10x:work-on` shipping pipeline (review, monitor, merge,
commit, push_safe, playbook resolution), **I want to** land
all of them as one atomic commit per child issue on a single
branch with one PR, **so I can** review, ship, and close the
parent meta-ticket in one cycle without 14 separate review
rounds.

## Commits

| Commit | Issue | Theme |
|---|---|---|
| `✨ GH-155` | #155 | Enable hook-block routing for bare pytest |
| `📝 GH-156` | #156 | Document ticket-create wrapper anti-pattern |
| `✨ GH-157` | #157 | Pre-staging gate in git-commit Step 10 |
| `📝 GH-153` | #153 | One-commit-scope-per-invocation invariant |
| `📝 GH-160` | #160 | Reinforce git-commit-split first-invocation trigger |
| `📝 GH-163` | #163 | Reinforce session-wrap-up mandatory triggers |
| `📝 GH-161` | #161 | Scope solo-maintainer review auto-skip by diff size |
| `📝 GH-166` | #166 | Enforce end-to-end instructions.md reading |
| `✨ GH-158` | #158 | Phase 3 plan-approval AskUserQuestion at every level |
| `📝 GH-165` | #165 | Forbid ls/cat probing during playbook resolution |
| `📝 GH-164` | #164 | Clarify bundled-execution commit step positioning |
| `✨ GH-159` | #159 | Enforce push-then-create order in gh-pr-create |
| `📝 GH-162` | #162 | Mandate gh-pr-monitor invocation after PR creation |
| `📝 GH-152` | #152 | Close work-on shipping-pipeline skill-bypass gaps |

All 14 child issues are linked via per-commit `Fixes:` footers,
which GitHub will auto-close on merge. The parent meta-ticket
GH-167 is closed by this PR's `Fixes:` line below.

## Test plan
- [x] Unit tests pass (2096 / 2098, 1 pre-existing baseline
      benchmark failure on develop unrelated to this branch)
- [x] `ruff check` passes for touched Python files
- [x] `black --check` passes for the docstring change
- [x] Doc-only changes verified inline by reading each
      modified `SKILL.md` / `instructions.md` section

Fixes: #167
Fixes: #166
Fixes: #165
Fixes: #164
Fixes: #163
Fixes: #162
Fixes: #161
Fixes: #160
Fixes: #159
Fixes: #158
Fixes: #157
Fixes: #156
Fixes: #155
Fixes: #153
Fixes: #152
