### PR TITLE
♻️ GH-144 Decompose hooks/session.py into archetype-aligned modules

### DIFF
--- a/src/dev10x/domain/session_document.py
+++ b/src/dev10x/domain/session_document.py
@@ -1,0 +1,78 @@
+"""Session Document I/O — file-backed session state and plan readers.
+
+Document archetype: pure I/O over the persisted session state JSON
+and the plan YAML. Callers compose these documents into queries
+(``dev10x.session.queries.SessionContextQuery``) rather than calling
+``json.load`` / ``Path.read_text`` directly.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from dev10x.domain.claude_paths import ClaudeDir
+
+
+def state_path_for_toplevel(*, toplevel: str) -> Path:
+    """Return the persisted session state file for a repo toplevel."""
+    project_hash = hashlib.md5(toplevel.encode()).hexdigest()
+    return ClaudeDir.session_state_dir() / f"{project_hash}.json"
+
+
+def plan_path_for_toplevel(*, toplevel: str) -> Path:
+    """Return the plan YAML file for a repo toplevel."""
+    return Path(toplevel) / ".claude" / "session" / "plan.yaml"
+
+
+def read_json(*, path: Path) -> dict[str, Any]:
+    """Read JSON from path; return empty dict on any error."""
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (json.JSONDecodeError, FileNotFoundError, OSError):
+        return {}
+
+
+def claim_state_file(*, path: Path) -> dict[str, Any]:
+    """Atomically rename the state file to a PID-scoped name, read, then unlink.
+
+    Ensures a SessionStart hook consumes the persisted state exactly once.
+    """
+    claimed = path.with_suffix(f".{os.getpid()}.claimed")
+    try:
+        os.rename(path, claimed)
+    except FileNotFoundError:
+        return {}
+    try:
+        return read_json(path=claimed)
+    finally:
+        claimed.unlink(missing_ok=True)
+
+
+def write_state(*, path: Path, state: dict[str, Any]) -> None:
+    """Write session state JSON to disk, ensuring the parent dir is 0700."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.parent.chmod(0o700)
+    path.write_text(json.dumps(state, indent=2))
+
+
+def read_plan_summary(*, toplevel: str) -> dict[str, Any]:
+    """Read the persisted plan via the task_plan_sync helpers."""
+    from dev10x.hooks.task_plan_sync import get_plan_path, read_plan
+
+    plan_path = get_plan_path(toplevel=toplevel)
+    return read_plan(plan_path=plan_path)
+
+
+__all__ = [
+    "state_path_for_toplevel",
+    "plan_path_for_toplevel",
+    "read_json",
+    "claim_state_file",
+    "write_state",
+    "read_plan_summary",
+]

--- a/src/dev10x/hooks/session.py
+++ b/src/dev10x/hooks/session.py
@@ -1,532 +1,90 @@
-"""Session hook logic — reload prior state and compact context.
+"""Backwards-compatible facade for the decomposed session modules (GH-144).
 
-SessionReloader: reads persisted state file and plan file, produces
-additionalContext for the agent on session start.
+The original ``hooks/session.py`` mixed Event dispatch, Document
+persistence, Rule/Policy, and Place provisioning. It has been split
+into archetype-aligned modules:
 
-ContextCompactor: injects structured context summary before compaction
-so the agent recovers gracefully after context window compression.
+* :mod:`dev10x.hooks.session_dispatch` — event routing.
+* :mod:`dev10x.domain.session_document` — Document I/O.
+* :mod:`dev10x.hooks.session_policy` — named Rule objects.
+* :mod:`dev10x.hooks.session_place` — Place provisioning.
+* :mod:`dev10x.session.queries` — aggregated SessionContextQuery.
+
+This module re-exports the public surface that
+``hooks/scripts/session-*.py``, ``commands/hook.py``, and the test
+suite import. Prefer importing from the new modules in new code.
 """
 
 from __future__ import annotations
 
-import hashlib
-import json
-import os
-import shutil
-import subprocess
-import sys
-from datetime import UTC, datetime
-from pathlib import Path
-from typing import Any
-
-from dev10x.domain.claude_paths import ClaudeDir
-from dev10x.domain.file_locks import atomic_write_text, file_lock
-from dev10x.domain.friction_level import FrictionLevel
-from dev10x.domain.git_context import GitContext
-
-_git = GitContext()
-
-
-def _get_toplevel() -> str | None:
-    return _git.toplevel
-
-
-def _get_branch() -> str:
-    return _git.branch
-
-
-def _run_git(*args: str) -> str:
-    try:
-        return GitContext().run(*args)
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return ""
+from dev10x.domain.session_document import (
+    claim_state_file as _claim_state_file,
+)
+from dev10x.domain.session_document import (
+    read_json as _read_json,
+)
+from dev10x.hooks.session_dispatch import (
+    build_guidance_context,
+    build_reload_context,
+    context_compact,
+    session_goodbye,
+    session_guidance,
+    session_migrate_permissions,
+    session_persist,
+    session_reload,
+)
+from dev10x.hooks.session_place import session_git_aliases, session_tmpdir
+from dev10x.hooks.session_policy import (
+    DecisionGuidanceRule,
+    ReadFrictionLevelRule,
+    _build_migration_replacements,
+    _deduplicate_rules,
+    _migrate_rules,
+)
 
 
-def _read_json(path: Path) -> dict[str, Any]:
-    try:
-        with open(path) as f:
-            return json.load(f)
-    except (json.JSONDecodeError, FileNotFoundError, OSError):
-        return {}
-
-
-def _claim_state_file(path: Path) -> dict[str, Any]:
-    claimed = path.with_suffix(f".{os.getpid()}.claimed")
-    try:
-        os.rename(path, claimed)
-    except FileNotFoundError:
-        return {}
-    try:
-        return _read_json(path=claimed)
-    finally:
-        claimed.unlink(missing_ok=True)
-
-
-def _read_plan_summary(*, toplevel: str) -> dict[str, Any]:
-    from dev10x.hooks.task_plan_sync import get_plan_path, read_plan
-
-    plan_path = get_plan_path(toplevel=toplevel)
-    return read_plan(plan_path=plan_path)
-
-
-def _escape_for_json(s: str) -> str:
-    return (
-        s.replace("\\", "\\\\")
-        .replace('"', '\\"')
-        .replace("\n", "\\n")
-        .replace("\r", "\\r")
-        .replace("\t", "\\t")
-    )
-
-
-def _format_session_state(state: dict[str, Any]) -> str:
+def _format_session_state(*, state):
+    """Compatibility shim — prefer ``SessionState.from_dict(...).format_for_display()``."""
     from dev10x.domain.session_state import SessionState
 
     return SessionState.from_dict(data=state).format_for_display()
 
 
-def _format_plan_summary(plan: dict[str, Any]) -> str:
+def _format_plan_summary(*, plan):
+    """Compatibility shim — prefer ``PlanSummary.from_dict(...).format_for_display()``."""
     from dev10x.domain.session_state import PlanSummary
 
     return PlanSummary.from_dict(data=plan).format_for_display()
 
 
-def _read_friction_level(*, toplevel: str) -> FrictionLevel:
-    session_yaml = Path(toplevel) / ".claude" / "Dev10x" / "session.yaml"
-    if not session_yaml.exists():
-        return FrictionLevel.default()
-    try:
-        import yaml
-
-        with open(session_yaml) as f:
-            data = yaml.safe_load(f) or {}
-        return FrictionLevel.from_yaml(data.get("friction_level"))
-    except Exception:
-        return FrictionLevel.default()
-
-
-def _format_decision_guidance(
-    *,
-    plan: dict[str, Any],
-    friction_level: FrictionLevel,
-) -> str:
-    from dev10x.domain.session_state import PlanSummary
-
-    summary = PlanSummary.from_dict(data=plan)
-    decisions = summary.pending_decisions
-    if not decisions:
-        has_remaining = any(t.get("status") not in ("completed", "deleted") for t in summary.tasks)
-        if has_remaining:
-            return "Session resumed with tasks remaining. Auto-advance through the task list."
-        return ""
-
-    if friction_level is FrictionLevel.ADAPTIVE:
-        return (
-            "Session resumed with pending decisions. Friction level is adaptive — "
-            "auto-select recommended options for all queued decisions and continue "
-            "advancing through the task list without calling AskUserQuestion."
-        )
-    return (
-        "Session resumed with pending decisions. "
-        "Re-ask each pending decision using AskUserQuestion — "
-        "invoke Dev10x:ask before advancing."
-    )
-
-
-def build_reload_context() -> str:
-    """Build the session-reload additionalContext string. Empty when no state."""
-    toplevel = _get_toplevel()
-    if not toplevel:
-        return ""
-
-    project_hash = hashlib.md5(toplevel.encode()).hexdigest()
-    state_dir = ClaudeDir.session_state_dir()
-    state_file = state_dir / f"{project_hash}.json"
-    plan_file = Path(toplevel) / ".claude" / "session" / "plan.yaml"
-
-    state = _claim_state_file(path=state_file)
-    has_plan = plan_file.exists()
-
-    if not state and not has_plan:
-        return ""
-
-    parts: list[str] = []
-
-    if state:
-        state_text = _format_session_state(state=state)
-        if state_text:
-            parts.append(state_text)
-
-    if has_plan:
-        plan = _read_plan_summary(toplevel=toplevel)
-        plan_text = _format_plan_summary(plan=plan)
-        if plan_text:
-            parts.append(plan_text)
-        friction_level = _read_friction_level(toplevel=toplevel)
-        guidance = _format_decision_guidance(plan=plan, friction_level=friction_level)
-        if guidance:
-            parts.append(guidance)
-
-    return "\n\n".join(parts)
-
-
-def session_reload() -> None:
-    context = build_reload_context()
-    if not context:
-        sys.exit(0)
-
-    escaped = _escape_for_json(s=context)
-    output = (
-        '{"hookSpecificOutput":{"hookEventName":"SessionStart",'
-        f'"additionalContext":"{escaped}"}}}}'
-    )
-    print(output)
-
-
-def context_compact() -> None:
-    toplevel = _get_toplevel()
-    if not toplevel:
-        sys.exit(0)
-
-    branch = _get_branch()
-    worktree_name = ""
-    git_file = Path(toplevel) / ".git"
-    if git_file.is_file():
-        worktree_name = Path(toplevel).name
-
-    modified = _run_git("diff", "--name-only").splitlines()[:20]
-    staged = _run_git("diff", "--cached", "--name-only").splitlines()[:20]
-    untracked = _run_git("ls-files", "--others", "--exclude-standard").splitlines()[:10]
-    recent_commits = _run_git("log", "--oneline", "-5")
-
-    plugin_root = Path(__file__).parents[3]
-    essentials_file = plugin_root / ".claude" / "rules" / "essentials.md"
-    essentials = ""
-    if essentials_file.exists():
-        essentials = essentials_file.read_text()
-
-    summary = f"# Post-Compaction Context Recovery\n\n## Git State\n- **Branch:** {branch}"
-    if worktree_name:
-        summary += f"\n- **Worktree:** {worktree_name}"
-    summary += f"\n- **Working directory:** {toplevel}"
-
-    def format_files(files: list[str]) -> str:
-        return "\n".join(f"- {f}" for f in files if f)
-
-    if modified:
-        summary += f"\n\n### Modified files (unstaged)\n{format_files(modified)}"
-    if staged:
-        summary += f"\n\n### Staged files\n{format_files(staged)}"
-    if untracked:
-        summary += f"\n\n### Untracked files\n{format_files(untracked)}"
-    if recent_commits:
-        summary += f"\n\n### Recent commits\n```\n{recent_commits}\n```"
-    if essentials:
-        summary += f"\n\n## Essential Conventions (from essentials.md)\n{essentials}"
-
-    plan_file = Path(toplevel) / ".claude" / "session" / "plan.yaml"
-    if plan_file.exists():
-        from dev10x.domain.session_state import PlanSummary
-
-        plan_data = _read_plan_summary(toplevel=toplevel)
-        plan = PlanSummary.from_dict(data=plan_data)
-
-        summary += "\n\n" + plan.format_for_compaction()
-
-        if not plan.context.routing_table:
-            recovery_file = plugin_root / "references" / "compaction-recovery.md"
-            if recovery_file.exists():
-                summary += f"\n\n{recovery_file.read_text()}"
-
-        friction_level = _read_friction_level(toplevel=toplevel)
-        guidance = _format_decision_guidance(
-            plan=plan_data,
-            friction_level=friction_level,
-        )
-        if guidance:
-            summary += f"\n\n### Resume Guidance\n{guidance}"
-
-        summary += (
-            "\n\n> Reconstructed from persisted plan file. Use TaskList to verify\n"
-            "> current session state. If tasks are missing, recreate them from\n"
-            "> this list. Use the routing table above for all shipping actions."
-        )
-
-    escaped = _escape_for_json(s=summary)
-    print(f'{{"hookSpecificOutput":{{"systemMessage":"{escaped}"}}}}')
-
-
-def session_tmpdir(data: dict | None = None) -> None:
-    """Create session scratch directory and install mktmp.sh (SessionStart hook)."""
-    if data is None:
-        try:
-            data = json.load(sys.stdin)
-        except (json.JSONDecodeError, EOFError):
-            sys.exit(0)
-
-    session_id = data.get("session_id") or ""
-    if not session_id:
-        return
-
-    Path(f"/tmp/Dev10x/{session_id}").mkdir(parents=True, exist_ok=True)
-
-    plugin_root = Path(__file__).parents[3]
-    mktmp_src = plugin_root / "bin" / "mktmp.sh"
-    dest_bin = Path("/tmp/Dev10x/bin")
-    dest_bin.mkdir(parents=True, exist_ok=True)
-
-    if mktmp_src.exists():
-        dest = dest_bin / "mktmp.sh"
-        shutil.copy2(src=mktmp_src, dst=dest)
-        dest.chmod(0o755)
-
-
-def build_guidance_context() -> str:
-    """Return the session-guidance.md contents, or empty string if missing."""
-    plugin_root = Path(__file__).parents[3]
-    guidance_file = plugin_root / "hooks" / "scripts" / "session-guidance.md"
-    if not guidance_file.exists():
-        return ""
-    return guidance_file.read_text()
-
-
-def session_guidance() -> None:
-    """Output session-guidance.md as additionalContext (SessionStart hook)."""
-    content = build_guidance_context()
-    if not content:
-        sys.exit(0)
-
-    escaped = _escape_for_json(s=content)
-    print(
-        '{"hookSpecificOutput":{"hookEventName":"SessionStart",'
-        f'"additionalContext":"{escaped}"}}}}'
-    )
-
-
-def session_git_aliases() -> None:
-    """Check git branch-comparison aliases and report status (SessionStart hook)."""
-    aliases = [
-        "develop-log",
-        "develop-diff",
-        "develop-rebase",
-        "autosquash-develop",
-        "development-log",
-        "development-diff",
-        "development-rebase",
-        "autosquash-development",
-        "trunk-log",
-        "trunk-diff",
-        "trunk-rebase",
-        "autosquash-trunk",
-        "main-log",
-        "main-diff",
-        "main-rebase",
-        "autosquash-main",
-        "master-log",
-        "master-diff",
-        "master-rebase",
-        "autosquash-master",
-    ]
-
-    missing = []
-    present = []
-    for alias in aliases:
-        if _run_git("config", "--get", f"alias.{alias}"):
-            present.append(alias)
-        else:
-            missing.append(alias)
-
-    if not missing:
-        print(f"Git aliases available: {' '.join(present)}")
-        print("Use `git {base}-log`, `git {base}-diff`, `git {base}-rebase`")
-        print("instead of $(git merge-base ...) to avoid permission prompts.")
-    else:
-        print(f"Git aliases missing: {' '.join(missing)}")
-        if present:
-            print(f"Git aliases available: {' '.join(present)}")
-        print("Run the git-alias-setup skill (/Dev10x:git-alias-setup) to configure them.")
-
-
-def _build_migration_replacements(
-    *,
-    plugin_root: Path,
-    home: str,
-) -> list[tuple[str, str]]:
-    version_parent = plugin_root.parent
-    current_abs = str(plugin_root) + "/"
-    current_tilde = current_abs.replace(home, "~")
-
-    replacements: list[tuple[str, str]] = []
-    try:
-        children = sorted(version_parent.iterdir())
-    except OSError:
-        return replacements
-
-    for child in children:
-        if not child.is_dir() or child == plugin_root:
-            continue
-        old_abs = str(child) + "/"
-        old_tilde = old_abs.replace(home, "~")
-        replacements.append((old_abs, current_abs))
-        replacements.append((old_tilde, current_tilde))
-
-    return replacements
-
-
-def _migrate_rules(
-    *,
-    rules: list[str],
-    replacements: list[tuple[str, str]],
-) -> tuple[list[str], int]:
-    migrated = 0
-    result = []
-    for rule in rules:
-        new_rule = rule
-        for old, new in replacements:
-            if old in rule:
-                new_rule = rule.replace(old, new)
-                migrated += 1
-                break
-        result.append(new_rule)
-    return result, migrated
-
-
-def _deduplicate_rules(rules: list[str]) -> list[str]:
-    seen: set[str] = set()
-    deduped: list[str] = []
-    for rule in rules:
-        if rule not in seen:
-            seen.add(rule)
-            deduped.append(rule)
-    return deduped
-
-
-def session_migrate_permissions() -> None:
-    """Migrate stale plugin permission rules to current version (SessionStart hook).
-
-    Only runs when installed via plugin cache (not --plugin-dir).
-    """
-    plugin_root = Path(__file__).parents[3]
-
-    if "plugins/cache/" not in str(plugin_root):
-        sys.exit(0)
-
-    home_path = Path.home()
-    home = str(home_path)
-    replacements = _build_migration_replacements(plugin_root=plugin_root, home=home)
-    if not replacements:
-        sys.exit(0)
-
-    settings_files = [
-        f
-        for f in [
-            home_path / ".claude" / "settings.json",
-            home_path / ".claude" / "settings.local.json",
-        ]
-        if f.exists()
-    ]
-
-    total_migrated = 0
-    files_changed: list[str] = []
-
-    for settings_file in settings_files:
-        try:
-            with file_lock(settings_file):
-                settings = json.loads(settings_file.read_text())
-                permissions = settings.get("permissions", {})
-                changed = False
-                for key in ("allow", "deny"):
-                    raw = permissions.get(key, [])
-                    if not raw:
-                        continue
-                    new_rules, count = _migrate_rules(rules=raw, replacements=replacements)
-                    new_rules = _deduplicate_rules(rules=new_rules)
-                    total_migrated += count
-                    if count:
-                        permissions[key] = new_rules
-                        changed = True
-                if not changed:
-                    continue
-                atomic_write_text(settings_file, json.dumps(settings, indent=2) + "\n")
-            files_changed.append(settings_file.name)
-        except (json.JSONDecodeError, OSError):
-            continue
-
-    if total_migrated > 0:
-        files_str = ", ".join(files_changed)
-        print(
-            f"Migrated {total_migrated} stale permission rule(s) "
-            f"to current plugin version in {files_str}"
-        )
-
-
-def session_persist(data: dict | None = None) -> None:
-    """Persist session state to disk for next-session reload (SessionStop hook)."""
-    if data is None:
-        try:
-            data = json.load(sys.stdin)
-        except (json.JSONDecodeError, EOFError):
-            sys.exit(0)
-
-    session_id = data.get("session_id") or ""
-    if not session_id:
-        return
-
-    toplevel = _get_toplevel()
-    if not toplevel:
-        return
-
-    project_hash = hashlib.md5(toplevel.encode()).hexdigest()
-    state_dir = ClaudeDir.session_state_dir()
-    state_dir.mkdir(parents=True, exist_ok=True)
-    state_dir.chmod(0o700)
-    state_file = state_dir / f"{project_hash}.json"
-
-    branch = _run_git("rev-parse", "--abbrev-ref", "HEAD") or "unknown"
-
-    worktree_name = ""
-    git_file = Path(toplevel) / ".git"
-    if git_file.is_file():
-        worktree_name = Path(toplevel).name
-
-    modified = _run_git("diff", "--name-only").splitlines()[:20]
-    staged = _run_git("diff", "--cached", "--name-only").splitlines()[:20]
-    recent_commits = _run_git("log", "--oneline", "-5").splitlines()
-
-    has_plan = (Path(toplevel) / ".claude" / "session" / "plan.yaml").exists()
-
-    timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-    state: dict[str, Any] = {
-        "session_id": session_id,
-        "branch": branch,
-        "worktree": worktree_name,
-        "working_directory": toplevel,
-        "timestamp": timestamp,
-        "modified_files": modified,
-        "staged_files": staged,
-        "recent_commits": recent_commits,
-        "has_plan": has_plan,
-    }
-    state_file.write_text(json.dumps(state, indent=2))
-
-
-def session_goodbye(data: dict | None = None) -> None:
-    """Output goodbye message with community link and resume hint (SessionStop hook)."""
-    if data is None:
-        try:
-            data = json.load(sys.stdin)
-        except (json.JSONDecodeError, EOFError):
-            data = {}
-
-    session_id = data.get("session_id") or ""
-
-    url = "https://www.skool.com/Dev10x-1892"
-    print()
-    print("Thank you for using Dev10x. Join the community to get the most out of the plugin:")
-    print(f"\033]8;;{url}\033\\{url}\033]8;;\033\\")
-
-    if session_id:
-        print()
-        print("Resume this session with:")
-        print(f"  claude --resume {session_id}")
+def _read_friction_level(*, toplevel: str):
+    """Compatibility shim — prefer ``ReadFrictionLevelRule(toplevel=...).apply()``."""
+    return ReadFrictionLevelRule(toplevel=toplevel).apply()
+
+
+def _format_decision_guidance(*, plan, friction_level):
+    """Compatibility shim — prefer ``DecisionGuidanceRule(...).apply()``."""
+    return DecisionGuidanceRule(plan=plan, friction_level=friction_level).apply()
+
+
+__all__ = [
+    "build_guidance_context",
+    "build_reload_context",
+    "context_compact",
+    "session_git_aliases",
+    "session_goodbye",
+    "session_guidance",
+    "session_migrate_permissions",
+    "session_persist",
+    "session_reload",
+    "session_tmpdir",
+    "_build_migration_replacements",
+    "_claim_state_file",
+    "_deduplicate_rules",
+    "_format_decision_guidance",
+    "_format_plan_summary",
+    "_format_session_state",
+    "_migrate_rules",
+    "_read_friction_level",
+    "_read_json",
+]

--- a/src/dev10x/hooks/session_dispatch.py
+++ b/src/dev10x/hooks/session_dispatch.py
@@ -1,0 +1,192 @@
+"""Session event dispatch — thin SessionStart / SessionStop / PreCompact handlers.
+
+Event-routing module. Owns the entry points referenced by
+``hooks/scripts/session-*.py`` and ``commands/hook.py``. Rendering and
+data assembly live elsewhere:
+
+* Document I/O — :mod:`dev10x.domain.session_document`.
+* Named policies (friction parsing, permission migration, decision
+  guidance) — :mod:`dev10x.hooks.session_policy`.
+* Place provisioning (``/tmp`` setup, git alias inventory) —
+  :mod:`dev10x.hooks.session_place`.
+* Aggregated query + formatters — :mod:`dev10x.session.queries`.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from dev10x.domain.claude_paths import ClaudeDir
+from dev10x.domain.git_context import GitContext
+from dev10x.domain.session_document import (
+    plan_path_for_toplevel,
+    state_path_for_toplevel,
+    write_state,
+)
+from dev10x.hooks.session_policy import MigratePluginPermissionsRule
+from dev10x.session.queries import (
+    SessionContextQuery,
+    format_compaction_summary,
+    format_reload_context,
+)
+
+_git = GitContext()
+
+
+def _get_toplevel() -> str | None:
+    return GitContext().toplevel
+
+
+def _escape_for_json(*, s: str) -> str:
+    return (
+        s.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+    )
+
+
+def _run_git(*args: str) -> str:
+    try:
+        return GitContext().run(*args)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return ""
+
+
+def _plugin_root() -> Path:
+    return Path(__file__).parents[3]
+
+
+def build_reload_context() -> str:
+    """Build the session-reload additionalContext string. Empty when no state."""
+    toplevel = _get_toplevel()
+    if not toplevel:
+        return ""
+    ctx = SessionContextQuery.gather_reload(toplevel=toplevel)
+    return format_reload_context(ctx=ctx)
+
+
+def session_reload() -> None:
+    context = build_reload_context()
+    if not context:
+        sys.exit(0)
+    escaped = _escape_for_json(s=context)
+    print(
+        '{"hookSpecificOutput":{"hookEventName":"SessionStart",'
+        f'"additionalContext":"{escaped}"}}}}'
+    )
+
+
+def context_compact() -> None:
+    toplevel = _get_toplevel()
+    if not toplevel:
+        sys.exit(0)
+    ctx = SessionContextQuery.gather_compaction(toplevel=toplevel)
+    summary = format_compaction_summary(ctx=ctx, plugin_root=_plugin_root())
+    escaped = _escape_for_json(s=summary)
+    print(f'{{"hookSpecificOutput":{{"systemMessage":"{escaped}"}}}}')
+
+
+def build_guidance_context() -> str:
+    """Return the session-guidance.md contents, or empty string if missing."""
+    guidance_file = _plugin_root() / "hooks" / "scripts" / "session-guidance.md"
+    return guidance_file.read_text() if guidance_file.exists() else ""
+
+
+def session_guidance() -> None:
+    """Output session-guidance.md as additionalContext (SessionStart hook)."""
+    content = build_guidance_context()
+    if not content:
+        sys.exit(0)
+    escaped = _escape_for_json(s=content)
+    print(
+        '{"hookSpecificOutput":{"hookEventName":"SessionStart",'
+        f'"additionalContext":"{escaped}"}}}}'
+    )
+
+
+def session_migrate_permissions() -> None:
+    """Migrate stale plugin permission rules to current version (SessionStart hook).
+
+    Delegates to :class:`MigratePluginPermissionsRule`. Only runs when
+    installed via the plugin cache (not ``--plugin-dir``).
+    """
+    rule = MigratePluginPermissionsRule(plugin_root=_plugin_root(), home_path=Path.home())
+    if not rule.applicable():
+        sys.exit(0)
+    total_migrated, files_changed = rule.apply()
+    if total_migrated > 0:
+        files_str = ", ".join(files_changed)
+        print(
+            f"Migrated {total_migrated} stale permission rule(s) "
+            f"to current plugin version in {files_str}"
+        )
+
+
+def session_persist(data: dict | None = None) -> None:
+    """Persist session state to disk for next-session reload (SessionStop hook)."""
+    if data is None:
+        try:
+            data = json.load(sys.stdin)
+        except (json.JSONDecodeError, EOFError):
+            sys.exit(0)
+    session_id = data.get("session_id") or ""
+    if not session_id:
+        return
+    toplevel = _get_toplevel()
+    if not toplevel:
+        return
+
+    state_dir = ClaudeDir.session_state_dir()
+    state_dir.mkdir(parents=True, exist_ok=True)
+    state_dir.chmod(0o700)
+
+    worktree_name = Path(toplevel).name if (Path(toplevel) / ".git").is_file() else ""
+    state: dict[str, Any] = {
+        "session_id": session_id,
+        "branch": _run_git("rev-parse", "--abbrev-ref", "HEAD") or "unknown",
+        "worktree": worktree_name,
+        "working_directory": toplevel,
+        "timestamp": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "modified_files": _run_git("diff", "--name-only").splitlines()[:20],
+        "staged_files": _run_git("diff", "--cached", "--name-only").splitlines()[:20],
+        "recent_commits": _run_git("log", "--oneline", "-5").splitlines(),
+        "has_plan": plan_path_for_toplevel(toplevel=toplevel).exists(),
+    }
+    write_state(path=state_path_for_toplevel(toplevel=toplevel), state=state)
+
+
+def session_goodbye(data: dict | None = None) -> None:
+    """Output goodbye message with community link and resume hint (SessionStop hook)."""
+    if data is None:
+        try:
+            data = json.load(sys.stdin)
+        except (json.JSONDecodeError, EOFError):
+            data = {}
+    session_id = data.get("session_id") or ""
+    url = "https://www.skool.com/Dev10x-1892"
+    print()
+    print("Thank you for using Dev10x. Join the community to get the most out of the plugin:")
+    print(f"\033]8;;{url}\033\\{url}\033]8;;\033\\")
+    if session_id:
+        print()
+        print("Resume this session with:")
+        print(f"  claude --resume {session_id}")
+
+
+__all__ = [
+    "build_reload_context",
+    "build_guidance_context",
+    "session_reload",
+    "context_compact",
+    "session_guidance",
+    "session_migrate_permissions",
+    "session_persist",
+    "session_goodbye",
+]

--- a/src/dev10x/hooks/session_place.py
+++ b/src/dev10x/hooks/session_place.py
@@ -1,0 +1,97 @@
+"""Session Place provisioning — temp directories and git alias inventory.
+
+Place archetype: side effects that prepare the workspace for a session
+(creating ``/tmp/Dev10x/<session_id>``) and surface infrastructure
+state to the user (which git alias shortcuts are wired up). Split out
+of ``hooks/session.py`` so the dispatcher stays at event-routing scope.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from dev10x.domain.git_context import GitContext
+
+BASE_BRANCH_ALIASES: tuple[str, ...] = (
+    "develop-log",
+    "develop-diff",
+    "develop-rebase",
+    "autosquash-develop",
+    "development-log",
+    "development-diff",
+    "development-rebase",
+    "autosquash-development",
+    "trunk-log",
+    "trunk-diff",
+    "trunk-rebase",
+    "autosquash-trunk",
+    "main-log",
+    "main-diff",
+    "main-rebase",
+    "autosquash-main",
+    "master-log",
+    "master-diff",
+    "master-rebase",
+    "autosquash-master",
+)
+
+
+def _run_git(*args: str) -> str:
+    try:
+        return GitContext().run(*args)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return ""
+
+
+def session_tmpdir(data: dict | None = None) -> None:
+    """Create session scratch directory and install mktmp.sh (SessionStart hook)."""
+    if data is None:
+        try:
+            data = json.load(sys.stdin)
+        except (json.JSONDecodeError, EOFError):
+            sys.exit(0)
+
+    session_id = data.get("session_id") or ""
+    if not session_id:
+        return
+
+    Path(f"/tmp/Dev10x/{session_id}").mkdir(parents=True, exist_ok=True)
+
+    plugin_root = Path(__file__).parents[3]
+    mktmp_src = plugin_root / "bin" / "mktmp.sh"
+    dest_bin = Path("/tmp/Dev10x/bin")
+    dest_bin.mkdir(parents=True, exist_ok=True)
+
+    if mktmp_src.exists():
+        dest = dest_bin / "mktmp.sh"
+        shutil.copy2(src=mktmp_src, dst=dest)
+        dest.chmod(0o755)
+
+
+def session_git_aliases() -> None:
+    """Check git branch-comparison aliases and report status (SessionStart hook)."""
+    missing: list[str] = []
+    present: list[str] = []
+    for alias in BASE_BRANCH_ALIASES:
+        if _run_git("config", "--get", f"alias.{alias}"):
+            present.append(alias)
+        else:
+            missing.append(alias)
+
+    if not missing:
+        print(f"Git aliases available: {' '.join(present)}")
+        print("Use `git {base}-log`, `git {base}-diff`, `git {base}-rebase`")
+        print("instead of $(git merge-base ...) to avoid permission prompts.")
+        return
+
+    print(f"Git aliases missing: {' '.join(missing)}")
+    if present:
+        print(f"Git aliases available: {' '.join(present)}")
+    print("Run the git-alias-setup skill (/Dev10x:git-alias-setup) to configure them.")
+
+
+__all__ = ["session_tmpdir", "session_git_aliases", "BASE_BRANCH_ALIASES"]

--- a/src/dev10x/hooks/session_policy.py
+++ b/src/dev10x/hooks/session_policy.py
@@ -1,0 +1,216 @@
+"""Session policy — named Rule objects for friction parsing, permission
+migration, and decision-guidance synthesis.
+
+Rule archetype: each class encapsulates one named decision the session
+hooks make. Pulling these out of ``hooks/session.py`` keeps the
+dispatcher thin and makes the policies testable in isolation.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from dev10x.domain.file_locks import atomic_write_text, file_lock
+from dev10x.domain.friction_level import FrictionLevel
+from dev10x.domain.session_state import PlanSummary
+
+
+class UnknownFrictionLevelError(ValueError):
+    """Raised when decision guidance is asked to format an unknown friction level."""
+
+
+def _build_migration_replacements(
+    *,
+    plugin_root: Path,
+    home: str,
+) -> list[tuple[str, str]]:
+    version_parent = plugin_root.parent
+    current_abs = str(plugin_root) + "/"
+    current_tilde = current_abs.replace(home, "~")
+
+    replacements: list[tuple[str, str]] = []
+    try:
+        children = sorted(version_parent.iterdir())
+    except OSError:
+        return replacements
+
+    for child in children:
+        if not child.is_dir() or child == plugin_root:
+            continue
+        old_abs = str(child) + "/"
+        old_tilde = old_abs.replace(home, "~")
+        replacements.append((old_abs, current_abs))
+        replacements.append((old_tilde, current_tilde))
+
+    return replacements
+
+
+def _migrate_rules(
+    *,
+    rules: list[str],
+    replacements: list[tuple[str, str]],
+) -> tuple[list[str], int]:
+    migrated = 0
+    result = []
+    for rule in rules:
+        new_rule = rule
+        for old, new in replacements:
+            if old in rule:
+                new_rule = rule.replace(old, new)
+                migrated += 1
+                break
+        result.append(new_rule)
+    return result, migrated
+
+
+def _deduplicate_rules(rules: list[str]) -> list[str]:
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for rule in rules:
+        if rule not in seen:
+            seen.add(rule)
+            deduped.append(rule)
+    return deduped
+
+
+@dataclass(frozen=True)
+class ReadFrictionLevelRule:
+    """Read the friction level from ``.claude/Dev10x/session.yaml``.
+
+    Returns ``FrictionLevel.default()`` when the file is missing or
+    unreadable — that is the soft fallback. Use ``DecisionGuidanceRule``
+    for strict behaviour at format time.
+    """
+
+    toplevel: str
+
+    def apply(self) -> FrictionLevel:
+        session_yaml = Path(self.toplevel) / ".claude" / "Dev10x" / "session.yaml"
+        if not session_yaml.exists():
+            return FrictionLevel.default()
+        try:
+            import yaml
+
+            with open(session_yaml) as f:
+                data = yaml.safe_load(f) or {}
+            return FrictionLevel.from_yaml(data.get("friction_level"))
+        except Exception:
+            return FrictionLevel.default()
+
+
+@dataclass(frozen=True)
+class DecisionGuidanceRule:
+    """Format resume guidance for the agent based on plan + friction level.
+
+    Raises ``UnknownFrictionLevelError`` when ``friction_level`` is not
+    a recognised :class:`FrictionLevel` member. Audit M7 #D2 calls out
+    the prior fall-through (which silently produced strict-style guidance
+    for adaptive sessions) as a latent bug.
+    """
+
+    plan: dict[str, Any]
+    friction_level: FrictionLevel
+
+    def apply(self) -> str:
+        if not isinstance(self.friction_level, FrictionLevel):
+            raise UnknownFrictionLevelError(f"Unknown friction level: {self.friction_level!r}")
+
+        summary = PlanSummary.from_dict(data=self.plan)
+        decisions = summary.pending_decisions
+        if not decisions:
+            has_remaining = any(
+                t.get("status") not in ("completed", "deleted") for t in summary.tasks
+            )
+            if has_remaining:
+                return "Session resumed with tasks remaining. Auto-advance through the task list."
+            return ""
+
+        if self.friction_level is FrictionLevel.ADAPTIVE:
+            return (
+                "Session resumed with pending decisions. Friction level is adaptive — "
+                "auto-select recommended options for all queued decisions and continue "
+                "advancing through the task list without calling AskUserQuestion."
+            )
+        if self.friction_level in (FrictionLevel.STRICT, FrictionLevel.GUIDED):
+            return (
+                "Session resumed with pending decisions. "
+                "Re-ask each pending decision using AskUserQuestion — "
+                "invoke Dev10x:ask before advancing."
+            )
+        raise UnknownFrictionLevelError(f"Unhandled friction level: {self.friction_level!r}")
+
+
+@dataclass(frozen=True)
+class MigratePluginPermissionsRule:
+    """Rewrite stale plugin-cache paths in user settings.{json,local.json}.
+
+    Only meaningful when installed via the plugin cache — direct
+    ``--plugin-dir`` installs have no version-pinned ancestors to clean
+    up. Returns the count of rules rewritten and the list of files
+    touched so the dispatcher can emit a single informational line.
+    """
+
+    plugin_root: Path
+    home_path: Path
+
+    def applicable(self) -> bool:
+        return "plugins/cache/" in str(self.plugin_root)
+
+    def apply(self) -> tuple[int, list[str]]:
+        replacements = _build_migration_replacements(
+            plugin_root=self.plugin_root,
+            home=str(self.home_path),
+        )
+        if not replacements:
+            return 0, []
+
+        settings_files = [
+            f
+            for f in [
+                self.home_path / ".claude" / "settings.json",
+                self.home_path / ".claude" / "settings.local.json",
+            ]
+            if f.exists()
+        ]
+
+        total_migrated = 0
+        files_changed: list[str] = []
+
+        for settings_file in settings_files:
+            try:
+                with file_lock(settings_file):
+                    settings = json.loads(settings_file.read_text())
+                    permissions = settings.get("permissions", {})
+                    changed = False
+                    for key in ("allow", "deny"):
+                        raw = permissions.get(key, [])
+                        if not raw:
+                            continue
+                        new_rules, count = _migrate_rules(rules=raw, replacements=replacements)
+                        new_rules = _deduplicate_rules(rules=new_rules)
+                        total_migrated += count
+                        if count:
+                            permissions[key] = new_rules
+                            changed = True
+                    if not changed:
+                        continue
+                    atomic_write_text(settings_file, json.dumps(settings, indent=2) + "\n")
+                files_changed.append(settings_file.name)
+            except (json.JSONDecodeError, OSError):
+                continue
+
+        return total_migrated, files_changed
+
+
+__all__ = [
+    "UnknownFrictionLevelError",
+    "ReadFrictionLevelRule",
+    "DecisionGuidanceRule",
+    "MigratePluginPermissionsRule",
+    "_build_migration_replacements",
+    "_migrate_rules",
+    "_deduplicate_rules",
+]

--- a/src/dev10x/session/queries.py
+++ b/src/dev10x/session/queries.py
@@ -1,0 +1,179 @@
+"""SessionContextQuery — single source of truth for session-context assembly.
+
+Query archetype: gathers the data both ``session_reload`` (SessionStart
+additionalContext) and ``context_compact`` (PreCompact systemMessage)
+need into one dataclass. Eliminates the duplicated multi-context
+assembly previously inlined in ``build_reload_context`` and
+``context_compact`` (audit memo Finding I3).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from dev10x.domain.friction_level import FrictionLevel
+from dev10x.domain.git_context import GitContext
+from dev10x.domain.session_document import (
+    claim_state_file,
+    plan_path_for_toplevel,
+    read_plan_summary,
+    state_path_for_toplevel,
+)
+
+
+def _run_git_safe(git: GitContext, *args: str) -> str:
+    try:
+        return git.run(*args)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return ""
+
+
+@dataclass(frozen=True)
+class SessionContextQuery:
+    """Aggregated session context for reload + compaction hooks."""
+
+    toplevel: str
+    branch: str = "unknown"
+    worktree_name: str = ""
+    state: dict[str, Any] = field(default_factory=dict)
+    plan_exists: bool = False
+    plan_data: dict[str, Any] = field(default_factory=dict)
+    friction_level: FrictionLevel = field(default_factory=FrictionLevel.default)
+    modified_files: list[str] = field(default_factory=list)
+    staged_files: list[str] = field(default_factory=list)
+    untracked_files: list[str] = field(default_factory=list)
+    recent_commits: str = ""
+
+    @classmethod
+    def gather_reload(cls, *, toplevel: str) -> SessionContextQuery:
+        """Gather context for SessionStart reload — consumes state file once."""
+        from dev10x.hooks.session_policy import ReadFrictionLevelRule
+
+        state = claim_state_file(path=state_path_for_toplevel(toplevel=toplevel))
+        plan_path = plan_path_for_toplevel(toplevel=toplevel)
+        plan_exists = plan_path.exists()
+        plan_data = read_plan_summary(toplevel=toplevel) if plan_exists else {}
+        friction_level = ReadFrictionLevelRule(toplevel=toplevel).apply()
+
+        return cls(
+            toplevel=toplevel,
+            state=state,
+            plan_exists=plan_exists,
+            plan_data=plan_data,
+            friction_level=friction_level,
+        )
+
+    @classmethod
+    def gather_compaction(cls, *, toplevel: str) -> SessionContextQuery:
+        """Gather context for PreCompact — reads git state, plan, friction."""
+        from dev10x.hooks.session_policy import ReadFrictionLevelRule
+
+        git = GitContext(cwd=toplevel)
+        branch = git.branch
+
+        worktree_name = ""
+        if (Path(toplevel) / ".git").is_file():
+            worktree_name = Path(toplevel).name
+
+        modified = _run_git_safe(git, "diff", "--name-only").splitlines()[:20]
+        staged = _run_git_safe(git, "diff", "--cached", "--name-only").splitlines()[:20]
+        untracked = _run_git_safe(git, "ls-files", "--others", "--exclude-standard").splitlines()[
+            :10
+        ]
+        recent_commits = _run_git_safe(git, "log", "--oneline", "-5")
+
+        plan_path = plan_path_for_toplevel(toplevel=toplevel)
+        plan_exists = plan_path.exists()
+        plan_data = read_plan_summary(toplevel=toplevel) if plan_exists else {}
+        friction_level = ReadFrictionLevelRule(toplevel=toplevel).apply()
+
+        return cls(
+            toplevel=toplevel,
+            branch=branch,
+            worktree_name=worktree_name,
+            plan_exists=plan_exists,
+            plan_data=plan_data,
+            friction_level=friction_level,
+            modified_files=modified,
+            staged_files=staged,
+            untracked_files=untracked,
+            recent_commits=recent_commits,
+        )
+
+
+def _format_files(*, files: list[str]) -> str:
+    return "\n".join(f"- {f}" for f in files if f)
+
+
+def format_reload_context(*, ctx: SessionContextQuery) -> str:
+    """Render a SessionContextQuery as the SessionStart additionalContext."""
+    from dev10x.domain.session_state import PlanSummary, SessionState
+    from dev10x.hooks.session_policy import DecisionGuidanceRule
+
+    if not ctx.state and not ctx.plan_exists:
+        return ""
+
+    parts: list[str] = []
+    if ctx.state:
+        state_text = SessionState.from_dict(data=ctx.state).format_for_display()
+        if state_text:
+            parts.append(state_text)
+    if ctx.plan_exists:
+        plan_text = PlanSummary.from_dict(data=ctx.plan_data).format_for_display()
+        if plan_text:
+            parts.append(plan_text)
+        guidance = DecisionGuidanceRule(
+            plan=ctx.plan_data, friction_level=ctx.friction_level
+        ).apply()
+        if guidance:
+            parts.append(guidance)
+    return "\n\n".join(parts)
+
+
+def format_compaction_summary(*, ctx: SessionContextQuery, plugin_root: Path) -> str:
+    """Render a SessionContextQuery as the PreCompact systemMessage body."""
+    from dev10x.domain.session_state import PlanSummary
+    from dev10x.hooks.session_policy import DecisionGuidanceRule
+
+    essentials_file = plugin_root / ".claude" / "rules" / "essentials.md"
+    essentials = essentials_file.read_text() if essentials_file.exists() else ""
+
+    summary = f"# Post-Compaction Context Recovery\n\n## Git State\n- **Branch:** {ctx.branch}"
+    if ctx.worktree_name:
+        summary += f"\n- **Worktree:** {ctx.worktree_name}"
+    summary += f"\n- **Working directory:** {ctx.toplevel}"
+    if ctx.modified_files:
+        summary += f"\n\n### Modified files (unstaged)\n{_format_files(files=ctx.modified_files)}"
+    if ctx.staged_files:
+        summary += f"\n\n### Staged files\n{_format_files(files=ctx.staged_files)}"
+    if ctx.untracked_files:
+        summary += f"\n\n### Untracked files\n{_format_files(files=ctx.untracked_files)}"
+    if ctx.recent_commits:
+        summary += f"\n\n### Recent commits\n```\n{ctx.recent_commits}\n```"
+    if essentials:
+        summary += f"\n\n## Essential Conventions (from essentials.md)\n{essentials}"
+
+    if ctx.plan_exists:
+        plan = PlanSummary.from_dict(data=ctx.plan_data)
+        summary += "\n\n" + plan.format_for_compaction()
+        if not plan.context.routing_table:
+            recovery_file = plugin_root / "references" / "compaction-recovery.md"
+            if recovery_file.exists():
+                summary += f"\n\n{recovery_file.read_text()}"
+        guidance = DecisionGuidanceRule(
+            plan=ctx.plan_data, friction_level=ctx.friction_level
+        ).apply()
+        if guidance:
+            summary += f"\n\n### Resume Guidance\n{guidance}"
+        summary += (
+            "\n\n> Reconstructed from persisted plan file. Use TaskList to verify\n"
+            "> current session state. If tasks are missing, recreate them from\n"
+            "> this list. Use the routing table above for all shipping actions."
+        )
+    return summary
+
+
+__all__ = ["SessionContextQuery", "format_reload_context", "format_compaction_summary"]

--- a/tests/hooks/test_session_formatters.py
+++ b/tests/hooks/test_session_formatters.py
@@ -278,3 +278,15 @@ class TestFormatDecisionGuidance:
         )
 
         assert "AskUserQuestion" in result
+
+    def test_raises_on_unknown_friction_level(
+        self,
+        plan_with_decision: dict,
+    ) -> None:
+        from dev10x.hooks.session_policy import UnknownFrictionLevelError
+
+        with pytest.raises(UnknownFrictionLevelError):
+            _format_decision_guidance(
+                plan=plan_with_decision,
+                friction_level="bogus",  # type: ignore[arg-type]
+            )

--- a/tests/hooks/test_session_start_hooks.py
+++ b/tests/hooks/test_session_start_hooks.py
@@ -92,26 +92,14 @@ class TestSessionGuidance:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        import dev10x.hooks.session as mod
+        import dev10x.hooks.session_dispatch as mod
 
-        monkeypatch.setattr(
-            mod,
-            "_escape_for_json",
-            lambda s: s,
-        )
         fake_root = Path("/tmp/nonexistent-plugin-root-xyz")
-        monkeypatch.setattr(
-            mod,
-            "Path",
-            type(
-                "PatchedPath",
-                (Path,),
-                {"parents": property(lambda self: [self, self, self, fake_root])},
-            ),
-        )
+        monkeypatch.setattr(mod, "_plugin_root", lambda: fake_root)
 
-        with pytest.raises((SystemExit, Exception)):
+        with pytest.raises(SystemExit) as exc_info:
             mod.session_guidance()
+        assert exc_info.value.code == 0
 
 
 class TestSessionGitAliases:
@@ -138,7 +126,7 @@ class TestSessionGitAliases:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        import dev10x.hooks.session as mod
+        import dev10x.hooks.session_place as mod
 
         monkeypatch.setattr(mod, "_run_git", lambda *args: "")
 
@@ -157,7 +145,7 @@ class TestSessionGitAliases:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        import dev10x.hooks.session as mod
+        import dev10x.hooks.session_place as mod
 
         call_count = 0
 

--- a/tests/hooks/test_session_stop_hooks.py
+++ b/tests/hooks/test_session_stop_hooks.py
@@ -20,7 +20,7 @@ def runner() -> CliRunner:
 
 class TestSessionPersist:
     def test_creates_state_file(self, runner: CliRunner, tmp_path: Path) -> None:
-        import dev10x.hooks.session as mod
+        import dev10x.hooks.session_dispatch as mod
 
         def fake_toplevel() -> str:
             return str(tmp_path / "myproject")
@@ -50,7 +50,7 @@ class TestSessionPersist:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        import dev10x.hooks.session as mod
+        import dev10x.hooks.session_dispatch as mod
 
         project_dir = tmp_path / "myproject"
         project_dir.mkdir(parents=True)
@@ -109,7 +109,7 @@ class TestSessionPersist:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        import dev10x.hooks.session as mod
+        import dev10x.hooks.session_dispatch as mod
 
         project_dir = tmp_path / "myproject"
         project_dir.mkdir(parents=True)


### PR DESCRIPTION
**When** a 532-LOC `hooks/session.py` mixed Event dispatch, Document persistence, Rule/Policy, and Place provisioning (audit memo T4), **I want to** split it into archetype-aligned modules with a single SessionContextQuery feeding both reload and compaction paths, **so** future hook authors can extend session behavior without re-reading the whole file, and `_format_decision_guidance` can fail loud on unknown friction values instead of silently mis-rendering.

---

[`28c2d990`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/182/commits/28c2d990db465ecac83d2be839ce68423ca9b725) ♻️ GH-144 Decompose hooks/session.py into archetype-aligned modules
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/144

---