### PR TITLE
♻️ GH-108 Unify MCP boundary error envelope via Result[T]

### DIFF
--- a/src/dev10x/audit/__init__.py
+++ b/src/dev10x/audit/__init__.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any
 
 from dev10x.audit.log_reader import iter_records, prune, summarize
+from dev10x.domain.result import Result, err, ok
 from dev10x.subprocess_utils import async_run_script
 
 __all__ = [
@@ -47,7 +48,7 @@ async def extract_session(
     *,
     jsonl_path: str,
     output_path: str | None = None,
-) -> dict[str, Any]:
+) -> Result[dict[str, Any]]:
     args = [jsonl_path]
     if output_path:
         args.append(output_path)
@@ -58,16 +59,16 @@ async def extract_session(
     )
 
     if result.returncode != 0:
-        return {"error": result.stderr.strip()}
+        return err(result.stderr.strip())
 
-    return {"success": True, "output": result.stdout.strip()}
+    return ok({"success": True, "output": result.stdout.strip()})
 
 
 async def analyze_actions(
     *,
     transcript_path: str,
     output_path: str | None = None,
-) -> dict[str, Any]:
+) -> Result[dict[str, Any]]:
     args = [transcript_path]
     if output_path:
         args.append(output_path)
@@ -78,9 +79,9 @@ async def analyze_actions(
     )
 
     if result.returncode != 0:
-        return {"error": result.stderr.strip()}
+        return err(result.stderr.strip())
 
-    return {"success": True, "output": result.stdout.strip()}
+    return ok({"success": True, "output": result.stdout.strip()})
 
 
 async def analyze_permissions(
@@ -88,7 +89,7 @@ async def analyze_permissions(
     transcript_path: str,
     settings_path: str | None = None,
     output_path: str | None = None,
-) -> dict[str, Any]:
+) -> Result[dict[str, Any]]:
     """Run permission-friction analysis in-process (GH-142).
 
     Previously shelled out to skills/skill-audit/scripts/analyze-permissions.py;
@@ -100,11 +101,9 @@ async def analyze_permissions(
 
     transcript_file = Path(transcript_path)
     if not transcript_file.exists():
-        return {"error": f"transcript not found: {transcript_path}"}
+        return err(f"transcript not found: {transcript_path}")
 
-    settings_file = Path(
-        settings_path or os.path.expanduser("~/.claude/settings.local.json")
-    )
+    settings_file = Path(settings_path or os.path.expanduser("~/.claude/settings.local.json"))
 
     try:
         report = build_audit_report(
@@ -112,18 +111,18 @@ async def analyze_permissions(
             settings_path=settings_file,
         )
     except Exception as exc:  # noqa: BLE001 — surface any analysis failure to caller
-        return {"error": f"analyze_permissions failed: {exc}"}
+        return err(f"analyze_permissions failed: {exc}")
 
     output = report.render_markdown()
 
     if output_path:
         Path(output_path).write_text(output)
-        return {"success": True, "output": f"Phase 4 output written to {output_path}"}
+        return ok({"success": True, "output": f"Phase 4 output written to {output_path}"})
 
-    return {"success": True, "output": output.strip()}
+    return ok({"success": True, "output": output.strip()})
 
 
-async def hook_log_path() -> dict[str, Any]:
+async def hook_log_path() -> Result[dict[str, Any]]:
     audit_dir = _resolve_audit_dir()
     today_log = _today_log_path(audit_dir)
 
@@ -131,15 +130,17 @@ async def hook_log_path() -> dict[str, Any]:
     if audit_dir.exists():
         available = sorted(p.name for p in audit_dir.glob("hooks-*.jsonl"))
 
-    return {
-        "audit_dir": str(audit_dir),
-        "today_log": str(today_log),
-        "today_log_exists": today_log.exists(),
-        "audit_dir_exists": audit_dir.exists(),
-        "available_logs": available,
-        "audit_disabled": os.environ.get("DEV10X_HOOK_AUDIT", "1").lower()
-        in {"0", "false", "no", "off"},
-    }
+    return ok(
+        {
+            "audit_dir": str(audit_dir),
+            "today_log": str(today_log),
+            "today_log_exists": today_log.exists(),
+            "audit_dir_exists": audit_dir.exists(),
+            "available_logs": available,
+            "audit_disabled": os.environ.get("DEV10X_HOOK_AUDIT", "1").lower()
+            in {"0", "false", "no", "off"},
+        }
+    )
 
 
 async def hook_recent(
@@ -148,17 +149,17 @@ async def hook_recent(
     hook_name: str | None = None,
     span_id: str | None = None,
     log_path: str | None = None,
-) -> dict[str, Any]:
+) -> Result[dict[str, Any]]:
     audit_dir = _resolve_audit_dir()
     target = Path(log_path) if log_path else _today_log_path(audit_dir)
 
     if not target.exists():
-        return {
-            "log_path": str(target),
-            "exists": False,
-            "records": [],
-            "error": f"audit log not found: {target}",
-        }
+        return err(
+            f"audit log not found: {target}",
+            log_path=str(target),
+            exists=False,
+            records=[],
+        )
 
     if log_path:
         records = iter_records(paths=[target])
@@ -173,9 +174,11 @@ async def hook_recent(
     if limit > 0:
         records = records[-limit:]
 
-    return {
-        "log_path": str(target),
-        "exists": True,
-        "count": len(records),
-        "records": records,
-    }
+    return ok(
+        {
+            "log_path": str(target),
+            "exists": True,
+            "count": len(records),
+            "records": records,
+        }
+    )

--- a/src/dev10x/mcp/server_cli.py
+++ b/src/dev10x/mcp/server_cli.py
@@ -726,13 +726,15 @@ async def mktmp(
     """
     from dev10x import utilities as util
 
-    return await util.mktmp(
-        namespace=namespace,
-        prefix=prefix,
-        ext=ext,
-        directory=directory,
-        create=create,
-    )
+    return (
+        await util.mktmp(
+            namespace=namespace,
+            prefix=prefix,
+            ext=ext,
+            directory=directory,
+            create=create,
+        )
+    ).to_dict()
 
 
 # ── Plan/Task tools ────────────────────────────────────────────
@@ -757,7 +759,7 @@ async def plan_sync_set_context(
     from dev10x.subprocess_utils import use_cwd
 
     with use_cwd(cwd):
-        return await plan_tools.set_context(args=args)
+        return (await plan_tools.set_context(args=args)).to_dict()
 
 
 @server.tool()
@@ -776,7 +778,7 @@ async def plan_sync_json_summary(cwd: str | None = None) -> dict:
     from dev10x.subprocess_utils import use_cwd
 
     with use_cwd(cwd):
-        return await plan_tools.json_summary()
+        return (await plan_tools.json_summary()).to_dict()
 
 
 @server.tool()
@@ -793,7 +795,7 @@ async def plan_sync_archive(cwd: str | None = None) -> dict:
     from dev10x.subprocess_utils import use_cwd
 
     with use_cwd(cwd):
-        return await plan_tools.archive()
+        return (await plan_tools.archive()).to_dict()
 
 
 # ── GitHub review tools ────────────────────────────────────────
@@ -912,15 +914,17 @@ async def ci_check_status(
     from dev10x.subprocess_utils import use_cwd
 
     with use_cwd(cwd):
-        return await mon.ci_check_status(
-            pr_number=pr_number,
-            repo=repo,
-            required_only=required_only,
-            wait=wait,
-            poll_interval=poll_interval,
-            initial_wait=initial_wait,
-            max_polls=max_polls,
-        )
+        return (
+            await mon.ci_check_status(
+                pr_number=pr_number,
+                repo=repo,
+                required_only=required_only,
+                wait=wait,
+                poll_interval=poll_interval,
+                initial_wait=initial_wait,
+                max_polls=max_polls,
+            )
+        ).to_dict()
 
 
 # ── Permission maintenance tools ───────────────────────────────
@@ -954,16 +958,18 @@ async def update_paths(
     """
     from dev10x import permission as perm
 
-    return await perm.update_paths(
-        version=version,
-        dry_run=dry_run,
-        ensure_base=ensure_base,
-        generalize=generalize,
-        ensure_scripts=ensure_scripts,
-        ensure_reads=ensure_reads,
-        init=init,
-        quiet=quiet,
-    )
+    return (
+        await perm.update_paths(
+            version=version,
+            dry_run=dry_run,
+            ensure_base=ensure_base,
+            generalize=generalize,
+            ensure_scripts=ensure_scripts,
+            ensure_reads=ensure_reads,
+            init=init,
+            quiet=quiet,
+        )
+    ).to_dict()
 
 
 # ── Release tools ──────────────────────────────────────────────
@@ -989,12 +995,14 @@ async def collect_prs(
     """
     from dev10x import release as rel
 
-    return await rel.collect_prs(
-        repo_path=repo_path,
-        from_tag=from_tag,
-        to_tag=to_tag,
-        ticket_pattern=ticket_pattern,
-    )
+    return (
+        await rel.collect_prs(
+            repo_path=repo_path,
+            from_tag=from_tag,
+            to_tag=to_tag,
+            ticket_pattern=ticket_pattern,
+        )
+    ).to_dict()
 
 
 # ── Skill index tools ─────────────────────────────────────────
@@ -1014,7 +1022,7 @@ async def generate_skill_index(
     """
     from dev10x import skill_index as idx
 
-    return await idx.generate_all(force=force)
+    return (await idx.generate_all(force=force)).to_dict()
 
 
 # ── Skill audit tools ─────────────────────────────────────────
@@ -1036,10 +1044,12 @@ async def audit_extract_session(
     """
     from dev10x import audit
 
-    return await audit.extract_session(
-        jsonl_path=jsonl_path,
-        output_path=output_path,
-    )
+    return (
+        await audit.extract_session(
+            jsonl_path=jsonl_path,
+            output_path=output_path,
+        )
+    ).to_dict()
 
 
 @server.tool()
@@ -1058,10 +1068,12 @@ async def audit_analyze_actions(
     """
     from dev10x import audit
 
-    return await audit.analyze_actions(
-        transcript_path=transcript_path,
-        output_path=output_path,
-    )
+    return (
+        await audit.analyze_actions(
+            transcript_path=transcript_path,
+            output_path=output_path,
+        )
+    ).to_dict()
 
 
 @server.tool()
@@ -1082,11 +1094,13 @@ async def audit_analyze_permissions(
     """
     from dev10x import audit
 
-    return await audit.analyze_permissions(
-        transcript_path=transcript_path,
-        settings_path=settings_path,
-        output_path=output_path,
-    )
+    return (
+        await audit.analyze_permissions(
+            transcript_path=transcript_path,
+            settings_path=settings_path,
+            output_path=output_path,
+        )
+    ).to_dict()
 
 
 @server.tool()
@@ -1102,7 +1116,7 @@ async def audit_hook_log_path() -> dict:
     """
     from dev10x import audit
 
-    return await audit.hook_log_path()
+    return (await audit.hook_log_path()).to_dict()
 
 
 @server.tool()
@@ -1125,12 +1139,14 @@ async def audit_hook_recent(
     """
     from dev10x import audit
 
-    return await audit.hook_recent(
-        limit=limit,
-        hook_name=hook_name,
-        span_id=span_id,
-        log_path=log_path,
-    )
+    return (
+        await audit.hook_recent(
+            limit=limit,
+            hook_name=hook_name,
+            span_id=span_id,
+            log_path=log_path,
+        )
+    ).to_dict()
 
 
 def main() -> None:

--- a/src/dev10x/monitor/__init__.py
+++ b/src/dev10x/monitor/__init__.py
@@ -6,8 +6,10 @@ check CI status without Bash allow-rule friction.
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
+from dev10x.domain.result import Result, err, ok
 from dev10x.subprocess_utils import async_run, get_plugin_root
 
 
@@ -20,7 +22,7 @@ async def ci_check_status(
     poll_interval: int = 30,
     initial_wait: int = 60,
     max_polls: int = 60,
-) -> dict[str, Any]:
+) -> Result[dict[str, Any]]:
     script = get_plugin_root() / "skills/gh-pr-monitor/scripts/ci-check-status.py"
     args: list[str] = [
         str(script),
@@ -40,11 +42,9 @@ async def ci_check_status(
     result = await async_run(args=args, timeout=timeout)
 
     if result.returncode != 0:
-        return {"error": result.stderr.strip()}
-
-    import json
+        return err(result.stderr.strip())
 
     try:
-        return json.loads(result.stdout)
+        return ok(json.loads(result.stdout))
     except json.JSONDecodeError:
-        return {"error": f"Invalid JSON output: {result.stdout[:200]}"}
+        return err(f"Invalid JSON output: {result.stdout[:200]}")

--- a/src/dev10x/permission/__init__.py
+++ b/src/dev10x/permission/__init__.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
+from dev10x.domain.result import Result, err, ok
 from dev10x.subprocess_utils import async_run, get_plugin_root
 
 
@@ -26,7 +27,7 @@ def _run_sub_command(
     ensure_reads: bool = False,
     dry_run: bool = False,
     quiet: bool = False,
-) -> dict[str, Any]:
+) -> Result[dict[str, Any]]:
     from dev10x.skills.permission import update_paths as mod
 
     config_path = mod.find_config()
@@ -36,7 +37,7 @@ def _run_sub_command(
         include_user=config.get("include_user_settings", True),
     )
     if not settings_files:
-        return {"error": "No settings files found."}
+        return err("No settings files found.")
 
     combined_messages: list[str] = []
     combined_errors: list[str] = []
@@ -104,19 +105,19 @@ def _run_sub_command(
             return _format_failure(combined_messages, combined_errors, exit_code)
 
     output = "\n".join(combined_messages).strip()
-    return {"success": True, "output": output, "messages": combined_messages}
+    return ok({"success": True, "output": output, "messages": combined_messages})
 
 
 def _format_failure(
     messages: list[str],
     errors: list[str],
     exit_code: int,
-) -> dict[str, Any]:
+) -> Result[dict[str, Any]]:
     error_text = "\n".join(errors).strip()
     if not error_text:
         body = "\n".join(messages).strip()
         error_text = body or f"Sub-command failed with exit code {exit_code}"
-    return {"error": error_text, "messages": messages, "errors": errors}
+    return err(error_text, messages=messages, errors=errors)
 
 
 async def update_paths(
@@ -130,7 +131,7 @@ async def update_paths(
     ensure_reads: bool = False,
     init: bool = False,
     quiet: bool = False,
-) -> dict[str, Any]:
+) -> Result[dict[str, Any]]:
     if ensure_base or generalize or ensure_scripts or ensure_workspace or ensure_reads:
         return await asyncio.to_thread(
             _run_sub_command,
@@ -158,6 +159,6 @@ async def update_paths(
     result = await async_run(args=args, timeout=60)
 
     if result.returncode != 0:
-        return {"error": result.stderr.strip()}
+        return err(result.stderr.strip())
 
-    return {"success": True, "output": result.stdout.strip()}
+    return ok({"success": True, "output": result.stdout.strip()})

--- a/src/dev10x/plan/__init__.py
+++ b/src/dev10x/plan/__init__.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from dev10x.domain.result import Result, err, ok
 from dev10x.plan.service import (
     PlanServiceError,
     archive_plan,
@@ -17,26 +18,26 @@ from dev10x.plan.service import (
 )
 
 
-async def set_context(*, args: list[str]) -> dict[str, Any]:
+async def set_context(*, args: list[str]) -> Result[dict[str, Any]]:
     try:
         updated = set_plan_context(args=args)
     except PlanServiceError as exc:
-        return {"error": str(exc)}
-    return {"success": True, "updated_keys": updated}
+        return err(str(exc))
+    return ok({"success": True, "updated_keys": updated})
 
 
-async def json_summary() -> dict[str, Any]:
+async def json_summary() -> Result[dict[str, Any]]:
     try:
-        return plan_summary()
+        return ok(plan_summary())
     except PlanServiceError as exc:
-        return {"error": str(exc)}
+        return err(str(exc))
 
 
-async def archive() -> dict[str, Any]:
+async def archive() -> Result[dict[str, Any]]:
     try:
         result = archive_plan()
     except PlanServiceError as exc:
-        return {"error": str(exc)}
+        return err(str(exc))
     if not result["archived"]:
-        return {"success": True, "message": "No plan file to archive"}
-    return {"success": True, "archive_name": result["archive_name"]}
+        return ok({"success": True, "message": "No plan file to archive"})
+    return ok({"success": True, "archive_name": result["archive_name"]})

--- a/src/dev10x/release/__init__.py
+++ b/src/dev10x/release/__init__.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from dev10x.domain.result import Result, err, ok
 from dev10x.subprocess_utils import async_run, get_plugin_root
 
 
@@ -17,7 +18,7 @@ async def collect_prs(
     from_tag: str | None = None,
     to_tag: str | None = None,
     ticket_pattern: str | None = None,
-) -> dict[str, Any]:
+) -> Result[dict[str, Any]]:
     script = get_plugin_root() / "skills/release-notes/scripts/collect-prs.py"
     args: list[str] = [str(script), repo_path]
 
@@ -31,6 +32,6 @@ async def collect_prs(
     result = await async_run(args=args, timeout=120)
 
     if result.returncode != 0:
-        return {"error": result.stderr.strip()}
+        return err(result.stderr.strip())
 
-    return {"success": True, "output": result.stdout.strip()}
+    return ok({"success": True, "output": result.stdout.strip()})

--- a/src/dev10x/skill_index/__init__.py
+++ b/src/dev10x/skill_index/__init__.py
@@ -8,13 +8,14 @@ from __future__ import annotations
 
 from typing import Any
 
+from dev10x.domain.result import Result, err, ok
 from dev10x.subprocess_utils import async_run_script
 
 
 async def generate_all(
     *,
     force: bool = False,
-) -> dict[str, Any]:
+) -> Result[dict[str, Any]]:
     args: list[str] = []
     if force:
         args.append("--force")
@@ -25,6 +26,6 @@ async def generate_all(
     )
 
     if result.returncode != 0:
-        return {"error": result.stderr.strip()}
+        return err(result.stderr.strip())
 
-    return {"success": True, "output": result.stdout.strip()}
+    return ok({"success": True, "output": result.stdout.strip()})

--- a/src/dev10x/utilities/__init__.py
+++ b/src/dev10x/utilities/__init__.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from dev10x.domain.result import Result, err, ok
 from dev10x.subprocess_utils import async_run_script
 
 
@@ -19,7 +20,7 @@ async def mktmp(
     ext: str = "",
     directory: bool = False,
     create: bool = False,
-) -> dict[str, Any]:
+) -> Result[dict[str, Any]]:
     """Generate a unique temp path under /tmp/Dev10x/<namespace>/.
 
     By default returns a path without creating the file so callers
@@ -39,6 +40,6 @@ async def mktmp(
     result = await async_run_script("bin/mktmp.sh", *mk_args)
 
     if result.returncode != 0:
-        return {"error": result.stderr.strip()}
+        return err(result.stderr.strip())
 
-    return {"path": result.stdout.strip()}
+    return ok({"path": result.stdout.strip()})

--- a/tests/audit/test_audit.py
+++ b/tests/audit/test_audit.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 audit_mod = pytest.importorskip("dev10x.audit", reason="dev10x not installed")
+from dev10x.domain.result import ErrorResult, SuccessResult  # noqa: E402
 
 
 class TestExtractSession:
@@ -22,7 +23,8 @@ class TestExtractSession:
             stderr="",
         )
         result = await audit_mod.extract_session(jsonl_path="/tmp/session.jsonl")
-        assert result["success"] is True
+        assert isinstance(result, SuccessResult)
+        assert result.value["success"] is True
 
     @pytest.mark.asyncio
     @patch("dev10x.audit.async_run_script", new_callable=AsyncMock)
@@ -37,7 +39,9 @@ class TestExtractSession:
             stderr="File not found",
         )
         result = await audit_mod.extract_session(jsonl_path="/tmp/missing.jsonl")
-        assert "error" in result
+        assert isinstance(result, ErrorResult)
+        assert result.error == "File not found"
+        assert result.to_dict() == {"error": "File not found"}
 
     @pytest.mark.asyncio
     @patch("dev10x.audit.async_run_script", new_callable=AsyncMock)
@@ -73,7 +77,8 @@ class TestAnalyzeActions:
             stderr="",
         )
         result = await audit_mod.analyze_actions(transcript_path="/tmp/transcript.md")
-        assert result["success"] is True
+        assert isinstance(result, SuccessResult)
+        assert result.value["success"] is True
 
     @pytest.mark.asyncio
     @patch("dev10x.audit.async_run_script", new_callable=AsyncMock)
@@ -88,7 +93,8 @@ class TestAnalyzeActions:
             stderr="Parse error",
         )
         result = await audit_mod.analyze_actions(transcript_path="/tmp/transcript.md")
-        assert "error" in result
+        assert isinstance(result, ErrorResult)
+        assert result.error == "Parse error"
 
 
 class TestAnalyzePermissions:
@@ -99,8 +105,8 @@ class TestAnalyzePermissions:
         result = await audit_mod.analyze_permissions(
             transcript_path=str(tmp_path / "missing.md"),
         )
-        assert "error" in result
-        assert "not found" in result["error"]
+        assert isinstance(result, ErrorResult)
+        assert "not found" in result.error
 
     @pytest.mark.asyncio
     async def test_empty_transcript_produces_report(self, tmp_path) -> None:
@@ -114,8 +120,9 @@ class TestAnalyzePermissions:
             settings_path=str(settings),
         )
 
-        assert result["success"] is True
-        assert "Permission Friction Analysis" in result["output"]
+        assert isinstance(result, SuccessResult)
+        assert result.value["success"] is True
+        assert "Permission Friction Analysis" in result.value["output"]
 
     @pytest.mark.asyncio
     async def test_writes_to_output_path(self, tmp_path) -> None:
@@ -131,7 +138,8 @@ class TestAnalyzePermissions:
             output_path=str(output),
         )
 
-        assert result["success"] is True
+        assert isinstance(result, SuccessResult)
+        assert result.value["success"] is True
         assert output.exists()
         assert "Permission Friction Analysis" in output.read_text()
 
@@ -148,8 +156,8 @@ class TestAnalyzePermissions:
                 transcript_path=str(transcript),
             )
 
-        assert "error" in result
-        assert "boom" in result["error"]
+        assert isinstance(result, ErrorResult)
+        assert "boom" in result.error
 
 
 class TestHookLogPath:
@@ -158,17 +166,19 @@ class TestHookLogPath:
         monkeypatch.delenv("DEV10X_HOOK_AUDIT_DIR", raising=False)
         monkeypatch.delenv("DEV10X_HOOK_AUDIT", raising=False)
         result = await audit_mod.hook_log_path()
-        assert result["audit_dir"] == "/tmp/Dev10x/hook-audit"
-        assert result["audit_disabled"] is False
+        assert isinstance(result, SuccessResult)
+        assert result.value["audit_dir"] == "/tmp/Dev10x/hook-audit"
+        assert result.value["audit_disabled"] is False
 
     @pytest.mark.asyncio
     async def test_honors_env_override(self, tmp_path, monkeypatch) -> None:
         monkeypatch.setenv("DEV10X_HOOK_AUDIT_DIR", str(tmp_path))
         result = await audit_mod.hook_log_path()
-        assert result["audit_dir"] == str(tmp_path)
-        assert result["audit_dir_exists"] is True
-        assert result["today_log_exists"] is False
-        assert result["available_logs"] == []
+        assert isinstance(result, SuccessResult)
+        assert result.value["audit_dir"] == str(tmp_path)
+        assert result.value["audit_dir_exists"] is True
+        assert result.value["today_log_exists"] is False
+        assert result.value["available_logs"] == []
 
     @pytest.mark.asyncio
     async def test_lists_available_logs(self, tmp_path, monkeypatch) -> None:
@@ -177,7 +187,8 @@ class TestHookLogPath:
         (tmp_path / "hooks-2026-04-29.jsonl").write_text("{}\n")
         (tmp_path / "unrelated.txt").write_text("x")
         result = await audit_mod.hook_log_path()
-        assert result["available_logs"] == [
+        assert isinstance(result, SuccessResult)
+        assert result.value["available_logs"] == [
             "hooks-2026-04-28.jsonl",
             "hooks-2026-04-29.jsonl",
         ]
@@ -187,7 +198,8 @@ class TestHookLogPath:
         monkeypatch.setenv("DEV10X_HOOK_AUDIT_DIR", str(tmp_path))
         monkeypatch.setenv("DEV10X_HOOK_AUDIT", "0")
         result = await audit_mod.hook_log_path()
-        assert result["audit_disabled"] is True
+        assert isinstance(result, SuccessResult)
+        assert result.value["audit_disabled"] is True
 
 
 class TestHookRecent:
@@ -195,9 +207,11 @@ class TestHookRecent:
     async def test_missing_log_returns_error(self, tmp_path) -> None:
         target = tmp_path / "hooks-2099-01-01.jsonl"
         result = await audit_mod.hook_recent(log_path=str(target))
-        assert result["exists"] is False
-        assert result["records"] == []
-        assert "error" in result
+        assert isinstance(result, ErrorResult)
+        envelope = result.to_dict()
+        assert envelope["exists"] is False
+        assert envelope["records"] == []
+        assert "audit log not found" in envelope["error"]
 
     @pytest.mark.asyncio
     async def test_reads_records_with_limit(self, tmp_path) -> None:
@@ -210,8 +224,9 @@ class TestHookRecent:
             '{"hook": "c", "span_id": "s3"}\n'
         )
         result = await audit_mod.hook_recent(log_path=str(log), limit=2)
-        assert result["count"] == 2
-        assert [r["hook"] for r in result["records"]] == ["b", "c"]
+        assert isinstance(result, SuccessResult)
+        assert result.value["count"] == 2
+        assert [r["hook"] for r in result.value["records"]] == ["b", "c"]
 
     @pytest.mark.asyncio
     async def test_filters_by_hook_name(self, tmp_path) -> None:
@@ -225,27 +240,30 @@ class TestHookRecent:
             log_path=str(log),
             hook_name="session-start",
         )
-        assert result["count"] == 2
-        assert all(r["hook"] == "session-start" for r in result["records"])
+        assert isinstance(result, SuccessResult)
+        assert result.value["count"] == 2
+        assert all(r["hook"] == "session-start" for r in result.value["records"])
 
     @pytest.mark.asyncio
     async def test_filters_by_span_id(self, tmp_path) -> None:
         log = tmp_path / "log.jsonl"
         log.write_text('{"hook": "a", "span_id": "abc"}\n{"hook": "b", "span_id": "xyz"}\n')
         result = await audit_mod.hook_recent(log_path=str(log), span_id="xyz")
-        assert result["count"] == 1
-        assert result["records"][0]["span_id"] == "xyz"
+        assert isinstance(result, SuccessResult)
+        assert result.value["count"] == 1
+        assert result.value["records"][0]["span_id"] == "xyz"
 
     @pytest.mark.asyncio
     async def test_zero_limit_returns_all(self, tmp_path) -> None:
         log = tmp_path / "log.jsonl"
         log.write_text('{"hook": "a"}\n{"hook": "b"}\n{"hook": "c"}\n')
         result = await audit_mod.hook_recent(log_path=str(log), limit=0)
-        assert result["count"] == 3
+        assert isinstance(result, SuccessResult)
+        assert result.value["count"] == 3
 
     @pytest.mark.asyncio
     async def test_default_path_uses_today(self, tmp_path, monkeypatch) -> None:
         monkeypatch.setenv("DEV10X_HOOK_AUDIT_DIR", str(tmp_path))
         result = await audit_mod.hook_recent()
-        assert result["exists"] is False
-        assert "hooks-" in result["log_path"]
+        assert isinstance(result, ErrorResult)
+        assert "hooks-" in result.to_dict()["log_path"]

--- a/tests/mcp/test_cli_server.py
+++ b/tests/mcp/test_cli_server.py
@@ -992,7 +992,7 @@ class TestPlanSyncSetContext:
         self,
         mock_fn: AsyncMock,
     ) -> None:
-        mock_fn.return_value = {"success": True, "updated_keys": ["x"]}
+        mock_fn.return_value = ok({"success": True, "updated_keys": ["x"]})
 
         result = await cli_server.plan_sync_set_context(args=["x=1"])
 
@@ -1007,7 +1007,7 @@ class TestPlanSyncJsonSummary:
         self,
         mock_fn: AsyncMock,
     ) -> None:
-        mock_fn.return_value = {"tasks": []}
+        mock_fn.return_value = ok({"tasks": []})
 
         result = await cli_server.plan_sync_json_summary()
 
@@ -1021,7 +1021,7 @@ class TestPlanSyncArchive:
         self,
         mock_fn: AsyncMock,
     ) -> None:
-        mock_fn.return_value = {"success": True, "archive_name": "plan-2026-01-01.md"}
+        mock_fn.return_value = ok({"success": True, "archive_name": "plan-2026-01-01.md"})
 
         result = await cli_server.plan_sync_archive()
 
@@ -1035,7 +1035,7 @@ class TestGenerateSkillIndex:
         self,
         mock_fn: AsyncMock,
     ) -> None:
-        mock_fn.return_value = {"success": True, "output": "done"}
+        mock_fn.return_value = ok({"success": True, "output": "done"})
 
         result = await cli_server.generate_skill_index()
 
@@ -1048,7 +1048,7 @@ class TestGenerateSkillIndex:
         self,
         mock_fn: AsyncMock,
     ) -> None:
-        mock_fn.return_value = {"success": True}
+        mock_fn.return_value = ok({"success": True})
 
         await cli_server.generate_skill_index(force=True)
 
@@ -1062,7 +1062,7 @@ class TestAuditExtractSession:
         self,
         mock_fn: AsyncMock,
     ) -> None:
-        mock_fn.return_value = {"success": True, "output": "extracted"}
+        mock_fn.return_value = ok({"success": True, "output": "extracted"})
 
         result = await cli_server.audit_extract_session(jsonl_path="/tmp/x.jsonl")
 
@@ -1076,7 +1076,7 @@ class TestAuditAnalyzeActions:
         self,
         mock_fn: AsyncMock,
     ) -> None:
-        mock_fn.return_value = {"success": True}
+        mock_fn.return_value = ok({"success": True})
 
         result = await cli_server.audit_analyze_actions(transcript_path="/tmp/x.md")
 
@@ -1090,7 +1090,7 @@ class TestAuditAnalyzePermissions:
         self,
         mock_fn: AsyncMock,
     ) -> None:
-        mock_fn.return_value = {"success": True}
+        mock_fn.return_value = ok({"success": True})
 
         result = await cli_server.audit_analyze_permissions(transcript_path="/tmp/x.md")
 
@@ -1104,14 +1104,16 @@ class TestAuditHookLogPath:
         self,
         mock_fn: AsyncMock,
     ) -> None:
-        mock_fn.return_value = {
-            "audit_dir": "/tmp/Dev10x/hook-audit",
-            "today_log": "/tmp/Dev10x/hook-audit/2026-01-01.jsonl",
-            "today_log_exists": False,
-            "audit_dir_exists": True,
-            "available_logs": [],
-            "audit_disabled": False,
-        }
+        mock_fn.return_value = ok(
+            {
+                "audit_dir": "/tmp/Dev10x/hook-audit",
+                "today_log": "/tmp/Dev10x/hook-audit/2026-01-01.jsonl",
+                "today_log_exists": False,
+                "audit_dir_exists": True,
+                "available_logs": [],
+                "audit_disabled": False,
+            }
+        )
 
         result = await cli_server.audit_hook_log_path()
 
@@ -1125,12 +1127,14 @@ class TestAuditHookRecent:
         self,
         mock_fn: AsyncMock,
     ) -> None:
-        mock_fn.return_value = {
-            "log_path": "/tmp/x.jsonl",
-            "exists": True,
-            "count": 0,
-            "records": [],
-        }
+        mock_fn.return_value = ok(
+            {
+                "log_path": "/tmp/x.jsonl",
+                "exists": True,
+                "count": 0,
+                "records": [],
+            }
+        )
 
         result = await cli_server.audit_hook_recent(limit=10)
 

--- a/tests/monitor/test_monitor.py
+++ b/tests/monitor/test_monitor.py
@@ -5,6 +5,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from dev10x.domain.result import ErrorResult, SuccessResult
+
 monitor_mod = pytest.importorskip("dev10x.monitor", reason="dev10x not installed")
 
 
@@ -22,8 +24,9 @@ class TestCiCheckStatus:
             stderr="",
         )
         result = await monitor_mod.ci_check_status(pr_number=42, repo="owner/repo")
-        assert result["verdict"] == "green"
-        assert result["total"] == 3
+        assert isinstance(result, SuccessResult)
+        assert result.value["verdict"] == "green"
+        assert result.value["total"] == 3
 
     @pytest.mark.asyncio
     @patch("dev10x.monitor.async_run", new_callable=AsyncMock)
@@ -38,7 +41,9 @@ class TestCiCheckStatus:
             stderr="Script error",
         )
         result = await monitor_mod.ci_check_status(pr_number=42, repo="owner/repo")
-        assert "error" in result
+        assert isinstance(result, ErrorResult)
+        assert result.error == "Script error"
+        assert result.to_dict() == {"error": "Script error"}
 
     @pytest.mark.asyncio
     @patch("dev10x.monitor.async_run", new_callable=AsyncMock)
@@ -53,7 +58,8 @@ class TestCiCheckStatus:
             stderr="",
         )
         result = await monitor_mod.ci_check_status(pr_number=42, repo="owner/repo")
-        assert "error" in result
+        assert isinstance(result, ErrorResult)
+        assert "Invalid JSON output" in result.error
 
     @pytest.mark.asyncio
     @patch("dev10x.monitor.async_run", new_callable=AsyncMock)

--- a/tests/permission/test_mcp_module.py
+++ b/tests/permission/test_mcp_module.py
@@ -1,0 +1,66 @@
+"""Tests for dev10x.permission MCP module (GH-108 Result[T] migration).
+
+Covers the structured-error contract for update_paths — both the
+sub-command branch and the subprocess branch — so the boundary
+handler in server_cli.py can rely on .to_dict() to render the
+envelope at the MCP edge.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+perm_mod = pytest.importorskip("dev10x.permission", reason="dev10x not installed")
+from dev10x.domain.result import ErrorResult, SuccessResult  # noqa: E402
+
+
+class TestUpdatePathsSubprocess:
+    @pytest.mark.asyncio
+    @patch("dev10x.permission.async_run", new_callable=AsyncMock)
+    async def test_returns_success_on_zero_exit(self, mock_run: AsyncMock) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="paths updated",
+            stderr="",
+        )
+        result = await perm_mod.update_paths()
+        assert isinstance(result, SuccessResult)
+        assert result.value["success"] is True
+        assert result.value["output"] == "paths updated"
+
+    @pytest.mark.asyncio
+    @patch("dev10x.permission.async_run", new_callable=AsyncMock)
+    async def test_returns_structured_error_on_failure(self, mock_run: AsyncMock) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=1,
+            stdout="",
+            stderr="config not found",
+        )
+        result = await perm_mod.update_paths()
+        assert isinstance(result, ErrorResult)
+        assert result.error == "config not found"
+        assert result.to_dict() == {"error": "config not found"}
+
+
+class TestUpdatePathsSubCommand:
+    @pytest.mark.asyncio
+    async def test_returns_error_when_no_settings_files(self) -> None:
+        with (
+            patch("dev10x.skills.permission.update_paths.find_config"),
+            patch(
+                "dev10x.skills.permission.update_paths.load_config",
+                return_value={"roots": [], "include_user_settings": False},
+            ),
+            patch(
+                "dev10x.skills.permission.update_paths.find_settings_files",
+                return_value=[],
+            ),
+        ):
+            result = await perm_mod.update_paths(ensure_base=True)
+        assert isinstance(result, ErrorResult)
+        assert "No settings files" in result.error

--- a/tests/permission/test_permission.py
+++ b/tests/permission/test_permission.py
@@ -5,6 +5,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from dev10x.domain.result import ErrorResult, SuccessResult, ok
+
 perm_mod = pytest.importorskip("dev10x.permission", reason="dev10x not installed")
 
 MOD_PATH = "dev10x.skills.permission.update_paths"
@@ -24,8 +26,9 @@ class TestUpdatePathsScriptRoute:
             stderr="",
         )
         result = await perm_mod.update_paths()
-        assert result["success"] is True
-        assert "Updated 3 files" in result["output"]
+        assert isinstance(result, SuccessResult)
+        assert result.value["success"] is True
+        assert "Updated 3 files" in result.value["output"]
 
     @pytest.mark.asyncio
     @patch("dev10x.permission.async_run", new_callable=AsyncMock)
@@ -40,7 +43,8 @@ class TestUpdatePathsScriptRoute:
             stderr="Config not found",
         )
         result = await perm_mod.update_paths()
-        assert "error" in result
+        assert isinstance(result, ErrorResult)
+        assert result.error == "Config not found"
 
     @pytest.mark.asyncio
     @patch("dev10x.permission.async_run", new_callable=AsyncMock)
@@ -75,9 +79,10 @@ class TestUpdatePathsSubCommandRoute:
         self,
         mock_sub: AsyncMock,
     ) -> None:
-        mock_sub.return_value = {"success": True, "output": "Added 2 permissions"}
+        mock_sub.return_value = ok({"success": True, "output": "Added 2 permissions"})
         result = await perm_mod.update_paths(ensure_base=True, dry_run=True)
-        assert result["success"] is True
+        assert isinstance(result, SuccessResult)
+        assert result.value["success"] is True
         mock_sub.assert_called_once_with(
             ensure_base=True,
             generalize=False,
@@ -94,9 +99,10 @@ class TestUpdatePathsSubCommandRoute:
         self,
         mock_sub: AsyncMock,
     ) -> None:
-        mock_sub.return_value = {"success": True, "output": "Generalized 5 permissions"}
+        mock_sub.return_value = ok({"success": True, "output": "Generalized 5 permissions"})
         result = await perm_mod.update_paths(generalize=True)
-        assert result["success"] is True
+        assert isinstance(result, SuccessResult)
+        assert result.value["success"] is True
         mock_sub.assert_called_once_with(
             ensure_base=False,
             generalize=True,
@@ -113,9 +119,10 @@ class TestUpdatePathsSubCommandRoute:
         self,
         mock_sub: AsyncMock,
     ) -> None:
-        mock_sub.return_value = {"success": True, "output": "Added 3 script rules"}
+        mock_sub.return_value = ok({"success": True, "output": "Added 3 script rules"})
         result = await perm_mod.update_paths(ensure_scripts=True)
-        assert result["success"] is True
+        assert isinstance(result, SuccessResult)
+        assert result.value["success"] is True
         mock_sub.assert_called_once_with(
             ensure_base=False,
             generalize=False,
@@ -132,9 +139,10 @@ class TestUpdatePathsSubCommandRoute:
         self,
         mock_sub: AsyncMock,
     ) -> None:
-        mock_sub.return_value = {"success": True, "output": "Added 12 Read rules"}
+        mock_sub.return_value = ok({"success": True, "output": "Added 12 Read rules"})
         result = await perm_mod.update_paths(ensure_reads=True)
-        assert result["success"] is True
+        assert isinstance(result, SuccessResult)
+        assert result.value["success"] is True
         mock_sub.assert_called_once_with(
             ensure_base=False,
             generalize=False,
@@ -153,7 +161,7 @@ class TestUpdatePathsSubCommandRoute:
         mock_sub: AsyncMock,
         mock_run: AsyncMock,
     ) -> None:
-        mock_sub.return_value = {"success": True, "output": "OK"}
+        mock_sub.return_value = ok({"success": True, "output": "OK"})
         await perm_mod.update_paths(ensure_base=True, generalize=True)
         mock_run.assert_not_called()
 
@@ -185,7 +193,8 @@ class TestRunSubCommand:
         mock_mod: dict,
     ) -> None:
         result = perm_mod._run_sub_command(ensure_base=True, dry_run=True)
-        assert result["success"] is True
+        assert isinstance(result, SuccessResult)
+        assert result.value["success"] is True
         mock_ensure.assert_called_once()
 
     @patch(
@@ -198,7 +207,8 @@ class TestRunSubCommand:
         mock_mod: dict,
     ) -> None:
         result = perm_mod._run_sub_command(generalize=True)
-        assert result["success"] is True
+        assert isinstance(result, SuccessResult)
+        assert result.value["success"] is True
         mock_gen.assert_called_once()
 
     @patch(
@@ -211,7 +221,8 @@ class TestRunSubCommand:
         mock_mod: dict,
     ) -> None:
         result = perm_mod._run_sub_command(ensure_scripts=True)
-        assert result["success"] is True
+        assert isinstance(result, SuccessResult)
+        assert result.value["success"] is True
         mock_scripts.assert_called_once()
 
     @patch(
@@ -224,7 +235,8 @@ class TestRunSubCommand:
         mock_mod: dict,
     ) -> None:
         result = perm_mod._run_sub_command(ensure_reads=True)
-        assert result["success"] is True
+        assert isinstance(result, SuccessResult)
+        assert result.value["success"] is True
         mock_reads.assert_called_once()
 
     @patch(
@@ -241,8 +253,8 @@ class TestRunSubCommand:
         mock_mod: dict,
     ) -> None:
         result = perm_mod._run_sub_command(ensure_base=True)
-        assert "error" in result
-        assert result["error"] == "boom"
+        assert isinstance(result, ErrorResult)
+        assert result.error == "boom"
 
     @patch(
         f"{MOD_PATH}.generalize",
@@ -259,7 +271,7 @@ class TestRunSubCommand:
         mock_mod: dict,
     ) -> None:
         result = perm_mod._run_sub_command(ensure_base=True, generalize=True)
-        assert "error" in result
+        assert isinstance(result, ErrorResult)
         mock_gen.assert_not_called()
 
     def test_does_not_capture_stdout(
@@ -278,9 +290,9 @@ class TestRunSubCommand:
         ):
             result = perm_mod._run_sub_command(ensure_base=True)
 
-        assert result["success"] is True
-        assert "Added 2 base permissions" in result["output"]
-        # Helper did not print to real stdout — capsys captures nothing.
+        assert isinstance(result, SuccessResult)
+        assert result.value["success"] is True
+        assert "Added 2 base permissions" in result.value["output"]
         captured = capsys.readouterr()
         assert captured.out == ""
         assert captured.err == ""
@@ -301,9 +313,9 @@ class TestRunSubCommand:
         ):
             result = perm_mod._run_sub_command(ensure_scripts=True)
 
-        assert "error" in result
-        assert "No versions found" in result["error"]
-        assert result["errors"] == ["ERROR: No versions found in /fake/cache"]
+        assert isinstance(result, ErrorResult)
+        assert "No versions found" in result.error
+        assert result.details["errors"] == ["ERROR: No versions found in /fake/cache"]
         captured = capsys.readouterr()
         assert captured.out == ""
         assert captured.err == ""
@@ -318,4 +330,5 @@ class TestRunSubCommand:
             load_cfg.return_value = {"roots": []}
             find_sf.return_value = []
             result = perm_mod._run_sub_command(ensure_base=True)
-            assert result["error"] == "No settings files found."
+            assert isinstance(result, ErrorResult)
+            assert result.error == "No settings files found."

--- a/tests/plan/test_plan.py
+++ b/tests/plan/test_plan.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 plan_mod = pytest.importorskip("dev10x.plan", reason="dev10x not installed")
+from dev10x.domain.result import ErrorResult, SuccessResult  # noqa: E402
 
 SERVICE = "dev10x.plan.service"
 
@@ -18,7 +19,9 @@ class TestSetContext:
         mock_toplevel: MagicMock,
     ) -> None:
         result = await plan_mod.set_context(args=["key=value"])
-        assert result == {"error": "Not in a git repository"}
+        assert isinstance(result, ErrorResult)
+        assert result.error == "Not in a git repository"
+        assert result.to_dict() == {"error": "Not in a git repository"}
 
     @pytest.mark.asyncio
     @patch(f"{SERVICE}.get_toplevel", return_value="/tmp/repo")
@@ -33,7 +36,7 @@ class TestSetContext:
         mock_plan = MagicMock()
         mock_plan_cls.load.return_value = mock_plan
         result = await plan_mod.set_context(args=["no-equals-sign"])
-        assert "error" in result
+        assert isinstance(result, ErrorResult)
 
     @pytest.mark.asyncio
     @patch(f"{SERVICE}.get_toplevel", return_value="/tmp/repo")
@@ -49,8 +52,9 @@ class TestSetContext:
         mock_plan.context_keys.return_value = ["key"]
         mock_plan_cls.load.return_value = mock_plan
         result = await plan_mod.set_context(args=["key=value"])
-        assert result["success"] is True
-        assert "key" in result["updated_keys"]
+        assert isinstance(result, SuccessResult)
+        assert result.value["success"] is True
+        assert "key" in result.value["updated_keys"]
 
 
 class TestJsonSummary:
@@ -61,7 +65,8 @@ class TestJsonSummary:
         mock_toplevel: MagicMock,
     ) -> None:
         result = await plan_mod.json_summary()
-        assert result == {"error": "Not in a git repository"}
+        assert isinstance(result, ErrorResult)
+        assert result.error == "Not in a git repository"
 
     @pytest.mark.asyncio
     @patch(f"{SERVICE}.get_toplevel", return_value="/tmp/repo")
@@ -77,7 +82,8 @@ class TestJsonSummary:
         mock_plan.is_new = True
         mock_plan_cls.load.return_value = mock_plan
         result = await plan_mod.json_summary()
-        assert result == {}
+        assert isinstance(result, SuccessResult)
+        assert result.value == {}
 
     @pytest.mark.asyncio
     @patch(f"{SERVICE}.get_toplevel", return_value="/tmp/repo")
@@ -94,7 +100,8 @@ class TestJsonSummary:
         mock_plan._to_dict.return_value = {"metadata": {"branch": "feature"}}
         mock_plan_cls.load.return_value = mock_plan
         result = await plan_mod.json_summary()
-        assert result == {"metadata": {"branch": "feature"}}
+        assert isinstance(result, SuccessResult)
+        assert result.value == {"metadata": {"branch": "feature"}}
 
 
 class TestArchive:
@@ -105,7 +112,8 @@ class TestArchive:
         mock_toplevel: MagicMock,
     ) -> None:
         result = await plan_mod.archive()
-        assert result == {"error": "Not in a git repository"}
+        assert isinstance(result, ErrorResult)
+        assert result.error == "Not in a git repository"
 
     @pytest.mark.asyncio
     @patch(f"{SERVICE}.get_toplevel", return_value="/tmp/repo")
@@ -118,5 +126,6 @@ class TestArchive:
     ) -> None:
         mock_plan_path.return_value = tmp_path / "nonexistent.yaml"
         result = await plan_mod.archive()
-        assert result["success"] is True
-        assert "No plan file" in result["message"]
+        assert isinstance(result, SuccessResult)
+        assert result.value["success"] is True
+        assert "No plan file" in result.value["message"]

--- a/tests/release/test_release.py
+++ b/tests/release/test_release.py
@@ -5,6 +5,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from dev10x.domain.result import ErrorResult, SuccessResult
+
 rel_mod = pytest.importorskip("dev10x.release", reason="dev10x not installed")
 
 
@@ -22,7 +24,8 @@ class TestCollectPrs:
             stderr="",
         )
         result = await rel_mod.collect_prs(repo_path="/tmp/repo")
-        assert result["success"] is True
+        assert isinstance(result, SuccessResult)
+        assert result.value["success"] is True
 
     @pytest.mark.asyncio
     @patch("dev10x.release.async_run", new_callable=AsyncMock)
@@ -37,7 +40,9 @@ class TestCollectPrs:
             stderr="Not a git repo",
         )
         result = await rel_mod.collect_prs(repo_path="/tmp/repo")
-        assert "error" in result
+        assert isinstance(result, ErrorResult)
+        assert result.error == "Not a git repo"
+        assert result.to_dict() == {"error": "Not a git repo"}
 
     @pytest.mark.asyncio
     @patch("dev10x.release.async_run", new_callable=AsyncMock)

--- a/tests/skill_index/test_skill_index.py
+++ b/tests/skill_index/test_skill_index.py
@@ -5,6 +5,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from dev10x.domain.result import ErrorResult, SuccessResult
+
 idx_mod = pytest.importorskip("dev10x.skill_index", reason="dev10x not installed")
 
 
@@ -22,7 +24,8 @@ class TestGenerateAll:
             stderr="",
         )
         result = await idx_mod.generate_all()
-        assert result["success"] is True
+        assert isinstance(result, SuccessResult)
+        assert result.value["success"] is True
 
     @pytest.mark.asyncio
     @patch("dev10x.skill_index.async_run_script", new_callable=AsyncMock)
@@ -37,7 +40,9 @@ class TestGenerateAll:
             stderr="Script failed",
         )
         result = await idx_mod.generate_all()
-        assert "error" in result
+        assert isinstance(result, ErrorResult)
+        assert result.error == "Script failed"
+        assert result.to_dict() == {"error": "Script failed"}
 
     @pytest.mark.asyncio
     @patch("dev10x.skill_index.async_run_script", new_callable=AsyncMock)

--- a/tests/utilities/test_utilities.py
+++ b/tests/utilities/test_utilities.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+util_mod = pytest.importorskip("dev10x.utilities", reason="dev10x not installed")
+from dev10x.domain.result import ErrorResult, SuccessResult  # noqa: E402
+
+
+class TestMktmp:
+    @pytest.mark.asyncio
+    @patch("dev10x.utilities.async_run_script", new_callable=AsyncMock)
+    async def test_returns_path_on_success(self, mock_run: AsyncMock) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="/tmp/Dev10x/git/msg.abc.txt",
+            stderr="",
+        )
+        result = await util_mod.mktmp(namespace="git", prefix="msg", ext=".txt")
+        assert isinstance(result, SuccessResult)
+        assert result.value == {"path": "/tmp/Dev10x/git/msg.abc.txt"}
+
+    @pytest.mark.asyncio
+    @patch("dev10x.utilities.async_run_script", new_callable=AsyncMock)
+    async def test_returns_structured_error_on_failure(self, mock_run: AsyncMock) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=1,
+            stdout="",
+            stderr="Permission denied",
+        )
+        result = await util_mod.mktmp(namespace="git", prefix="msg")
+        assert isinstance(result, ErrorResult)
+        assert result.error == "Permission denied"
+        assert result.to_dict() == {"error": "Permission denied"}


### PR DESCRIPTION
**When** a cross-module MCP caller hits an error from audit, release, monitor, permission, plan, skill_index, or utilities tools, **I want to** dispatch on a uniform `Result[T]` envelope **so** I **can** handle errors with one check (`isinstance(result, ErrorResult)`) instead of probing each module's bespoke dict shape.

---

[`7a363e84`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/183/commits/7a363e840c0a57d894b1cd1cc4efe4b0e58f5451) ♻️ GH-108 Unify MCP boundary error envelope via Result[T]
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/108

---