### PR TITLE
📝 GH-149 Lift Verify AC invariant to a universal Dev10x rule

### DIFF
--- a/.claude/rules/essentials.md
+++ b/.claude/rules/essentials.md
@@ -54,6 +54,53 @@ options. Queue decisions per `references/task-orchestration.md` (Batched
 Decision Queue pattern) and present them in a single batch when all
 tasks are blocked.
 
+## Task List Invariant (GH-149)
+
+**The session task list must never be empty.** When a Dev10x skill
+completes its last work item, it MUST leave at least one open task on
+the list — by default, a `Verify AC` task that summarizes what was
+shipped and prompts the supervisor to confirm completion before the
+session is closed.
+
+`Dev10x:work-on` already enforces this for its multi-phase plans (see
+`skills/work-on/instructions.md` § Phase 4). This rule lifts the same
+invariant to a universal contract for **every** Dev10x skill that
+mutates the task list, including standalone invocations that finish a
+discrete unit while a broader plan is in flight.
+
+**Required `Verify AC` task content:**
+
+- PR URL(s) created or updated during the session
+- One-line summary per change shipped
+- Confirmation of CI status (passing / pending / failing)
+- Confirmation that no review comments are unaddressed
+- Any ACs/DoD items still requiring manual sign-off
+
+**Why this matters:**
+
+- A new prompt landing on an empty task list competes for attention
+  with whatever is already in flight; with the task list populated,
+  the new prompt lands as a TODO under the existing plan
+- The supervisor confirms completion explicitly rather than the agent
+  declaring itself done
+- The supervisor can extend scope by adding tasks BEFORE `Verify AC`
+  without restarting the session
+
+**Behavior when skill execution completes:**
+
+1. If a `Verify AC` task already exists (created by `Dev10x:work-on`
+   or `Dev10x:verify-acc-dod`), leave it `pending` and STOP
+2. If no `Verify AC` task exists AND the task list would otherwise be
+   empty, create one before declaring completion:
+   ```
+   TaskCreate(subject="Verify AC and close session",
+       description="Summary of changes: <PR URLs, commits, CI status>",
+       activeForm="Verifying AC")
+   ```
+3. Never mark `Verify AC` `completed` autonomously — the supervisor
+   completes it explicitly during `Dev10x:verify-acc-dod` or
+   `Dev10x:session-wrap-up`
+
 ## Reference Documents
 
 | Document | Topic | Loaded by |

--- a/skills/session-tasks/SKILL.md
+++ b/skills/session-tasks/SKILL.md
@@ -74,7 +74,27 @@ Use `TaskUpdate` with the task ID and new `status`:
 - `completed` — done
 - `pending` — deferred within this session
 
+## Task List Invariant (GH-149)
+
+The session task list must never be empty. When all work items are
+`completed`, this skill MUST seed a `Verify AC and close session`
+task before returning control to the supervisor:
+
+```
+TaskCreate(subject="Verify AC and close session",
+    description="<summary of shipped changes, PR links, CI status>",
+    activeForm="Verifying AC")
+```
+
+See `.claude/rules/essentials.md` § Task List Invariant for the full
+contract. Standalone `session-tasks` invocations that find an empty
+task list at the end MUST create this task before completing — a
+new prompt arriving on an empty list competes for attention with
+whatever is in flight; with `Verify AC` present, the new prompt
+lands as a TODO under the existing plan.
+
 ## Used By
 
 - `Dev10x:park` — when user picks "keep for this session"
 - `Dev10x:session-wrap-up` — Phase 1 auto-scan reads the task list
+- `Dev10x:verify-acc-dod` — owns the `Verify AC` task completion


### PR DESCRIPTION
**When** the Verify AC task-list invariant only binds `Dev10x:work-on` plans (per d3db368), **I want to** lift the same contract to a universal rule that every Dev10x skill respects when mutating the task list, **so** standalone invocations of skills like `git-commit`, `gh-pr-respond`, or `session-tasks` cannot return control to the supervisor with an empty task list while a broader plan is in flight.

Sits on top of d3db368 which made the invariant binding for `work-on`'s Phase 4 plan. This PR adds the universal layer in `.claude/rules/essentials.md` (loaded every session) and ties `skills/session-tasks` to the same contract.

GH-181 was shipped in parallel via 01090bd — that commit covers the same nine findings this branch originally addressed, so those changes were dropped. The branch was rebased to retain only the universal GH-149 refinement.

Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/149