### PR TITLE
📝 GH-149 Close 4 skill-audit findings across work-on shipping pipeline

### DIFF
--- a/references/baseline-permissions.yaml
+++ b/references/baseline-permissions.yaml
@@ -10,9 +10,14 @@
 #     — those rot on every plugin upgrade. The `~/.claude/plugins/cache/**/`
 #     form is also acceptable; the doctor canonicalizes pinned paths to
 #     that form.
-#   - Trailing wildcard form: prefer `Bash(cmd *)` (space). The `Bash(cmd:*)`
-#     form is equivalent per Claude Code docs but the UI writes the space
-#     form on "always allow", so we standardize on it.
+#   - Trailing wildcard form: prefer `Bash(cmd:*)` (colon). GH-127 audit
+#     showed the colon form is the only one that reliably matches
+#     general invocations like `rg -n PATTERN path/`. The space form
+#     (`Bash(cmd *)`) is retained for tools where it has historically
+#     been written by the UI on "always allow", but new rules should
+#     use the colon form. Keep both when the historical space form is
+#     already widespread in user settings (rewriting risks breaking
+#     existing matches).
 #   - Built-in read-only commands (`ls`, `cat`, `head`, `tail`, `grep`,
 #     `find`, `wc`, `diff`, `stat`, `du`, `cd`) are NOT listed — they
 #     never prompt for the command itself. Path access still gated by
@@ -166,6 +171,11 @@ groups:
       - Write(/tmp/claude/git/**)
       - Read(/tmp/Dev10x/**)
       - Write(/tmp/Dev10x/**)
+      # GH-127 #4: skills load their own instructions.md and references
+      # from the marketplace cache; without this, every fresh skill
+      # invocation triggers a Read prompt.
+      - "Read(~/.claude/plugins/marketplaces/Dev10x-Guru/**)"
+      - "Read(~/.claude/plugins/cache/Dev10x-Guru/**)"
       - "Bash(${CLAUDE_PLUGIN_ROOT}/bin/**)"
       - "Bash(${CLAUDE_PLUGIN_ROOT}/hooks/scripts/**)"
       - "Bash(${CLAUDE_PLUGIN_ROOT}/skills/**)"
@@ -182,8 +192,11 @@ groups:
     rules:
       - Bash(jq:*)
       - Bash(yq:*)
-      - Bash(rg *)
+      # GH-127: colon-form matches `rg <pattern> <path>` invocations;
+      # space-form (`Bash(rg *)`) does not match the common case.
+      - Bash(rg:*)
       - Bash(rg --files *)
+      - Bash(sed:*)
       - Bash(sed *)
       - Bash(awk *)
       - Bash(awk:*)

--- a/skills/db-psql/SKILL.md
+++ b/skills/db-psql/SKILL.md
@@ -13,6 +13,20 @@ allowed-tools:
   - Bash(${CLAUDE_PLUGIN_ROOT}/skills/db-psql/scripts/db.sh:*)
 ---
 
+<!--
+GH-127 #1 — `${CLAUDE_PLUGIN_ROOT}` is expanded by Claude Code at
+runtime to the resolved cache path. User settings that pin the
+absolute path (`/home/<user>/.claude/plugins/cache/.../db.sh:*`)
+or omit the tilde will not match this rule. Run
+`Dev10x:plugin-maintenance` (mode: full) or
+`Dev10x:upgrade-cleanup` to canonicalize pinned/absolute paths in
+`settings.local.json` to the `~/.claude/plugins/cache/.../**/`
+wildcard form, which matches across plugin version bumps. The
+canonicalization is implemented in
+`src/dev10x/skills/permission/doctor.py::canonicalize_rule`.
+-->
+
+
 # PostgreSQL Query Execution
 
 ## Orchestration

--- a/skills/gh-pr-monitor/instructions.md
+++ b/skills/gh-pr-monitor/instructions.md
@@ -135,6 +135,29 @@ two specs (`haiku-ci-poll`, `haiku-thread-scan`).
 The supervisor walks Phases 0 → 4, interpreting each micro-agent's
 returned JSON between dispatches.
 
+**Surface launch parameters (GH-127 #6).** Before each
+`Agent(...)` dispatch, print a one-line startup banner so the
+supervisor can confirm the run-time parameters were honored:
+
+```
+[gh-pr-monitor] dispatch=haiku-ci-poll model=haiku max_turns=50 background=true pr=#{N}
+```
+
+**Exit-reason taxonomy (GH-127 #6).** Each micro-agent's final
+JSON line is the canonical exit reason. The supervisor MUST
+classify the result before deciding next action:
+
+| `verdict` | Meaning | Supervisor action |
+|---|---|---|
+| `green` / `failing` / `conflicting` | Completed normally | Branch on verdict (Phase 2+) |
+| `timeout` | Hit `max_turns` budget without resolution | Re-dispatch with the same prompt (CI just slow) |
+| missing JSON line | Permission denied or hard crash | Inspect transcript; do NOT silently re-dispatch — surface the failure to the user |
+| explicit `"error": …` | The agent reported an error and exited | Propagate the error message to the user |
+
+The "permission denied vs budget exhausted" distinction matters
+for re-dispatch decisions: budget exhaustion is safe to retry,
+permission denial is not.
+
 ### Micro-Agents (GH-68)
 
 Two narrow haiku sub-agents replace the prior monolithic background

--- a/skills/gh-pr-review/SKILL.md
+++ b/skills/gh-pr-review/SKILL.md
@@ -12,7 +12,10 @@ invocation-name: Dev10x:gh-pr-review
 allowed-tools:
   - Bash(gh:*)
   - Bash(/tmp/Dev10x/bin/mktmp.sh:*)
+  - Bash(~/.claude/tools/gh-bot-comment.py:*)
   - Write(/tmp/Dev10x/git/**)
+  - mcp__plugin_Dev10x_cli__pr_detect
+  - mcp__plugin_Dev10x_cli__mktmp
 ---
 
 # GitHub PR Review
@@ -67,10 +70,14 @@ number is given, use the current git remote origin.
 
 ### Step 2: Gather PR Context
 
-Run in parallel:
-1. `gh pr view {N} --json title,body,baseRefName,headRefName,
-   state,author,labels,commits,files`
-2. `gh pr diff {N}`
+**REQUIRED first call:** `mcp__plugin_Dev10x_cli__pr_detect` to
+resolve PR number, repo, state, base/head refs, and merge status
+in one structured response (GH-181 F4). Raw `gh pr view --json`
+is fallback only when the MCP tool is unavailable.
+
+Then run in parallel:
+1. `mcp__plugin_Dev10x_cli__pr_detect` (state, refs, merge state, labels)
+2. `gh pr diff {N}` — full diff
 3. `gh pr view {N} --json comments` — existing bot/human comments
 4. `gh api repos/{owner}/{repo}/pulls/{N}/reviews` — existing reviews
 5. `gh api repos/{owner}/{repo}/pulls/{N}/comments` — inline comments
@@ -78,6 +85,20 @@ Run in parallel:
 **Why all 5?** Avoids duplicating feedback from previous review cycles
 (per `review-guidelines.md` — "NEVER repeat feedback from previous
 review cycles").
+
+**Oversize-diff fallback (GH-181 F5).** GitHub's `gh pr diff` fails
+with `HTTP 406: Sorry, the diff exceeded the maximum number of
+lines (20000)` for very large PRs. When this happens:
+
+1. Fall back to file-list-only context:
+   `gh pr view {N} --json files,additions,deletions,changedFiles`
+2. Read changed files individually at the PR head SHA via
+   `gh api repos/{owner}/{repo}/contents/{path}?ref={head_sha}`
+   (or from local checkout if present — but DO NOT `git checkout`
+   the PR branch; see Step 3 REQUIRED).
+3. Record `oversize_diff=true` so Step 8 selects the bot-comment
+   transport (inline review threads anchor on diff hunks, which
+   are unavailable).
 
 ### Step 2b: Phase 0 — Spec Compliance Gate (GH-69)
 
@@ -155,17 +176,31 @@ For each file in the PR's file list, use the Read tool to read the
 file at the current HEAD of the PR's base branch. Compare with the
 diff to understand the full context.
 
-**Important**: Read files from your local checkout. If the PR branch
-is not checked out locally, the diff from Step 2 is sufficient for
-review — do not checkout the branch.
+**REQUIRED: do NOT run `git checkout` on the PR branch (GH-181
+F2).** If the PR branch is not checked out locally, the diff from
+Step 2 is sufficient for review. When you need a file's full text
+at the PR head, fetch it via
+`gh api repos/{owner}/{repo}/contents/{path}?ref={head_sha}` (or
+the equivalent `pr_detect` head SHA) — never disrupt the working
+tree by checking out the PR branch. Checking out the branch risks
+overwriting in-flight worktree changes and is a documented
+regression.
 
 ### Step 4: Impact Analysis
+
+**REQUIRED — main agent runs the grep pass (GH-181 F6).** Subagents
+may help, but the main agent must perform (or summarize subagent
+output of) the grep-for-callers sweep and include the findings in
+the draft review's impact-analysis section. A skipped or
+silently-delegated grep pass is a Step 4 violation.
 
 For changed interfaces (renamed methods, changed signatures, modified
 DTOs):
 - Grep for all callers/consumers of the changed interface
 - Verify the PR updates all call sites
 - Flag any missed references
+- Summarize the grep results in the draft review body (one bullet
+  per affected call site or "no other callers found").
 
 ### Step 4b: Architecture Evaluation (GH-916)
 
@@ -195,16 +230,25 @@ structural evaluation regardless of prior feedback.
 
 ### Step 5: Apply Review Guidelines
 
-Load project review guidelines from `references/`:
-- `review-guidelines.md` — workflow, threads, summaries
-- `review-checks-common.md` — false positive prevention
-- Domain-specific agents from `.claude/agents/` based on file types
+**REQUIRED — Read the reference files (GH-181 F1).** Skipping
+these because "I know the rules" is the regression that
+prompted this requirement. Apply the gate to every drafted
+inline comment, not just to a sample.
 
-Apply the **False Positive Prevention Gate** before drafting any
-inline comment:
+1. `Read(file_path=".../references/review-guidelines.md")` — workflow,
+   threads, summaries
+2. `Read(file_path=".../references/review-checks-common.md")` —
+   false positive prevention
+3. Load domain-specific agents from `.claude/agents/` for the
+   changed file types
+
+Apply the **False Positive Prevention Gate** (defined in
+`review-checks-common.md`) before drafting any inline comment:
 1. Does this violate a documented rule? (No rule = preference)
 2. Does this contradict an established codebase pattern?
 3. Quality improvement or just preference?
+
+If the gate fails any criterion, do not file the comment.
 
 ### Step 6: Draft Review
 
@@ -221,8 +265,14 @@ Compose:
 
 ### Step 7: Hide Obsolete Review Summaries
 
-Before posting the new review, minimize previous Claude review
-summaries that are fully resolved (per `review-guidelines.md` step 6):
+**Skip Step 7 entirely on closed/merged PRs (GH-181 F7).** The
+`minimizeComment` mutation only meaningfully affects the
+reviewer's pane on open PRs; on merged PRs nobody reads it and
+the call is a no-op. Closed/merged PR → jump straight to Step 8.
+
+Before posting the new review on an **open** PR, minimize previous
+Claude review summaries that are fully resolved (per
+`review-guidelines.md` step 6):
 
 1. Query review threads via GraphQL — check `isResolved` and group
    by `pullRequestReview.databaseId`
@@ -241,14 +291,30 @@ Skip this step on the first review (no previous summaries exist).
 
 ### Step 8: Post Review to GitHub
 
+**Transport selection (GH-181 F3, F8).** Pick the transport based
+on the PR state and diff size detected in Step 2:
+
+| Condition | Transport |
+|---|---|
+| PR is OPEN AND diff fits in `gh pr diff` (≤ ~5,000 LOC, no 406) | A. `gh api .../pulls/{N}/reviews` with inline comments |
+| PR is MERGED / CLOSED, OR `oversize_diff=true`, OR inline anchors infeasible | B. Bot top-level comment via `~/.claude/tools/gh-bot-comment.py` |
+
+#### A. Standard review payload (open PR, normal diff)
+
 Use the Write tool to create the review JSON, then post via `gh api --input`:
 
-1. Create a unique temp file:
-```bash
-/tmp/Dev10x/bin/mktmp.sh git pr-review .json
-```
+1. **MUST** create the unique temp path via the MCP tool — the shell
+   `mktmp.sh` is a fallback for when the MCP server is unavailable.
+   Reaching for the shell first is the regression GH-181 F8 closes:
 
-2. Write the review payload to the unique path:
+   ```
+   mcp__plugin_Dev10x_cli__mktmp(namespace="git", prefix="pr-review", ext=".json")
+   ```
+
+   Shell fallback (only when MCP unavailable):
+   `/tmp/Dev10x/bin/mktmp.sh git pr-review .json`
+
+2. Write the review payload to the returned path:
 ```json
 {
   "event": "COMMENT",
@@ -277,6 +343,58 @@ gh api repos/{owner}/{repo}/pulls/{N}/reviews \
 - Always use `"event": "COMMENT"` — never REQUEST_CHANGES or APPROVE
 - Include `commit_id` from the PR's latest commit
 - Inline comments must reference lines that exist in the PR diff
+
+#### B. Bot top-level comment (merged PR / oversize diff)
+
+The `pulls/{N}/reviews` endpoint requires every entry in
+`comments[]` to anchor on a line that exists in the diff. On
+merged PRs the diff is finalized and inline anchors still work,
+but the bot-identity transport is preferred because it preserves
+review attribution after merge. For oversize diffs, inline
+anchors are unavailable (no diff fetched). In both cases,
+restructure the review into a single top-level issue comment
+posted as the GitHub App.
+
+1. **Detect bot config:** `Read(file_path="~/.claude/Dev10x/github-bot/github-app.yaml")`.
+   If `enabled: true`, proceed; otherwise fall back to transport A
+   (best-effort with whatever inline anchors are available).
+
+2. **Restructure the payload:** convert each `comments[]` entry
+   into a quoted `file:line` block inside the body:
+
+   ```markdown
+   ## Review Summary
+
+   <summary text>
+
+   ### Findings
+
+   **`src/file.py:42`** — Issue description
+
+   ```suggestion
+   fix
+   ```
+
+   **`src/other.py:101`** — …
+   ```
+
+3. **Create the body file** via the MCP tool (MUST, not shell):
+   ```
+   mcp__plugin_Dev10x_cli__mktmp(namespace="git", prefix="pr-review-body", ext=".md")
+   ```
+   Write the restructured body to the returned path.
+
+4. **Post via the bot tool:**
+   ```bash
+   ~/.claude/tools/gh-bot-comment.py OWNER/REPO PR_NUMBER <body-path>
+   ```
+
+   This posts a top-level issue comment using the GitHub App
+   identity configured in `github-app.yaml`. The bot transport
+   does NOT support inline review threads — every finding must
+   be in the body with explicit `path:line` references.
+
+5. Report the resulting comment URL to the user in Step 9.
 
 ### Step 9: Report to User
 

--- a/skills/git/SKILL.md
+++ b/skills/git/SKILL.md
@@ -83,6 +83,33 @@ fall back to the wrapper script (blocked by
 `validate-bash-command.py`) or use `DEV10X_SKIP_CMD_VALIDATION` —
 see `references/mcp-unavailable-escape-hatch.md`.
 
+### Post-push CI monitoring (GH-117 #2)
+
+**On successful push to a branch with an open PR, the next
+action is `Skill(Dev10x:gh-pr-monitor)` — not "wait and see".**
+A push to a PR branch retriggers CI; failing to monitor it
+turns a deviation into an oversight.
+
+After `push_safe` returns (empty dict `{}` means success — see
+`.claude/rules/mcp-tools.md`):
+
+1. Resolve PR state for the pushed branch via
+   `mcp__plugin_Dev10x_cli__pr_detect`.
+2. If a PR exists and is OPEN, immediately invoke
+   `Skill(Dev10x:gh-pr-monitor)` so the supervisor's CI-poll
+   micro-agent dispatches before the user has to ask.
+3. If no PR exists (push is the first push of a new branch),
+   skip this auto-chain — the next step is `Dev10x:gh-pr-create`
+   in the work-on plan.
+
+When this skill is invoked from inside `Dev10x:work-on`,
+work-on's pr-continuation play moves `Monitor CI` to
+`in_progress` automatically (see work-on instructions §
+Post-push auto-advance). When invoked standalone, the user is
+responsible for the chain, but this skill's success message
+should still surface a "Next: `Skill(Dev10x:gh-pr-monitor)`"
+hint so the next move is unambiguous.
+
 **Fallback: wrapper script** (only when MCP is healthy but the
 tool call errored for another reason):
 

--- a/skills/skill-audit/instructions.md
+++ b/skills/skill-audit/instructions.md
@@ -307,13 +307,26 @@ completely different project's session (GH-805).
 **Skip this gate when the user provided an explicit JSONL path.**
 An explicit path means the user deliberately chose the session.
 
-**When the path was auto-resolved** (no arg, or arg is a
-directory), extract the session ID from the filename (the UUID
-portion before `.jsonl`) and the file's modification time, then
-confirm with the user before proceeding.
+**Skip this gate when the invocation turn contains a clear
+adaptive-friction affirmative (GH-127 #7).** When `friction_level
+== adaptive` AND the same user message that invoked the skill
+contains an unambiguous affirmative like `go`, `proceed`, `yes`,
+`run it`, `audit it`, treat that as the confirmation and skip
+the `AskUserQuestion`. The user has already chosen — re-asking
+adds friction without information value. Affirmatives must be
+in the **same turn** as the invocation (not from prior
+conversation) and unambiguous (mere "ok" or "k" does not
+qualify).
 
-**REQUIRED: Call `AskUserQuestion`** (ALWAYS_ASK — fires at all
-friction levels, do NOT use plain text).
+**When the path was auto-resolved** (no arg, or arg is a
+directory) AND no adaptive affirmative is present, extract the
+session ID from the filename (the UUID portion before `.jsonl`)
+and the file's modification time, then confirm with the user
+before proceeding.
+
+**REQUIRED: Call `AskUserQuestion`** (ALWAYS_ASK — fires at
+strict/guided friction levels, and at adaptive when no
+affirmative is present; do NOT use plain text).
 
 Display the resolved path, session ID, and mtime in the question
 so the user can verify it's the correct session:

--- a/skills/skill-reinforcement/SKILL.md
+++ b/skills/skill-reinforcement/SKILL.md
@@ -60,8 +60,13 @@ Store the command string for matching.
 
 ### Step 2: Match against command-skill map
 
-Read the command-skill mapping from the canonical location:
-`${CLAUDE_PLUGIN_ROOT}/src/dev10x/validators/command-skill-map.yaml`.
+**REQUIRED — `Read` the canonical map first (GH-181 F9).** Do
+NOT inline knowledge from the parent skill's SKILL.md or
+recall mappings from training. The hook's YAML is authoritative
+and ships updates ahead of skill docs; skipping the Read is a
+documented Step 2 violation.
+
+1. `Read(file_path="${CLAUDE_PLUGIN_ROOT}/src/dev10x/validators/command-skill-map.yaml")`
 
 The YAML in `skills/skill-reinforcement/references/command-skill-map.yaml`
 is a legacy copy — prefer the hook's YAML which is the single

--- a/skills/work-on/instructions.md
+++ b/skills/work-on/instructions.md
@@ -720,6 +720,30 @@ specific file/line, that is the starting point for investigation.
 4.10 [detailed] Verify acceptance criteria
 ```
 
+**Pr-continuation deletion guard (GH-117 #1).** Tasks 4.6
+(Monitor CI), 4.8 (Update PR description), 4.9 (Request
+re-review), and 4.10 (Verify acceptance criteria) MUST NOT be
+marked `status=deleted` while still `pending`. The terminal
+gate is `Dev10x:verify-acc-dod`, NOT a mid-session pivot to an
+inline edit. When the user pivots inside Phase 4 — for example,
+"actually, also fix this nit" — the pivot becomes a **new
+subtask inserted before 4.10**; it does not replace the existing
+Phase 4 plan. Deleting still-pending pr-continuation tasks
+empties the task list, kills CI monitoring, and lets unaddressed
+review comments slip through. The recurrence in GH-117 evidence
+(deletion happened twice in the same session) shows the
+regression is easy to repeat under user-pivot pressure.
+
+**Post-push auto-advance (GH-117 #2).** After
+`Skill(Dev10x:git)` returns a successful push on a branch that
+already has an open PR, the next active task is **always**
+`Monitor CI`. Move task 4.6 to `in_progress` immediately on
+push success — do not wait for the user to ask "did CI run?".
+A missed CI failure on an unattended post-push is documented as
+the most common pr-continuation oversight; auto-moving the
+monitor task converts it from oversight to deviation (visible
+in `TaskList`).
+
 **Local-only work (no ticket, no PR):**
 ```
 4.1  [detailed] Summarize the work from gathered context

--- a/skills/work-on/instructions.md
+++ b/skills/work-on/instructions.md
@@ -17,6 +17,19 @@ the plan, and can pause at any point with `Dev10x:session-wrap-up`.
 The visible task list is the supervisor's interface for adding
 new tasks mid-session. Skipping it removes that capability.
 
+**Invariant: never leave the session with an empty task list
+(GH-149).** Until the supervisor explicitly closes the session
+(`Dev10x:session-wrap-up` or session restart), the task list MUST
+contain at least one open task. The terminal task is always
+`Verify acceptance criteria` — it is the last task in every play
+and it MUST NOT be marked `completed` or `deleted` until the
+supervisor confirms the work is shippable (PR linked, CI green,
+no unresolved review comments, AC satisfied). When new
+instructions arrive mid-session, the new TODOs land **before**
+the Verify-AC task — they do not replace it. An empty task list
+at the moment of a new prompt creates competition for attention
+and is a Phase 4 violation.
+
 **REQUIRED: Create phase tasks before ANY work.** At session
 start, create exactly 4 top-level tasks — one per phase:
 
@@ -592,7 +605,29 @@ The last subtask is always acceptance criteria verification.
 ### Acceptance Criteria Verification
 
 The **last task** in every plan verifies the work is shippable
-or ready for handover.
+or ready for handover. This task is the session's terminal
+gate — see the empty-task-list invariant above (GH-149). It
+remains `pending` (or `in_progress` while the supervisor is
+reviewing) until the supervisor explicitly confirms closure.
+Never mark Verify-AC `completed` without an explicit supervisor
+"ship it" / "looks good" / "close session" / equivalent
+affirmation; never mark it `deleted` while pending — that
+empties the task list and breaks the invariant.
+
+**Verify-AC summary contents.** When invoked, the verification
+must surface a structured summary so the supervisor can confirm
+closure without re-reading the conversation:
+
+- PR link(s) and merge state
+- Per-ticket: ID, title, link, "addressed by commit(s) …"
+- CI status (green/red/pending; link to failing checks)
+- Open review comments (count + links) — should be zero to ship
+- Working-copy state (clean / staged / uncommitted)
+- Acceptance criteria items, each `[x]` or `[ ]`
+
+The supervisor may extend or modify the AC at this point —
+treat new instructions as additional tasks inserted **before**
+Verify-AC, never as replacements for it.
 
 **REQUIRED:** Delegate to `Dev10x:verify-acc-dod` skill:
 

--- a/src/dev10x/validators/prefix_friction.py
+++ b/src/dev10x/validators/prefix_friction.py
@@ -64,13 +64,27 @@ REDIRECT_THEN_POSITIONAL_RE = re.compile(
 
 # GH-119: ';' chains match the whole command string against allow rules
 # rather than individual clauses. Detect non-trivial chains (two
-# read-only commands) so the agent splits them into separate tool calls.
-# Excludes `; ` inside quoted strings via a lookbehind heuristic — the
-# initial filter is by token shape on the chain head/tail.
+# read-only or low-risk commands) so the agent splits them into separate
+# tool calls. Excludes `; ` inside quoted strings via a lookbehind
+# heuristic — the initial filter is by token shape on the chain head/tail.
+#
+# GH-127 #5: head/tail set widened to catch the documented nuisance
+# patterns (e.g., `git status; git fetch`, `ls dir1; ls dir2`,
+# `pwd; whoami`). Each entry is a command that does not, in its most
+# common forms, mutate global state beyond the working directory —
+# chains of these are nearly always two probes that should be split
+# into two Bash tool calls. State-changing commands (rm, mv, cp,
+# mkdir, touch, kubectl apply, docker run, etc.) are intentionally
+# absent: forcing a split there would be more disruptive than helpful.
+_CHAIN_HEAD_RE = (
+    r"(?:find|grep|ls|rg|cat|head|tail|wc|"
+    r"git|gh|pwd|which|whoami|env|date|printenv|"
+    r"echo|sleep|uv|python|python3|docker|kubectl)"
+)
 SEMICOLON_CHAIN_RE = re.compile(
-    r"^\s*(?P<head>(?:find|grep|ls|rg|cat|head|tail|wc)\b[^;]*?)"
+    rf"^\s*(?P<head>{_CHAIN_HEAD_RE}\b[^;]*?)"
     r"\s*;\s*"
-    r"(?P<tail>(?:find|grep|ls|rg|cat|head|tail|wc)\b.*)$"
+    rf"(?P<tail>{_CHAIN_HEAD_RE}\b.*)$"
 )
 
 CD_REVPARSE_MSG = (

--- a/tests/validators/test_prefix_friction.py
+++ b/tests/validators/test_prefix_friction.py
@@ -365,3 +365,50 @@ class TestSemicolonChain:
         inp = _make_input(command="find /home -name '*.py' -type f")
         result = validator.validate(inp=inp)
         assert result is None
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git status; git fetch",
+            "git log -1; git diff HEAD~1",
+            "gh pr view 1; gh pr checks 1",
+            "pwd; whoami",
+            "echo a; echo b",
+            "uv run pytest; uv run ruff check",
+            "docker ps; docker images",
+            "kubectl get pods; kubectl get svc",
+            "python3 -V; which python3",
+            "env; printenv HOME",
+        ],
+    )
+    def test_blocks_widened_chain_heads(
+        self,
+        validator: PrefixFrictionValidator,
+        command: str,
+    ) -> None:
+        """GH-127 #5: widened head set catches documented nuisance chains."""
+        inp = _make_input(command=command)
+        result = validator.validate(inp=inp)
+        assert result is not None
+        assert "separate Bash tool calls" in result.message
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # State-changing commands intentionally NOT widened.
+            "rm a.txt; rm b.txt",
+            "mkdir foo; cd foo",
+            "mv a b; mv c d",
+            "touch x; touch y",
+        ],
+    )
+    def test_allows_state_changing_chains(
+        self,
+        validator: PrefixFrictionValidator,
+        command: str,
+    ) -> None:
+        """State-changing chains stay out of scope — splitting would be
+        more disruptive than helpful."""
+        inp = _make_input(command=command)
+        result = validator.validate(inp=inp)
+        assert result is None


### PR DESCRIPTION
## Job Story

**When** Dev10x skill instructions silently drop guardrails — empty
task lists, missing reference-file reads, raw `git checkout` of PR
branches, narrow `;`-chain detection, deletable Phase 4 tasks —
**I want to** ship hardened instructions across `Dev10x:work-on`,
`Dev10x:gh-pr-review`, `Dev10x:skill-reinforcement`,
`Dev10x:gh-pr-monitor`, `Dev10x:skill-audit`, `Dev10x:git`,
`Dev10x:db-psql`, plus the shared `baseline-permissions.yaml`
catalog and the `prefix_friction` validator, **so** Dev10x agents
default to the safe, audited paths on the first attempt without
having to be corrected mid-session.

## What changed

| Ticket | Scope |
|---|---|
| **GH-149** | `Dev10x:work-on` — empty-task-list invariant; `Verify acceptance criteria` is the session's terminal task and the structured shippability summary contents are documented. |
| **GH-181** | `Dev10x:gh-pr-review` Steps 2–8 (REQUIRED `pr_detect` MCP delegation, HTTP 406 fallback, REQUIRED no-`git checkout`, main-agent grep pass, REQUIRED references reads, transport selection for open vs merged/oversize PRs, MUST `mktmp` MCP) + `Dev10x:skill-reinforcement` Step 2 (REQUIRED Read of canonical `command-skill-map.yaml`). |
| **GH-127** | Closes 7 of 8 audit findings: `Bash(rg:*)` colon-form scaffolding, marketplace `Read(~/.claude/plugins/marketplaces/...)` in baseline, widened `SEMICOLON_CHAIN_RE` heads (`git`, `gh`, `pwd`, `uv`, `docker`, `kubectl`, …) in `prefix_friction`, `gh-pr-monitor` launch-banner + exit-reason taxonomy, `skill-audit` Phase 1.1 adaptive-affirmative skip, `db-psql` runtime-path doc note pointing at `Dev10x:plugin-maintenance` canonicalization. (Findings #3 mktmp no-touch and #8 versioned-path canonicalize already shipped via GH-39 and `permission/doctor.py`.) |
| **GH-117** | `Dev10x:work-on` pr-continuation deletion guard for tasks 4.6/4.8/4.9/4.10 + post-push auto-advance to Monitor CI; `Dev10x:git` post-push CI monitoring chain into `Dev10x:gh-pr-monitor`. |

## Commits

- `📝 GH-181 Mandate references reads and merged-PR transport`
- `📝 GH-127 Close 7 permission/hook gaps across scaffolding and skills`
- `📝 GH-149 Guarantee non-empty task list through Verify-AC terminal task`
- `📝 GH-117 Guard pr-continuation tasks and auto-chain CI monitor after push`

## Test plan

- [x] `uv run --extra dev pytest tests/validators/test_prefix_friction.py` — 53 passed (incl. 14 new parametrized cases for widened chain heads + state-changing exclusions)
- [x] Full suite — 2111 passed, 1 pre-existing benchmark regression (`mcp_server_import` 250ms vs 13ms baseline) confirmed pre-existing on `develop` and unrelated to this PR
- [x] Doc-only changes verified by manual read

Fixes: GH-149, GH-181, GH-127, GH-117