### PR TITLE
📝 GH-181 Enable reliable gh-pr-review on merged and oversize PRs

### DIFF
--- a/skills/gh-pr-review/SKILL.md
+++ b/skills/gh-pr-review/SKILL.md
@@ -346,6 +346,23 @@ gh api repos/{owner}/{repo}/pulls/{N}/reviews \
 
 #### B. Bot top-level comment (merged PR / oversize diff)
 
+**Prerequisites.** Transport B requires two user-provided
+resources outside this plugin:
+
+- `~/.claude/tools/gh-bot-comment.py` — user-installed script
+  that posts comments under a GitHub App identity. Not bundled
+  with Dev10x. Users wire it up alongside their own GitHub App
+  credentials.
+- `~/.claude/Dev10x/github-bot/github-app.yaml` — App identity
+  config (App ID, private-key path, installation ID). Users
+  create this file when setting up the bot. Step 1 below checks
+  `enabled: true` before selecting Transport B.
+
+If either is missing, Transport B falls back to Transport A even
+for merged or oversize PRs. The fallback posts under the user's
+own GitHub identity rather than the App's — document the chosen
+identity in the eventual review summary.
+
 The `pulls/{N}/reviews` endpoint requires every entry in
 `comments[]` to anchor on a line that exists in the diff. On
 merged PRs the diff is finalized and inline anchors still work,


### PR DESCRIPTION
**When** I run `Dev10x:gh-pr-review` on a merged PR with a 36K-LOC diff, **I want to** find the documented path for oversize-diff transport and reference-file Reads, **so I can** post a faithful review without re-discovering the bot tool from first principles or skipping the False Positive Prevention Gate.

---

[`7db0e06f`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/194/commits/7db0e06f89e51c1161c497dae7f0a210736489d5) 📝 GH-181 Enable reliable gh-pr-review on merged and oversize PRs
[`e9b2ae42`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/194/commits/e9b2ae4237326ce6035c4400f8844b785cda90f3) 🎨 Restore ruff format compliance in audit/__init__.py
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/181

---