### PR TITLE
✨ GH-190 Enrich audit issues with bundling labels

### DIFF
--- a/skills/audit-report/SKILL.md
+++ b/skills/audit-report/SKILL.md
@@ -16,6 +16,8 @@ allowed-tools:
   - Skill(Dev10x:ticket-create)
   - Bash(ls ~/.claude/plugins/cache/:*)
   - Bash(gh issue create:*)
+  - Bash(gh label list:*)
+  - Bash(gh label create:*)
 ---
 
 # Audit Report — File Findings Upstream
@@ -157,22 +159,71 @@ Use the primary skill name (most findings) as the title anchor:
 
 Write the assembled body to that file using the Write tool.
 
-### Step 7: File the issue
+### Step 7: Derive bundling labels (REQUIRED)
+
+Audit issues are batched by an automated session, so similar
+findings should cluster under a shared label and be discoverable
+as a bundle during implementation. Derive the label set from the
+fictionalized findings BEFORE filing — never hardcode a single
+`enhancement` label.
+
+Apply the resolution algorithm in
+[`references/labels.md`](references/labels.md):
+
+1. Start with `enhancement`
+2. Add the audit-session bundle: `audit-YYYY-MM-DD` (parse from the
+   findings file's "Audit date" line)
+3. Add one `skill:<name>` per unique skill referenced in the
+   findings table (strip the `Dev10x:` prefix; fictionalized names
+   only — see Step 3)
+4. Scan finding descriptions + proposed fixes against the topical
+   heuristic table in `references/labels.md` § 4; add each matching
+   topical label once
+5. De-duplicate and cap at 8 labels per issue
+
+Collect the result as a comma-separated string (e.g.,
+`enhancement,audit-2026-05-16,skill:work-on,routing-bypass`).
+Store it as `$LABELS` for Step 8.
+
+### Step 8: Ensure labels exist on the repo
+
+GitHub fails issue creation if any label is missing. Before
+filing, fetch the current label set once and create only the
+missing ones:
+
+```bash
+gh label list --repo Dev10x-Guru/Dev10x-Claude --limit 200 \
+    --json name -q '.[].name' > /tmp/Dev10x/skill-audit/existing-labels.txt
+
+for label in $(echo "$LABELS" | tr ',' ' '); do
+    grep -qxF "$label" /tmp/Dev10x/skill-audit/existing-labels.txt || \
+        gh label create "$label" --repo Dev10x-Guru/Dev10x-Claude \
+            --color "$COLOR_FOR_CATEGORY" \
+            --description "$DESC_FOR_CATEGORY"
+done
+```
+
+Colors and descriptions per category live in
+`references/labels.md`. `gh label create` is idempotent here
+because the loop only runs for missing labels.
+
+### Step 9: File the issue
 
 Delegate to `Dev10x:ticket-create` — never use raw `gh issue create`.
 Write the title as the first line of the temp file (followed by a
 blank line and the body) to avoid permission friction from special
-characters in the args string:
+characters in the args string. Pass the comma-separated label set
+derived in Step 7:
 
 ```
 Skill(skill="Dev10x:ticket-create",
-  args="--repo Dev10x-Guru/dev10x-claude --body-file {temp-file-path} --label enhancement")
+  args="--repo Dev10x-Guru/dev10x-claude --body-file {temp-file-path} --label {LABELS}")
 ```
 
 The ticket-create skill reads the first line as the title when
 no `--title` flag is provided.
 
-### Step 8: Report result
+### Step 10: Report result
 
 Display the created issue URL. If filing fails, show the error
 and the temp file path so the user can file manually.
@@ -188,6 +239,10 @@ and the temp file path so the user can file manually.
   of context per finding, not raw transcript blocks.
 - **One issue per audit**: Batch all findings into a single
   issue per audit session to avoid issue spam.
+- **Bundle via labels, not separate issues**: Apply the label
+  taxonomy in `references/labels.md` so similar issues can be
+  filtered and worked together during implementation. Never
+  file with only the default `enhancement` label.
 - **Privacy by default (Step 3)**: The source session may belong
   to a private codebase. Fictionalize repo names, owners,
   branches, tracker IDs, file paths, hostnames, and personal

--- a/skills/audit-report/references/labels.md
+++ b/skills/audit-report/references/labels.md
@@ -1,0 +1,102 @@
+# Bundling Label Taxonomy
+
+Labels applied to upstream skill-audit issues so similar findings
+can be grouped and worked together during implementation.
+
+## Goal
+
+When several audit issues share a root cause (e.g., five findings
+about permission friction across different skills), a maintainer
+should be able to filter by one label and address them as a bundle
+rather than re-discovering the relationship per issue.
+
+## Label Categories
+
+### 1. `enhancement` (always applied)
+
+Every audit-filed issue carries this label — it places the issue
+in the standard "feature request" backlog and matches GitHub's
+default label set.
+
+### 2. Audit-session label: `audit-YYYY-MM-DD`
+
+One label per audit session, derived from the **Audit date** line
+in the findings file (`## Session Context` → `- **Date**: ...`).
+All findings filed from a single audit session share this label.
+
+Precedents already present in `Dev10x-Guru/Dev10x-Claude`:
+
+- `audit-2026-04-29` — Skill-audit findings from session c83f5182
+- `audit-2026-05-09` — Architecture audit 2026-05-09 findings
+
+Color: `#5319E7` (purple). Description:
+`Skill-audit findings from session YYYY-MM-DD`.
+
+### 3. Per-skill labels: `skill:<name>`
+
+One label per unique skill that appears in the findings table
+"Skill" column. The `Dev10x:` prefix is stripped — e.g., findings
+about `Dev10x:work-on` produce `skill:work-on`.
+
+Color: `#1D76DB` (blue). Description:
+`Findings about the Dev10x:<name> skill`.
+
+These labels bundle all findings about the same skill so a
+maintainer can sweep them in one fixup pass when touching the
+skill.
+
+### 4. Topical labels (heuristic)
+
+Topical labels capture cross-cutting failure modes so that issues
+about the same anti-pattern across different skills cluster
+together. Apply each label when the heuristic matches any finding
+description, classification, or proposed fix.
+
+| Label | Heuristic match (case-insensitive) | Precedent |
+|-------|-----------------------------------|-----------|
+| `permission-friction` | "permission prompt", "allow rule", "friction" | existing label |
+| `silent-failure` | "silent", "swallowed", "no error surfaced" | new |
+| `routing-bypass` | "raw `git`", "raw `gh`", "bypass skill", "skill routing" | new |
+| `gate-bypass` | "plain text", "skipped AskUserQuestion", "decision gate" | new |
+| `compaction-loss` | "after compaction", "lost context", "routing table" | new |
+| `task-orchestration` | "TaskCreate skipped", "task list", "phase task" | new |
+| `playbook-drift` | "ad-hoc plan", "playbook", "fragment" | new |
+
+Color: `#D73A4A` (red). Description: tied to the anti-pattern.
+
+## Label Resolution
+
+1. Parse the findings file for the audit date and unique skill names
+2. Initialize labels = `[enhancement, audit-<date>]`
+3. Add one `skill:<name>` per unique skill (after stripping `Dev10x:`)
+4. Scan finding descriptions + proposed fixes against the topical
+   heuristic table; add each matching topical label once
+5. De-duplicate; cap at 8 labels per issue (GitHub UI noise)
+
+## Ensure-exists protocol
+
+GitHub fails issue creation if a label is missing. Before filing:
+
+```bash
+gh label list --repo Dev10x-Guru/Dev10x-Claude --limit 200 \
+    --json name -q '.[].name' > /tmp/existing-labels.txt
+
+for label in $LABELS; do
+    grep -qxF "$label" /tmp/existing-labels.txt || \
+        gh label create "$label" --repo Dev10x-Guru/Dev10x-Claude \
+            --color "$COLOR" --description "$DESCRIPTION"
+done
+```
+
+Use the colors and descriptions from the tables above. Skip the
+create call for labels already present — `gh label create` errors
+on duplicates and `--force` is not idempotent across descriptions.
+
+## Anti-patterns
+
+- ❌ Hardcoding a single `enhancement` label — defeats the bundling goal
+- ❌ Adding a label per finding row — labels are issue-level, not row-level
+- ❌ Creating labels with the real (non-fictional) skill name when the
+  finding references a private project skill — public Dev10x skills only
+- ❌ Filing the issue without ensuring labels exist — `gh` fails the
+  whole call on the first missing label


### PR DESCRIPTION
**When** I run `Dev10x:skill-audit` and file findings upstream, **I want to** see filed issues carry an audit-session label, per-skill labels, and topical labels **so** I can filter the upstream backlog by one label and address similar findings as a bundle during implementation, instead of re-discovering relationships issue by issue.

---

[`4d67aeab`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/195/commits/4d67aeab19df19a59e3fad91c1284322d58a1fbf) ✨ GH-190 Enrich audit issues with bundling labels
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/190

---