### PR TITLE
✨ GH-192 Compare user playbooks against plugin defaults

### DIFF
--- a/skills/plugin-maintenance/SKILL.md
+++ b/skills/plugin-maintenance/SKILL.md
@@ -87,6 +87,7 @@ on the mode. Execute these `TaskCreate` calls at startup:
 10. `TaskCreate(subject="Audit permissions for friction", activeForm="Auditing permissions")`
 11. `TaskCreate(subject="Clean project files", activeForm="Cleaning project files")`
 12. `TaskCreate(subject="Run permission doctor", activeForm="Running doctor sweep")`
+13. `TaskCreate(subject="Diff user playbooks against defaults", activeForm="Diffing playbooks")`
 
 Set sequential dependencies. Mark each step `in_progress` when
 starting and `completed` when done. Steps that produce no
@@ -431,6 +432,40 @@ uv run dev10x permission doctor cross-contamination
 ```bash
 uv run dev10x permission doctor enable-group kubernetes-readonly --dry-run
 uv run dev10x permission doctor enable-group kubernetes-readonly
+```
+
+### 13. Diff user playbooks against plugin defaults *(full only)* (GH-192)
+
+User playbook overrides under `.claude/Dev10x/playbooks/` and
+`~/.claude/memory/Dev10x/playbooks/` drift from the plugin defaults as
+new versions ship new steps, fragments, or field changes. This step
+surfaces those upstream changes without overwriting user customizations.
+
+```bash
+uv run dev10x playbook diff
+```
+
+The report distinguishes:
+
+- **New** steps present in the plugin default but missing from the user
+  override — typically upstream additions worth pulling in
+- **Removed** steps or plays the user overrides that no longer exist in
+  the default — either intentional pruning or upstream removal
+- **Changed** steps where the user has not overridden a field whose
+  default value moved upstream
+- **Customized** fields the user has explicitly set — flagged as
+  preserved; the diff never proposes overwriting them
+
+To pull in upstream changes interactively, run:
+
+```bash
+/Dev10x:playbook edit <skill> <play>
+```
+
+To target one skill (skip the rest):
+
+```bash
+uv run dev10x playbook diff --skill work-on
 ```
 
 ## Configuration

--- a/src/dev10x/cli.py
+++ b/src/dev10x/cli.py
@@ -45,6 +45,7 @@ class LazyGroup(click.Group):
         "init": "dev10x.commands.init.init",
         "permission": "dev10x.commands.permission.permission",
         "platform": "dev10x.commands.platform.platform",
+        "playbook": "dev10x.commands.playbook.playbook",
         "validate": "dev10x.commands.validate.validate",
         "skill": "dev10x.commands.skill.skill",
     },

--- a/src/dev10x/commands/playbook.py
+++ b/src/dev10x/commands/playbook.py
@@ -1,0 +1,126 @@
+"""CLI for playbook diagnostics (GH-192).
+
+``dev10x playbook diff`` compares every user playbook override visible
+from the current working directory against the matching plugin default
+and prints a markdown report of upstream changes. User customizations
+are preserved — the diff reports them but never writes.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import click
+import yaml
+
+from dev10x.skills.playbook import (
+    compare_playbooks,
+    find_user_playbooks,
+    plugin_default_path,
+    render_markdown_report,
+)
+
+
+def _resolve_plugin_root() -> Path | None:
+    """Locate the active plugin root.
+
+    Honors ``$CLAUDE_PLUGIN_ROOT`` first (set by Claude Code when invoking
+    skills) and falls back to walking up from this file. Returns ``None``
+    when no plausible root is found so callers can emit a useful error.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        root = Path(env_root)
+        if root.is_dir():
+            return root
+    candidate = Path(__file__).resolve().parent.parent.parent.parent
+    if (candidate / "skills").is_dir() and (candidate / ".claude-plugin").is_dir():
+        return candidate
+    return None
+
+
+def _load_yaml(path: Path) -> dict:
+    """Load a YAML file. Empty files return ``{}``."""
+    text = path.read_text()
+    data = yaml.safe_load(text)
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise click.ClickException(
+            f"Expected a mapping at the top of {path}, got {type(data).__name__}"
+        )
+    return data
+
+
+@click.group()
+def playbook() -> None:
+    """Inspect user playbook overrides against plugin defaults."""
+
+
+@playbook.command(name="diff")
+@click.option(
+    "--skill",
+    "skill_key",
+    default=None,
+    help="Limit the diff to one skill key (e.g., work-on). Default: all overrides.",
+)
+@click.option(
+    "--plugin-root",
+    type=click.Path(file_okay=False, exists=True),
+    default=None,
+    help="Override the auto-detected plugin root (debug aid).",
+)
+def playbook_diff(*, skill_key: str | None, plugin_root: str | None) -> None:
+    """Diff user playbook overrides against plugin defaults.
+
+    Surfaces upstream additions, removals, and field changes that the user
+    may want to pull into their override. User customizations are preserved
+    — the diff is read-only.
+    """
+    root = Path(plugin_root) if plugin_root else _resolve_plugin_root()
+    if root is None:
+        click.echo(
+            "ERROR: Could not resolve plugin root. Set $CLAUDE_PLUGIN_ROOT or pass --plugin-root.",
+            err=True,
+        )
+        sys.exit(1)
+
+    overrides = find_user_playbooks()
+    if skill_key:
+        overrides = [o for o in overrides if o.skill_key == skill_key]
+
+    if not overrides:
+        if skill_key:
+            click.echo(f"No user override found for skill {skill_key!r}.")
+        else:
+            click.echo("No user playbook overrides found.")
+        return
+
+    findings_count = 0
+    for override in overrides:
+        default_path = plugin_default_path(skill_key=override.skill_key, plugin_root=root)
+        if not default_path.is_file():
+            click.echo(
+                f"\n## Skipping `{override.skill_key}` ({override.scope})\n"
+                f"  No plugin default at {default_path}\n"
+            )
+            continue
+        default_doc = _load_yaml(default_path)
+        user_doc = _load_yaml(override.path)
+        diff = compare_playbooks(
+            default_doc=default_doc,
+            user_doc=user_doc,
+            skill_key=f"{override.skill_key} ({override.scope})",
+            user_path=str(override.path),
+            default_path=str(default_path),
+        )
+        click.echo(render_markdown_report(diff))
+        if diff.has_findings:
+            findings_count += 1
+
+    if findings_count == 0:
+        click.echo("All user overrides are up to date with plugin defaults.")
+    else:
+        click.echo(f"{findings_count} override(s) have upstream changes worth reviewing.")

--- a/src/dev10x/skills/playbook/__init__.py
+++ b/src/dev10x/skills/playbook/__init__.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dev10x.skills.playbook.compare import (
+    FieldDiff,
+    PlaybookDiff,
+    PlayDiff,
+    StepDiff,
+    compare_playbooks,
+)
+from dev10x.skills.playbook.discovery import (
+    UserPlaybook,
+    find_user_playbooks,
+    plugin_default_path,
+)
+from dev10x.skills.playbook.report import render_markdown_report
+
+__all__ = [
+    "FieldDiff",
+    "PlayDiff",
+    "PlaybookDiff",
+    "StepDiff",
+    "UserPlaybook",
+    "compare_playbooks",
+    "find_user_playbooks",
+    "plugin_default_path",
+    "render_markdown_report",
+]

--- a/src/dev10x/skills/playbook/compare.py
+++ b/src/dev10x/skills/playbook/compare.py
@@ -1,0 +1,297 @@
+"""Compare a user playbook override against the plugin default (GH-192).
+
+Surfaces upstream changes that the user may want to pull into their override
+while preserving user customizations. Two playbook documents are compared:
+
+- ``default`` — the plugin-shipped ``references/playbook.yaml``
+- ``user``    — the user override at
+                ``.claude/Dev10x/playbooks/<key>.yaml`` or
+                ``~/.claude/memory/Dev10x/playbooks/<key>.yaml``
+
+The diff distinguishes:
+
+- **NEW** — a step or play present in the default but missing from the user
+  override. Most often an upstream addition the user has not pulled in.
+- **REMOVED** — a step or play in the user override that no longer exists
+  in the default. Either the user intentionally pruned it, or upstream
+  removed it.
+- **CHANGED** — a step exists in both, but at least one inherited field
+  has diverged. ``customized_fields`` lists keys the user has set to a
+  value different from the default — those are preserved untouched.
+  ``upstream_changed_fields`` lists keys the user did **not** override
+  where the default value has changed.
+
+The output is structured (dataclasses) so callers can render JSON, markdown,
+or a CLI summary without re-parsing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+# Step fields the diff inspects. ``steps`` (epic children) and ``fragment``
+# are handled separately because they recurse / are structural references.
+COMPARED_FIELDS: tuple[str, ...] = (
+    "type",
+    "prompt",
+    "skills",
+    "agent",
+    "model",
+    "condition",
+    "modes",
+    "friction",
+    "optional",
+)
+
+MISSING = object()
+
+
+@dataclass(frozen=True)
+class FieldDiff:
+    """One field on one step whose default has changed."""
+
+    field_name: str
+    default_value: Any
+    user_value: Any  # MISSING sentinel when the user did not set the field
+
+
+@dataclass
+class StepDiff:
+    """Per-step diff entry."""
+
+    subject: str
+    status: str  # "new" | "removed" | "changed" | "unchanged"
+    customized_fields: list[str] = field(default_factory=list)
+    upstream_changed_fields: list[FieldDiff] = field(default_factory=list)
+
+
+@dataclass
+class PlayDiff:
+    """Per-play diff entry."""
+
+    play_name: str
+    status: str  # "new" | "removed" | "changed" | "unchanged" | "not-overridden"
+    step_diffs: list[StepDiff] = field(default_factory=list)
+    prompt_changed: bool = False
+
+
+@dataclass
+class PlaybookDiff:
+    """Top-level diff for one user playbook file vs the plugin default."""
+
+    skill_key: str
+    user_path: str
+    default_path: str
+    default_version: str | None
+    user_version: str | None
+    play_diffs: list[PlayDiff] = field(default_factory=list)
+    fragment_diffs: list[PlayDiff] = field(default_factory=list)
+
+    @property
+    def has_findings(self) -> bool:
+        return any(
+            p.status not in ("unchanged", "not-overridden")
+            for p in self.play_diffs + self.fragment_diffs
+        )
+
+
+def _step_key(step: dict[str, Any]) -> str:
+    """Return the natural key for a step.
+
+    Plain steps use ``subject``. Fragment references use ``fragment:<name>``
+    so the diff can detect fragment-reference additions / removals without
+    expanding the fragment inline.
+    """
+    fragment = step.get("fragment")
+    if fragment:
+        return f"fragment:{fragment}"
+    subject = step.get("subject")
+    if not subject:
+        raise ValueError(f"Step missing subject and fragment: {step!r}")
+    return str(subject)
+
+
+def _index_steps(steps: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Index steps by natural key. Later duplicates overwrite earlier ones."""
+    return {_step_key(step): step for step in steps if isinstance(step, dict)}
+
+
+def _diff_step(
+    *,
+    subject: str,
+    default_step: dict[str, Any],
+    user_step: dict[str, Any],
+) -> StepDiff:
+    """Diff one step that exists in both default and user playbooks."""
+    customized: list[str] = []
+    upstream_changed: list[FieldDiff] = []
+    for key in COMPARED_FIELDS:
+        default_value = default_step.get(key, MISSING)
+        user_value = user_step.get(key, MISSING)
+        if user_value is MISSING:
+            if default_value is MISSING:
+                continue
+            upstream_changed.append(
+                FieldDiff(
+                    field_name=key,
+                    default_value=default_value,
+                    user_value=MISSING,
+                )
+            )
+            continue
+        if user_value != default_value:
+            customized.append(key)
+    status = "changed" if upstream_changed or customized else "unchanged"
+    return StepDiff(
+        subject=subject,
+        status=status,
+        customized_fields=customized,
+        upstream_changed_fields=upstream_changed,
+    )
+
+
+def _diff_steps(
+    *,
+    default_steps: list[dict[str, Any]],
+    user_steps: list[dict[str, Any]],
+) -> list[StepDiff]:
+    """Compare two step lists by natural key.
+
+    Order is preserved using the default playbook as the canonical sequence:
+    default steps first (in their order), then user-only steps appended.
+    """
+    default_index = _index_steps(default_steps)
+    user_index = _index_steps(user_steps)
+    diffs: list[StepDiff] = []
+    for key, default_step in default_index.items():
+        if key in user_index:
+            diffs.append(
+                _diff_step(
+                    subject=key,
+                    default_step=default_step,
+                    user_step=user_index[key],
+                )
+            )
+        else:
+            diffs.append(StepDiff(subject=key, status="new"))
+    for key in user_index:
+        if key not in default_index:
+            diffs.append(StepDiff(subject=key, status="removed"))
+    return diffs
+
+
+def _user_play_steps(
+    *,
+    play_name: str,
+    user_doc: dict[str, Any],
+) -> list[dict[str, Any]] | None:
+    """Locate the user's override step list for a play, if any."""
+    for override in user_doc.get("overrides") or []:
+        if isinstance(override, dict) and override.get("play") == play_name:
+            steps = override.get("steps")
+            if isinstance(steps, list):
+                return steps
+    return None
+
+
+def _diff_play(
+    *,
+    play_name: str,
+    default_play: dict[str, Any],
+    user_steps: list[dict[str, Any]] | None,
+) -> PlayDiff:
+    """Diff one play. ``user_steps=None`` means the user has not overridden it."""
+    default_steps = default_play.get("steps") or []
+    if user_steps is None:
+        return PlayDiff(play_name=play_name, status="not-overridden")
+    step_diffs = _diff_steps(default_steps=default_steps, user_steps=user_steps)
+    has_changes = any(diff.status != "unchanged" for diff in step_diffs)
+    status = "changed" if has_changes else "unchanged"
+    return PlayDiff(play_name=play_name, status=status, step_diffs=step_diffs)
+
+
+def _diff_fragments(
+    *,
+    default_fragments: dict[str, Any],
+    user_fragments: dict[str, Any],
+) -> list[PlayDiff]:
+    """Diff fragment maps. Each fragment is treated as a tiny play."""
+    diffs: list[PlayDiff] = []
+    for name, default_steps in default_fragments.items():
+        if not isinstance(default_steps, list):
+            continue
+        user_steps = user_fragments.get(name)
+        if not isinstance(user_steps, list):
+            diffs.append(PlayDiff(play_name=name, status="not-overridden"))
+            continue
+        step_diffs = _diff_steps(default_steps=default_steps, user_steps=user_steps)
+        has_changes = any(d.status != "unchanged" for d in step_diffs)
+        diffs.append(
+            PlayDiff(
+                play_name=name,
+                status="changed" if has_changes else "unchanged",
+                step_diffs=step_diffs,
+            )
+        )
+    for name in user_fragments:
+        if name not in default_fragments:
+            diffs.append(PlayDiff(play_name=name, status="removed"))
+    return diffs
+
+
+def compare_playbooks(
+    *,
+    default_doc: dict[str, Any],
+    user_doc: dict[str, Any],
+    skill_key: str,
+    user_path: str,
+    default_path: str,
+) -> PlaybookDiff:
+    """Compare two parsed playbook documents.
+
+    Both inputs are the result of ``yaml.safe_load``. ``default_doc`` is
+    expected to follow the playbook schema (``defaults:`` map of plays);
+    ``user_doc`` follows the override schema (``overrides:`` list of plays).
+    Either may also define a top-level ``fragments:`` map.
+    """
+    defaults = default_doc.get("defaults") or {}
+    default_fragments = default_doc.get("fragments") or {}
+    user_fragments = user_doc.get("fragments") or {}
+
+    play_diffs: list[PlayDiff] = []
+    for play_name, default_play in defaults.items():
+        if not isinstance(default_play, dict):
+            continue
+        user_steps = _user_play_steps(play_name=play_name, user_doc=user_doc)
+        play_diffs.append(
+            _diff_play(
+                play_name=play_name,
+                default_play=default_play,
+                user_steps=user_steps,
+            )
+        )
+
+    # Flag user overrides for plays that no longer exist upstream.
+    default_play_names = set(defaults.keys())
+    for override in user_doc.get("overrides") or []:
+        if not isinstance(override, dict):
+            continue
+        play_name = override.get("play")
+        if play_name and play_name not in default_play_names:
+            play_diffs.append(PlayDiff(play_name=str(play_name), status="removed"))
+
+    fragment_diffs = _diff_fragments(
+        default_fragments=default_fragments,
+        user_fragments=user_fragments,
+    )
+
+    return PlaybookDiff(
+        skill_key=skill_key,
+        user_path=user_path,
+        default_path=default_path,
+        default_version=default_doc.get("version"),
+        user_version=user_doc.get("version"),
+        play_diffs=play_diffs,
+        fragment_diffs=fragment_diffs,
+    )

--- a/src/dev10x/skills/playbook/discovery.py
+++ b/src/dev10x/skills/playbook/discovery.py
@@ -1,0 +1,70 @@
+"""Locate user playbook overrides and matching plugin defaults (GH-192)."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+PROJECT_OVERRIDE_DIR = ".claude/Dev10x/playbooks"
+GLOBAL_OVERRIDE_DIR = "~/.claude/memory/Dev10x/playbooks"
+
+
+@dataclass(frozen=True)
+class UserPlaybook:
+    """One user playbook override on disk.
+
+    ``skill_key`` matches the skill directory name (e.g., ``work-on``).
+    ``scope`` is ``project`` for repo-local overrides and ``global`` for
+    user-home overrides.
+    """
+
+    skill_key: str
+    path: Path
+    scope: str  # "project" | "global"
+
+
+def _yaml_files(directory: Path) -> list[Path]:
+    """Return ``*.yaml`` files in ``directory`` (sorted, non-recursive).
+
+    Returns an empty list when the directory does not exist — playbook
+    overrides are optional and a missing directory is not an error.
+    """
+    if not directory.is_dir():
+        return []
+    return sorted(p for p in directory.glob("*.yaml") if p.is_file())
+
+
+def find_user_playbooks(
+    *,
+    project_root: Path | None = None,
+    home: Path | None = None,
+) -> list[UserPlaybook]:
+    """Find every user playbook override visible from ``project_root``.
+
+    Searches both the project-local override directory and the global
+    override directory under ``home``. ``project_root`` defaults to the
+    current working directory; ``home`` defaults to ``$HOME``.
+    """
+    root = project_root or Path.cwd()
+    home_dir = home or Path(os.path.expanduser("~"))
+    project_dir = root / PROJECT_OVERRIDE_DIR
+    global_dir = home_dir / Path(GLOBAL_OVERRIDE_DIR.replace("~/", ""))
+
+    found: list[UserPlaybook] = []
+    for path in _yaml_files(project_dir):
+        found.append(UserPlaybook(skill_key=path.stem, path=path, scope="project"))
+    for path in _yaml_files(global_dir):
+        found.append(UserPlaybook(skill_key=path.stem, path=path, scope="global"))
+    return found
+
+
+def plugin_default_path(*, skill_key: str, plugin_root: Path) -> Path:
+    """Return the path to the plugin default playbook for ``skill_key``.
+
+    The default playbook for any skill lives at
+    ``<plugin_root>/skills/<skill_key>/references/playbook.yaml``.
+    The path is returned whether or not it exists; callers decide how to
+    handle a missing default (typically: the skill is not playbook-powered).
+    """
+    return plugin_root / "skills" / skill_key / "references" / "playbook.yaml"

--- a/src/dev10x/skills/playbook/report.py
+++ b/src/dev10x/skills/playbook/report.py
@@ -1,0 +1,108 @@
+"""Render a ``PlaybookDiff`` as markdown for CLI output (GH-192)."""
+
+from __future__ import annotations
+
+from dev10x.skills.playbook.compare import (
+    MISSING,
+    FieldDiff,
+    PlaybookDiff,
+    PlayDiff,
+    StepDiff,
+)
+
+_MISSING_REPR = "<not set>"
+
+
+def _format_field_value(value: object) -> str:
+    """Render a field value for display, eliding long prompts."""
+    if isinstance(value, str):
+        compact = " ".join(value.split())
+        if len(compact) > 80:
+            return f"{compact[:77]}..."
+        return compact
+    return repr(value)
+
+
+def _render_field_diff(diff: FieldDiff) -> str:
+    default_repr = _format_field_value(diff.default_value)
+    user_repr = (
+        _MISSING_REPR if diff.user_value is MISSING else _format_field_value(diff.user_value)
+    )
+    return f"  - `{diff.field_name}`: default=`{default_repr}` user=`{user_repr}`"
+
+
+def _render_step(step_diff: StepDiff) -> list[str]:
+    symbol = {
+        "new": "+",
+        "removed": "-",
+        "changed": "~",
+        "unchanged": " ",
+    }.get(step_diff.status, "?")
+    header = f"{symbol} **{step_diff.subject}** _({step_diff.status})_"
+    lines = [header]
+    if step_diff.customized_fields:
+        joined = ", ".join(sorted(step_diff.customized_fields))
+        lines.append(f"    customized (preserved): {joined}")
+    for field_diff in step_diff.upstream_changed_fields:
+        lines.append(_render_field_diff(field_diff))
+    return lines
+
+
+def _render_play(play: PlayDiff, *, kind: str) -> list[str]:
+    heading = f"### {kind}: `{play.play_name}` — {play.status}"
+    if play.status == "unchanged":
+        return [heading, "  (no upstream changes detected)"]
+    if play.status == "not-overridden":
+        return [heading, "  (user has not overridden this — defaults apply)"]
+    if play.status == "removed":
+        return [heading, "  (no longer present in plugin default — orphan override)"]
+    lines: list[str] = [heading]
+    for step_diff in play.step_diffs:
+        if step_diff.status == "unchanged":
+            continue
+        lines.extend(_render_step(step_diff))
+    return lines
+
+
+def render_markdown_report(diff: PlaybookDiff) -> str:
+    """Render a ``PlaybookDiff`` as a human-readable markdown report."""
+    lines: list[str] = []
+    lines.append(f"## Playbook diff: `{diff.skill_key}`")
+    lines.append("")
+    lines.append(f"- user: `{diff.user_path}`")
+    lines.append(f"- default: `{diff.default_path}`")
+    if diff.default_version or diff.user_version:
+        lines.append(f"- versions: default=`{diff.default_version}` user=`{diff.user_version}`")
+    lines.append("")
+
+    if not diff.has_findings:
+        lines.append("**No upstream changes detected.** User customizations are up to date.")
+        return "\n".join(lines) + "\n"
+
+    overridden = [p for p in diff.play_diffs if p.status not in ("unchanged", "not-overridden")]
+    if overridden:
+        lines.append("### Plays with upstream changes")
+        lines.append("")
+        for play in overridden:
+            lines.extend(_render_play(play, kind="Play"))
+            lines.append("")
+
+    fragments_with_changes = [
+        f for f in diff.fragment_diffs if f.status not in ("unchanged", "not-overridden")
+    ]
+    if fragments_with_changes:
+        lines.append("### Fragments with upstream changes")
+        lines.append("")
+        for fragment in fragments_with_changes:
+            lines.extend(_render_play(fragment, kind="Fragment"))
+            lines.append("")
+
+    lines.append("### How to apply")
+    lines.append("")
+    lines.append(
+        "Customized fields are listed under each step and will **not** be"
+        " overwritten. Run `/Dev10x:playbook edit <skill> <play>` to pull"
+        " in upstream changes interactively, or edit the user YAML"
+        " directly to add the new steps shown above."
+    )
+    return "\n".join(lines) + "\n"

--- a/tests/skills/playbook/test_compare.py
+++ b/tests/skills/playbook/test_compare.py
@@ -1,0 +1,235 @@
+"""Tests for ``dev10x.skills.playbook.compare`` (GH-192)."""
+
+from __future__ import annotations
+
+import pytest
+
+from dev10x.skills.playbook.compare import (
+    MISSING,
+    compare_playbooks,
+)
+
+
+@pytest.fixture
+def default_doc() -> dict:
+    return {
+        "version": "0.72.0",
+        "fragments": {
+            "shipping": [
+                {"subject": "Commit", "type": "detailed", "skills": ["dev10x:git-commit"]},
+                {"subject": "Create PR", "type": "detailed", "skills": ["dev10x:gh-pr-create"]},
+            ]
+        },
+        "defaults": {
+            "feature": {
+                "prompt": "Use when adding new functionality.",
+                "steps": [
+                    {"subject": "Set up workspace", "type": "detailed"},
+                    {"subject": "Implement", "type": "epic", "prompt": "Do the work."},
+                    {"fragment": "shipping"},
+                ],
+            },
+            "bugfix": {
+                "steps": [
+                    {"subject": "Reproduce", "type": "detailed"},
+                    {"subject": "Fix", "type": "epic"},
+                ]
+            },
+        },
+    }
+
+
+def _diff(default_doc: dict, user_doc: dict):
+    return compare_playbooks(
+        default_doc=default_doc,
+        user_doc=user_doc,
+        skill_key="work-on",
+        user_path="/u/playbook.yaml",
+        default_path="/p/playbook.yaml",
+    )
+
+
+class TestComparePlaybooks:
+    def test_no_overrides_marks_all_plays_not_overridden(self, default_doc: dict) -> None:
+        result = _diff(default_doc, {})
+        statuses = {p.play_name: p.status for p in result.play_diffs}
+        assert statuses == {"feature": "not-overridden", "bugfix": "not-overridden"}
+        assert not result.has_findings
+
+    def test_identical_override_is_unchanged(self, default_doc: dict) -> None:
+        user = {
+            "overrides": [
+                {
+                    "play": "feature",
+                    "steps": [
+                        {"subject": "Set up workspace", "type": "detailed"},
+                        {"subject": "Implement", "type": "epic", "prompt": "Do the work."},
+                        {"fragment": "shipping"},
+                    ],
+                }
+            ]
+        }
+        result = _diff(default_doc, user)
+        feature = next(p for p in result.play_diffs if p.play_name == "feature")
+        assert feature.status == "unchanged"
+
+    def test_upstream_added_step_marked_new(self, default_doc: dict) -> None:
+        user = {
+            "overrides": [
+                {
+                    "play": "feature",
+                    "steps": [
+                        {"subject": "Set up workspace", "type": "detailed"},
+                        {"fragment": "shipping"},
+                    ],
+                }
+            ]
+        }
+        result = _diff(default_doc, user)
+        feature = next(p for p in result.play_diffs if p.play_name == "feature")
+        assert feature.status == "changed"
+        new_steps = [s for s in feature.step_diffs if s.status == "new"]
+        assert [s.subject for s in new_steps] == ["Implement"]
+
+    def test_user_only_step_marked_removed(self, default_doc: dict) -> None:
+        user = {
+            "overrides": [
+                {
+                    "play": "feature",
+                    "steps": [
+                        {"subject": "Set up workspace", "type": "detailed"},
+                        {"subject": "Implement", "type": "epic", "prompt": "Do the work."},
+                        {"subject": "Extra user step", "type": "detailed"},
+                        {"fragment": "shipping"},
+                    ],
+                }
+            ]
+        }
+        result = _diff(default_doc, user)
+        feature = next(p for p in result.play_diffs if p.play_name == "feature")
+        removed = [s for s in feature.step_diffs if s.status == "removed"]
+        assert [s.subject for s in removed] == ["Extra user step"]
+
+    def test_user_customized_field_is_preserved(self, default_doc: dict) -> None:
+        """A user-set field that differs from default is reported as customized,
+        not as an upstream-changed field."""
+        user = {
+            "overrides": [
+                {
+                    "play": "feature",
+                    "steps": [
+                        {"subject": "Set up workspace", "type": "detailed"},
+                        {
+                            "subject": "Implement",
+                            "type": "epic",
+                            "prompt": "Custom prompt — preserved.",
+                        },
+                        {"fragment": "shipping"},
+                    ],
+                }
+            ]
+        }
+        result = _diff(default_doc, user)
+        feature = next(p for p in result.play_diffs if p.play_name == "feature")
+        implement = next(s for s in feature.step_diffs if s.subject == "Implement")
+        assert implement.status == "changed"
+        assert "prompt" in implement.customized_fields
+        assert implement.upstream_changed_fields == []
+
+    def test_user_missing_field_present_in_default_is_upstream_change(
+        self, default_doc: dict
+    ) -> None:
+        """When the default sets a field the user hasn't, the user would
+        inherit a new value — flag it as an upstream change."""
+        user = {
+            "overrides": [
+                {
+                    "play": "feature",
+                    "steps": [
+                        {"subject": "Set up workspace", "type": "detailed"},
+                        {"subject": "Implement", "type": "epic"},  # missing prompt
+                        {"fragment": "shipping"},
+                    ],
+                }
+            ]
+        }
+        result = _diff(default_doc, user)
+        feature = next(p for p in result.play_diffs if p.play_name == "feature")
+        implement = next(s for s in feature.step_diffs if s.subject == "Implement")
+        assert implement.status == "changed"
+        assert implement.customized_fields == []
+        field_names = [f.field_name for f in implement.upstream_changed_fields]
+        assert field_names == ["prompt"]
+        assert implement.upstream_changed_fields[0].user_value is MISSING
+
+    def test_orphan_user_play_marked_removed(self, default_doc: dict) -> None:
+        user = {
+            "overrides": [
+                {
+                    "play": "legacy-play-no-longer-in-defaults",
+                    "steps": [{"subject": "X", "type": "detailed"}],
+                }
+            ]
+        }
+        result = _diff(default_doc, user)
+        orphan = next(
+            p for p in result.play_diffs if p.play_name == "legacy-play-no-longer-in-defaults"
+        )
+        assert orphan.status == "removed"
+
+    def test_fragment_diff_detects_new_step(self, default_doc: dict) -> None:
+        user = {
+            "fragments": {
+                "shipping": [
+                    {"subject": "Commit", "type": "detailed", "skills": ["dev10x:git-commit"]},
+                    # missing "Create PR" — should appear as new upstream step
+                ]
+            }
+        }
+        result = _diff(default_doc, user)
+        shipping = next(f for f in result.fragment_diffs if f.play_name == "shipping")
+        assert shipping.status == "changed"
+        new_steps = [s for s in shipping.step_diffs if s.status == "new"]
+        assert [s.subject for s in new_steps] == ["Create PR"]
+
+    def test_fragment_not_overridden_when_user_omits_it(self, default_doc: dict) -> None:
+        result = _diff(default_doc, {})
+        shipping = next(f for f in result.fragment_diffs if f.play_name == "shipping")
+        assert shipping.status == "not-overridden"
+
+    def test_fragment_reference_treated_as_step(self, default_doc: dict) -> None:
+        """A bare ``- fragment: shipping`` entry should match a matching
+        reference in the default — not be flagged as a new step."""
+        user = {
+            "overrides": [
+                {
+                    "play": "feature",
+                    "steps": [
+                        {"subject": "Set up workspace", "type": "detailed"},
+                        {"subject": "Implement", "type": "epic", "prompt": "Do the work."},
+                        {"fragment": "shipping"},
+                    ],
+                }
+            ]
+        }
+        result = _diff(default_doc, user)
+        feature = next(p for p in result.play_diffs if p.play_name == "feature")
+        assert feature.status == "unchanged"
+
+    def test_has_findings_false_for_clean_diff(self, default_doc: dict) -> None:
+        result = _diff(default_doc, {})
+        assert result.has_findings is False
+
+    def test_has_findings_true_when_play_changes(self, default_doc: dict) -> None:
+        user = {
+            "overrides": [
+                {
+                    "play": "feature",
+                    "steps": [
+                        {"subject": "Set up workspace", "type": "detailed"},
+                    ],
+                }
+            ]
+        }
+        result = _diff(default_doc, user)
+        assert result.has_findings is True

--- a/tests/skills/playbook/test_discovery.py
+++ b/tests/skills/playbook/test_discovery.py
@@ -1,0 +1,52 @@
+"""Tests for ``dev10x.skills.playbook.discovery`` (GH-192)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dev10x.skills.playbook.discovery import (
+    find_user_playbooks,
+    plugin_default_path,
+)
+
+
+class TestFindUserPlaybooks:
+    def test_returns_empty_when_no_overrides_exist(self, tmp_path: Path) -> None:
+        assert find_user_playbooks(project_root=tmp_path, home=tmp_path / "home") == []
+
+    def test_finds_project_local_overrides(self, tmp_path: Path) -> None:
+        project_dir = tmp_path / ".claude" / "Dev10x" / "playbooks"
+        project_dir.mkdir(parents=True)
+        (project_dir / "work-on.yaml").write_text("overrides: []")
+        found = find_user_playbooks(project_root=tmp_path, home=tmp_path / "home")
+        assert len(found) == 1
+        assert found[0].skill_key == "work-on"
+        assert found[0].scope == "project"
+
+    def test_finds_global_overrides(self, tmp_path: Path) -> None:
+        home = tmp_path / "home"
+        global_dir = home / ".claude" / "memory" / "Dev10x" / "playbooks"
+        global_dir.mkdir(parents=True)
+        (global_dir / "release-notes.yaml").write_text("overrides: []")
+        found = find_user_playbooks(project_root=tmp_path, home=home)
+        assert len(found) == 1
+        assert found[0].skill_key == "release-notes"
+        assert found[0].scope == "global"
+
+    def test_returns_both_scopes(self, tmp_path: Path) -> None:
+        home = tmp_path / "home"
+        project_dir = tmp_path / ".claude" / "Dev10x" / "playbooks"
+        global_dir = home / ".claude" / "memory" / "Dev10x" / "playbooks"
+        project_dir.mkdir(parents=True)
+        global_dir.mkdir(parents=True)
+        (project_dir / "work-on.yaml").write_text("overrides: []")
+        (global_dir / "work-on.yaml").write_text("overrides: []")
+        found = find_user_playbooks(project_root=tmp_path, home=home)
+        scopes = sorted(p.scope for p in found)
+        assert scopes == ["global", "project"]
+
+
+class TestPluginDefaultPath:
+    def test_builds_expected_path(self, tmp_path: Path) -> None:
+        result = plugin_default_path(skill_key="work-on", plugin_root=tmp_path)
+        assert result == tmp_path / "skills" / "work-on" / "references" / "playbook.yaml"

--- a/tests/skills/playbook/test_report.py
+++ b/tests/skills/playbook/test_report.py
@@ -1,0 +1,138 @@
+"""Tests for ``dev10x.skills.playbook.report`` (GH-192)."""
+
+from __future__ import annotations
+
+from dev10x.skills.playbook.compare import compare_playbooks
+from dev10x.skills.playbook.report import render_markdown_report
+
+
+def _diff(default_doc: dict, user_doc: dict):
+    return compare_playbooks(
+        default_doc=default_doc,
+        user_doc=user_doc,
+        skill_key="work-on",
+        user_path="/u/playbook.yaml",
+        default_path="/p/playbook.yaml",
+    )
+
+
+def test_no_findings_emits_up_to_date_message() -> None:
+    default = {"defaults": {"feature": {"steps": [{"subject": "A", "type": "detailed"}]}}}
+    rendered = render_markdown_report(_diff(default, {}))
+    assert "No upstream changes detected" in rendered
+    assert "work-on" in rendered
+
+
+def test_new_step_appears_in_report() -> None:
+    default = {
+        "defaults": {
+            "feature": {
+                "steps": [
+                    {"subject": "Existing", "type": "detailed"},
+                    {"subject": "Brand new step", "type": "detailed"},
+                ]
+            }
+        }
+    }
+    user = {
+        "overrides": [
+            {
+                "play": "feature",
+                "steps": [{"subject": "Existing", "type": "detailed"}],
+            }
+        ]
+    }
+    rendered = render_markdown_report(_diff(default, user))
+    assert "Brand new step" in rendered
+    assert "(new)" in rendered
+
+
+def test_customized_field_is_marked_preserved() -> None:
+    default = {
+        "defaults": {
+            "feature": {
+                "steps": [
+                    {"subject": "A", "type": "detailed", "prompt": "default prompt"},
+                ]
+            }
+        }
+    }
+    user = {
+        "overrides": [
+            {
+                "play": "feature",
+                "steps": [
+                    {"subject": "A", "type": "detailed", "prompt": "user prompt"},
+                ],
+            }
+        ]
+    }
+    rendered = render_markdown_report(_diff(default, user))
+    assert "customized" in rendered
+    assert "prompt" in rendered
+
+
+def test_upstream_changed_field_shows_default_and_missing_user() -> None:
+    default = {
+        "defaults": {
+            "feature": {
+                "steps": [
+                    {"subject": "A", "type": "detailed", "prompt": "new default prompt"},
+                ]
+            }
+        }
+    }
+    user = {
+        "overrides": [
+            {
+                "play": "feature",
+                "steps": [{"subject": "A", "type": "detailed"}],
+            }
+        ]
+    }
+    rendered = render_markdown_report(_diff(default, user))
+    assert "new default prompt" in rendered
+    assert "<not set>" in rendered
+
+
+def test_long_prompts_are_elided() -> None:
+    long_prompt = "x " * 200
+    default = {
+        "defaults": {
+            "feature": {"steps": [{"subject": "A", "type": "detailed", "prompt": long_prompt}]}
+        }
+    }
+    user = {
+        "overrides": [
+            {
+                "play": "feature",
+                "steps": [{"subject": "A", "type": "detailed"}],
+            }
+        ]
+    }
+    rendered = render_markdown_report(_diff(default, user))
+    assert "..." in rendered
+
+
+def test_orphan_play_message_present() -> None:
+    default = {"defaults": {"feature": {"steps": []}}}
+    user = {"overrides": [{"play": "ghost-play", "steps": [{"subject": "X", "type": "detailed"}]}]}
+    rendered = render_markdown_report(_diff(default, user))
+    assert "ghost-play" in rendered
+    assert "orphan" in rendered
+
+
+def test_fragment_changes_section_appears() -> None:
+    default = {
+        "fragments": {
+            "shipping": [
+                {"subject": "Step1", "type": "detailed"},
+                {"subject": "Step2", "type": "detailed"},
+            ]
+        },
+        "defaults": {"feature": {"steps": []}},
+    }
+    user = {"fragments": {"shipping": [{"subject": "Step1", "type": "detailed"}]}}
+    rendered = render_markdown_report(_diff(default, user))
+    assert "Fragments with upstream changes" in rendered
+    assert "Step2" in rendered


### PR DESCRIPTION
**When** maintaining a Dev10x install across plugin upgrades, **I want to** see exactly which steps changed upstream in playbooks I have customized, **so that** I **can** pull in upstream improvements without losing my edits.

## What changed

Adds `dev10x playbook diff` — a read-only command that compares user playbook overrides under `.claude/Dev10x/playbooks/` and `~/.claude/memory/Dev10x/playbooks/` against the plugin defaults in `${CLAUDE_PLUGIN_ROOT}/skills/<key>/references/playbook.yaml`.

For each user override the diff reports:

- **New** — steps present in the plugin default but missing from the user override (typically upstream additions worth pulling in).
- **Removed** — steps or whole plays the user has that no longer exist in the default (either intentional pruning or upstream removal).
- **Changed** — a field whose default value moved upstream where the user has not overridden it.
- **Customized** — fields the user has explicitly set; flagged as preserved. The diff never proposes overwriting them.

Wires the new command into `Dev10x:plugin-maintenance` full mode as step 13, so it runs automatically during `Dev10x:upgrade-cleanup` after `claude plugin update`.

## Files

- `src/dev10x/skills/playbook/{__init__,compare,discovery,report}.py` — core comparison + reporting
- `src/dev10x/commands/playbook.py` — Click CLI group with `diff` subcommand
- `src/dev10x/cli.py` — register `playbook` as a lazy subgroup
- `skills/plugin-maintenance/SKILL.md` — document step 13 (`dev10x playbook diff`)
- `tests/skills/playbook/test_{compare,discovery,report}.py` — 24 tests covering comparison semantics, fragment handling, orphan plays, customized-field preservation, and report rendering

Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/192
