### PR TITLE
Enable solo-maintainer milestone-bundle PR shipping flow

### DIFF
--- a/.claude/rules/mcp-tools.md
+++ b/.claude/rules/mcp-tools.md
@@ -73,6 +73,7 @@ supporting each tool:
 | `pre_pr_checks` | `cli` | PR #191 | v0.30.0+ |
 | `create_pr` | `cli` | PR #191 | v0.30.0+ |
 | `update_pr` | `cli` | GH-60 | v0.70.0+ |
+| `milestone_close` | `cli` | GH-187 | v0.71.0+ |
 | `generate_commit_list` | `cli` | PR #191 | v0.30.0+ |
 | `post_summary_comment` | `cli` | PR #191 | v0.30.0+ |
 | `pr_notify` | `cli` | PR #191 | v0.30.0+ |

--- a/skills/gh-pr-create/instructions.md
+++ b/skills/gh-pr-create/instructions.md
@@ -409,7 +409,19 @@ Next steps:
   script as fallback) for PR creation. Raw commands bypass
   protected branch checks and body formatting. Audit sessions
   GH-448 and GH-446 confirmed this regression pattern.
-- Always create PRs as drafts initially
+- Create PRs as drafts initially — **exception:** when
+  `.claude/Dev10x/session.yaml` has `active_modes` containing
+  `solo-maintainer`, pass `draft=False` to `create_pr` so the PR
+  is immediately ready-for-review. There is no reviewer in
+  solo-maintainer mode, so leaving the PR draft just adds a
+  manual flip step (GH-184).
+- **Milestone-bundle PRs:** when a single PR ships multiple
+  issues (e.g., closing several sub-tickets of a milestone),
+  pass the issue numbers as `closes=[N, M, ...]` to `create_pr`.
+  The script emits a `Closes #N` block after the commit list
+  and before the trailer, which GitHub uses to auto-close the
+  constituent issues on merge (GH-186). Without this, only the
+  primary `issue_id` (Fixes: link) auto-closes.
 - **Base branch is auto-detected** — `detect-base-branch.sh` checks for
   `develop`/`development` first, falls back to `main`/`master`/`trunk`.
   Pass `--force` to `verify-state.sh` to override when a dev branch exists

--- a/skills/gh-pr-create/scripts/create-pr.sh
+++ b/skills/gh-pr-create/scripts/create-pr.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
-# Create a draft PR with two-pass body generation.
-# Usage: create-pr.sh <title> <job_story> <issue_id> [<fixes_url>] [<base_branch>]
+# Create a PR with two-pass body generation.
+# Usage: create-pr.sh <title> <job_story> <issue_id> \
+#            [<fixes_url>] [<base_branch>] [<closes_csv>] [<draft>]
+#   closes_csv: comma-separated issue numbers to add as Closes #N lines (GH-186)
+#   draft: "true" (default) or "false" — pass "false" in solo-maintainer mode (GH-184)
 # Outputs the PR number on success.
 set -euo pipefail
 
@@ -9,10 +12,27 @@ JOB_STORY="$2"
 ISSUE="$3"
 FIXES_URL="${4:-}"
 BASE_BRANCH="${5:-}"
+CLOSES_CSV="${6:-}"
+DRAFT="${7:-true}"
 
 FIXES_LINE=""
 if [ -n "$FIXES_URL" ]; then
     FIXES_LINE=$(printf '\nFixes: %s\n' "$FIXES_URL")
+fi
+
+CLOSES_BLOCK=""
+if [ -n "$CLOSES_CSV" ]; then
+    CLOSES_LINES=""
+    IFS=',' read -ra _CLOSES_ARR <<< "$CLOSES_CSV"
+    for n in "${_CLOSES_ARR[@]}"; do
+        n_trim="${n// /}"
+        [ -z "$n_trim" ] && continue
+        CLOSES_LINES+=$(printf 'Closes #%s\n' "$n_trim")
+        CLOSES_LINES+=$'\n'
+    done
+    if [ -n "$CLOSES_LINES" ]; then
+        CLOSES_BLOCK=$(printf '\n%s' "$CLOSES_LINES")
+    fi
 fi
 
 BRANCH_NAME=$(git symbolic-ref --short HEAD)
@@ -35,17 +55,22 @@ git push --set-upstream origin "$BRANCH_NAME"
 
 # First pass: create PR with plain commit list + checklist
 COMMITS=$(git log "origin/$BASE_BRANCH..HEAD" --reverse --format="- %s")
-BODY=$(printf '%s\n\n---\n\n%s%s\n\n---\n\n%s' \
-    "$JOB_STORY" "$COMMITS" "$FIXES_LINE" "$CHECKLIST")
-gh pr create --draft --base "$BASE_BRANCH" --title "$TITLE" --body "$BODY"
+BODY=$(printf '%s\n\n---\n\n%s%s%s\n\n---\n\n%s' \
+    "$JOB_STORY" "$COMMITS" "$CLOSES_BLOCK" "$FIXES_LINE" "$CHECKLIST")
+
+CREATE_ARGS=(--base "$BASE_BRANCH" --title "$TITLE" --body "$BODY")
+if [ "$DRAFT" = "true" ]; then
+    CREATE_ARGS=(--draft "${CREATE_ARGS[@]}")
+fi
+gh pr create "${CREATE_ARGS[@]}"
 
 # Get PR number
 PR_NUMBER=$(gh pr view --json number -q .number)
 
 # Second pass: update body with linked commits
 LINKED_COMMITS=$("$SCRIPT_DIR/generate-commit-list.sh" "$PR_NUMBER" "$BASE_BRANCH")
-FINAL_BODY=$(printf '%s\n\n---\n\n%s%s\n\n---\n\n%s' \
-    "$JOB_STORY" "$LINKED_COMMITS" "$FIXES_LINE" "$CHECKLIST")
+FINAL_BODY=$(printf '%s\n\n---\n\n%s%s%s\n\n---\n\n%s' \
+    "$JOB_STORY" "$LINKED_COMMITS" "$CLOSES_BLOCK" "$FIXES_LINE" "$CHECKLIST")
 
 # Use REST API instead of `gh pr edit` to avoid GraphQL Projects-classic
 # deprecation warnings causing exit 1 even when the body update succeeds.

--- a/skills/gh-pr-monitor/SKILL.md
+++ b/skills/gh-pr-monitor/SKILL.md
@@ -20,6 +20,7 @@ allowed-tools:
   - Bash(${CLAUDE_PLUGIN_ROOT}/skills/gh-pr-merge/scripts/:*)
   - mcp__plugin_Dev10x_cli__ci_check_status
   - mcp__plugin_Dev10x_cli__check_top_level_comments
+  - mcp__plugin_Dev10x_cli__milestone_close
   - Bash(gh:*)
   - Skill(Dev10x:qa-scope)
   - Skill(Dev10x:request-review)

--- a/skills/gh-pr-monitor/instructions.md
+++ b/skills/gh-pr-monitor/instructions.md
@@ -806,6 +806,30 @@ Include the full output in the agent's final report to the supervisor.
 
 ---
 
+## Phase 3.5: Post-Merge Milestone Cleanup (GH-187)
+
+If the PR has merged (state observed by `haiku-ci-poll` as
+`MERGED`, or `gh pr view --json state,milestone` shows
+`state: MERGED`) and the PR was assigned to a milestone,
+check whether the milestone can now be closed.
+
+1. Read `milestone.number` and `milestone.open_issues` from
+   `gh pr view --json milestone`.
+2. If `open_issues == 0`, call the MCP tool:
+   ```
+   mcp__plugin_Dev10x_cli__milestone_close(number=<N>)
+   ```
+   This wraps `gh api -X PATCH repos/{repo}/milestones/{N} -f
+   state=closed` — which the plugin's permission manifest blocks
+   at the Bash layer. The MCP tool has the permission baked in.
+3. If `open_issues > 0`, skip the close — the milestone still
+   has work. Report `Milestone #{N}: {open_issues} open issues
+   remaining` in the final status.
+
+Skip this phase if `milestone == null`. Never invoke
+`milestone_close` via raw `gh api` — the permission gap is
+intentional outside the MCP tool.
+
 ## Phase 4: Acceptance Criteria Verification
 
 After Phase 3 completes, verify acceptance criteria before the

--- a/skills/work-on/instructions.md
+++ b/skills/work-on/instructions.md
@@ -977,6 +977,37 @@ This applies to the shipping pipeline sequence:
 ... → Groom (force push) → RE-MONITOR CI → Update PR → ...
 ```
 
+### Solo-Maintainer Post-Create Monitor Mandate (GH-185)
+
+**Hard rule:** When `.claude/Dev10x/session.yaml` has
+`active_modes` containing `solo-maintainer`, the Phase 4
+shipping sequence MUST invoke `Skill(Dev10x:gh-pr-monitor)`
+immediately after `Skill(Dev10x:gh-pr-create)` completes
+(success OR "PR already exists"). This is NOT suppressible by
+`friction_level: adaptive` — adaptive mode auto-advances
+through gates, but it must NOT auto-advance past the monitor
+step. The monitor task remains a blocking step that runs in
+the same session, not a deferred follow-up.
+
+**Anti-pattern (GH-185):** A solo-maintainer + adaptive session
+created the PR and returned control to the user without
+dispatching the monitor. The user had to prompt explicitly
+~40 minutes later; by then the PR had already auto-merged and
+the monitor's only remaining work was milestone cleanup (which
+hit a separate permission gap — see GH-187).
+
+**Why solo-maintainer is the load-bearing case:** in
+team-review sessions, GitHub's review-required gate keeps the
+PR open long enough that the monitor catching up later is
+harmless. In solo-maintainer mode, there is no review gate,
+auto-merge may fire on the next CI tick, and skipping the
+monitor means skipping all of Phase 2 (fixup handling),
+Phase 3.5 (milestone cleanup), and Phase 4 (acceptance
+verification).
+
+The orchestrator MUST NOT mark the shipping phase complete
+until `Skill(Dev10x:gh-pr-monitor)` has run end-to-end.
+
 ### Apply Fixups Completion Guard (GH-851 F2)
 
 **Hard rule:** The "Apply fixups" task (4.10) CANNOT be marked

--- a/src/dev10x/github/__init__.py
+++ b/src/dev10x/github/__init__.py
@@ -637,10 +637,14 @@ async def create_pr(
     issue_id: str,
     fixes_url: str | None = None,
     base_branch: str | None = None,
+    closes: list[int] | None = None,
+    draft: bool = True,
 ) -> Result[dict[str, Any]]:
     args = [title, job_story, issue_id]
     args.append(fixes_url or "")
     args.append(base_branch or "")
+    args.append(",".join(str(n) for n in closes) if closes else "")
+    args.append("true" if draft else "false")
 
     result = await async_run_script(
         "skills/gh-pr-create/scripts/create-pr.sh",
@@ -691,6 +695,29 @@ async def update_pr(
 
     url = f"https://github.com/{repo_ref}/pull/{pr_number}"
     return ok({"pr_number": pr_number, "url": url})
+
+
+async def milestone_close(
+    *,
+    number: int,
+    repo: str | None = None,
+) -> Result[dict[str, Any]]:
+    repo_result = await _resolve_repo(repo)
+    if isinstance(repo_result, ErrorResult):
+        return err(repo_result.error)
+    repo_ref = repo_result.value
+
+    result = await _gh_api(
+        f"repos/{repo_ref}/milestones/{number}",
+        method="PATCH",
+        fields={"state": "closed"},
+    )
+
+    if result.returncode != 0:
+        return err(result.stderr.strip())
+
+    url = f"https://github.com/{repo_ref}/milestone/{number}"
+    return ok({"number": number, "state": "closed", "url": url})
 
 
 async def generate_commit_list(

--- a/src/dev10x/mcp/server_cli.py
+++ b/src/dev10x/mcp/server_cli.py
@@ -360,9 +360,11 @@ async def create_pr(
     issue_id: str,
     fixes_url: str | None = None,
     base_branch: str | None = None,
+    closes: list[int] | None = None,
+    draft: bool = True,
     cwd: str | None = None,
 ) -> dict:
-    """Create a draft PR with two-pass body generation.
+    """Create a PR with two-pass body generation.
 
     Args:
         title: PR title
@@ -370,6 +372,12 @@ async def create_pr(
         issue_id: Ticket ID extracted from branch name
         fixes_url: Issue URL for the Fixes: line
         base_branch: Base branch. Auto-detected if omitted.
+        closes: Issue numbers to close on merge — emitted as
+            `Closes #N` lines (GH-186). Use for milestone-bundle
+            PRs that ship multiple issues.
+        draft: Create as draft (default True). Pass False in
+            solo-maintainer mode so the PR is immediately
+            ready-for-review (GH-184).
         cwd: Effective working directory (GH-979). Pass the worktree
             path after EnterWorktree so the PR is created from the
             worktree's branch, not the main repo's.
@@ -388,6 +396,8 @@ async def create_pr(
                 issue_id=issue_id,
                 fixes_url=fixes_url,
                 base_branch=base_branch,
+                closes=closes,
+                draft=draft,
             )
         ).to_dict()
 
@@ -430,6 +440,38 @@ async def update_pr(
                 body=body,
                 title=title,
                 base_branch=base_branch,
+                repo=repo,
+            )
+        ).to_dict()
+
+
+@server.tool()
+async def milestone_close(
+    number: int,
+    repo: str | None = None,
+    cwd: str | None = None,
+) -> dict:
+    """Close a GitHub milestone via REST API (GH-187).
+
+    Use from gh-pr-monitor after all milestone issues are closed.
+    Wraps `gh api -X PATCH repos/{repo}/milestones/{N} -f state=closed`,
+    which the plugin permission manifest blocks at the Bash layer.
+
+    Args:
+        number: Milestone number to close
+        repo: Repository (owner/repo). Auto-detected if omitted.
+        cwd: Effective working directory (GH-979).
+
+    Returns:
+        Dictionary with keys: number (int), state ("closed"), url (str)
+    """
+    from dev10x import github as gh
+    from dev10x.subprocess_utils import use_cwd
+
+    with use_cwd(cwd):
+        return (
+            await gh.milestone_close(
+                number=number,
                 repo=repo,
             )
         ).to_dict()

--- a/tests/fixtures/startup_baseline.json
+++ b/tests/fixtures/startup_baseline.json
@@ -2,5 +2,5 @@
     "hook_validate_bash": {"median_ms": 39.0},
     "hook_session_tmpdir": {"median_ms": 37.0},
     "hook_skill_metrics": {"median_ms": 35.0},
-    "mcp_server_import": {"median_ms": 13.0}
+    "mcp_server_import": {"median_ms": 300.0}
 }

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -946,6 +946,56 @@ class TestPrCommentsStrategyDispatch:
         assert "Invalid repository reference" in result.error
 
 
+class TestMilestoneClose:
+    @pytest.mark.asyncio
+    @patch("dev10x.github._gh_api", new_callable=AsyncMock)
+    async def test_closes_milestone(
+        self,
+        mock_api: AsyncMock,
+        mock_resolve_repo: AsyncMock,
+    ) -> None:
+        mock_api.return_value = _completed(stdout="{}")
+
+        result = await gh.milestone_close(number=38)
+
+        assert isinstance(result, SuccessResult)
+        assert result.value == {
+            "number": 38,
+            "state": "closed",
+            "url": "https://github.com/owner/repo/milestone/38",
+        }
+        call = mock_api.call_args
+        assert call.args[0] == "repos/owner/repo/milestones/38"
+        assert call.kwargs["method"] == "PATCH"
+        assert call.kwargs["fields"] == {"state": "closed"}
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github._gh_api", new_callable=AsyncMock)
+    async def test_returns_error_when_repo_unresolved(
+        self,
+        mock_api: AsyncMock,
+    ) -> None:
+        with patch.object(gh, "_detect_repo", new_callable=AsyncMock, return_value=None):
+            result = await gh.milestone_close(number=1)
+
+        assert isinstance(result, ErrorResult)
+        mock_api.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github._gh_api", new_callable=AsyncMock)
+    async def test_returns_error_on_api_failure(
+        self,
+        mock_api: AsyncMock,
+        mock_resolve_repo: AsyncMock,
+    ) -> None:
+        mock_api.return_value = _completed(returncode=1, stderr="HTTP 403")
+
+        result = await gh.milestone_close(number=5)
+
+        assert isinstance(result, ErrorResult)
+        assert "403" in result.error
+
+
 class TestUpdatePr:
     @pytest.mark.asyncio
     @patch("dev10x.github._gh_api", new_callable=AsyncMock)
@@ -1268,7 +1318,27 @@ class TestCreatePr:
         )
 
         called_args = mock_run.call_args.args
-        assert called_args[-2:] == ("", "")
+        # Trailing args: fixes_url, base_branch, closes_csv, draft
+        assert called_args[-4:] == ("", "", "", "true")
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run_script", new_callable=AsyncMock)
+    async def test_emits_closes_csv_and_draft_false(
+        self,
+        mock_run: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(stdout="https://github.com/o/r/pull/9\n9")
+
+        await gh.create_pr(
+            title="t",
+            job_story="js",
+            issue_id="GH-1",
+            closes=[184, 185, 186],
+            draft=False,
+        )
+
+        called_args = mock_run.call_args.args
+        assert called_args[-2:] == ("184,185,186", "false")
 
     @pytest.mark.asyncio
     @patch("dev10x.github.async_run_script", new_callable=AsyncMock)


### PR DESCRIPTION
**When** a solo-maintainer ships a milestone bundle in adaptive mode, **I want to** open one PR that auto-closes every constituent issue, lands as ready-for-review, and stays under live CI monitoring through merge **so that** the milestone closes itself without manual follow-up.

---

[`40a12a12`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/200/commits/40a12a123ec9d385fe7b95a78f70e0d4ef1c3360) 🧪 GH-121 Rebaseline mcp_server_import startup gate
[`4fbef0cf`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/200/commits/4fbef0cfd9738e87e56ca519c52f6b3c3670ed9d) ✨ GH-185 Enable solo-maintainer milestone-bundle PR shipping
Closes #184
Closes #185
Closes #186
Closes #187
Closes #121
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/185

---