### PR TITLE
✨ GH-205 Enable top-level PR issue-comment replies via MCP

### DIFF
--- a/.claude/rules/mcp-tools.md
+++ b/.claude/rules/mcp-tools.md
@@ -67,6 +67,7 @@ supporting each tool:
 | `issue_create` | `cli` | PR #552 | v0.44.0+ |
 | `pr_comments` | `cli` | PR #126 | v0.25.0+ |
 | `pr_comment_reply` | `cli` | PR #399 | v0.37.0+ |
+| `pr_issue_comment` | `cli` | GH-205 | v0.72.0+ |
 | `request_review` | `cli` | PR #126 | v0.25.0+ |
 | `detect_base_branch` | `cli` | PR #191 | v0.30.0+ |
 | `verify_pr_state` | `cli` | PR #191 | v0.30.0+ |

--- a/skills/gh-pr-respond/SKILL.md
+++ b/skills/gh-pr-respond/SKILL.md
@@ -14,6 +14,7 @@ allowed-tools:
   - mcp__plugin_Dev10x_cli__pr_comment_reply
   - mcp__plugin_Dev10x_cli__pr_comments
   - mcp__plugin_Dev10x_cli__pr_detect
+  - mcp__plugin_Dev10x_cli__pr_issue_comment
   - Bash(gh pr ready:*)
   - Bash(gh api graphql:*)
   - Bash(gh api repos/:*)

--- a/skills/gh-pr-respond/instructions.md
+++ b/skills/gh-pr-respond/instructions.md
@@ -541,7 +541,22 @@ resolved while the body contains unaddressed items.
    above, then continue to Step 2 (triage)
 
 **Replying to body findings:** Since body findings have no inline
-comment thread, replies are posted as top-level PR comments via:
+comment thread, replies are posted as top-level PR comments. Use
+the MCP tool (no permission friction, structured response):
+
+```
+mcp__plugin_Dev10x_cli__pr_issue_comment(
+    pr_number={pr_number},
+    body="Re: {finding_summary}\n\n{reply}",
+    repo="{owner}/{repo}",
+)
+```
+
+This also covers replies to top-level bot comments (e.g., `claude[bot]`
+findings posted via `gh pr comment`) that surface through
+`check_top_level_comments` but have no review thread.
+
+**Fallback** (only when the MCP server is unavailable):
 ```bash
 gh api --method POST \
   repos/{owner}/{repo}/issues/{pr_number}/comments \

--- a/skills/gh-pr-triage/SKILL.md
+++ b/skills/gh-pr-triage/SKILL.md
@@ -13,6 +13,7 @@ invocation-name: Dev10x:gh-pr-triage
 allowed-tools:
   - mcp__plugin_Dev10x_cli__pr_comment_reply
   - mcp__plugin_Dev10x_cli__pr_comments
+  - mcp__plugin_Dev10x_cli__pr_issue_comment
   - Bash(gh api:*)
 ---
 
@@ -278,6 +279,25 @@ gh api \
   repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies \
   -f body="{reply_text}"
 ```
+
+**Top-level / body finding replies:** If the triaged comment is a
+top-level PR comment (URL contains `#issuecomment-`, posted via
+`gh pr comment`) or a review-body finding without a thread, the
+review-thread reply mechanism above returns 404. Use the
+issue-level MCP tool instead:
+
+```
+mcp__plugin_Dev10x_cli__pr_issue_comment(
+    pr_number=<int>,
+    body="<reply_text>",
+    repo="<owner>/<repo>",
+)
+```
+
+This wraps `POST /repos/{owner}/{repo}/issues/{pr_number}/comments`
+and is the same channel `claude[bot]` uses to post top-level
+findings — replies posted through it appear inline with the
+original finding in the PR conversation.
 
 **Thread resolution:** Do NOT resolve threads. Return the verdict to the
 caller (`Dev10x:gh-pr-respond` or the user). Resolution only happens when the user

--- a/src/dev10x/github/__init__.py
+++ b/src/dev10x/github/__init__.py
@@ -543,6 +543,28 @@ async def pr_comment_reply(
     return _parse_gh_api_result(result)
 
 
+async def pr_issue_comment(
+    *,
+    pr_number: int,
+    body: str,
+    repo: str | None = None,
+) -> Result[dict[str, Any]]:
+    repo_result = await _resolve_repo(repo)
+    if isinstance(repo_result, ErrorResult):
+        return repo_result
+    resolved_repo = repo_result.value
+
+    result = await _gh_api(
+        f"repos/{resolved_repo}/issues/{pr_number}/comments",
+        method="POST",
+        fields={"body": body},
+        repo=str(resolved_repo),
+        as_bot=True,
+    )
+
+    return _parse_gh_api_result(result)
+
+
 async def request_review(
     *,
     pr_number: int,

--- a/src/dev10x/mcp/server_cli.py
+++ b/src/dev10x/mcp/server_cli.py
@@ -220,6 +220,44 @@ async def pr_comment_reply(
 
 
 @server.tool()
+async def pr_issue_comment(
+    pr_number: int,
+    body: str,
+    repo: str | None = None,
+    cwd: str | None = None,
+) -> dict:
+    """Post a top-level issue-level comment on a PR.
+
+    Wraps `gh api --method POST /repos/{owner}/{repo}/issues/{pr_number}/comments
+    -f body=...`. Use this for replying to top-level bot findings posted via
+    `gh pr comment` (claude[bot], hygiene-review) that surface through
+    `check_top_level_comments` but have no review thread.
+
+    For inline review-thread replies, use `pr_comment_reply` instead.
+
+    Args:
+        pr_number: PR number (treated as the parent issue for comment routing)
+        body: Comment body (supports markdown)
+        repo: Repository (owner/repo). If omitted, uses current repo
+        cwd: Effective working directory (GH-979).
+
+    Returns:
+        Dictionary with comment details (id, body, created_at) or error.
+    """
+    from dev10x import github as gh
+    from dev10x.subprocess_utils import use_cwd
+
+    with use_cwd(cwd):
+        return (
+            await gh.pr_issue_comment(
+                pr_number=pr_number,
+                body=body,
+                repo=repo,
+            )
+        ).to_dict()
+
+
+@server.tool()
 async def minimize_comments(
     node_ids: list[str],
     classifier: str = "OUTDATED",

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -689,6 +689,53 @@ class TestPrCommentReply:
         assert mock_api.call_count == 0
 
 
+class TestPrIssueComment:
+    @pytest.mark.asyncio
+    @patch("dev10x.github._gh_api", new_callable=AsyncMock)
+    async def test_posts_top_level_comment(
+        self,
+        mock_api: AsyncMock,
+        mock_resolve_repo: AsyncMock,
+    ) -> None:
+        mock_api.return_value = _completed(
+            stdout=json.dumps({"id": 4468, "body": "bundle reply"}),
+        )
+
+        result = await gh.pr_issue_comment(
+            pr_number=203,
+            body="bundle reply",
+        )
+
+        assert isinstance(result, SuccessResult)
+        endpoint = mock_api.call_args.args[0]
+        assert endpoint == "repos/owner/repo/issues/203/comments"
+        call_kwargs = mock_api.call_args.kwargs
+        assert call_kwargs["method"] == "POST"
+        assert call_kwargs["fields"] == {"body": "bundle reply"}
+        assert "in_reply_to" not in call_kwargs["fields"]
+        assert call_kwargs["as_bot"] is True
+        assert call_kwargs["repo"] == "owner/repo"
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github._gh_api", new_callable=AsyncMock)
+    async def test_returns_error_on_api_failure(
+        self,
+        mock_api: AsyncMock,
+        mock_resolve_repo: AsyncMock,
+    ) -> None:
+        mock_api.return_value = _completed(
+            returncode=1,
+            stderr="Not Found",
+        )
+
+        result = await gh.pr_issue_comment(
+            pr_number=203,
+            body="body",
+        )
+
+        assert isinstance(result, ErrorResult)
+
+
 class TestPrCommentsActionReply:
     @pytest.mark.asyncio
     @patch("dev10x.github._gh_api", new_callable=AsyncMock)


### PR DESCRIPTION
**When** I am triaging a top-level bot finding on a PR (e.g. a `claude[bot]` PR-format complaint surfaced via `gh pr comment`), **I want to** reply through a structured MCP tool **so** the gh-pr-triage / gh-pr-respond flow can address the finding without falling back to raw `gh api --method POST .../issues/N/comments`, which triggers per-call permission prompts and the "stated-but-not-executed" delegation bypass.

---

[`1c9fd1b6`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/207/commits/1c9fd1b6d586aec66dc82e9edd41f1e2400ba5ec) ✨ GH-205 Enable top-level PR issue-comment replies via MCP
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/205

---