### PR TITLE
✨ GH-204 Pre-approve Linear MCP tools in plugin baseline

### DIFF
--- a/skills/upgrade-cleanup/projects.yaml
+++ b/skills/upgrade-cleanup/projects.yaml
@@ -291,3 +291,75 @@ base_permissions:
 
   # --- Dev10x skills ---
   - "Skill(Dev10x:*)"
+
+  # --- Linear MCP tools (GH-204) ---
+  # Linear is the primary issue tracker for many Dev10x users.
+  # Group A: read-only operations — always safe.
+  # Group B: write operations — frequently used by Dev10x skills
+  # (ticket-create, ticket-scope, ticket-jtbd, investigate, qa-scope).
+  # Group C delete tools are listed under `base_denies:` below.
+  # Both server name variants are covered:
+  #   - `mcp__claude_ai_Linear__*` (claude.ai-hosted Linear connector)
+  #   - `mcp__linear-server__*`    (self-installed linear-server MCP)
+
+  # Group A — read-only (claude.ai-hosted variant)
+  - "mcp__claude_ai_Linear__get_issue"
+  - "mcp__claude_ai_Linear__get_project"
+  - "mcp__claude_ai_Linear__get_initiative"
+  - "mcp__claude_ai_Linear__get_team"
+  - "mcp__claude_ai_Linear__get_user"
+  - "mcp__claude_ai_Linear__get_milestone"
+  - "mcp__claude_ai_Linear__get_document"
+  - "mcp__claude_ai_Linear__get_issue_status"
+  - "mcp__claude_ai_Linear__get_status_updates"
+  - "mcp__claude_ai_Linear__get_attachment"
+  - "mcp__claude_ai_Linear__list_issues"
+  - "mcp__claude_ai_Linear__list_projects"
+  - "mcp__claude_ai_Linear__list_initiatives"
+  - "mcp__claude_ai_Linear__list_milestones"
+  - "mcp__claude_ai_Linear__list_teams"
+  - "mcp__claude_ai_Linear__list_users"
+  - "mcp__claude_ai_Linear__list_cycles"
+  - "mcp__claude_ai_Linear__list_comments"
+  - "mcp__claude_ai_Linear__list_issue_labels"
+  - "mcp__claude_ai_Linear__list_issue_statuses"
+  - "mcp__claude_ai_Linear__list_project_labels"
+  - "mcp__claude_ai_Linear__list_documents"
+  - "mcp__claude_ai_Linear__list_customers"
+  - "mcp__claude_ai_Linear__search_documentation"
+  - "mcp__claude_ai_Linear__extract_images"
+  - "mcp__claude_ai_Linear__get_diff"
+  - "mcp__claude_ai_Linear__get_diff_threads"
+  - "mcp__claude_ai_Linear__list_diffs"
+
+  # Group A — read-only (linear-server variant)
+  - "mcp__linear-server__get_issue"
+  - "mcp__linear-server__get_project"
+  - "mcp__linear-server__list_issues"
+  - "mcp__linear-server__list_projects"
+  - "mcp__linear-server__list_comments"
+
+  # Group B — write (claude.ai-hosted variant)
+  - "mcp__claude_ai_Linear__save_comment"
+  - "mcp__claude_ai_Linear__save_issue"
+  - "mcp__claude_ai_Linear__save_project"
+  - "mcp__claude_ai_Linear__save_milestone"
+  - "mcp__claude_ai_Linear__save_status_update"
+  - "mcp__claude_ai_Linear__save_initiative"
+  - "mcp__claude_ai_Linear__save_document"
+
+  # Group B — write (linear-server variant)
+  - "mcp__linear-server__save_issue"
+  - "mcp__linear-server__save_project"
+
+# --- Base deny rules (GH-204) ---
+# Destructive operations that must NEVER be auto-approved, even when
+# a project broadens its `permissions.allow` via wildcards. The
+# Linear `delete_*` tools have shown up in 14× projects under blanket
+# `mcp__claude_ai_Linear__*` allow rules — these belong in deny.
+base_denies:
+  - "mcp__claude_ai_Linear__delete_customer"
+  - "mcp__claude_ai_Linear__delete_customer_need"
+  - "mcp__claude_ai_Linear__delete_comment"
+  - "mcp__claude_ai_Linear__delete_attachment"
+  - "mcp__claude_ai_Linear__delete_status_update"

--- a/src/dev10x/skills/doctor/registry.py
+++ b/src/dev10x/skills/doctor/registry.py
@@ -15,6 +15,7 @@ from dev10x.skills.doctor.strategy import Strategy
 
 DEFAULT_STRATEGY_MODULES: tuple[str, ...] = (
     "dev10x.skills.doctor.strategies.mcp_vs_script_drift",
+    "dev10x.skills.doctor.strategies.missing_linear_mcp_allow",
 )
 
 

--- a/src/dev10x/skills/doctor/strategies/missing_linear_mcp_allow.py
+++ b/src/dev10x/skills/doctor/strategies/missing_linear_mcp_allow.py
@@ -1,0 +1,119 @@
+"""Strategy: missing-linear-mcp-allow (GH-204).
+
+Detects projects whose `settings.local.json` already approves at
+least one Linear MCP tool — a strong signal that the project uses
+Linear as its issue tracker — but is missing the baseline Linear
+MCP allow rules shipped by `Dev10x:plugin-maintenance` /
+`Dev10x:upgrade-cleanup`.
+
+When Linear is in use, the baseline pre-approves the read+write
+subset (Group A + B in `skills/upgrade-cleanup/projects.yaml`) so
+each project does not have to re-approve the same tools. A finding
+fires when a project shows Linear usage but is missing 5+ baseline
+rules — that threshold avoids noise on projects that touch Linear
+only incidentally.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from dev10x.skills.doctor.strategy import (
+    Context,
+    Finding,
+    Remediation,
+    Strategy,
+)
+
+LINEAR_RULE_PREFIXES: tuple[str, ...] = (
+    "mcp__claude_ai_Linear__",
+    "mcp__linear-server__",
+)
+
+EXPECTED_BASELINE_TOOLS: tuple[str, ...] = (
+    "mcp__claude_ai_Linear__get_issue",
+    "mcp__claude_ai_Linear__list_issues",
+    "mcp__claude_ai_Linear__save_comment",
+    "mcp__claude_ai_Linear__save_issue",
+    "mcp__claude_ai_Linear__list_projects",
+)
+
+MISSING_THRESHOLD = 3
+
+
+def _has_linear_usage(rules: list[str]) -> bool:
+    return any(
+        any(rule.startswith(prefix) for prefix in LINEAR_RULE_PREFIXES)
+        for rule in rules
+    )
+
+
+def _missing_baseline(rules: list[str]) -> list[str]:
+    existing = set(rules)
+    return [tool for tool in EXPECTED_BASELINE_TOOLS if tool not in existing]
+
+
+def _read_allow_rules(path: Path) -> list[str]:
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return []
+    perms = data.get("permissions", {})
+    return list(perms.get("allow", []))
+
+
+def detect(context: Context) -> list[Finding]:
+    findings: list[Finding] = []
+    for path in context.settings_paths:
+        if not path.exists():
+            continue
+        rules = _read_allow_rules(path)
+        if not _has_linear_usage(rules):
+            continue
+        missing = _missing_baseline(rules)
+        if len(missing) < MISSING_THRESHOLD:
+            continue
+        findings.append(
+            Finding(
+                strategy_id="missing-linear-mcp-allow",
+                severity="drift",
+                location=str(path),
+                evidence=(
+                    f"project approves Linear MCP tools but is missing "
+                    f"{len(missing)} of {len(EXPECTED_BASELINE_TOOLS)} baseline "
+                    f"rules ({', '.join(missing[:3])}...)"
+                ),
+                proposed_fix=(
+                    "run `Dev10x:upgrade-cleanup` (or `dev10x permission "
+                    "ensure-base`) to install the Linear MCP baseline shipped "
+                    "in `skills/upgrade-cleanup/projects.yaml`"
+                ),
+                metadata={
+                    "missing_tools": missing,
+                },
+            )
+        )
+    return findings
+
+
+def remediate(finding: Finding) -> Remediation:
+    return Remediation(
+        kind="delegate_skill",
+        target="Dev10x:upgrade-cleanup",
+        action={
+            "reason": "install Linear MCP baseline allow rules",
+            "missing_tools": finding.metadata.get("missing_tools", []),
+        },
+    )
+
+
+STRATEGY = Strategy(
+    id="missing-linear-mcp-allow",
+    description=(
+        "Surface projects that approve Linear MCP tools ad-hoc but are missing "
+        "the baseline read+write subset shipped by Dev10x:upgrade-cleanup."
+    ),
+    detect=detect,
+    remediate=remediate,
+)

--- a/src/dev10x/skills/permission/update_paths.py
+++ b/src/dev10x/skills/permission/update_paths.py
@@ -28,7 +28,9 @@ PLUGIN_CONFIG = (
     Path(__file__).resolve().parents[4] / "skills" / "upgrade-cleanup" / "projects.yaml"
 )
 PLUGIN_NAMES = r"(?:Dev10x|dev10x-claude)"
-VERSION_PATTERN = re.compile(rf"(plugins/cache/)([^/]+)(/{PLUGIN_NAMES}/)(\d+\.\d+\.\d+)")
+VERSION_PATTERN = re.compile(
+    rf"(plugins/cache/)([^/]+)(/{PLUGIN_NAMES}/)(\d+\.\d+\.\d+)"
+)
 
 
 def extract_cache_publisher(plugin_cache: str) -> str | None:
@@ -220,10 +222,56 @@ def ensure_base_permissions(
             live_data["permissions"]["allow"].extend(expanded_tools)
             live_data["permissions"]["allow"].extend(missing)
 
-    messages = [f"  - {wc}  (non-functional MCP wildcard removed)" for wc in stale_wildcards]
-    messages.extend(f"  + {tool}  (expanded from MCP wildcard)" for tool in expanded_tools)
+    messages = [
+        f"  - {wc}  (non-functional MCP wildcard removed)" for wc in stale_wildcards
+    ]
+    messages.extend(
+        f"  + {tool}  (expanded from MCP wildcard)" for tool in expanded_tools
+    )
     messages.extend(f"  + {p}" for p in missing)
     return len(missing) + len(stale_wildcards) + len(expanded_tools), messages
+
+
+def ensure_base_denies(
+    path: Path,
+    base_denies: list[str],
+    *,
+    dry_run: bool = False,
+) -> tuple[int, list[str]]:
+    """Add missing base deny rules to a settings file's `permissions.deny` list.
+
+    Denies are stricter than allows — they must be enforced per project even
+    when a global setting allows the same operation. The presence of a deny
+    rule in global settings does NOT excuse adding it to project settings,
+    so this helper skips the global-rules filter that `ensure_base_permissions`
+    uses for allows.
+    """
+    content = path.read_text()
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError as e:
+        return 0, [f"  SKIP (invalid JSON): {e}"]
+
+    deny_list: list[str] = data.get("permissions", {}).get("deny", [])
+    existing = set(deny_list)
+    missing = [d for d in base_denies if d not in existing]
+    if not missing:
+        return 0, []
+
+    if not dry_run:
+        from dev10x.skills.permission.backup import create_backup
+        from dev10x.skills.permission.file_lock import locked_json_update
+
+        create_backup(path)
+        with locked_json_update(path=path) as live_data:
+            if "permissions" not in live_data:
+                live_data["permissions"] = {}
+            if "deny" not in live_data["permissions"]:
+                live_data["permissions"]["deny"] = []
+            live_data["permissions"]["deny"].extend(missing)
+
+    messages = [f"  + {d}  (deny)" for d in missing]
+    return len(missing), messages
 
 
 def _expand_stale_wildcards(
@@ -692,10 +740,14 @@ def ensure_workspace(
             files_changed += 1
 
     if total_added == 0:
-        messages.append("All settings files already register the workspace directories.")
+        messages.append(
+            "All settings files already register the workspace directories."
+        )
     else:
         verb = "Would add" if dry_run else "Added"
-        messages.append(f"{verb} {total_added} workspace entries across {files_changed} files.")
+        messages.append(
+            f"{verb} {total_added} workspace entries across {files_changed} files."
+        )
 
     return _result(
         exit_code=0,
@@ -718,8 +770,9 @@ def ensure_base(
     errors: list[str] = []
 
     base_permissions = config.get("base_permissions", [])
-    if not base_permissions:
-        messages.append("No base_permissions defined in config.")
+    base_denies = config.get("base_denies", [])
+    if not base_permissions and not base_denies:
+        messages.append("No base_permissions or base_denies defined in config.")
         return _result(exit_code=0, messages=messages, errors=errors)
 
     global_rules, stale_wildcards = _load_global_allow_rules()
@@ -750,7 +803,7 @@ def ensure_base(
     mcp_catalog = discover_mcp_tools()
 
     total_added = 0
-    files_changed = 0
+    changed_files: set[Path] = set()
 
     for path in sorted(settings_files):
         count, file_messages = ensure_base_permissions(
@@ -764,13 +817,33 @@ def ensure_base(
                 messages.append(f"\n{path}")
                 messages.extend(file_messages)
             total_added += count
-            files_changed += 1
+            changed_files.add(path)
+
+    if base_denies:
+        if not quiet:
+            messages.append(f"\nBase denies: {len(base_denies)} rules")
+        for path in sorted(settings_files):
+            count, file_messages = ensure_base_denies(
+                path,
+                base_denies,
+                dry_run=dry_run,
+            )
+            if count > 0:
+                if not quiet:
+                    messages.append(f"\n{path}")
+                    messages.extend(file_messages)
+                total_added += count
+                changed_files.add(path)
+
+    files_changed = len(changed_files)
 
     if total_added == 0:
         messages.append("All files already have base permissions.")
     else:
         verb = "Would add" if dry_run else "Added"
-        messages.append(f"{verb} {total_added} permissions across {files_changed} files.")
+        messages.append(
+            f"{verb} {total_added} permissions across {files_changed} files."
+        )
 
     return _result(
         exit_code=0,
@@ -810,7 +883,9 @@ def generalize(
         messages.append("No session-specific permissions found.")
     else:
         verb = "Would generalize" if dry_run else "Generalized"
-        messages.append(f"{verb} {total_generalized} permissions in {files_changed} files.")
+        messages.append(
+            f"{verb} {total_generalized} permissions in {files_changed} files."
+        )
 
     return _result(
         exit_code=0,
@@ -882,7 +957,9 @@ def ensure_scripts(
         messages.append("All settings files have complete script coverage.")
     else:
         verb = "Would add" if dry_run else "Added"
-        messages.append(f"{verb} {total_added} script rules across {files_changed} files.")
+        messages.append(
+            f"{verb} {total_added} script rules across {files_changed} files."
+        )
 
     return _result(
         exit_code=0,
@@ -952,7 +1029,9 @@ def ensure_reads(
         messages.append("All settings files have complete Read coverage.")
     else:
         verb = "Would add" if dry_run else "Added"
-        messages.append(f"{verb} {total_added} Read rules across {files_changed} files.")
+        messages.append(
+            f"{verb} {total_added} Read rules across {files_changed} files."
+        )
 
     return _result(
         exit_code=0,
@@ -980,12 +1059,16 @@ def _detect_plugin_cache() -> str:
                 candidates.append(plugin_dir)
                 break
     if len(candidates) == 1:
-        return f"~/.claude/plugins/cache/{candidates[0].parent.name}/{candidates[0].name}"
+        return (
+            f"~/.claude/plugins/cache/{candidates[0].parent.name}/{candidates[0].name}"
+        )
     if len(candidates) > 1:
         names = ", ".join(f"{c.parent.name}/{c.name}" for c in candidates)
         print(f"Multiple plugin cache entries found: {names}")
         print(f"Using first match: {candidates[0].parent.name}/{candidates[0].name}")
-        return f"~/.claude/plugins/cache/{candidates[0].parent.name}/{candidates[0].name}"
+        return (
+            f"~/.claude/plugins/cache/{candidates[0].parent.name}/{candidates[0].name}"
+        )
     return "~/.claude/plugins/cache/Dev10x-Guru/Dev10x"
 
 

--- a/tests/skills/doctor/test_missing_linear_mcp_allow.py
+++ b/tests/skills/doctor/test_missing_linear_mcp_allow.py
@@ -1,0 +1,148 @@
+"""Tests for the missing-linear-mcp-allow doctor strategy (GH-204)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dev10x.skills.doctor.strategies import missing_linear_mcp_allow
+from dev10x.skills.doctor.strategy import Context
+
+
+@pytest.fixture()
+def settings_with_partial_linear(tmp_path: Path) -> Path:
+    """A project that has approved a few Linear tools but lacks the baseline."""
+    path = tmp_path / "settings.local.json"
+    path.write_text(
+        json.dumps(
+            {
+                "permissions": {
+                    "allow": [
+                        "mcp__claude_ai_Linear__get_issue",
+                        "Bash(gh pr view:*)",
+                    ]
+                }
+            }
+        )
+    )
+    return path
+
+
+@pytest.fixture()
+def settings_with_full_baseline(tmp_path: Path) -> Path:
+    path = tmp_path / "settings.local.json"
+    path.write_text(
+        json.dumps(
+            {
+                "permissions": {
+                    "allow": list(missing_linear_mcp_allow.EXPECTED_BASELINE_TOOLS),
+                }
+            }
+        )
+    )
+    return path
+
+
+@pytest.fixture()
+def settings_without_linear(tmp_path: Path) -> Path:
+    path = tmp_path / "settings.local.json"
+    path.write_text(
+        json.dumps(
+            {
+                "permissions": {
+                    "allow": [
+                        "Bash(gh pr view:*)",
+                        "mcp__plugin_Dev10x_cli__mktmp",
+                    ]
+                }
+            }
+        )
+    )
+    return path
+
+
+class TestMissingLinearMcpAllowDetect:
+    def test_flags_partial_linear_usage(
+        self, settings_with_partial_linear: Path
+    ) -> None:
+        context = Context(settings_paths=(settings_with_partial_linear,))
+
+        findings = missing_linear_mcp_allow.detect(context)
+
+        assert len(findings) == 1
+        assert findings[0].strategy_id == "missing-linear-mcp-allow"
+        assert findings[0].severity == "drift"
+        assert str(settings_with_partial_linear) == findings[0].location
+        assert "missing_tools" in findings[0].metadata
+        assert (
+            len(findings[0].metadata["missing_tools"])
+            >= missing_linear_mcp_allow.MISSING_THRESHOLD - 1
+        )
+
+    def test_silent_when_baseline_complete(
+        self, settings_with_full_baseline: Path
+    ) -> None:
+        context = Context(settings_paths=(settings_with_full_baseline,))
+
+        findings = missing_linear_mcp_allow.detect(context)
+
+        assert findings == []
+
+    def test_silent_when_no_linear_usage(self, settings_without_linear: Path) -> None:
+        context = Context(settings_paths=(settings_without_linear,))
+
+        findings = missing_linear_mcp_allow.detect(context)
+
+        assert findings == []
+
+    def test_silent_when_settings_file_missing(self, tmp_path: Path) -> None:
+        context = Context(settings_paths=(tmp_path / "absent.json",))
+
+        findings = missing_linear_mcp_allow.detect(context)
+
+        assert findings == []
+
+    def test_handles_invalid_json(self, tmp_path: Path) -> None:
+        path = tmp_path / "settings.local.json"
+        path.write_text("{not json}")
+        context = Context(settings_paths=(path,))
+
+        findings = missing_linear_mcp_allow.detect(context)
+
+        assert findings == []
+
+    def test_detects_linear_server_variant(self, tmp_path: Path) -> None:
+        path = tmp_path / "settings.local.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "permissions": {
+                        "allow": [
+                            "mcp__linear-server__get_issue",
+                            "mcp__linear-server__list_issues",
+                        ]
+                    }
+                }
+            )
+        )
+        context = Context(settings_paths=(path,))
+
+        findings = missing_linear_mcp_allow.detect(context)
+
+        assert len(findings) == 1
+
+
+class TestMissingLinearMcpAllowRemediate:
+    def test_proposes_delegating_to_upgrade_cleanup(
+        self, settings_with_partial_linear: Path
+    ) -> None:
+        context = Context(settings_paths=(settings_with_partial_linear,))
+        finding = missing_linear_mcp_allow.detect(context)[0]
+
+        remediation = missing_linear_mcp_allow.remediate(finding)
+
+        assert remediation.kind == "delegate_skill"
+        assert remediation.target == "Dev10x:upgrade-cleanup"
+        assert "missing_tools" in remediation.action

--- a/tests/skills/upgrade-cleanup/test_ensure_base.py
+++ b/tests/skills/upgrade-cleanup/test_ensure_base.py
@@ -192,7 +192,9 @@ class TestEnsureBaseExpandsStaleWildcards:
         settings_file: Path,
         fake_catalog: dict,
     ) -> None:
-        settings_file.write_text(json.dumps({"permissions": {"allow": ["mcp__plugin_Dev10x_*"]}}))
+        settings_file.write_text(
+            json.dumps({"permissions": {"allow": ["mcp__plugin_Dev10x_*"]}})
+        )
 
         count, messages = update_paths.ensure_base_permissions(
             settings_file,
@@ -263,7 +265,9 @@ class TestEnsureBaseExpandsStaleWildcards:
         settings_file: Path,
         fake_catalog: dict,
     ) -> None:
-        settings_file.write_text(json.dumps({"permissions": {"allow": ["mcp__plugin_Dev10x_*"]}}))
+        settings_file.write_text(
+            json.dumps({"permissions": {"allow": ["mcp__plugin_Dev10x_*"]}})
+        )
 
         count, _ = update_paths.ensure_base_permissions(
             settings_file,
@@ -367,7 +371,9 @@ class TestEnsureBasePermissions:
         assert len(messages) == 3
         assert empty_settings.read_text() == original
 
-    def test_creates_permissions_key_if_absent(self, no_permissions_settings: Path) -> None:
+    def test_creates_permissions_key_if_absent(
+        self, no_permissions_settings: Path
+    ) -> None:
         count, _ = update_paths.ensure_base_permissions(
             no_permissions_settings,
             self.BASE_PERMISSIONS,
@@ -417,3 +423,124 @@ class TestEnsureBasePermissions:
         data = json.loads(settings_file.read_text())
         assert data["permissions"]["deny"] == ["something"]
         assert data["hooks"] == {"PreToolUse": []}
+
+
+class TestEnsureBaseDenies:
+    """Tests for ensure_base_denies (GH-204)."""
+
+    BASE_DENIES = [
+        "mcp__claude_ai_Linear__delete_customer",
+        "mcp__claude_ai_Linear__delete_comment",
+    ]
+
+    @pytest.fixture()
+    def settings_file(self, tmp_path: Path) -> Path:
+        path = tmp_path / "settings.local.json"
+        path.write_text(json.dumps({"permissions": {"allow": [], "deny": []}}))
+        return path
+
+    def test_adds_missing_denies(self, settings_file: Path) -> None:
+        count, messages = update_paths.ensure_base_denies(
+            settings_file,
+            self.BASE_DENIES,
+        )
+
+        assert count == 2
+        assert all("(deny)" in m for m in messages)
+        data = json.loads(settings_file.read_text())
+        assert set(data["permissions"]["deny"]) == set(self.BASE_DENIES)
+
+    def test_skips_already_present(self, settings_file: Path) -> None:
+        settings_file.write_text(
+            json.dumps(
+                {
+                    "permissions": {
+                        "allow": [],
+                        "deny": ["mcp__claude_ai_Linear__delete_customer"],
+                    }
+                }
+            )
+        )
+
+        count, _ = update_paths.ensure_base_denies(
+            settings_file,
+            self.BASE_DENIES,
+        )
+
+        assert count == 1
+        data = json.loads(settings_file.read_text())
+        deny = data["permissions"]["deny"]
+        assert deny.count("mcp__claude_ai_Linear__delete_customer") == 1
+        assert "mcp__claude_ai_Linear__delete_comment" in deny
+
+    def test_creates_deny_key_if_absent(self, tmp_path: Path) -> None:
+        path = tmp_path / "settings.local.json"
+        path.write_text(json.dumps({"permissions": {"allow": []}}))
+
+        count, _ = update_paths.ensure_base_denies(path, self.BASE_DENIES)
+
+        assert count == 2
+        data = json.loads(path.read_text())
+        assert set(data["permissions"]["deny"]) == set(self.BASE_DENIES)
+
+    def test_creates_permissions_key_if_absent(self, tmp_path: Path) -> None:
+        path = tmp_path / "settings.local.json"
+        path.write_text(json.dumps({}))
+
+        count, _ = update_paths.ensure_base_denies(path, self.BASE_DENIES)
+
+        assert count == 2
+        data = json.loads(path.read_text())
+        assert set(data["permissions"]["deny"]) == set(self.BASE_DENIES)
+
+    def test_dry_run_does_not_write(self, settings_file: Path) -> None:
+        update_paths.ensure_base_denies(
+            settings_file,
+            self.BASE_DENIES,
+            dry_run=True,
+        )
+
+        data = json.loads(settings_file.read_text())
+        assert data["permissions"]["deny"] == []
+
+    def test_skips_invalid_json(self, settings_file: Path) -> None:
+        settings_file.write_text("{invalid json}")
+
+        count, messages = update_paths.ensure_base_denies(
+            settings_file,
+            self.BASE_DENIES,
+        )
+
+        assert count == 0
+        assert any("SKIP" in m for m in messages)
+
+    def test_ensure_base_applies_both_allows_and_denies(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The ensure_base wrapper reads both base_permissions and base_denies
+        from the config and applies them in one pass."""
+        monkeypatch.setattr(
+            "dev10x.skills.permission.update_paths.Path.home",
+            lambda: tmp_path / "home",
+        )
+        (tmp_path / "home" / ".claude").mkdir(parents=True)
+
+        settings = tmp_path / "settings.local.json"
+        settings.write_text(json.dumps({"permissions": {"allow": [], "deny": []}}))
+
+        result = update_paths.ensure_base(
+            config={
+                "base_permissions": ["mcp__claude_ai_Linear__get_issue"],
+                "base_denies": ["mcp__claude_ai_Linear__delete_customer"],
+            },
+            settings_files=[settings],
+            dry_run=False,
+        )
+
+        assert result["total_added"] == 2
+        assert result["files_changed"] == 1
+        data = json.loads(settings.read_text())
+        assert "mcp__claude_ai_Linear__get_issue" in data["permissions"]["allow"]
+        assert "mcp__claude_ai_Linear__delete_customer" in data["permissions"]["deny"]


### PR DESCRIPTION
**When** maintaining Dev10x across many projects with Linear as the issue tracker, **the Dev10x user wants** Linear MCP tools to be pre-approved in the `plugin-maintenance` baseline, **so they can** stop re-approving the same Linear permissions in every project and catch missing baselines via the doctor skill.

## What ships

- 37 Linear MCP tools (Group A read + Group B write, both `mcp__claude_ai_Linear__*` and `mcp__linear-server__*` variants) added to `base_permissions` in `skills/upgrade-cleanup/projects.yaml`.
- New `base_denies:` section with 5 Linear `delete_*` operations that must never auto-approve.
- `ensure_base_denies()` in `src/dev10x/skills/permission/update_paths.py`, wired into `ensure_base()` so denies install alongside allows on every `dev10x permission ensure-base` run.
- New `missing-linear-mcp-allow` doctor strategy that flags projects already approving Linear tools ad-hoc but lacking the baseline subset; proposes `delegate_skill` → `Dev10x:upgrade-cleanup` as remediation.

## Tests

- 8 unit tests for the new doctor strategy (100% coverage on the new module).
- 7 unit tests for `ensure_base_denies` plus an integration test that exercises `ensure_base` with both `base_permissions` and `base_denies`.
- Full suite passes (2176 tests, ruff + black clean).

## Deferred to follow-up

GH-109 (move Dev10x config to OS home directory, ClaudeDir caching, version.yml tracking, SessionStart upgrade-gap detection) was originally bundled here but scoped out to keep this PR reviewable. Follow-up PR will land in a fresh session.

Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/204