### PR TITLE
✨ GH-218 Address 2026-05-18 audit findings (#219 #222)

### DIFF
--- a/.claude/rules/mcp-tools.md
+++ b/.claude/rules/mcp-tools.md
@@ -101,6 +101,9 @@ supporting each tool:
 | `issue_comment` | `cli` | GH-220 | v0.73.0+ |
 | `issue_list` | `cli` | GH-220 | v0.73.0+ |
 | `slack_thread_is_forward` | `cli` | GH-218 | v0.73.0+ |
+| `milestones_bulk_create` | `cli` | GH-222 | v0.73.0+ |
+| `issues_bulk_create` | `cli` | GH-222 | v0.73.0+ |
+| `issues_bulk_edit` | `cli` | GH-222 | v0.73.0+ |
 | `generate_commit_list` | `cli` | PR #191 | v0.30.0+ |
 | `post_summary_comment` | `cli` | PR #191 | v0.30.0+ |
 | `pr_notify` | `cli` | PR #191 | v0.30.0+ |

--- a/.claude/rules/mcp-tools.md
+++ b/.claude/rules/mcp-tools.md
@@ -100,6 +100,7 @@ supporting each tool:
 | `issue_edit` | `cli` | GH-220 | v0.73.0+ |
 | `issue_comment` | `cli` | GH-220 | v0.73.0+ |
 | `issue_list` | `cli` | GH-220 | v0.73.0+ |
+| `slack_thread_is_forward` | `cli` | GH-218 | v0.73.0+ |
 | `generate_commit_list` | `cli` | PR #191 | v0.30.0+ |
 | `post_summary_comment` | `cli` | PR #191 | v0.30.0+ |
 | `pr_notify` | `cli` | PR #191 | v0.30.0+ |

--- a/skills/project-scope/SKILL.md
+++ b/skills/project-scope/SKILL.md
@@ -21,15 +21,18 @@ allowed-tools:
   - mcp__claude_ai_Linear__list_milestones
   - mcp__claude_ai_Linear__list_issue_statuses
   - Bash(${CLAUDE_PLUGIN_ROOT}/skills/gh-context/scripts/:*)
-  - Bash(gh issue create:*)
   - Bash(gh label create:*)
-  - Bash(gh api repos/:*)
   - Bash(/tmp/Dev10x/bin/mktmp.sh:*)
   - Skill(Dev10x:ticket-create)
-  - Bash(gh issue view:*)
-  - Bash(gh issue edit:*)
-  - Bash(gh api:*)
   - mcp__plugin_Dev10x_cli__detect_tracker
+  - mcp__plugin_Dev10x_cli__milestone_create
+  - mcp__plugin_Dev10x_cli__milestones_bulk_create
+  - mcp__plugin_Dev10x_cli__issue_create
+  - mcp__plugin_Dev10x_cli__issue_edit
+  - mcp__plugin_Dev10x_cli__issue_comment
+  - mcp__plugin_Dev10x_cli__issue_list
+  - mcp__plugin_Dev10x_cli__issues_bulk_create
+  - mcp__plugin_Dev10x_cli__issues_bulk_edit
 ---
 
 # Project Scope - Multi-Ticket Project Creation
@@ -191,10 +194,17 @@ the relevant instructions in the agent's prompt.
 | Operation | Linear | JIRA | GitHub Issues |
 |-----------|--------|------|---------------|
 | Create project | `save_project` (optional) | Epic via `Dev10x:jira` | N/A (use milestones) |
-| Create milestone | `save_milestone` | Sprint/Fix Version via `Dev10x:jira` | `gh api repos/{owner}/{repo}/milestones --method POST` |
+| Create milestone | `save_milestone` | Sprint/Fix Version via `Dev10x:jira` | `mcp__plugin_Dev10x_cli__milestone_create` (single) / `milestones_bulk_create` (batch) |
 | Create label | (via `save_issue`) | (via `Dev10x:jira`) | `gh label create` |
-| Create ticket | `save_issue` + milestone + project | via `Dev10x:jira` | `gh issue create --milestone --label --body-file` |
-| Set blocking | `save_issue` blockedBy/blocks | Link via `Dev10x:jira` | Cross-reference in issue body (no native blocking) |
+| Create ticket | `save_issue` + milestone + project | via `Dev10x:jira` | `mcp__plugin_Dev10x_cli__issue_create` (single) / `issues_bulk_create` (batch) |
+| Edit ticket | `save_issue` (upsert) | via `Dev10x:jira` | `mcp__plugin_Dev10x_cli__issue_edit` / `issues_bulk_edit` (batch) |
+| Set blocking | `save_issue` blockedBy/blocks | Link via `Dev10x:jira` | `mcp__plugin_Dev10x_cli__issue_comment` cross-reference (no native blocking) |
+
+GitHub Issues operations route through MCP wrappers — raw `gh issue
+edit`, `gh issue comment`, `gh api .../milestones POST`, and `gh
+issue create` are blocked by the skill-redirect hook. The MCP path
+avoids per-invocation permission prompts and returns structured
+responses.
 
 ### 3.2 Create/Resolve Parent Ticket
 
@@ -218,61 +228,80 @@ See `Dev10x:linear` § Project Assignment for the full pattern.
 
 ### 3.4 Create Milestones
 
-Create milestones sequentially (tickets reference them by ID).
 Check for existing milestones by name before creating to avoid
-duplicates.
+duplicates — call `mcp__plugin_Dev10x_cli__issue_list` with a
+`milestone:` filter, or query directly via the tracker API.
+
+**GitHub Issues:** Call `mcp__plugin_Dev10x_cli__milestones_bulk_create`
+once with the full list. The wrapper iterates `milestone_create`
+per entry and returns `{created: [...], failed: [...]}`. Failed
+entries do not abort the batch — inspect `failed` for duplicates
+or validation errors and address them before proceeding to 3.5.
+
+For one or two milestones, prefer the single-entry tool
+`mcp__plugin_Dev10x_cli__milestone_create` to keep payloads simple.
 
 ### 3.5 Create Tickets
 
 Create all tickets with milestone and project assignments.
 Use the project UUID resolved in 3.3 — never pass a display name.
-Batch creation is possible since all milestones exist at this point.
 Check for existing tickets by title before creating.
 
 **GitHub Issues batch pattern (10+ issues):**
 
-When creating many issues, use a sidecar metadata pattern to keep
-issue bodies clean and reduce permission friction:
-
-1. Create a temp directory for the batch:
-   ```bash
-   BATCH_DIR=$(/tmp/Dev10x/bin/mktmp.sh -d gh-issues batch)
+1. Write each ticket body to a temp file via the Write tool. Keep
+   the file as **clean Markdown only** — no metadata header. Use
+   `mcp__plugin_Dev10x_cli__mktmp` to allocate the path:
+   `mktmp(namespace="gh-issues", prefix="NNN-slug", ext=".md")`.
+2. Build the `issues` payload as a list of dicts:
+   ```python
+   issues = [
+     {
+       "title": "Ticket title here",
+       "body": Read("<path-from-mktmp>"),  # body content from step 1
+       "milestone": "Milestone Name",
+       "labels": ["enhancement", "area/payments"],
+     },
+     # ... one entry per ticket
+   ]
    ```
-2. For each issue, write two files via the Write tool:
-   - `$BATCH_DIR/NNN-slug.md` — clean body content only
-   - `$BATCH_DIR/NNN-slug.vars` — metadata:
-     ```bash
-     TITLE="Ticket title here"
-     MILESTONE="Milestone Name"
-     LABELS="enhancement,area/payments"
-     ```
-3. Create issues by iterating inline (no temp script):
-   ```bash
-   for vars in $BATCH_DIR/*.vars; do
-     source "$vars"
-     body="${vars%.vars}.md"
-     gh issue create --repo "$REPO" --title "$TITLE" \
-       --body-file "$body" --milestone "$MILESTONE" --label "$LABELS"
-   done
-   ```
+3. Call `mcp__plugin_Dev10x_cli__issues_bulk_create(issues=issues)`
+   in a single tool call. The wrapper returns
+   `{created: [{number, url, title}, ...], failed: [...]}`. The
+   batch does not abort on individual failures — inspect `failed`
+   and retry per-entry as needed.
 
-This pattern was discovered in a session creating 36 issues — a single
-loop approval replaced 36 individual `gh issue create` approvals.
+A single bulk call replaces N per-ticket `gh issue create`
+invocations and removes the per-invocation permission prompts
+that the loop pattern produced.
 
-**Anti-patterns to avoid (permission friction):**
+For one or two tickets, prefer `mcp__plugin_Dev10x_cli__issue_create`
+directly.
 
-- Do NOT use command substitution in `gh` commands:
-  `gh issue edit --body "$(gh issue view ... | sed ...)"` — the `$()` breaks
-  allow-rule prefix matching. Instead, write the body to a temp file first
-  via Write tool, then `gh issue edit --body-file /tmp/file.md`.
-- Do NOT prefix `gh` commands with env var assignments:
-  `REPO="owner/repo" gh issue create ...` — the env prefix shifts the command
-  prefix. Use `--repo owner/repo` inline instead.
+**Batch edits:** When the same field needs to change across many
+tickets (e.g., reassigning milestone after the project has
+re-shaped), build an `edits` list and call
+`mcp__plugin_Dev10x_cli__issues_bulk_edit` once. Each entry
+requires `number` plus at least one of `title`, `body`,
+`milestone`, `labels`.
+
+**If raw `gh` is needed as fallback** (e.g., MCP server
+unavailable): write bodies to temp files via Write tool, then
+`gh issue create --body-file ...`. Watch for these friction
+sources — they exist for raw `gh` only:
+
+- Command substitution: `gh issue edit --body "$(gh issue view ...)"`
+  breaks allow-rule prefix matching. Write to a temp file first.
+- Env-var prefix: `REPO="owner/repo" gh issue create ...` shifts
+  the command prefix. Use `--repo owner/repo` inline.
 
 ### 3.6 Set Blocking Relationships
 
 Set blocking/blocked-by relationships between tickets per the
-approved blocking chain. Execute in parallel since all tickets exist.
+approved blocking chain. On GitHub Issues, blocking is conveyed
+via cross-reference comments — call
+`mcp__plugin_Dev10x_cli__issue_comment(number, body)` per
+relationship. Execute in parallel since all tickets exist.
 
 ### 3.7 Link Tickets to Project
 

--- a/skills/skill-audit-queue/SKILL.md
+++ b/skills/skill-audit-queue/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: Dev10x:skill-audit-queue
+description: >
+  Queue a skill-audit invocation for later by appending a tracker task
+  to the end of the current task list. Use mid-session when you notice
+  friction but do not want to interrupt in-flight work — the audit
+  runs when the supervisor reaches the queued task.
+  TRIGGER when: friction noticed mid-session, but interrupting current
+  work is not desirable; supervisor wants the audit deferred until
+  the active task completes.
+  DO NOT TRIGGER when: supervisor wants the audit to run NOW (use
+  Dev10x:skill-audit directly), or no friction has been observed.
+user-invocable: true
+invocation-name: Dev10x:skill-audit-queue
+allowed-tools:
+  - TaskCreate
+  - TaskList
+---
+
+# Skill Audit Queue
+
+Append a tracker task that defers a `Dev10x:skill-audit` invocation
+to the end of the current task list. The audit itself does not run
+here — only the TODO is recorded. When the supervisor reaches the
+queued task, they invoke `Dev10x:skill-audit` directly to run the
+diagnosis.
+
+## Why this exists
+
+`Dev10x:skill-audit` used to self-append a "cycle-audit" task as
+its Step 0a (GH-148), but that coupled deferral semantics to the
+audit invocation itself: the audit task only appeared when the
+supervisor was ready to run it *now*, which made mid-session
+deferral awkward and created an "audit pauses prior work" anti-
+pattern (issue GH-219).
+
+This skill separates the two concerns:
+
+- **Defer the audit** → `Dev10x:skill-audit-queue` (this skill).
+  Records intent. Does not interrupt current work.
+- **Run the audit** → `Dev10x:skill-audit`. Executes the actual
+  diagnosis when the supervisor is ready.
+
+## Orchestration
+
+This skill is a single-shot append. There are no phases.
+
+**REQUIRED: Create one task at invocation.** Execute at startup:
+
+1. `TaskCreate(subject="Run Dev10x:skill-audit-queue append", activeForm="Queueing audit")`
+
+Mark `completed` after the audit task is appended.
+
+## Workflow
+
+### Step 1: Read current task list
+
+Call `TaskList` to see existing tasks. Use this to locate the
+correct insertion point.
+
+### Step 2: Determine the insertion position
+
+The audit task is appended at the **end** of the open task list,
+with one exception: if a `Verify acceptance criteria` (or
+`Verify AC`) task exists as the terminal task per the Task List
+Invariant (`.claude/rules/essentials.md` § Task List Invariant
+GH-149), insert the audit task **immediately before** it. The
+verify-AC task must remain last.
+
+No dependency wiring on the new task — it is independent of the
+in-flight work.
+
+### Step 3: Append the audit task
+
+Build the task description from arguments (if any) or from a
+short generic frame:
+
+```
+TaskCreate(
+    subject="Invoke Dev10x:skill-audit to diagnose recent friction",
+    description="Supervisor queued a skill audit during session. "
+                "<frame from args or 'Investigate recent skill compliance gaps.'> "
+                "When ready, invoke /Dev10x:skill-audit.",
+    activeForm="Auditing skill usage"
+)
+```
+
+If the supervisor passed free-text arguments (e.g.,
+`/Dev10x:skill-audit-queue retry logic kept stalling`), use that
+text as the frame.
+
+### Step 4: Confirm
+
+Print one line:
+
+```
+Queued Dev10x:skill-audit at end of task list. The audit will
+not run until you reach the task and invoke /Dev10x:skill-audit.
+```
+
+Mark this skill's own startup task `completed`.
+
+## Examples
+
+### Example 1: Free-text frame
+
+**Invocation:** `/Dev10x:skill-audit-queue git-commit kept asking redundant questions`
+
+**Result:** A new task is appended (before Verify AC if present):
+- subject: "Invoke Dev10x:skill-audit to diagnose recent friction"
+- description: "Supervisor queued a skill audit during session.
+  Frame: git-commit kept asking redundant questions. When ready,
+  invoke /Dev10x:skill-audit."
+
+### Example 2: No arguments
+
+**Invocation:** `/Dev10x:skill-audit-queue`
+
+**Result:** A new task is appended with a generic frame:
+- description: "Supervisor queued a skill audit during session.
+  Investigate recent skill compliance gaps. When ready, invoke
+  /Dev10x:skill-audit."
+
+## Related Skills
+
+- `Dev10x:skill-audit` — runs the actual audit; invoke this from
+  the queued task when ready
+- `Dev10x:park` — generic deferral router; this skill is the
+  specific audit-deferral path

--- a/skills/skill-audit/evals/evals.json
+++ b/skills/skill-audit/evals/evals.json
@@ -25,11 +25,6 @@
       "id": "early-insight-gate",
       "name": "Early-Insight Gate",
       "description": "Phase 0 detects narrow, transcript-evident questions, presents inline findings, and routes via AskUserQuestion with three options (select & file, step back, discard) without dispatching wave subagents"
-    },
-    {
-      "id": "cycle-audit-task",
-      "name": "Cycle-Audit Task Append (GH-148)",
-      "description": "Step 0a always appends a single 'Audit cycle: diagnose, fix, note in memory, file upstream' task at the end of the current task list before Phase 0 fires, regardless of downstream path. Empty-list edge case: task is created and immediately marked in_progress."
     }
   ],
   "evals": [
@@ -210,73 +205,6 @@
           "check": "tool_called",
           "tool": "TaskCreate",
           "signal": "All 10 setup/wave/synthesis tasks are created"
-        }
-      ]
-    },
-    {
-      "id": 5,
-      "name": "cycle-audit-task-appended-empty-list",
-      "prompt": "/Dev10x:skill-audit",
-      "description": "Tests that Step 0a (GH-148) creates a single cycle-audit task at the very start of the invocation, before Phase 0 fires. With an empty task list, the task is marked in_progress immediately and the audit proceeds.",
-      "setup": {
-        "task_list_state": "empty",
-        "invocation": "/Dev10x:skill-audit"
-      },
-      "dimensions": ["cycle-audit-task"],
-      "assertions": [
-        {
-          "id": "cycle_task_created_first",
-          "text": "TaskCreate for the cycle-audit task fires before any Phase 0 / Step 0 task or Agent dispatch",
-          "check": "tool_called_before",
-          "tool": "TaskCreate",
-          "args_contain": "Audit cycle",
-          "before_tool": "AskUserQuestion",
-          "signal": "Cycle-audit task is the first TaskCreate of the invocation"
-        },
-        {
-          "id": "cycle_task_subject_text",
-          "text": "Cycle-audit task subject names the four-stage frame",
-          "check": "output_contains",
-          "signals": [
-            "Audit cycle",
-            "diagnose",
-            "memory",
-            "upstream"
-          ]
-        },
-        {
-          "id": "cycle_task_in_progress_on_empty_list",
-          "text": "When prior task list was empty, the cycle-audit task is set to in_progress before Phase 0 fires",
-          "check": "behavioral",
-          "assertion": "task_in_progress_on_empty_list",
-          "signal": "TaskUpdate with status=in_progress fires on the cycle-audit task immediately after creation"
-        }
-      ]
-    },
-    {
-      "id": 6,
-      "name": "cycle-audit-task-appended-non-empty-list",
-      "prompt": "/Dev10x:skill-audit",
-      "description": "Tests that Step 0a (GH-148) appends the cycle-audit task at the end of an existing task list without disrupting prior tasks or wiring any dependencies on them.",
-      "setup": {
-        "task_list_state": "non-empty (prior unrelated tasks present)",
-        "invocation": "/Dev10x:skill-audit"
-      },
-      "dimensions": ["cycle-audit-task"],
-      "assertions": [
-        {
-          "id": "cycle_task_appended_no_dependencies",
-          "text": "Cycle-audit task is created without addBlocks or addBlockedBy wiring to prior tasks",
-          "check": "behavioral",
-          "assertion": "no_dependency_wiring_to_existing_tasks",
-          "signal": "TaskCreate for the cycle-audit task has no blocks/blockedBy targeting existing task IDs"
-        },
-        {
-          "id": "prior_tasks_unchanged",
-          "text": "Prior tasks in the list are not modified, deleted, or reordered",
-          "check": "behavioral",
-          "assertion": "existing_tasks_preserved",
-          "signal": "TaskUpdate is not called on any pre-existing task during Step 0a"
         }
       ]
     }

--- a/skills/skill-audit/instructions.md
+++ b/skills/skill-audit/instructions.md
@@ -10,36 +10,25 @@ This skill follows `references/task-orchestration.md` patterns.
 **Auto-advance:** Complete each phase, immediately start the next.
 Never pause between phases.
 
-### Step 0a: Append cycle-audit task (MANDATORY, GH-148)
+### Deferral (GH-219)
 
-**Always runs first — before Phase 0 and Step 0.** Invoking
-`Dev10x:skill-audit` is itself a declaration of supervisor intent:
-"something didn't work out in the last couple of cycles, and I
-want to diagnose the problem, find a solution, note it in memory,
-and file an upstream issue."
+To **defer** an audit until later without interrupting current
+work, invoke `Dev10x:skill-audit-queue` instead. That skill
+appends a tracker task at the end of the current task list with
+a TODO to invoke `Dev10x:skill-audit`. When the supervisor
+reaches the queued task, they invoke this skill directly.
 
-Record that intent as a single tracking task at the END of the
-current task list, regardless of which downstream path Phase 0
-selects (early-insight, full wave, or discard):
+Invoking `Dev10x:skill-audit` (this skill) is a declaration that
+the audit should run **now** — proceed directly to Phase 0.
 
-1. Call `TaskList` to see the existing tasks (if any).
-2. `TaskCreate(subject="Audit cycle: diagnose, fix, note in memory, file upstream", description="Supervisor invoked Dev10x:skill-audit. Frame: something didn't work in the last couple of cycles — diagnose the problem, find a solution, persist the lesson to memory, and file an upstream issue when warranted. This task is the supervisor-facing wrapper for the whole skill-audit invocation; Phase 0 / Step 0 add their own sub-tasks.", activeForm="Auditing cycle")`
+### Important Rules
 
-**Edge case — empty task list.** If `TaskList` returned no
-tasks (or only completed ones), the cycle-audit task IS the
-work — immediately mark it `in_progress` and proceed to Phase 0
-without waiting for other tasks.
-
-**Edge case — pre-existing task list.** Append at the end with
-no dependency wiring. The cycle-audit task remains visible as
-the supervisor's frame for the whole invocation; Phase 0 and
-Step 0 below add their own task lists alongside it.
-
-**Completion.** Mark the cycle-audit task `completed` only after
-the chosen path terminates:
-- Phase 0 "Discard" → mark completed immediately (no further work)
-- Phase 0 "Select & file now" → mark completed after Phase 7 finishes
-- Phase 0 "Step back" / fall-through → mark completed after Phase 7 finishes
+**When asked about this skill's behavior, re-Read
+`instructions.md` before answering (GH-219).** Do not rely on
+summarized recall from earlier in the session. Questions about
+phase semantics, deferral, gates, or task-list behavior must be
+answered against the current source — agents that answer from
+prior context routinely contradict the live instructions.
 
 ### Phase 0: Early-Insight Gate
 

--- a/skills/ticket-scope/instructions.md
+++ b/skills/ticket-scope/instructions.md
@@ -90,6 +90,33 @@ Look for:
 - Previous comments with context
 - Attachments or links
 
+#### 1.2a Detect Slack Forwards (GH-218)
+
+When a Slack thread URL is part of the input context, after the
+`slack_read_thread` fetch, pass the parent message body and reply
+count to `mcp__plugin_Dev10x_cli__slack_thread_is_forward`. The
+tool returns `is_forward`, `confidence`, `signals`, and any
+extracted `upstream_hints` (external URLs found in the parent).
+
+When `confidence` is `high` or `medium`, the parent message is
+likely a forward / cross-post of an upstream thread that holds the
+real context. Do NOT silently consume it as canonical source.
+
+**REQUIRED: Call `AskUserQuestion`** (do NOT use plain text).
+Options:
+- Provide upstream Slack URL (Recommended) — supervisor pastes
+  the upstream thread URL; restart Phase 1.1 with it
+- Continue with current thread anyway — the thin parent is
+  intentional; proceed to Phase 2 with what we have
+- Abort scope — supervisor needs to gather more context first
+
+When `confidence` is `low`, proceed normally to Phase 2.
+
+The heuristic itself lives in the MCP tool, not in this document
+— sibling skills (`Dev10x:investigate`, `Dev10x:ticket-create`,
+`Dev10x:work-on`) that ingest Slack URLs should call the same
+tool rather than re-implement the logic.
+
 ### Phase 2: Technical Research (Uses base scope skill)
 
 Follow the base `scope` skill for:

--- a/src/dev10x/github/__init__.py
+++ b/src/dev10x/github/__init__.py
@@ -961,6 +961,143 @@ async def issue_list(
     return ok({"issues": issues})
 
 
+async def milestones_bulk_create(
+    *,
+    milestones: list[dict[str, Any]],
+    repo: str | None = None,
+) -> Result[dict[str, Any]]:
+    """Create multiple GitHub milestones in one call (GH-222).
+
+    Iterates milestone_create per entry; collects per-milestone
+    successes and failures. The call does not short-circuit on
+    individual failures so the caller sees the full batch outcome.
+
+    Args:
+        milestones: List of dicts; each entry accepts ``title`` (required),
+            ``description`` (optional), and ``due_on`` (optional).
+        repo: Repository (owner/repo). Auto-detected if omitted.
+
+    Returns:
+        On success: ``{"created": [{title, number, url}, ...],
+        "failed": [{title, error}, ...]}``. The wrapper never
+        errors as long as at least one entry was attempted; entry-
+        level failures land in ``failed``.
+    """
+    if not milestones:
+        return err("milestones_bulk_create requires at least one milestone")
+
+    created: list[dict[str, Any]] = []
+    failed: list[dict[str, Any]] = []
+    for entry in milestones:
+        title = entry.get("title")
+        if not title:
+            failed.append({"title": entry.get("title"), "error": "missing title"})
+            continue
+        result = await milestone_create(
+            title=title,
+            description=entry.get("description"),
+            due_on=entry.get("due_on"),
+            repo=repo,
+        )
+        if isinstance(result, ErrorResult):
+            failed.append({"title": title, "error": result.error})
+        else:
+            created.append(result.value)
+    return ok({"created": created, "failed": failed})
+
+
+async def issues_bulk_create(
+    *,
+    issues: list[dict[str, Any]],
+    repo: str | None = None,
+) -> Result[dict[str, Any]]:
+    """Create multiple GitHub issues in one call (GH-222).
+
+    Iterates issue_create per entry; collects per-issue successes
+    and failures. Use for batch project scaffolding (e.g.,
+    Dev10x:project-scope creating N tickets).
+
+    Args:
+        issues: List of dicts; each entry accepts ``title`` (required),
+            ``body`` (optional), ``labels`` (optional list of str),
+            ``milestone`` (optional).
+        repo: Repository (owner/repo). Auto-detected if omitted.
+
+    Returns:
+        ``{"created": [{number, url, title}, ...],
+        "failed": [{title, error}, ...]}``.
+    """
+    if not issues:
+        return err("issues_bulk_create requires at least one issue")
+
+    created: list[dict[str, Any]] = []
+    failed: list[dict[str, Any]] = []
+    for entry in issues:
+        title = entry.get("title")
+        if not title:
+            failed.append({"title": entry.get("title"), "error": "missing title"})
+            continue
+        result = await issue_create(
+            title=title,
+            body=entry.get("body"),
+            labels=entry.get("labels"),
+            milestone=entry.get("milestone"),
+            repo=repo,
+        )
+        if isinstance(result, ErrorResult):
+            failed.append({"title": title, "error": result.error})
+        else:
+            payload = dict(result.value)
+            payload.setdefault("title", title)
+            created.append(payload)
+    return ok({"created": created, "failed": failed})
+
+
+async def issues_bulk_edit(
+    *,
+    edits: list[dict[str, Any]],
+    repo: str | None = None,
+) -> Result[dict[str, Any]]:
+    """Edit multiple GitHub issues in one call (GH-222).
+
+    Iterates issue_edit per entry; collects per-issue successes
+    and failures. Use for batch milestone reassignment, label
+    additions, or title/body fixes across many issues.
+
+    Args:
+        edits: List of dicts; each entry requires ``number`` and at
+            least one of ``title``, ``body``, ``milestone``, ``labels``.
+        repo: Repository (owner/repo). Auto-detected if omitted.
+
+    Returns:
+        ``{"edited": [{number, url}, ...],
+        "failed": [{number, error}, ...]}``.
+    """
+    if not edits:
+        return err("issues_bulk_edit requires at least one edit")
+
+    edited: list[dict[str, Any]] = []
+    failed: list[dict[str, Any]] = []
+    for entry in edits:
+        number = entry.get("number")
+        if not isinstance(number, int):
+            failed.append({"number": number, "error": "missing or non-integer number"})
+            continue
+        result = await issue_edit(
+            number=number,
+            title=entry.get("title"),
+            body=entry.get("body"),
+            milestone=entry.get("milestone"),
+            labels=entry.get("labels"),
+            repo=repo,
+        )
+        if isinstance(result, ErrorResult):
+            failed.append({"number": number, "error": result.error})
+        else:
+            edited.append(result.value)
+    return ok({"edited": edited, "failed": failed})
+
+
 async def generate_commit_list(
     *,
     pr_number: int,

--- a/src/dev10x/github/slack.py
+++ b/src/dev10x/github/slack.py
@@ -1,0 +1,100 @@
+"""Slack thread forward-detection helper (GH-218).
+
+Pure, stateless heuristic over an already-fetched Slack thread payload.
+The MCP tool does not call Slack itself — the caller fetches the thread
+via `mcp__claude_ai_Slack__slack_read_thread` and passes the relevant
+fields here. This keeps the helper testable and free of MCP-fetch
+coupling.
+
+Signals:
+- Short body: parent message body word-count below threshold
+- Zero replies: thread has no replies
+- External artifact: parent body contains a non-Slack URL OR
+  forwarding language
+
+Confidence:
+- high: all 3 signals present
+- medium: exactly 2 signals present
+- low: 0 or 1 signals present
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from dev10x.domain.common.result import Result, ok
+
+SHORT_BODY_WORD_THRESHOLD = 30
+
+_FORWARD_LANGUAGE_PATTERN = re.compile(
+    r"\b(fwd|forwarded|forwarding|flagging|sharing|fyi|cross[- ]post(?:ing|ed)?)\b",
+    re.IGNORECASE,
+)
+
+_URL_PATTERN = re.compile(r"https?://[^\s>)]+", re.IGNORECASE)
+
+_SLACK_HOST_PATTERN = re.compile(r"^https?://[^/]*\.slack\.com(/|$)", re.IGNORECASE)
+
+
+def _word_count(text: str) -> int:
+    return len(text.split())
+
+
+def _extract_url_hints(body: str) -> list[str]:
+    return [url for url in _URL_PATTERN.findall(body) if not _SLACK_HOST_PATTERN.match(url)]
+
+
+def _has_external_link(body: str) -> bool:
+    return bool(_extract_url_hints(body))
+
+
+def _has_forwarding_language(body: str) -> bool:
+    return bool(_FORWARD_LANGUAGE_PATTERN.search(body))
+
+
+async def slack_thread_is_forward(
+    *,
+    parent_body: str,
+    reply_count: int,
+) -> Result[dict[str, Any]]:
+    """Detect whether a Slack thread is likely a forward / cross-post (GH-218).
+
+    Args:
+        parent_body: The parent message text from the Slack thread.
+        reply_count: Number of replies on the thread (0 means none).
+
+    Returns:
+        On success: ``{"is_forward": bool, "confidence": str,
+        "signals": list[str], "upstream_hints": list[str]}``.
+        The function never errors — heuristic over inputs only.
+    """
+    signals: list[str] = []
+
+    if _word_count(parent_body) < SHORT_BODY_WORD_THRESHOLD:
+        signals.append("short_body")
+
+    if reply_count == 0:
+        signals.append("zero_replies")
+
+    has_link = _has_external_link(parent_body)
+    has_fwd_lang = _has_forwarding_language(parent_body)
+    if has_link or has_fwd_lang:
+        signals.append("external_link" if has_link else "forwarding_language")
+
+    score = len(signals)
+    if score >= 3:
+        confidence = "high"
+    elif score == 2:
+        confidence = "medium"
+    else:
+        confidence = "low"
+
+    return ok(
+        {
+            "is_forward": confidence in ("high", "medium"),
+            "confidence": confidence,
+            "signals": signals,
+            "upstream_hints": _extract_url_hints(parent_body),
+        }
+    )

--- a/src/dev10x/mcp/server_cli.py
+++ b/src/dev10x/mcp/server_cli.py
@@ -641,6 +641,100 @@ async def milestone_create(
 
 
 @server.tool()
+async def milestones_bulk_create(
+    milestones: list[dict],
+    repo: str | None = None,
+    cwd: str | None = None,
+) -> dict:
+    """Create multiple GitHub milestones in one call (GH-222).
+
+    Iterates `milestone_create` per entry and collects per-entry
+    successes and failures.
+
+    Args:
+        milestones: List of dicts; each entry: {title, description?, due_on?}.
+        repo: Repository (owner/repo). Auto-detected if omitted.
+        cwd: Effective working directory (GH-979).
+
+    Returns:
+        Dictionary with keys: created (list), failed (list).
+    """
+    from dev10x import github as gh
+    from dev10x.subprocess_utils import use_cwd
+
+    with use_cwd(cwd):
+        return (
+            await gh.milestones_bulk_create(
+                milestones=milestones,
+                repo=repo,
+            )
+        ).to_dict()
+
+
+@server.tool()
+async def issues_bulk_create(
+    issues: list[dict],
+    repo: str | None = None,
+    cwd: str | None = None,
+) -> dict:
+    """Create multiple GitHub issues in one call (GH-222).
+
+    Iterates `issue_create` per entry and collects per-entry
+    successes and failures.
+
+    Args:
+        issues: List of dicts; each entry: {title, body?, labels?, milestone?}.
+        repo: Repository (owner/repo). Auto-detected if omitted.
+        cwd: Effective working directory (GH-979).
+
+    Returns:
+        Dictionary with keys: created (list), failed (list).
+    """
+    from dev10x import github as gh
+    from dev10x.subprocess_utils import use_cwd
+
+    with use_cwd(cwd):
+        return (
+            await gh.issues_bulk_create(
+                issues=issues,
+                repo=repo,
+            )
+        ).to_dict()
+
+
+@server.tool()
+async def issues_bulk_edit(
+    edits: list[dict],
+    repo: str | None = None,
+    cwd: str | None = None,
+) -> dict:
+    """Edit multiple GitHub issues in one call (GH-222).
+
+    Iterates `issue_edit` per entry and collects per-entry
+    successes and failures.
+
+    Args:
+        edits: List of dicts; each entry requires `number` and at least
+            one of `title`, `body`, `milestone`, `labels`.
+        repo: Repository (owner/repo). Auto-detected if omitted.
+        cwd: Effective working directory (GH-979).
+
+    Returns:
+        Dictionary with keys: edited (list), failed (list).
+    """
+    from dev10x import github as gh
+    from dev10x.subprocess_utils import use_cwd
+
+    with use_cwd(cwd):
+        return (
+            await gh.issues_bulk_edit(
+                edits=edits,
+                repo=repo,
+            )
+        ).to_dict()
+
+
+@server.tool()
 async def slack_thread_is_forward(
     parent_body: str,
     reply_count: int,

--- a/src/dev10x/mcp/server_cli.py
+++ b/src/dev10x/mcp/server_cli.py
@@ -641,6 +641,46 @@ async def milestone_create(
 
 
 @server.tool()
+async def slack_thread_is_forward(
+    parent_body: str,
+    reply_count: int,
+) -> dict:
+    """Detect whether a Slack thread is likely a forward / cross-post (GH-218).
+
+    Pure heuristic over an already-fetched thread payload. The caller
+    fetches the thread via `mcp__claude_ai_Slack__slack_read_thread`
+    and passes the parent message body + reply count here.
+
+    Signals:
+    - short_body: parent body word count below threshold (~30 words)
+    - zero_replies: thread has no replies
+    - external_link OR forwarding_language: parent references an
+      external URL or uses forwarding phrasing (fwd, FYI, sharing, ...)
+
+    Confidence:
+    - high: all 3 signals present
+    - medium: exactly 2 signals present
+    - low: 0 or 1 signals present
+
+    Args:
+        parent_body: The parent message text from the Slack thread.
+        reply_count: Number of replies on the thread.
+
+    Returns:
+        Dictionary with keys: is_forward (bool), confidence (str),
+        signals (list[str]), upstream_hints (list[str]).
+    """
+    from dev10x.github import slack as slack_helper
+
+    return (
+        await slack_helper.slack_thread_is_forward(
+            parent_body=parent_body,
+            reply_count=reply_count,
+        )
+    ).to_dict()
+
+
+@server.tool()
 async def milestone_close(
     number: int,
     repo: str | None = None,

--- a/tests/github/test_bulk.py
+++ b/tests/github/test_bulk.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dev10x.domain.common.result import SuccessResult, err, ok
+
+gh = pytest.importorskip("dev10x.github", reason="dev10x not installed")
+
+
+class TestMilestonesBulkCreate:
+    @pytest.mark.asyncio
+    @patch.object(gh, "milestone_create", new_callable=AsyncMock)
+    async def test_creates_all_when_each_succeeds(self, mock_create: AsyncMock) -> None:
+        mock_create.side_effect = [
+            ok({"number": 1, "title": "M1", "url": "u1"}),
+            ok({"number": 2, "title": "M2", "url": "u2"}),
+        ]
+
+        result = await gh.milestones_bulk_create(
+            milestones=[{"title": "M1"}, {"title": "M2", "description": "d"}],
+        )
+
+        assert isinstance(result, SuccessResult)
+        assert len(result.value["created"]) == 2
+        assert result.value["failed"] == []
+        assert mock_create.call_count == 2
+
+    @pytest.mark.asyncio
+    @patch.object(gh, "milestone_create", new_callable=AsyncMock)
+    async def test_collects_per_entry_failures(self, mock_create: AsyncMock) -> None:
+        mock_create.side_effect = [
+            ok({"number": 1, "title": "M1", "url": "u1"}),
+            err("already exists"),
+        ]
+
+        result = await gh.milestones_bulk_create(
+            milestones=[{"title": "M1"}, {"title": "M2"}],
+        )
+
+        assert len(result.value["created"]) == 1
+        assert result.value["failed"] == [{"title": "M2", "error": "already exists"}]
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_input(self) -> None:
+        result = await gh.milestones_bulk_create(milestones=[])
+        assert result.error == "milestones_bulk_create requires at least one milestone"
+
+    @pytest.mark.asyncio
+    @patch.object(gh, "milestone_create", new_callable=AsyncMock)
+    async def test_records_missing_title_as_failure(self, mock_create: AsyncMock) -> None:
+        result = await gh.milestones_bulk_create(milestones=[{}])
+        assert result.value["created"] == []
+        assert result.value["failed"][0]["error"] == "missing title"
+        mock_create.assert_not_called()
+
+
+class TestIssuesBulkCreate:
+    @pytest.mark.asyncio
+    @patch.object(gh, "issue_create", new_callable=AsyncMock)
+    async def test_creates_all_when_each_succeeds(self, mock_create: AsyncMock) -> None:
+        mock_create.side_effect = [
+            ok({"number": 100, "url": "u1"}),
+            ok({"number": 101, "url": "u2", "title": "I2"}),
+        ]
+
+        result = await gh.issues_bulk_create(
+            issues=[
+                {"title": "I1", "labels": ["bug"]},
+                {"title": "I2", "milestone": "M1", "body": "details"},
+            ],
+        )
+
+        assert len(result.value["created"]) == 2
+        # title is back-filled when the underlying tool omits it
+        assert result.value["created"][0]["title"] == "I1"
+        assert result.value["created"][1]["title"] == "I2"
+
+    @pytest.mark.asyncio
+    @patch.object(gh, "issue_create", new_callable=AsyncMock)
+    async def test_collects_per_entry_failures(self, mock_create: AsyncMock) -> None:
+        mock_create.side_effect = [
+            err("milestone not found"),
+            ok({"number": 5, "url": "u"}),
+        ]
+
+        result = await gh.issues_bulk_create(
+            issues=[{"title": "I1"}, {"title": "I2"}],
+        )
+
+        assert len(result.value["created"]) == 1
+        assert result.value["failed"] == [{"title": "I1", "error": "milestone not found"}]
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_input(self) -> None:
+        result = await gh.issues_bulk_create(issues=[])
+        assert result.error == "issues_bulk_create requires at least one issue"
+
+
+class TestIssuesBulkEdit:
+    @pytest.mark.asyncio
+    @patch.object(gh, "issue_edit", new_callable=AsyncMock)
+    async def test_edits_all_when_each_succeeds(self, mock_edit: AsyncMock) -> None:
+        mock_edit.side_effect = [
+            ok({"number": 10, "url": "u10"}),
+            ok({"number": 11, "url": "u11"}),
+        ]
+
+        result = await gh.issues_bulk_edit(
+            edits=[
+                {"number": 10, "milestone": "M2"},
+                {"number": 11, "labels": ["wontfix"]},
+            ],
+        )
+
+        assert len(result.value["edited"]) == 2
+        assert result.value["failed"] == []
+
+    @pytest.mark.asyncio
+    @patch.object(gh, "issue_edit", new_callable=AsyncMock)
+    async def test_collects_per_entry_failures(self, mock_edit: AsyncMock) -> None:
+        mock_edit.side_effect = [
+            err("issue locked"),
+            ok({"number": 11, "url": "u11"}),
+        ]
+
+        result = await gh.issues_bulk_edit(
+            edits=[{"number": 10, "title": "new"}, {"number": 11, "body": "x"}],
+        )
+
+        assert len(result.value["edited"]) == 1
+        assert result.value["failed"] == [{"number": 10, "error": "issue locked"}]
+
+    @pytest.mark.asyncio
+    @patch.object(gh, "issue_edit", new_callable=AsyncMock)
+    async def test_records_missing_number_as_failure(self, mock_edit: AsyncMock) -> None:
+        result = await gh.issues_bulk_edit(edits=[{"title": "x"}])
+        assert result.value["edited"] == []
+        assert result.value["failed"][0]["error"] == "missing or non-integer number"
+        mock_edit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_input(self) -> None:
+        result = await gh.issues_bulk_edit(edits=[])
+        assert result.error == "issues_bulk_edit requires at least one edit"

--- a/tests/github/test_slack.py
+++ b/tests/github/test_slack.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import pytest
+
+from dev10x.domain.common.result import SuccessResult
+from dev10x.github import slack
+
+
+class TestSlackThreadIsForward:
+    @pytest.mark.asyncio
+    async def test_all_three_signals_returns_high_confidence(self) -> None:
+        result = await slack.slack_thread_is_forward(
+            parent_body="FYI flagging this: https://linear.app/team/issue/X-1",
+            reply_count=0,
+        )
+
+        assert isinstance(result, SuccessResult)
+        assert result.value["is_forward"] is True
+        assert result.value["confidence"] == "high"
+        assert "short_body" in result.value["signals"]
+        assert "zero_replies" in result.value["signals"]
+        # external_link wins over forwarding_language when both present
+        assert "external_link" in result.value["signals"]
+        assert "https://linear.app/team/issue/X-1" in result.value["upstream_hints"]
+
+    @pytest.mark.asyncio
+    async def test_two_signals_returns_medium_confidence(self) -> None:
+        result = await slack.slack_thread_is_forward(
+            parent_body="Short note here",
+            reply_count=0,
+        )
+
+        assert result.value["is_forward"] is True
+        assert result.value["confidence"] == "medium"
+        assert set(result.value["signals"]) == {"short_body", "zero_replies"}
+        assert result.value["upstream_hints"] == []
+
+    @pytest.mark.asyncio
+    async def test_one_signal_returns_low_confidence(self) -> None:
+        long_body = "word " * 50 + "and a final period."
+        result = await slack.slack_thread_is_forward(
+            parent_body=long_body,
+            reply_count=0,
+        )
+
+        assert result.value["is_forward"] is False
+        assert result.value["confidence"] == "low"
+        assert result.value["signals"] == ["zero_replies"]
+
+    @pytest.mark.asyncio
+    async def test_no_signals_returns_low_confidence(self) -> None:
+        long_body = "word " * 50
+        result = await slack.slack_thread_is_forward(
+            parent_body=long_body,
+            reply_count=5,
+        )
+
+        assert result.value["is_forward"] is False
+        assert result.value["confidence"] == "low"
+        assert result.value["signals"] == []
+
+    @pytest.mark.asyncio
+    async def test_forwarding_language_without_external_link(self) -> None:
+        result = await slack.slack_thread_is_forward(
+            parent_body="fwd from #another-channel for visibility",
+            reply_count=0,
+        )
+
+        assert result.value["confidence"] == "high"
+        assert "forwarding_language" in result.value["signals"]
+        assert "external_link" not in result.value["signals"]
+
+    @pytest.mark.asyncio
+    async def test_slack_internal_url_is_not_external(self) -> None:
+        body = "see https://workspace.slack.com/archives/C123/p456 for context"
+        result = await slack.slack_thread_is_forward(
+            parent_body=body,
+            reply_count=0,
+        )
+
+        # short_body + zero_replies = medium; Slack URL must not count
+        # as external_link
+        assert "external_link" not in result.value["signals"]
+        assert result.value["confidence"] == "medium"
+
+    @pytest.mark.asyncio
+    async def test_extracts_only_external_urls(self) -> None:
+        body = "fwd: see https://example.com/x and https://workspace.slack.com/archives/C1/p2"
+        result = await slack.slack_thread_is_forward(
+            parent_body=body,
+            reply_count=0,
+        )
+
+        assert result.value["upstream_hints"] == ["https://example.com/x"]


### PR DESCRIPTION
**When** the 2026-05-18 skill-audit findings are ready for implementation, **I want to** ship the ticket-scope Slack-forward heuristic, the new skill-audit-queue deferral skill, and the project-scope bulk-MCP rewrite as one bundled PR **so the maintainer can** close M4 without dragging three audit findings through separate review cycles.

Milestone: [M4: skill-audit Findings 2026-05-18](https://github.com/Dev10x-Guru/Dev10x-Claude/milestone/5)

---

[`d240ef18`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/235/commits/d240ef181426741e6c7ce1b2b7660a0bf3415c2b) ✨ GH-218 Detect Slack-forwarded threads in ticket-scope Phase 1.2
[`d109f7c0`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/235/commits/d109f7c0ab41e706b9e2a37c595ce246526bc06f) ✨ GH-219 Defer skill-audit invocations via Dev10x:skill-audit-queue
[`7692e255`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/235/commits/7692e255010e17c10c8f5dee4ef43334bfde6857) ✨ GH-222 Route project-scope through bulk MCP wrappers
Closes #218
Closes #219
Closes #222
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/218

---