### PR TITLE
📝 Document Example 5 in diag-friction examples list

### DIFF
--- a/skills/diag-friction/SKILL.md
+++ b/skills/diag-friction/SKILL.md
@@ -302,7 +302,7 @@ rejected workflow.
 
 ## Examples
 
-See [`references/examples.md`](references/examples.md) for four
+See [`references/examples.md`](references/examples.md) for five
 walkthroughs:
 
 1. **kubectl usage** — direct CLI match (`Dev10x:k8s`)
@@ -310,3 +310,5 @@ walkthroughs:
 3. **friction from chaining** — Step 3b audit surfaces a
    pre-approved alternative
 4. **no match found** — fallback to SKILLS.md scan
+5. **structural friction** — no safe local rule fits, file an
+   upstream issue


### PR DESCRIPTION
**When** the diag-friction SKILL.md Examples section listed only four walkthroughs while `references/examples.md` shipped five, **I want to** sync the SKILL.md bullet list with the actual example count, **so I can** keep readers from missing the structural-friction upstream-filing walkthrough that was added in PR #216.

---

[`acac4067`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/236/commits/acac4067ad7aed8ef489b165963d5bd97ad50cc8) 📝 Document Example 5 in diag-friction examples list
Fixes: none — self-motivated (addresses bot review r3255262947 on merged PR #216)

---