### PR TITLE
✨ GH-232 Enable gh-pr-merge Step 5 via merge_pr MCP tool

### DIFF
--- a/.claude/rules/mcp-tools.md
+++ b/.claude/rules/mcp-tools.md
@@ -95,6 +95,7 @@ supporting each tool:
 | `pre_pr_checks` | `cli` | PR #191 | v0.30.0+ |
 | `create_pr` | `cli` | PR #191 | v0.30.0+ |
 | `update_pr` | `cli` | GH-60 | v0.70.0+ |
+| `merge_pr` | `cli` | GH-232 | v0.73.0+ |
 | `milestone_close` | `cli` | GH-187 | v0.71.0+ |
 | `milestone_create` | `cli` | GH-220 | v0.73.0+ |
 | `issue_edit` | `cli` | GH-220 | v0.73.0+ |
@@ -207,7 +208,7 @@ the MCP server is unavailable.
 | `gh api .../milestones POST` | `mcp__plugin_Dev10x_cli__milestone_create` |
 | `gh pr edit` | `mcp__plugin_Dev10x_cli__update_pr` |
 | `gh pr create` | `Dev10x:gh-pr-create` (wraps `create_pr`) |
-| `gh pr merge` | `Dev10x:gh-pr-merge` |
+| `gh pr merge` | `Dev10x:gh-pr-merge` (wraps `merge_pr`) |
 
 ## Official GitHub MCP Server
 

--- a/skills/gh-pr-merge/SKILL.md
+++ b/skills/gh-pr-merge/SKILL.md
@@ -12,11 +12,11 @@ invocation-name: Dev10x:gh-pr-merge
 allowed-tools:
   - AskUserQuestion
   - Bash(gh pr view:*)
-  - Bash(gh pr merge:*)
   - Bash(gh pr checks:*)
   - Bash(gh api graphql:*)
   - Bash(${CLAUDE_PLUGIN_ROOT}/skills/gh-pr-merge/scripts/:*)
   - mcp__plugin_Dev10x_cli__check_top_level_comments
+  - mcp__plugin_Dev10x_cli__merge_pr
   - Bash(gh repo view:*)
   - Bash(git status:*)
   - Bash(git log:*)
@@ -51,8 +51,10 @@ GH-152 caught a session where the agent ran
 partially reading this SKILL.md — only the CI check was
 performed inline, every other check was skipped.
 
-The PreToolUse hook for raw `gh pr merge` is tracked
-separately (extends the existing blocks on `git commit`,
-`git push`, and `git checkout -b`). Until the hook lands,
-the contract is enforced by convention: agent self-discipline
-plus orchestrator skill-routing tables.
+The PreToolUse hook blocks raw `gh pr merge` (extends the
+existing blocks on `git commit`, `git push`, and `git
+checkout -b`). The skill executes Step 5 via
+`mcp__plugin_Dev10x_cli__merge_pr` (GH-232) — symmetric to
+`create_pr` / `push_safe` — so the documented flow ships
+through a structured MCP tool instead of relying on the
+`DEV10X_SKIP_CMD_VALIDATION` escape hatch.

--- a/skills/gh-pr-merge/instructions.md
+++ b/skills/gh-pr-merge/instructions.md
@@ -348,25 +348,39 @@ If any check fails, show `[ ]` with failure details:
 
 ### Step 5: Merge or refuse
 
-**All checks pass:** Execute merge with configured strategy:
+**All checks pass:** Execute merge via the MCP tool (GH-232):
 
-```bash
-gh pr merge NUMBER --repo OWNER/REPO --STRATEGY --delete-branch
+```
+mcp__plugin_Dev10x_cli__merge_pr(
+    pr_number=NUMBER,
+    strategy="rebase",        # or "squash" / "merge" per config
+    delete_branch=True,       # or False per config
+    repo="OWNER/REPO",        # auto-detected if omitted
+)
 ```
 
-Where `--STRATEGY` is one of `--squash`, `--rebase`, or
-`--merge` based on config.
+The MCP tool wraps `gh pr merge` inside the MCP server's
+subprocess, so the PreToolUse hook that blocks raw `gh pr
+merge` Bash invocations does not apply. This is the only
+authorized way to execute the merge — do NOT fall back to
+`DEV10X_SKIP_CMD_VALIDATION=true gh pr merge ...`, which is
+reserved for transient MCP-unavailability emergencies and
+not for the documented Step 5 flow.
 
-**Worktree safety (GH-773):** Always include `--repo OWNER/REPO`
-in the merge command. Without it, `gh pr merge` tries to check
-out the base branch locally, which fails in worktree setups
-where the base branch is already checked out in another
-worktree (`fatal: 'develop' is already used by worktree`).
-The `--repo` flag bypasses local checkout entirely. Detect
-the repo via `gh repo view --json nameWithOwner -q
-.nameWithOwner`.
+The tool returns `{pr_number, url, strategy, branch_deleted,
+repo}` on success and `{error: "..."}` on failure.
 
-If `delete_branch` is `false`, omit `--delete-branch`.
+**Worktree safety (GH-773):** The tool always passes
+`--repo OWNER/REPO` to `gh pr merge` (auto-detected when
+`repo` is omitted) so it never tries to check out the base
+branch locally — required when the base branch is already
+checked out in another worktree.
+
+**MCP unavailable fallback:** If the MCP server is
+disconnected (`merge_pr` listed as "no longer available" in
+system-reminders), STOP and ask the user to reconnect via
+`/mcp` or restart the session. Raw `gh pr merge` is blocked
+and the SKIP env-var prefix is not the documented contract.
 
 **Any check fails:** Do NOT merge. Report which checks failed
 and what action is needed to resolve each one. Suggest the

--- a/src/dev10x/github/__init__.py
+++ b/src/dev10x/github/__init__.py
@@ -719,6 +719,71 @@ async def update_pr(
     return ok({"pr_number": pr_number, "url": url})
 
 
+async def merge_pr(
+    *,
+    pr_number: int,
+    strategy: str = "rebase",
+    delete_branch: bool = True,
+    repo: str | None = None,
+) -> Result[dict[str, Any]]:
+    """Merge a pull request via ``gh pr merge``.
+
+    Symmetric to ``create_pr`` / ``update_pr`` — wraps the ``gh``
+    CLI so callers reach the same code path through a structured
+    MCP tool instead of a raw Bash command (GH-232). The subprocess
+    is launched from the MCP server, so the PreToolUse hook that
+    blocks raw ``gh pr merge`` Bash invocations does not apply.
+
+    Args:
+        pr_number: PR number to merge.
+        strategy: One of ``rebase``, ``squash``, ``merge``.
+        delete_branch: Pass ``--delete-branch`` when True.
+        repo: Repository (owner/repo). Auto-detected if omitted.
+            Always passed as ``--repo`` to ``gh pr merge`` so the
+            command never tries to check out the base branch
+            locally — required for worktree safety (GH-773).
+
+    Returns:
+        ok({"pr_number", "url", "strategy", "branch_deleted", "repo"})
+        on success, err(...) otherwise.
+    """
+    if strategy not in {"rebase", "squash", "merge"}:
+        return err(f"Invalid merge strategy: {strategy!r}. Use rebase, squash, or merge.")
+
+    repo_result = await _resolve_repo(repo)
+    if isinstance(repo_result, ErrorResult):
+        return err(repo_result.error)
+    repo_ref = repo_result.value
+
+    args = [
+        "gh",
+        "pr",
+        "merge",
+        str(pr_number),
+        "--repo",
+        str(repo_ref),
+        f"--{strategy}",
+    ]
+    if delete_branch:
+        args.append("--delete-branch")
+
+    result = await async_run(args=args, timeout=60)
+
+    if result.returncode != 0:
+        return err(result.stderr.strip() or result.stdout.strip())
+
+    url = f"https://github.com/{repo_ref}/pull/{pr_number}"
+    return ok(
+        {
+            "pr_number": pr_number,
+            "url": url,
+            "strategy": strategy,
+            "branch_deleted": delete_branch,
+            "repo": str(repo_ref),
+        }
+    )
+
+
 async def milestone_close(
     *,
     number: int,

--- a/src/dev10x/mcp/server_cli.py
+++ b/src/dev10x/mcp/server_cli.py
@@ -484,6 +484,55 @@ async def update_pr(
 
 
 @server.tool()
+async def merge_pr(
+    pr_number: int,
+    strategy: str = "rebase",
+    delete_branch: bool = True,
+    repo: str | None = None,
+    cwd: str | None = None,
+) -> dict:
+    """Merge a pull request via ``gh pr merge`` (GH-232).
+
+    Symmetric to ``create_pr``/``update_pr``. Provides a structured
+    MCP entry point for the merge so ``Dev10x:gh-pr-merge`` Step 5
+    can ship the merge without hitting the PreToolUse hook that
+    blocks raw ``gh pr merge`` Bash invocations.
+
+    The skill must still run all 8 pre-merge checks before calling
+    this tool — the hook block was the only reason the documented
+    Step 5 was unreachable; the checks themselves remain mandatory.
+
+    Args:
+        pr_number: PR number to merge.
+        strategy: One of ``rebase`` (default), ``squash``, ``merge``.
+            Resolved by the skill from
+            ``~/.claude/memory/Dev10x/settings-pr-merge.yaml``.
+        delete_branch: Pass ``--delete-branch`` to ``gh pr merge``
+            when True (default).
+        repo: Repository (owner/repo). Auto-detected if omitted.
+            Always passed as ``--repo`` to ``gh pr merge`` for
+            worktree safety (GH-773).
+        cwd: Effective working directory (GH-979).
+
+    Returns:
+        Dictionary with keys: pr_number (int), url (str),
+        strategy (str), branch_deleted (bool), repo (str).
+    """
+    from dev10x import github as gh
+    from dev10x.subprocess_utils import use_cwd
+
+    with use_cwd(cwd):
+        return (
+            await gh.merge_pr(
+                pr_number=pr_number,
+                strategy=strategy,
+                delete_branch=delete_branch,
+                repo=repo,
+            )
+        ).to_dict()
+
+
+@server.tool()
 async def issue_edit(
     number: int,
     title: str | None = None,

--- a/src/dev10x/validators/command-skill-map.yaml
+++ b/src/dev10x/validators/command-skill-map.yaml
@@ -102,12 +102,14 @@ rules:
         skill: Dev10x:gh-pr-merge
         guardrails: 8 pre-merge checks (unresolved threads, CI, draft, mergeability, working copy, fixup commits, approval, branch protection)
         fallback: >
-          If Skill(Dev10x:gh-pr-merge) fails, manually verify all 8
-          pre-merge conditions: (1) all review threads resolved, (2)
-          CI green, (3) PR not draft, (4) MERGEABLE state, (5) no
-          uncommitted changes, (6) no unsquashed fixup! commits, (7)
-          approval or solo-maintainer override, (8) protected-branch
-          policy honored.
+          The skill's Step 5 executes the merge via
+          `mcp__plugin_Dev10x_cli__merge_pr` (GH-232) — symmetric
+          to `create_pr` / `push_safe`. Do NOT bypass this with
+          `DEV10X_SKIP_CMD_VALIDATION=true gh pr merge ...`; that
+          flag is reserved for transient MCP-unavailability
+          emergencies, not the documented flow. If the MCP tool is
+          unavailable, stop and ask the user to reconnect via
+          `/mcp` rather than running raw `gh pr merge`.
     reason: >
       Direct gh pr merge bypasses the 8 pre-merge checks the skill
       enforces. Adaptive friction does not waive the skill body —

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -1586,6 +1586,85 @@ class TestCreatePr:
         assert "branch not pushed" in result.error
 
 
+class TestMergePr:
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run", new_callable=AsyncMock)
+    async def test_merges_pr_with_defaults(
+        self,
+        mock_run: AsyncMock,
+        mock_resolve_repo,
+    ) -> None:
+        mock_run.return_value = _completed(stdout="merged\n")
+
+        result = await gh.merge_pr(pr_number=42)
+
+        assert isinstance(result, SuccessResult)
+        assert result.value == {
+            "pr_number": 42,
+            "url": "https://github.com/owner/repo/pull/42",
+            "strategy": "rebase",
+            "branch_deleted": True,
+            "repo": "owner/repo",
+        }
+        called_args = mock_run.call_args.kwargs["args"]
+        assert called_args == [
+            "gh",
+            "pr",
+            "merge",
+            "42",
+            "--repo",
+            "owner/repo",
+            "--rebase",
+            "--delete-branch",
+        ]
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run", new_callable=AsyncMock)
+    async def test_squash_strategy_without_delete_branch(
+        self,
+        mock_run: AsyncMock,
+        mock_resolve_repo,
+    ) -> None:
+        mock_run.return_value = _completed()
+
+        result = await gh.merge_pr(
+            pr_number=7,
+            strategy="squash",
+            delete_branch=False,
+        )
+
+        assert isinstance(result, SuccessResult)
+        assert result.value["strategy"] == "squash"
+        assert result.value["branch_deleted"] is False
+        called_args = mock_run.call_args.kwargs["args"]
+        assert "--squash" in called_args
+        assert "--delete-branch" not in called_args
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_strategy(self) -> None:
+        result = await gh.merge_pr(pr_number=1, strategy="bogus")
+
+        assert isinstance(result, ErrorResult)
+        assert "Invalid merge strategy" in result.error
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run", new_callable=AsyncMock)
+    async def test_returns_error_on_gh_failure(
+        self,
+        mock_run: AsyncMock,
+        mock_resolve_repo,
+    ) -> None:
+        mock_run.return_value = _completed(
+            returncode=1,
+            stderr="Pull request is not mergeable",
+        )
+
+        result = await gh.merge_pr(pr_number=42)
+
+        assert isinstance(result, ErrorResult)
+        assert "not mergeable" in result.error
+
+
 class TestGenerateCommitList:
     @pytest.mark.asyncio
     @patch("dev10x.github.async_run_script", new_callable=AsyncMock)

--- a/tests/mcp/test_cli_server.py
+++ b/tests/mcp/test_cli_server.py
@@ -747,6 +747,47 @@ class TestUpdatePrMcp:
         assert "error" in result
 
 
+class TestMergePrMcp:
+    @pytest.mark.asyncio
+    @patch("dev10x.github.merge_pr", new_callable=AsyncMock)
+    async def test_delegates_to_github_module(
+        self,
+        mock_fn: AsyncMock,
+    ) -> None:
+        mock_fn.return_value = ok(
+            {
+                "pr_number": 42,
+                "url": "https://github.com/o/r/pull/42",
+                "strategy": "rebase",
+                "branch_deleted": True,
+                "repo": "o/r",
+            }
+        )
+
+        result = await cli_server.merge_pr(pr_number=42)
+
+        assert result["pr_number"] == 42
+        assert result["strategy"] == "rebase"
+        assert mock_fn.call_args.kwargs == {
+            "pr_number": 42,
+            "strategy": "rebase",
+            "delete_branch": True,
+            "repo": None,
+        }
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.merge_pr", new_callable=AsyncMock)
+    async def test_returns_error_on_failure(
+        self,
+        mock_fn: AsyncMock,
+    ) -> None:
+        mock_fn.return_value = err("not mergeable")
+
+        result = await cli_server.merge_pr(pr_number=42)
+
+        assert "error" in result
+
+
 class TestGenerateCommitListMcp:
     @pytest.mark.asyncio
     @patch("dev10x.github.async_run_script", new_callable=AsyncMock)


### PR DESCRIPTION
When the agent finishes the 8 pre-merge checks under solo-maintainer adaptive mode, **I want to** ship the merge through a structured MCP tool **so the agent can** complete Dev10x:gh-pr-merge's documented Step 5 without hitting the PreToolUse hook that blocks raw `gh pr merge` and without reaching for the DEV10X_SKIP_CMD_VALIDATION escape hatch that user memory forbids for callers.

---

[`0a6b50bc`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/237/commits/0a6b50bceca9f1283e8b0cb1a9a4c83569138bac) ✨ GH-232 Enable gh-pr-merge Step 5 via merge_pr MCP tool
Closes #232
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/232

---