### PR TITLE
✨ GH-231 Enable walk-away mode for unattended sessions

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Dev10x",
-  "description": "v0.73.0.dev0 — 68 skills for structured commits, PR lifecycle, branch hygiene, ticket management, task tracking, code review, scoping, and QA automation in Claude Code.",
+  "description": "v0.73.0.dev0 — 69 skills for structured commits, PR lifecycle, branch hygiene, ticket management, task tracking, code review, scoping, and QA automation in Claude Code.",
   "version": "0.73.0.dev0",
   "author": {
     "name": "Janusz Skonieczny",

--- a/references/friction-levels.md
+++ b/references/friction-levels.md
@@ -234,10 +234,31 @@ Skills adopting friction-level awareness should:
 3. Add tests for adaptive auto-selection logic
 4. Update playbook steps if level-specific behavior differs
 
+## Walk-Away Layer
+
+`Dev10x:afk` adds a `walk_away: true` flag on top of `adaptive`
+that further suppresses `AskUserQuestion` gates which do not
+classify as destructive or blocking. Suppressed doubts are
+logged to a configured `doubt_sink` (PR description by default)
+instead of pausing execution.
+
+Walk-away is **orthogonal to friction level** — it changes
+*which gates fire at all*, not how a fired gate resolves. See
+`references/walk-away.md` for the full contract and
+classification table.
+
+Precedence at a single gate:
+
+1. Destructive or blocking → fire (walk-away does not waive)
+2. Else `walk_away: true` → suppress + log to `doubt_sink`
+3. Else friction_level rules apply (strict/guided/adaptive)
+
 ## References
 
 - ADR-0002: Data-driven skill redirect with friction levels
 - `references/execution-modes.md`: Structural modes (orthogonal)
+- `references/walk-away.md`: Walk-away layer contract
 - `src/dev10x/validators/command-skill-map.yaml`: Config source
 - `src/dev10x/validators/skill_redirect.py`: Hook implementation
 - `skills/verify-acc-dod/SKILL.md`: First skill-level adopter
+- `skills/afk/SKILL.md`: Walk-away mode skill

--- a/references/walk-away.md
+++ b/references/walk-away.md
@@ -1,0 +1,169 @@
+# Walk-Away Mode — Contract for Downstream Skills
+
+Defines how skills that emit `AskUserQuestion` consult the
+`walk_away` flag set by `Dev10x:afk` and route mid-flight
+doubts to the `doubt_sink` instead of pausing.
+
+Companion to `references/friction-levels.md` (which controls
+gate behavior universally) and `skills/afk/SKILL.md` (which
+sets the flag).
+
+## Config Surface
+
+```yaml
+# .claude/Dev10x/session.yaml
+friction_level: adaptive
+active_modes: [solo-maintainer]
+walk_away: true
+doubt_sink: pr-description    # pr-description | session-bookmark | commit-footer
+```
+
+The four fields together define a "walk-away session." Skills
+read all four with one `Read` call and branch on `walk_away`
+before classifying the question.
+
+## Question Classification
+
+Skills that call `AskUserQuestion` MUST classify the question
+into one of four categories before firing:
+
+| Class | Examples | Walk-away behavior |
+|-------|----------|---------------------|
+| `destructive` | Force-push to protected branch, mass file delete, `aws-vault` secret retrieval, `git reset --hard origin/main` | **Fire normally** (ALWAYS_ASK) |
+| `blocking` | No auth credentials, conflicting upstream merge, missing required ADR, MCP server unreachable | **Fire normally** — the supervisor must intervene |
+| `strategy` | "Bundle or split PRs?", "Fixup or full restructure?", "Which milestone?" | **Suppress, pick Recommended, log to doubt_sink** |
+| `informational` | "Which slug?", "Add this nit to PR?", "Confirm title?" | **Suppress, pick best-guess, log to doubt_sink** |
+
+Re-strategy questions (asking the same strategy a second time
+mid-execution) are always `strategy`-class. The first prompt may
+have fired before walk-away was enabled; the second MUST be
+suppressed.
+
+## Decision Flowchart
+
+```
+AskUserQuestion call site
+  │
+  ▼
+Read .claude/Dev10x/session.yaml
+  │
+  ▼
+walk_away == true ?
+  ├── no → fire AskUserQuestion (existing adaptive/guided/strict rules apply)
+  └── yes
+        │
+        ▼
+   Classify question
+        ├── destructive → fire AskUserQuestion (ALWAYS_ASK)
+        ├── blocking    → fire AskUserQuestion (cannot proceed)
+        ├── strategy    → pick Recommended, log to doubt_sink
+        └── informational → pick best-guess, log to doubt_sink
+```
+
+## doubt_sink Targets
+
+The `doubt_sink` field controls where suppressed-doubt entries
+land. Skills append, never overwrite.
+
+### `pr-description` (default)
+
+Append to the active PR body under a dedicated header. If no
+PR exists yet, buffer the entries in session state and flush
+them when `Dev10x:gh-pr-create` runs.
+
+```markdown
+## Concerns surfaced during implementation
+
+- [walk-away] Considered splitting commit 4 (auth refactor) into a
+  separate PR; proceeded with bundle to match approved strategy.
+  Recommended option: "keep in bundle".
+- [walk-away] Test coverage on `RetryHandler.backoff` is 0%; added
+  TODO instead of writing tests this PR. Followup: GH-???.
+```
+
+Each entry includes:
+- A `[walk-away]` tag so reviewers can grep
+- The doubt in one sentence
+- What the agent did instead (the Recommended option taken)
+- Optional pointer to a followup ticket
+
+### `session-bookmark`
+
+Append to the PR bookmark comment created by
+`Dev10x:gh-pr-bookmark`. Use for doubts that should survive
+session boundaries but do not belong in the merged PR body.
+
+### `commit-footer`
+
+Append to the most recent commit message as a `Concerns:` footer.
+Use only when the doubt is commit-scoped, not PR-scoped.
+
+## Skill Integration Checklist
+
+For a skill that emits `AskUserQuestion`:
+
+1. ✓ Read `.claude/Dev10x/session.yaml` before the gate
+2. ✓ Skip the read if `walk_away` is already known in scope
+3. ✓ Classify the question into one of four classes
+4. ✓ When suppressing, call the same code path that handles the
+     Recommended option at `adaptive` friction
+5. ✓ Append a one-line entry to the configured `doubt_sink`
+6. ✓ Log the suppression to the audit hook so `Dev10x:skill-audit`
+     can surface "walk-away suppressions" in the session report
+
+## Relationship to Friction Levels
+
+| Layer | Controls | Source of truth |
+|-------|----------|----------------|
+| `friction_level` | How gates with a `(Recommended)` option resolve | `references/friction-levels.md` |
+| `active_modes` | Which playbook steps exist | `references/execution-modes.md` |
+| `walk_away` | Whether non-destructive gates fire **at all** | this document |
+| `doubt_sink` | Where suppressed doubts are logged | this document |
+
+Precedence at a single gate:
+
+1. If question is `destructive` or `blocking` → fire (walk-away off)
+2. Else if `walk_away: true` → suppress + log to `doubt_sink`
+3. Else if `friction_level: adaptive` and gate has Recommended → auto-select
+4. Else → fire normally
+
+## Anti-Patterns
+
+- **Classifying every gate as `blocking` to keep the prompt** —
+  defeats walk-away. Reserve `blocking` for upstream/auth/credential
+  failures the supervisor cannot fix later.
+- **Logging to `commit-footer` when the doubt is PR-wide** —
+  commit footers should be commit-scoped; cross-commit concerns
+  belong in the PR body.
+- **Silent suppression** — every suppressed gate MUST log to
+  `doubt_sink`. A gate that was suppressed without a log entry
+  is indistinguishable from a bug.
+
+## Known Failure Modes (Pre-Walk-Away)
+
+These are the recurring failures walk-away mode addresses,
+documented from user feedback memory:
+
+- `feedback_adaptive_no_pre_approval_gates` — adaptive still
+  fires gates that have no Recommended option
+- `feedback_ambient_chatter_not_pause_signal` — agent treats
+  the user's `[USER PASTED A SLACK SNIPPET]` chatter as a
+  reason to pause; walk-away forces push-through
+- `feedback_solo_maintainer_pr_loop` — solo-maintainer mode
+  loops waiting for reviewer assignment; walk-away short-circuits
+- `feedback_no_restrategy_after_user_chose` — agent re-prompts
+  for a strategy already chosen in Phase 3; walk-away suppresses
+  the duplicate prompt and logs the doubt to the PR body
+
+## Out of Scope (Followups)
+
+These are deliberate gaps the MVP `Dev10x:afk` skill does not close:
+
+- **Automatic classification of arbitrary `AskUserQuestion` calls**
+  by static analysis — each emitting skill must classify its own
+  questions
+- **Retroactive cancellation** of an `AskUserQuestion` already in
+  flight — walk-away takes effect on the next gate
+- **doubt_sink: slack** — Slack-routed doubts are a candidate
+  followup; today the three sinks (pr-description, session-bookmark,
+  commit-footer) cover the documented use cases

--- a/skills/afk/SKILL.md
+++ b/skills/afk/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: Dev10x:afk
+description: >
+  Walk-away mode — harden adaptive + solo-maintainer auto-advance so
+  long-running sessions do not stall on re-strategy or confirmation
+  gates. Writes walk_away: true and doubt_sink: pr-description to
+  .claude/Dev10x/session.yaml; downstream skills consult the flag and
+  route mid-flight doubts to the PR body instead of pausing.
+  TRIGGER when: starting a long-running unattended session (e.g.,
+  bundle work, fanout swarm, overnight implementation), or user says
+  "walk away" / "afk" / "headless" / "no more questions".
+  DO NOT TRIGGER when: actively pair-programming, scoping a new
+  ticket (use Dev10x:ticket-scope), or session is already complete.
+user-invocable: true
+invocation-name: Dev10x:afk
+allowed-tools:
+  - Read(.claude/Dev10x/session.yaml)
+  - Write(.claude/Dev10x/session.yaml)
+---
+
+# Dev10x:afk — Walk-Away Mode
+
+**Announce:** "Using Dev10x:afk to harden auto-advance for this session."
+
+Hardens `friction_level: adaptive` + `active_modes: [solo-maintainer]`
+so the agent does not re-litigate a decision the supervisor already
+made. Couples two rules:
+
+1. Do not call `AskUserQuestion` unless the action is **destructive**
+   (force-push to protected branch, mass delete, secret retrieval) or
+   a **hard upstream blocker** (missing ADR, conflicting upstream,
+   no auth credentials).
+2. If you start to doubt the chosen plan mid-execution, **push through
+   and append the doubt to the PR description** under a "Concerns
+   surfaced during implementation" header. Do not pause.
+
+See [`references/walk-away.md`](../../references/walk-away.md) for
+the full contract downstream skills consult.
+
+## Orchestration
+
+**REQUIRED: Create a task at invocation.** Execute at startup:
+
+1. `TaskCreate(subject="Enable walk-away mode", activeForm="Enabling walk-away")`
+
+Mark completed when the session config write returns (or is skipped
+because the flag already matches).
+
+## When to Use
+
+Invoke this skill at the start of a session where the supervisor
+will be unavailable for hours. Typical entry points:
+
+- `Dev10x:afk` then `Dev10x:work-on bundle <milestone-url>`
+- `Dev10x:afk` then `Dev10x:fanout` over a queue of tickets
+- Resuming an unattended run after compaction — the flag survives
+  in `session.yaml` and is re-read on the next Phase 0
+
+## Instructions
+
+### Step 1: Read existing session config
+
+Read `.claude/Dev10x/session.yaml` if it exists. Capture
+`friction_level`, `active_modes`, `walk_away`, and `doubt_sink`.
+If the file is missing, treat all four as unset.
+
+### Step 2: Compute desired state
+
+The walk-away invariants:
+
+```yaml
+friction_level: adaptive            # required
+active_modes: [solo-maintainer]     # required (merged, not replaced)
+walk_away: true
+doubt_sink: pr-description
+```
+
+Merge `solo-maintainer` into the existing `active_modes` list if
+absent. **Never overwrite a non-empty `active_modes` list with the
+single-mode form** — preserve modes the user already enabled (e.g.,
+`research-spike`, `release-train`). The merged list is the union.
+
+If `friction_level` is currently `strict` or `guided`, walk-away
+**downgrades it to `adaptive`** — that is the entire point. Surface
+this to the user in the announcement so they can revert if it was
+unintentional.
+
+### Step 3: Read-before-write gate (GH-846)
+
+**Skip the write entirely** if all four desired keys already match
+the on-disk values. This avoids spurious permission prompts and
+prevents clobbering co-edited entries.
+
+Only when at least one key differs, write the merged config back
+to `.claude/Dev10x/session.yaml` using the Write tool.
+
+### Step 4: Report
+
+Print a one-line summary of what changed:
+
+- `walk_away: true` — first time enabling
+- `walk_away: already true` — no-op, surface as confirmation
+- `friction_level: guided → adaptive` — when downgraded
+- `active_modes: + solo-maintainer` — when merged
+
+Do **not** emit an `AskUserQuestion` confirmation. The invocation
+itself is the confirmation; firing a gate here would violate the
+contract this skill is meant to enforce.
+
+## Contract for Downstream Skills
+
+Skills that emit `AskUserQuestion` MUST consult `walk_away` before
+firing. The classification rule:
+
+| Question class | Walk-away behavior |
+|----------------|---------------------|
+| `destructive` (force-push, mass delete, secret retrieval) | Fire normally (ALWAYS_ASK) |
+| `blocking` (missing creds, conflicting upstream, missing ADR) | Fire normally |
+| `strategy` / `confirmation` / `re-strategy` | Suppress, auto-pick Recommended, log to `doubt_sink` |
+| `informational` (which slug? which title?) | Suppress, pick best-guess, log to `doubt_sink` |
+
+Full classification rules and per-skill integration guidance live in
+[`references/walk-away.md`](../../references/walk-away.md).
+
+## Relationship to Friction Levels
+
+`walk_away` is **orthogonal to** `friction_level`. The adaptive
+friction level already auto-selects `(Recommended)` options at
+gates, but it has two known failure modes that walk-away closes:
+
+1. **Gates without a Recommended option** — adaptive still fires
+   them. Walk-away suppresses anything that is not destructive or
+   hard-blocking.
+2. **Mid-flight re-strategy prompts** — adaptive does not prevent
+   a skill from emitting a fresh `AskUserQuestion` after partial
+   recon reveals scope. Walk-away forces the doubt into the
+   `doubt_sink` instead.
+
+See `references/friction-levels.md` § Walk-Away Layer for the
+precedence rules.
+
+## Anti-Patterns
+
+- **Calling `Dev10x:afk` mid-flight to silence an active prompt** —
+  this skill modifies session config, it does not retroactively
+  cancel a pending `AskUserQuestion`. Answer the prompt first, then
+  invoke `Dev10x:afk` to prevent the next one.
+- **Combining with `friction_level: strict`** — the skill downgrades
+  strict to adaptive. If you want strict gating, do not invoke
+  walk-away.
+- **Using on a session where the supervisor is actively reviewing** —
+  walk-away suppresses informational gates too, which removes the
+  ability for the supervisor to inject mid-session steering. Reserve
+  for genuinely unattended runs.
+
+## Reverting
+
+To exit walk-away mode mid-session, edit `.claude/Dev10x/session.yaml`
+directly and set `walk_away: false` (or delete the key). The
+next gate-emitting skill will read the updated value and resume
+normal adaptive behavior.


### PR DESCRIPTION
**When** I kick off a long-running work-on session (e.g. `Dev10x:work-on bundle <milestone-url>`) and walk away expecting steady progress, **I want** a single skill invocation that locks the agent into "no AskUserQuestion gates unless destructive or hard-blocked, and surface doubt in the PR body instead of pausing", **so I can** trust that adaptive + solo-maintainer mode will actually auto-advance through N tickets without me returning hours later to find a stalled session re-litigating a strategy I already approved.

---

[`763e460f`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/239/commits/763e460fb54f814ba69b9f856bc19f1819a57788) ✨ GH-231 Enable walk-away mode for unattended sessions
Closes #231
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/231

---