### PR TITLE
✨ M7 Surface push_safe results and close Gate 6 silent-skip gap

### DIFF
--- a/.claude/rules/mcp-tools.md
+++ b/.claude/rules/mcp-tools.md
@@ -65,10 +65,12 @@ modules MUST mirror the pattern — return `Result[T]` internally, call
 - `mktmp`: returns `{"path": "/tmp/file"}`
 - Some tools return `{"success": True, "data": result}`
 - Some tools return only tool-specific fields without a `success` flag
-- `push_safe`: returns `{}` on a clean fast-forward push (GH-152) —
-  emptiness is NOT failure; only `{"error": ...}` is failure. Verify
-  the remote with `git ls-remote --heads origin <branch>` if a
-  payload is needed.
+- `push_safe`: returns `{"pushed": true, "ref": "...", "remote":
+  "...", "sha": "...", "tracking": "...", "ci_run_url": null}` on a
+  successful push (GH-188). On a blocked or failed push, `pushed` is
+  `false` and `blocked_reason` names the cause. Only `{"error": ...}`
+  signals an MCP-level failure. Older callers that treat any non-error
+  payload as success continue to work.
 
 Callers must know each tool's specific success response format. Branch
 on the presence of an `"error"` key, never on whether the dict is

--- a/skills/gh-pr-respond/evals/evals.json
+++ b/skills/gh-pr-respond/evals/evals.json
@@ -104,6 +104,16 @@
           "text": "Step 1c is skipped if the user chose 'Leave open' in Step 1b",
           "check": "behavioral",
           "signals": ["no AskUserQuestion about Hide when thread left open"]
+        },
+        {
+          "id": "gate6-fires-after-resolution-single",
+          "text": "In single mode, minimize_comments is invoked after a successful resolve_review_thread — Gate 6 never silently skips when the thread was resolved",
+          "check": "tool_called",
+          "signals": [
+            "mcp__plugin_Dev10x_cli__resolve_review_thread",
+            "mcp__plugin_Dev10x_cli__minimize_comments",
+            "AskUserQuestion"
+          ]
         }
       ]
     },
@@ -191,6 +201,25 @@
           "text": "Step 5b is skipped if no threads were resolved in Step 5",
           "check": "behavioral",
           "signals": ["no AskUserQuestion about Hide when no threads resolved"]
+        },
+        {
+          "id": "gate6-fires-after-resolution",
+          "text": "minimize_comments is invoked after a successful resolve_review_thread call — Gate 6 never silently skips when threads were resolved",
+          "check": "tool_called",
+          "signals": [
+            "mcp__plugin_Dev10x_cli__resolve_review_thread",
+            "mcp__plugin_Dev10x_cli__minimize_comments",
+            "AskUserQuestion"
+          ]
+        },
+        {
+          "id": "gate6-fires-at-adaptive-friction",
+          "text": "Gate 6 fires (AskUserQuestion called) even at adaptive friction — adaptive only auto-selects the recommended option, it does not skip the gate",
+          "check": "behavioral",
+          "signals": [
+            "AskUserQuestion called regardless of friction_level=adaptive",
+            "minimize_comments invoked after resolve"
+          ]
         },
         {
           "id": "gate5-post-response-continuation",

--- a/skills/gh-pr-respond/instructions.md
+++ b/skills/gh-pr-respond/instructions.md
@@ -90,6 +90,9 @@ step description. If you see that marker, you MUST call the
 4. Gate 4 (resolve threads): `AskUserQuestion` — MANDATORY
 5. Gate 5 (shipping pipeline): `AskUserQuestion` — MANDATORY
 6. Gate 6 (hide comments): `AskUserQuestion` — MANDATORY
+   (fires at every friction level, including `adaptive`; adaptive
+   auto-selects "Hide all resolved" but the gate still fires and
+   `minimize_comments` is invoked — GH-208)
 7. VALID comments: `Skill(Dev10x:gh-pr-fixup)` — NEVER inline,
    invoke immediately after triage verdict (no pause, no report)
 8. Triage: `Skill(Dev10x:gh-pr-triage)` — NEVER inline, even
@@ -745,6 +748,15 @@ Hide these comments?
 ```
 
 **REQUIRED: Call `AskUserQuestion`** (do NOT use plain text).
+**Adaptive friction does NOT skip this gate** — at
+`friction_level: adaptive`, the recommended option ("Hide all
+resolved") is auto-selected, but the `AskUserQuestion` call still
+fires and `mcp__plugin_Dev10x_cli__minimize_comments` MUST be
+invoked on the resolved comments. Silently auto-advancing into
+the shipping pipeline without calling `minimize_comments` is the
+GH-208 regression and is caught by the
+`gate6_fires_after_resolution` eval assertion.
+
 Options:
 - **"Hide all resolved" (Recommended)** — Minimize all resolved
   thread root comments with classifier `OUTDATED`

--- a/skills/git/SKILL.md
+++ b/skills/git/SKILL.md
@@ -90,8 +90,33 @@ action is `Skill(Dev10x:gh-pr-monitor)` — not "wait and see".**
 A push to a PR branch retriggers CI; failing to monitor it
 turns a deviation into an oversight.
 
-After `push_safe` returns (empty dict `{}` means success — see
-`.claude/rules/mcp-tools.md`):
+### `push_safe` return shape
+
+On success, `push_safe` returns a structured payload:
+
+```json
+{
+  "pushed": true,
+  "ref": "<branch>",
+  "remote": "origin",
+  "sha": "<short-sha>",
+  "tracking": "origin/<branch>",
+  "ci_run_url": null
+}
+```
+
+On a blocked or failed push, `pushed` is `false` and `blocked_reason`
+names the cause (`protected_branch_force_push`, `push_failed`, …).
+A returned `{"error": "..."}` payload signals an MCP-level failure
+distinct from `pushed: false`.
+
+> **Historical note (GH-188):** earlier versions returned `{}` on
+> success and required a separate `git ls-remote` round-trip to
+> confirm the remote accepted the ref. New callers should branch on
+> the `pushed` field; existing callers tolerating `{}` continue to
+> work because the new payload is strictly additive.
+
+After `push_safe` returns:
 
 1. Resolve PR state for the pushed branch via
    `mcp__plugin_Dev10x_cli__pr_detect`.

--- a/skills/git/scripts/git-push-safe.sh
+++ b/skills/git/scripts/git-push-safe.sh
@@ -44,23 +44,50 @@ for arg in "${PUSH_ARGS[@]}"; do
     fi
 done
 
-if [[ $force -eq 1 ]]; then
-    target_branch=""
-    for arg in "${PUSH_ARGS[@]}"; do
-        if [[ "$arg" != -* ]]; then
+# Resolve the target branch and remote from the parsed PUSH_ARGS.
+# Defaults match `git push` behavior: remote=origin, branch=HEAD.
+target_branch=""
+remote="origin"
+for arg in "${PUSH_ARGS[@]}"; do
+    if [[ "$arg" != -* ]]; then
+        if [[ "$remote" == "origin" && -z "$target_branch" ]]; then
+            # First positional is remote, second is refspec — but a single
+            # positional is the remote when no refspec is given.
+            remote="$arg"
+        else
             target_branch="${arg##*:}"
         fi
-    done
-
-    if [[ -z "$target_branch" ]]; then
-        target_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
     fi
+done
 
-    if is_protected_branch "$target_branch"; then
-        echo "BLOCKED: --force push to protected branch '$target_branch' is not allowed." >&2
-        echo "Use --force-with-lease on a feature branch instead." >&2
-        exit 2
-    fi
+if [[ -z "$target_branch" ]]; then
+    target_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
 fi
 
-exec git push "${PUSH_ARGS[@]}"
+if [[ $force -eq 1 ]] && is_protected_branch "$target_branch"; then
+    # JSON blocked result on stdout (success exit code so callers can parse
+    # the structured payload), plus a human-readable warning on stderr.
+    echo "BLOCKED: --force push to protected branch '$target_branch' is not allowed." >&2
+    echo "Use --force-with-lease on a feature branch instead." >&2
+    printf '{"pushed":false,"ref":"%s","remote":"%s","blocked_reason":"protected_branch_force_push"}\n' \
+        "$target_branch" "$remote"
+    exit 2
+fi
+
+# Run the push; capture stderr so we can re-emit it after the JSON payload.
+push_stderr=$(mktemp)
+trap 'rm -f "$push_stderr"' EXIT
+if ! git push "${PUSH_ARGS[@]}" 2>"$push_stderr"; then
+    rc=$?
+    cat "$push_stderr" >&2
+    printf '{"pushed":false,"ref":"%s","remote":"%s","blocked_reason":"push_failed"}\n' \
+        "$target_branch" "$remote"
+    exit "$rc"
+fi
+cat "$push_stderr" >&2
+
+sha=$(git rev-parse --short HEAD 2>/dev/null || echo "")
+tracking=$(git rev-parse --abbrev-ref --symbolic-full-name "@{u}" 2>/dev/null || echo "")
+
+printf '{"pushed":true,"ref":"%s","remote":"%s","sha":"%s","tracking":"%s","ci_run_url":null}\n' \
+    "$target_branch" "$remote" "$sha" "$tracking"

--- a/src/dev10x/skills/doctor/strategies/missing_linear_mcp_allow.py
+++ b/src/dev10x/skills/doctor/strategies/missing_linear_mcp_allow.py
@@ -43,10 +43,7 @@ MISSING_THRESHOLD = 3
 
 
 def _has_linear_usage(rules: list[str]) -> bool:
-    return any(
-        any(rule.startswith(prefix) for prefix in LINEAR_RULE_PREFIXES)
-        for rule in rules
-    )
+    return any(any(rule.startswith(prefix) for prefix in LINEAR_RULE_PREFIXES) for rule in rules)
 
 
 def _missing_baseline(rules: list[str]) -> list[str]:

--- a/src/dev10x/skills/permission/update_paths.py
+++ b/src/dev10x/skills/permission/update_paths.py
@@ -28,9 +28,7 @@ PLUGIN_CONFIG = (
     Path(__file__).resolve().parents[4] / "skills" / "upgrade-cleanup" / "projects.yaml"
 )
 PLUGIN_NAMES = r"(?:Dev10x|dev10x-claude)"
-VERSION_PATTERN = re.compile(
-    rf"(plugins/cache/)([^/]+)(/{PLUGIN_NAMES}/)(\d+\.\d+\.\d+)"
-)
+VERSION_PATTERN = re.compile(rf"(plugins/cache/)([^/]+)(/{PLUGIN_NAMES}/)(\d+\.\d+\.\d+)")
 
 
 def extract_cache_publisher(plugin_cache: str) -> str | None:
@@ -222,12 +220,8 @@ def ensure_base_permissions(
             live_data["permissions"]["allow"].extend(expanded_tools)
             live_data["permissions"]["allow"].extend(missing)
 
-    messages = [
-        f"  - {wc}  (non-functional MCP wildcard removed)" for wc in stale_wildcards
-    ]
-    messages.extend(
-        f"  + {tool}  (expanded from MCP wildcard)" for tool in expanded_tools
-    )
+    messages = [f"  - {wc}  (non-functional MCP wildcard removed)" for wc in stale_wildcards]
+    messages.extend(f"  + {tool}  (expanded from MCP wildcard)" for tool in expanded_tools)
     messages.extend(f"  + {p}" for p in missing)
     return len(missing) + len(stale_wildcards) + len(expanded_tools), messages
 
@@ -740,14 +734,10 @@ def ensure_workspace(
             files_changed += 1
 
     if total_added == 0:
-        messages.append(
-            "All settings files already register the workspace directories."
-        )
+        messages.append("All settings files already register the workspace directories.")
     else:
         verb = "Would add" if dry_run else "Added"
-        messages.append(
-            f"{verb} {total_added} workspace entries across {files_changed} files."
-        )
+        messages.append(f"{verb} {total_added} workspace entries across {files_changed} files.")
 
     return _result(
         exit_code=0,
@@ -841,9 +831,7 @@ def ensure_base(
         messages.append("All files already have base permissions.")
     else:
         verb = "Would add" if dry_run else "Added"
-        messages.append(
-            f"{verb} {total_added} permissions across {files_changed} files."
-        )
+        messages.append(f"{verb} {total_added} permissions across {files_changed} files.")
 
     return _result(
         exit_code=0,
@@ -883,9 +871,7 @@ def generalize(
         messages.append("No session-specific permissions found.")
     else:
         verb = "Would generalize" if dry_run else "Generalized"
-        messages.append(
-            f"{verb} {total_generalized} permissions in {files_changed} files."
-        )
+        messages.append(f"{verb} {total_generalized} permissions in {files_changed} files.")
 
     return _result(
         exit_code=0,
@@ -957,9 +943,7 @@ def ensure_scripts(
         messages.append("All settings files have complete script coverage.")
     else:
         verb = "Would add" if dry_run else "Added"
-        messages.append(
-            f"{verb} {total_added} script rules across {files_changed} files."
-        )
+        messages.append(f"{verb} {total_added} script rules across {files_changed} files.")
 
     return _result(
         exit_code=0,
@@ -1029,9 +1013,7 @@ def ensure_reads(
         messages.append("All settings files have complete Read coverage.")
     else:
         verb = "Would add" if dry_run else "Added"
-        messages.append(
-            f"{verb} {total_added} Read rules across {files_changed} files."
-        )
+        messages.append(f"{verb} {total_added} Read rules across {files_changed} files.")
 
     return _result(
         exit_code=0,
@@ -1059,16 +1041,12 @@ def _detect_plugin_cache() -> str:
                 candidates.append(plugin_dir)
                 break
     if len(candidates) == 1:
-        return (
-            f"~/.claude/plugins/cache/{candidates[0].parent.name}/{candidates[0].name}"
-        )
+        return f"~/.claude/plugins/cache/{candidates[0].parent.name}/{candidates[0].name}"
     if len(candidates) > 1:
         names = ", ".join(f"{c.parent.name}/{c.name}" for c in candidates)
         print(f"Multiple plugin cache entries found: {names}")
         print(f"Using first match: {candidates[0].parent.name}/{candidates[0].name}")
-        return (
-            f"~/.claude/plugins/cache/{candidates[0].parent.name}/{candidates[0].name}"
-        )
+        return f"~/.claude/plugins/cache/{candidates[0].parent.name}/{candidates[0].name}"
     return "~/.claude/plugins/cache/Dev10x-Guru/Dev10x"
 
 

--- a/tests/git/test_git.py
+++ b/tests/git/test_git.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from dev10x.domain.common.result import ErrorResult, SuccessResult
-from dev10x.git import mass_rewrite, rebase_groom
+from dev10x.git import mass_rewrite, push_safe, rebase_groom
 
 
 def _completed(
@@ -161,3 +161,43 @@ class TestMassRewriteConflictDetection:
 
         assert isinstance(result, SuccessResult)
         assert "Enable feature" in result.value["output"]
+
+
+class TestPushSafeStructuredOutput:
+    @pytest.mark.asyncio
+    @patch("dev10x.git.async_run_script", new_callable=AsyncMock)
+    async def test_parses_structured_success_payload(
+        self,
+        mock_run_script: AsyncMock,
+    ) -> None:
+        payload = (
+            '{"pushed":true,"ref":"feature","remote":"origin",'
+            '"sha":"abc1234","tracking":"origin/feature","ci_run_url":null}'
+        )
+        mock_run_script.return_value = _completed(stdout=payload)
+
+        result = await push_safe(args=["origin", "feature"])
+
+        assert isinstance(result, SuccessResult)
+        assert result.value["pushed"] is True
+        assert result.value["ref"] == "feature"
+        assert result.value["remote"] == "origin"
+        assert result.value["sha"] == "abc1234"
+        assert result.value["tracking"] == "origin/feature"
+        assert result.value["ci_run_url"] is None
+
+    @pytest.mark.asyncio
+    @patch("dev10x.git.async_run_script", new_callable=AsyncMock)
+    async def test_returns_error_on_blocked_force_push(
+        self,
+        mock_run_script: AsyncMock,
+    ) -> None:
+        mock_run_script.return_value = _completed(
+            returncode=2,
+            stderr="BLOCKED: --force push to protected branch 'main' is not allowed.",
+        )
+
+        result = await push_safe(args=["origin", "main", "--force"])
+
+        assert isinstance(result, ErrorResult)
+        assert "BLOCKED" in result.error

--- a/tests/skills/doctor/test_missing_linear_mcp_allow.py
+++ b/tests/skills/doctor/test_missing_linear_mcp_allow.py
@@ -64,9 +64,7 @@ def settings_without_linear(tmp_path: Path) -> Path:
 
 
 class TestMissingLinearMcpAllowDetect:
-    def test_flags_partial_linear_usage(
-        self, settings_with_partial_linear: Path
-    ) -> None:
+    def test_flags_partial_linear_usage(self, settings_with_partial_linear: Path) -> None:
         context = Context(settings_paths=(settings_with_partial_linear,))
 
         findings = missing_linear_mcp_allow.detect(context)
@@ -81,9 +79,7 @@ class TestMissingLinearMcpAllowDetect:
             >= missing_linear_mcp_allow.MISSING_THRESHOLD - 1
         )
 
-    def test_silent_when_baseline_complete(
-        self, settings_with_full_baseline: Path
-    ) -> None:
+    def test_silent_when_baseline_complete(self, settings_with_full_baseline: Path) -> None:
         context = Context(settings_paths=(settings_with_full_baseline,))
 
         findings = missing_linear_mcp_allow.detect(context)

--- a/tests/skills/upgrade-cleanup/test_ensure_base.py
+++ b/tests/skills/upgrade-cleanup/test_ensure_base.py
@@ -192,9 +192,7 @@ class TestEnsureBaseExpandsStaleWildcards:
         settings_file: Path,
         fake_catalog: dict,
     ) -> None:
-        settings_file.write_text(
-            json.dumps({"permissions": {"allow": ["mcp__plugin_Dev10x_*"]}})
-        )
+        settings_file.write_text(json.dumps({"permissions": {"allow": ["mcp__plugin_Dev10x_*"]}}))
 
         count, messages = update_paths.ensure_base_permissions(
             settings_file,
@@ -265,9 +263,7 @@ class TestEnsureBaseExpandsStaleWildcards:
         settings_file: Path,
         fake_catalog: dict,
     ) -> None:
-        settings_file.write_text(
-            json.dumps({"permissions": {"allow": ["mcp__plugin_Dev10x_*"]}})
-        )
+        settings_file.write_text(json.dumps({"permissions": {"allow": ["mcp__plugin_Dev10x_*"]}}))
 
         count, _ = update_paths.ensure_base_permissions(
             settings_file,
@@ -371,9 +367,7 @@ class TestEnsureBasePermissions:
         assert len(messages) == 3
         assert empty_settings.read_text() == original
 
-    def test_creates_permissions_key_if_absent(
-        self, no_permissions_settings: Path
-    ) -> None:
+    def test_creates_permissions_key_if_absent(self, no_permissions_settings: Path) -> None:
         count, _ = update_paths.ensure_base_permissions(
             no_permissions_settings,
             self.BASE_PERMISSIONS,


### PR DESCRIPTION
**When** an orchestrator finishes a push or resolves a review thread mid-pipeline, **I want to** see structured confirmation of what happened, **so I can** auto-advance to the next step (CI poll, hide-obsolete prompt) without inferring success from emptiness or silently skipping the gate.

---

[`6dca2894`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/251/commits/6dca2894937269918eb4cad5bb75110bb00bfdf9) ✨ GH-188 Surface push_safe results so callers can confirm pushes
[`dc6933cc`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/251/commits/dc6933ccdafee9d0f995b85e3ab2d6de7ebeebcf) 🐛 GH-208 Stop Gate 6 from silently skipping after resolve
[`ada5054f`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/251/commits/ada5054f555ca2b145657229d87c341648895df2) 🎨 Restore ruff format on doctor and permission modules
Closes #188
Closes #208
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/milestone/7

---