### PR TITLE
✨ GH-133 Enable sibling pub/sub coordination via JSONL bus

### DIFF
--- a/references/orchestration/fanout-bus.md
+++ b/references/orchestration/fanout-bus.md
@@ -1,0 +1,225 @@
+# Fanout JSONL Pub/Sub Bus (v1)
+
+Sibling-to-sibling coordination protocol for `Dev10x:fanout`
+swarm children. Lets concurrently-running agents publish and
+consume file-lock requests, conflict signals, progress
+heartbeats, and bailout notices without serialising the wave
+at the first sign of drift.
+
+**Status:** v1 — append-only JSONL file per wave. No MCP server,
+no daemon. If field experience shows tail-based polling is
+insufficient, promote to `mcp__plugin_Dev10x_fanout_bus__*`
+(see § Future Work).
+
+**Scope:** This document is referenced by the
+`Dev10x:fanout` Phase 3 dispatch prompt and consumed directly
+by swarm-child agents. ADR 0004 leaves real-time coordination
+out of the native-Agent swarm baseline and points at this
+follow-up.
+
+## Why file-based, not MCP
+
+ADR 0004 ships native-Agent swarm dispatch with no
+sibling-to-sibling channel: drift is reported through the
+agent's result message and the orchestrator resolves between
+waves. That's adequate when conflicts are rare but loses
+parallelism whenever conflicts actually occur. The four
+mechanisms compared in GH-133's issue body:
+
+| Mechanism | Pros | Cons |
+|---|---|---|
+| Append-only JSONL bus per wave (this doc) | Zero new infra; deterministic; inspectable | Tail-based polling |
+| MCP server `fanout_bus` with topics + subscriptions | Cleanest API; persist + filter | Requires building the server |
+| `SendMessage` between named agents | Already exists | Peer-to-peer rather than pub/sub; orchestrator loses visibility |
+| Orchestrator as broker | Centralised; parent stays in the loop | Adds latency; parent context fills up |
+
+JSONL wins for v1 because every Dev10x swarm child already has
+Bash + Read + Write + `mcp__plugin_Dev10x_cli__mktmp` in scope.
+No new tool, no server lifecycle, no protocol versioning past
+the event schema below. The file itself is the audit trail.
+
+## File layout
+
+The orchestrator creates a per-wave directory **before**
+dispatching any Agent calls in that wave:
+
+```
+/tmp/Dev10x/fanout/<wave_id>/
+    bus.jsonl       — append-only event stream
+```
+
+Creation goes through `mcp__plugin_Dev10x_cli__mktmp`:
+
+```
+mcp__plugin_Dev10x_cli__mktmp(
+    namespace="fanout",
+    prefix=f"<wave_id>/bus",
+    ext=".jsonl"
+)
+```
+
+The returned `path` is inlined into every sibling's swarm
+context prompt as `bus_path`. The wave_id is the same UUID the
+swarm context already carries — the bus path is just a
+deterministic suffix.
+
+`<wave_id>` is the only path-variable component. Children MUST
+NOT create new files under this directory; they only append to
+`bus.jsonl`.
+
+## Event schema
+
+Every event is a single JSON object on one line, newline-terminated.
+No multi-line JSON, no comments. Append-only — never rewrite
+prior events.
+
+Common envelope on every event:
+
+| Field | Type | Description |
+|---|---|---|
+| `ts` | string | RFC 3339 UTC timestamp |
+| `from` | string | Publisher's `item_id` (matches swarm context) |
+| `event` | string | One of the event types below |
+| `seq` | integer | Monotonic per-publisher counter starting at 1 |
+
+The `seq` field lets consumers detect dropped events when
+tailing the file. Implementations MAY skip enforcement in v1.
+
+### `file_lock_request`
+
+A child intends to write to one or more paths and asks
+siblings to defer touching them.
+
+| Field | Type | Description |
+|---|---|---|
+| `paths` | array of strings | Repo-relative paths the publisher claims |
+| `intent` | string | Short human label, e.g. `"refactor"`, `"fix-test"` |
+| `expires_at` | string | RFC 3339; advisory expiry. Consumers may ignore stale locks. |
+
+### `file_lock_grant`
+
+A sibling acknowledges another sibling's `file_lock_request`
+and confirms it will NOT touch the listed paths. Optional —
+absence of a grant within `lock_wait_timeout` (default 30s)
+is treated as implicit non-conflict.
+
+| Field | Type | Description |
+|---|---|---|
+| `request_ts` | string | The `ts` of the `file_lock_request` being granted |
+| `granted_to` | string | The requester's `item_id` |
+
+### `conflict_signal`
+
+A child has discovered a file-scope drift it cannot resolve
+locally. Sent before the child decides whether to wait or
+bail out.
+
+| Field | Type | Description |
+|---|---|---|
+| `path` | string | Repo-relative path in conflict |
+| `with_item` | string | Sibling `item_id` that owns the path per Phase 2 conflict graph (may be `"unknown"`) |
+| `severity` | string | `"hard"` (cannot proceed) or `"soft"` (could proceed with risk) |
+
+### `progress`
+
+Optional heartbeat. Lets the orchestrator and siblings see
+that a child is still alive between commits.
+
+| Field | Type | Description |
+|---|---|---|
+| `stage` | string | Free-form short label, e.g. `"design"`, `"implementing"`, `"reviewing"` |
+| `note` | string | Optional one-line context (≤80 chars) |
+
+### `bailout`
+
+Final event published when a child decides to abort its work
+rather than wait. The orchestrator reads this on wave-drain
+to decide whether to re-dispatch in a follow-up wave.
+
+| Field | Type | Description |
+|---|---|---|
+| `reason` | string | `"conflict"`, `"timeout"`, `"permission"`, or free-form |
+| `recoverable` | boolean | `true` if a re-dispatch with adjusted ownership could succeed |
+
+## Decision gate: wait vs bail
+
+When a swarm child publishes a `conflict_signal`, it MUST
+choose one of two responses — never busy-loop:
+
+| Response | When | How |
+|---|---|---|
+| **Wait** | Sibling reachable; `severity: "soft"`; the sibling can plausibly finish first | Poll `bus.jsonl` for a matching `file_lock_grant` or for the sibling's terminal event (`bailout` or its result return). Cap the wait at `lock_wait_timeout` (default 30s). On timeout, transition to **bail**. |
+| **Bail** | `severity: "hard"`, sibling unreachable, or wait timed out | Publish `bailout` with `recoverable: true|false`, return `BLOCKED: file-scope drift on <path> (sibling=<id>)` from the Agent result. Do NOT push a partial branch. |
+
+The orchestrator MUST treat any `bailout` published in a wave
+as a signal to consider rebasing successors and re-dispatching
+the bailed item in a follow-up wave.
+
+## Producer rules (swarm child)
+
+1. Open the bus path read-only first to load prior events from
+   the same wave (Phase 2 conflict-graph guidance may already
+   have been emitted by the orchestrator). Use `Read` or
+   `Bash(tail -F)` for live consumption.
+2. Before writing to a path that overlaps with
+   `shared_files_with_siblings`, publish a
+   `file_lock_request`. Wait up to `lock_wait_timeout` for a
+   `file_lock_grant` from each implicated sibling.
+3. On detected drift, publish `conflict_signal` and follow the
+   decision gate above.
+4. Publish `progress` at most once per minute. The bus is not
+   a debug log.
+5. Never delete or truncate `bus.jsonl`. Append only.
+
+## Consumer rules (swarm child)
+
+1. Tail `bus.jsonl` periodically; ignore events whose `from`
+   field is your own `item_id`.
+2. Respond to `file_lock_request` with a `file_lock_grant`
+   when you are confident you will not touch the listed paths
+   within the current wave. Silence is acceptable; explicit
+   denial is published as `conflict_signal` with
+   `with_item: <requester>`.
+3. Treat `bailout` from a sibling as a hint that any paths
+   that sibling claimed are now available — but do not assume
+   the sibling reverted partial changes. Inspect the worktree.
+
+## Orchestrator rules
+
+The orchestrator (the main `Dev10x:fanout` session) is a
+passive consumer in v1:
+
+1. Create the bus directory and file before each wave
+   dispatch.
+2. Inline `bus_path` into every child's swarm-context prompt.
+3. On wave drain, read `bus.jsonl` once to harvest
+   `bailout`/`conflict_signal` events and feed them into the
+   Phase 4 re-dispatch decision.
+4. Do NOT publish into the bus. The bus is a sibling-to-sibling
+   channel; orchestrator coordination stays in agent result
+   messages.
+5. Keep the bus file after the wave completes — it doubles as
+   an audit trail. The `/tmp/Dev10x/fanout/<wave_id>/`
+   directory is cleaned up by normal `/tmp` rotation.
+
+## Defaults
+
+| Parameter | Default | Override |
+|---|---|---|
+| `lock_wait_timeout` | 30s | Per-child via swarm-context payload |
+| `progress_interval` | 60s | Same |
+| `max_events_per_wave` | 500 | Soft cap — log a warning on the bus and continue |
+
+## Future work
+
+Promote to `mcp__plugin_Dev10x_fanout_bus__*` when ANY hold:
+
+- File-tailing latency causes measurable wasted parallelism
+  in a real swarm run (not a synthetic benchmark)
+- Cross-wave coordination is required (e.g., long-lived
+  cross-pipeline lockfiles)
+- Schema needs publish-side validation that the current
+  free-form JSONL cannot enforce
+
+Until then, the bus is plain JSONL. The simplicity is the
+feature.

--- a/skills/fanout/instructions.md
+++ b/skills/fanout/instructions.md
@@ -304,6 +304,26 @@ tool uses** so they run concurrently and share the
 parent's prompt-cache prefix. Wait for completion
 notifications before dispatching the next wave; do NOT poll.
 
+**Sibling pub/sub bus (GH-133).** Before dispatching a wave,
+create the per-wave JSONL bus that lets children coordinate
+file ownership without serialising through the orchestrator:
+
+```
+mcp__plugin_Dev10x_cli__mktmp(
+    namespace="fanout",
+    prefix=f"{wave_id}/bus",
+    ext=".jsonl",
+)
+```
+
+Inline the returned `path` into every child's prompt as
+`bus_path`. The orchestrator is a passive consumer — it reads
+the bus once on wave drain to harvest `bailout` and
+`conflict_signal` events for re-dispatch decisions, but never
+publishes. Full event schema, decision-gate rules
+(wait vs bail), and producer/consumer contracts live in
+[`references/orchestration/fanout-bus.md`](../../references/orchestration/fanout-bus.md).
+
 **Per-item agent prompt template:**
 
 ```
@@ -315,6 +335,8 @@ Swarm context:
 - your_item_id: <item_id>
 - conflict_group: <group_id>
 - shared_files_with_siblings: [<paths>]  # should be empty within a wave
+- bus_path: /tmp/Dev10x/fanout/<wave_id>/bus.jsonl
+- lock_wait_timeout: 30s
 
 Bootstrap (REQUIRED first, before Skill invocation):
 1. Write .claude/Dev10x/session.yaml inside your isolated
@@ -327,12 +349,31 @@ Bootstrap (REQUIRED first, before Skill invocation):
 Task:
 Invoke Skill(Dev10x:work-on) with this input: <issue or PR URL>
 
+Sibling coordination (REQUIRED when shared_files_with_siblings
+is non-empty OR mid-work drift is detected):
+- Append events to bus_path. One JSON object per line.
+- Before writing a path that overlaps with a sibling, append
+  a file_lock_request event and wait up to lock_wait_timeout
+  for a matching file_lock_grant from the implicated sibling.
+- On detected drift, append a conflict_signal event then
+  apply the decision gate:
+    - Wait: severity=soft AND sibling reachable AND timeout
+      not yet exceeded → poll bus.jsonl for a file_lock_grant
+      or the sibling's bailout.
+    - Bail: severity=hard, sibling unreachable, or wait
+      timed out → append a bailout event and return
+      "BLOCKED: file-scope drift on <path>".
+- Never busy-loop. Never delete or rewrite bus.jsonl.
+- Full schema and field definitions:
+  references/orchestration/fanout-bus.md
+
 Etiquette (REQUIRED):
 - You are running concurrently with siblings. Do NOT call
   Skill(Dev10x:fanout) recursively.
 - If you discover a file conflict with a sibling mid-work,
-  pause, report via your result message, and do not push.
-  The orchestrator will resolve.
+  use the bus to coordinate (above). If the bus does not
+  resolve the conflict, pause, report via your result
+  message, and do not push. The orchestrator will resolve.
 - Do not force-push and do not touch main/develop directly.
 - Your worktree is ephemeral; assume it is destroyed if you
   make no changes.
@@ -340,7 +381,8 @@ Etiquette (REQUIRED):
 Return on completion:
 - PR URL (or "no PR produced — <reason>")
 - Cost (total_cost_usd if known)
-- Any sibling-coordination signals raised
+- Any sibling-coordination signals raised (reference bus
+  event types: file_lock_request, conflict_signal, bailout)
 - One of: DONE | DONE_WITH_CONCERNS: <text> |
   NEEDS_CONTEXT: <what> | BLOCKED: <reason>
 ```
@@ -538,7 +580,17 @@ Phase 4's job is therefore **collection**, not orchestration:
 3. For `BLOCKED` results, queue an `AskUserQuestion` so the
    orchestrator can decide between retry, fallback to
    serial, or skip.
-4. After a full wave drains, before dispatching the next
+4. **Harvest the sibling pub/sub bus (GH-133).** Once per
+   wave drain, read `/tmp/Dev10x/fanout/<wave_id>/bus.jsonl`
+   (using `Read`; the file is JSONL with one event per line).
+   Collect every `bailout` and `conflict_signal` event.
+   `bailout` events with `recoverable: true` mark their item
+   for re-dispatch in a follow-up wave; `recoverable: false`
+   bailouts escalate via `AskUserQuestion` alongside any
+   `BLOCKED:` agent results. Treat the bus as authoritative
+   for sibling-to-sibling drift — it captures conflicts the
+   agent result message may have omitted.
+5. After a full wave drains, before dispatching the next
    wave: rebase downstream conflict-chain successors onto
    the latest develop via `Skill(Dev10x:git-groom)`.
 


### PR DESCRIPTION
**When** a `Dev10x:fanout` swarm child discovers mid-work that a file it needs is owned by a concurrently-running sibling, **I want to** publish on a shared pub/sub channel and let the siblings coordinate directly (e.g. "commit your changes first" / "I'll bail and retry next wave"), **so** the orchestrator does not have to serialise the wave at the first sign of conflict drift and the swarm preserves its parallelism guarantee.

---

[`3e26e3cd`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/255/commits/3e26e3cd77ec8883192bb16e08793a70d7a847de) ✨ GH-133 Enable sibling pub/sub coordination via JSONL bus
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/133

---