### PR TITLE
✨ GH-215 Enable Dev10x config at OS-standard XDG location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the Dev10x Claude Code Plugin are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Features
+
+- **Move Dev10x userspace config out of `~/.claude/`** — config now
+  lives under the OS-standard XDG path (`~/.config/Dev10x/` on
+  Linux/macOS, `%APPDATA%/Dev10x/` on Windows; override via
+  `DEV10X_CONFIG_HOME`). Legacy files at `~/.claude/memory/Dev10x/`
+  and `~/.claude/Dev10x/` are migrated lazily on first read and
+  explicitly by `dev10x config migrate` (wired into both
+  `Dev10x:upgrade-cleanup` Step 1 and `Dev10x:doctor` Step 0)
+  ([GH-215](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/215))
+
 ## 0.72.0 — Doctor, Fanout Swarm & Permission Hygiene
 
 Released 2026-05-17

--- a/references/config-resolution.md
+++ b/references/config-resolution.md
@@ -11,21 +11,29 @@ All Dev10x configuration files follow a consistent resolution order
 | Priority | Location | Scope | Committed? |
 |----------|----------|-------|------------|
 | 1 (highest) | `.claude/Dev10x/` | Project-local | No (gitignored) |
-| 2 | `~/.claude/memory/Dev10x/` | Global with repo mapping | N/A (user home) |
+| 2 | `~/.config/Dev10x/` (XDG; legacy `~/.claude/memory/Dev10x/`) | Global with repo mapping | N/A (user home) |
 | 3 (lowest) | `${CLAUDE_PLUGIN_ROOT}/skills/*/references/` | Plugin defaults | Yes (plugin repo) |
 
 **Tier 1 — Project-local** (`.claude/Dev10x/`):
 Runtime and session data. Highest priority for truly project-specific
 overrides that should not be shared across repos. Gitignored.
 
-**Tier 2 — Global with repo mapping** (`~/.claude/memory/Dev10x/`):
+**Tier 2 — Global with repo mapping** (`~/.config/Dev10x/`):
 Single file serves multiple projects via `projects[].match` globs.
 Preferred for overrides that apply to several repos (e.g., all
 ExampleCorp repos share the same shipping pipeline).
 
 > **Note (GH-941):** The old `~/.claude/projects/<key>/memory/`
 > path is removed. All tier 2 config lives under
-> `~/.claude/memory/Dev10x/`.
+> `~/.config/Dev10x/`.
+>
+> **Note (GH-215):** Dev10x userspace config moved out of
+> `~/.claude/` to the XDG location: `~/.config/Dev10x/` on
+> Linux/macOS, `%APPDATA%/Dev10x/` on Windows. Override via
+> `DEV10X_CONFIG_HOME`. Legacy paths under `~/.claude/memory/Dev10x/`
+> and `~/.claude/Dev10x/` are migrated lazily on first read and
+> explicitly by `dev10x config migrate` (wired into
+> `Dev10x:upgrade-cleanup` and `Dev10x:doctor`).
 
 **Tier 3 — Plugin defaults** (`${CLAUDE_PLUGIN_ROOT}/skills/*/references/`):
 Shipped with the plugin. Used when no user override exists.
@@ -62,13 +70,13 @@ This follows the same pattern as `gitmoji.yaml` project overrides.
 | Tier | Path | Format |
 |------|------|--------|
 | 1 | `.claude/Dev10x/playbooks/<key>.yaml` | Standard playbook YAML |
-| 2 | `~/.claude/memory/Dev10x/playbooks/<key>.yaml` | Playbook + `projects` mapping |
+| 2 | `~/.config/Dev10x/playbooks/<key>.yaml` | Playbook + `projects` mapping |
 | 3 | `${CLAUDE_PLUGIN_ROOT}/skills/<key>/references/playbook.yaml` | Default playbook |
 
 **Global playbook format** (Tier 2):
 
 ```yaml
-# ~/.claude/memory/Dev10x/playbooks/work-on.yaml
+# ~/.config/Dev10x/playbooks/work-on.yaml
 
 fragments:
   shipping-pipeline-solo:
@@ -111,12 +119,12 @@ Session config is always project-local. It contains runtime state
 
 | Tier | Path | Format |
 |------|------|--------|
-| 2 | `~/.claude/memory/Dev10x/settings-pr-merge.yaml` | Settings + `projects` mapping |
+| 2 | `~/.config/Dev10x/settings-pr-merge.yaml` | Settings + `projects` mapping |
 
 **Global format** (Tier 2):
 
 ```yaml
-# ~/.claude/memory/Dev10x/settings-pr-merge.yaml
+# ~/.config/Dev10x/settings-pr-merge.yaml
 projects:
   - match: "Dev10x-Guru/*"
     strategy: rebase
@@ -133,7 +141,7 @@ projects:
 
 | Tier | Path |
 |------|------|
-| 2 | `~/.claude/memory/Dev10x/dod-acceptance-criteria.yaml` |
+| 2 | `~/.config/Dev10x/dod-acceptance-criteria.yaml` |
 | 3 | Plugin defaults (hardcoded in skill) |
 
 ### Gitmoji Overrides
@@ -141,38 +149,38 @@ projects:
 
 | Tier | Path |
 |------|------|
-| 2 | `~/.claude/memory/Dev10x/gitmoji.yaml` |
+| 2 | `~/.config/Dev10x/gitmoji.yaml` |
 | 3 | `${CLAUDE_PLUGIN_ROOT}/skills/git-commit/references/gitmoji-defaults.yaml` |
 
 ### Database Schema
 
 | Tier | Path |
 |------|------|
-| 2 | `~/.claude/memory/Dev10x/db-<name>-schema.md` |
+| 2 | `~/.config/Dev10x/db-<name>-schema.md` |
 
 ### GitHub Reviewers
 
 | Tier | Path |
 |------|------|
-| 2 | `~/.claude/memory/Dev10x/github-reviewers-config.yaml` |
+| 2 | `~/.config/Dev10x/github-reviewers-config.yaml` |
 
 ### Slack Config
 
 | Tier | Path |
 |------|------|
-| 2 | `~/.claude/memory/Dev10x/slack-config.yaml` |
+| 2 | `~/.config/Dev10x/slack-config.yaml` |
 
 ### Slack Code Review Requests
 
 | Tier | Path |
 |------|------|
-| 2 | `~/.claude/memory/Dev10x/slack-config-code-review-requests.yaml` |
+| 2 | `~/.config/Dev10x/slack-config-code-review-requests.yaml` |
 
 ### Database Connections
 
 | Tier | Path |
 |------|------|
-| 2 | `~/.claude/memory/Dev10x/databases.yaml` |
+| 2 | `~/.config/Dev10x/databases.yaml` |
 
 ## Skills That Reference These Paths
 

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -27,6 +27,8 @@ allowed-tools:
   - TaskUpdate
   - mcp__plugin_Dev10x_cli__audit_hook_recent
   - mcp__plugin_Dev10x_cli__issue_create
+  - Bash(dev10x config doctor:*)
+  - Bash(dev10x config migrate:*)
 ---
 
 # Dev10x:doctor — Intent Drift Diagnostic (GH-87)
@@ -58,6 +60,20 @@ diagnoses, then delegates concrete edits.
 1. `TaskCreate(subject="Phase 1: Load enabled strategies", activeForm="Loading strategies")`
 2. `TaskCreate(subject="Phase 2: Detect drift per strategy", activeForm="Detecting drift")`
 3. `TaskCreate(subject="Phase 3: Present findings and remediations", activeForm="Presenting findings")`
+
+## Step 0 — Check Dev10x config location (GH-215)
+
+Before strategy detection, run `dev10x config doctor` to report
+any legacy Dev10x config files still living under `~/.claude/`.
+If files are found, offer to run `dev10x config migrate` (or
+delegate to `Dev10x:upgrade-cleanup` which migrates as Step 1).
+
+```
+Bash("dev10x config doctor")
+```
+
+Treat any "Found N legacy ..." output as a finding to surface
+in Phase 3, alongside the strategy detections.
 4. `TaskCreate(subject="Phase 4: Apply approved fixes", activeForm="Applying fixes")`
 
 Set sequential dependencies. Mark each completed when done.

--- a/skills/upgrade-cleanup/SKILL.md
+++ b/skills/upgrade-cleanup/SKILL.md
@@ -19,6 +19,7 @@ invocation-name: Dev10x:upgrade-cleanup
 allowed-tools:
   - Skill
   - mcp__plugin_Dev10x_cli__record_upgrade
+  - Bash(dev10x config migrate:*)
 ---
 
 # Dev10x:upgrade-cleanup
@@ -44,7 +45,15 @@ without forcing them to remember the underlying skill name.
 
 ## Execution
 
-Delegate to the maintenance skill in `full` mode:
+Step 1 — migrate legacy Dev10x config out of `~/.claude/` to the
+XDG location (`~/.config/Dev10x/` on Linux/macOS, `%APPDATA%/Dev10x/`
+on Windows). Idempotent — skips paths already migrated. See GH-215.
+
+```
+Bash("dev10x config migrate")
+```
+
+Step 2 — delegate to the maintenance skill in `full` mode:
 
 ```
 Skill(skill="Dev10x:plugin-maintenance", args="full")
@@ -66,7 +75,7 @@ mcp__plugin_Dev10x_cli__record_upgrade()
 
 The MCP tool reads the version from
 `$CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json` and writes it
-to `~/.claude/Dev10x/version.yml`. Skip this step if the
+to `~/.config/Dev10x/version.yml` (post-GH-215). Skip this step if the
 maintenance pass reported failures — leaving `version.yml`
 stale keeps the upgrade prompt visible until the issue is
 resolved.
@@ -74,6 +83,8 @@ resolved.
 ## Configuration
 
 See `Dev10x:plugin-maintenance` for `projects.yaml` location
-and base-permission semantics. The userspace config path
-(`~/.claude/skills/Dev10x:upgrade-cleanup/projects.yaml`) is
-unchanged for backward compatibility.
+and base-permission semantics. Post-GH-215 the userspace config
+path is `~/.config/Dev10x/upgrade-cleanup-projects.yaml`. Old
+files at `~/.claude/skills/Dev10x:upgrade-cleanup/projects.yaml`
+and `~/.claude/memory/Dev10x/*` are migrated lazily on first
+read and explicitly by `dev10x config migrate`.

--- a/src/dev10x/cli.py
+++ b/src/dev10x/cli.py
@@ -40,6 +40,7 @@ class LazyGroup(click.Group):
 @click.group(
     cls=LazyGroup,
     lazy_subcommands={
+        "config": "dev10x.commands.config.config",
         "github-app": "dev10x.commands.github_app.github_app",
         "hook": "dev10x.commands.hook.hook",
         "init": "dev10x.commands.init.init",

--- a/src/dev10x/commands/config.py
+++ b/src/dev10x/commands/config.py
@@ -1,0 +1,61 @@
+"""CLI for Dev10x userspace config — migration helpers (GH-215)."""
+
+from __future__ import annotations
+
+import click
+
+from dev10x.domain.dev10x_paths import (
+    Dev10xConfigDir,
+    migrate_all,
+    stale_legacy_paths,
+)
+
+
+@click.group()
+def config() -> None:
+    """Manage Dev10x userspace configuration."""
+
+
+@config.command(name="root")
+def root() -> None:
+    """Print the resolved Dev10x config root."""
+    click.echo(Dev10xConfigDir.home())
+
+
+@config.command(name="migrate")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Show which legacy files would be copied without writing.",
+)
+def migrate(*, dry_run: bool) -> None:
+    """Copy legacy ~/.claude/{memory/Dev10x,Dev10x}/ files to ~/.config/Dev10x/."""
+    stale = stale_legacy_paths()
+    if not stale:
+        click.echo("No legacy Dev10x config files found.")
+        return
+    if dry_run:
+        click.echo(f"Would migrate {len(stale)} legacy entr{'y' if len(stale) == 1 else 'ies'}:")
+        for path in stale:
+            click.echo(f"  - {path}")
+        return
+    migrated = migrate_all()
+    if not migrated:
+        click.echo("Nothing to migrate — destination already populated.")
+        return
+    click.echo(f"Migrated {len(migrated)} entr{'y' if len(migrated) == 1 else 'ies'}:")
+    for path in migrated:
+        click.echo(f"  - {path}")
+
+
+@config.command(name="doctor")
+def doctor() -> None:
+    """Report legacy Dev10x config files that still need migration."""
+    stale = stale_legacy_paths()
+    if not stale:
+        click.echo("Dev10x config: all files at canonical XDG location.")
+        return
+    click.echo(f"Found {len(stale)} legacy Dev10x config entr{'y' if len(stale) == 1 else 'ies'}:")
+    for path in stale:
+        click.echo(f"  - {path}")
+    click.echo("\nRun `dev10x config migrate` to copy them to ~/.config/Dev10x/.")

--- a/src/dev10x/commands/github_app.py
+++ b/src/dev10x/commands/github_app.py
@@ -17,10 +17,10 @@ from pathlib import Path
 import click
 
 from dev10x.commands import github_app_api as api
-from dev10x.domain.claude_paths import ClaudeDir
+from dev10x.domain.dev10x_paths import Dev10xConfigDir
 
-CONFIG_DIR = ClaudeDir.github_bot_dir()
-CONFIG_PATH = ClaudeDir.github_app_yaml()
+CONFIG_DIR = Dev10xConfigDir.github_bot_dir()
+CONFIG_PATH = Dev10xConfigDir.github_app_yaml()
 KEY_PATH = CONFIG_DIR / "dev10x-bot.pem"
 
 PERSONAL_NEW_APP_URL = "https://github.com/settings/apps/new"

--- a/src/dev10x/domain/dev10x_paths.py
+++ b/src/dev10x/domain/dev10x_paths.py
@@ -1,0 +1,215 @@
+"""Canonical Dev10x config paths, independent of ``~/.claude``.
+
+GH-215: Dev10x's userspace config moves out of ``~/.claude/`` so the
+plugin no longer depends on Claude Code's home directory layout.
+
+Default root resolution (in order):
+1. ``DEV10X_CONFIG_HOME`` env var (test/CI override)
+2. ``$XDG_CONFIG_HOME/Dev10x`` if ``XDG_CONFIG_HOME`` is set
+3. ``%APPDATA%/Dev10x`` on Windows
+4. ``~/.config/Dev10x`` everywhere else (Linux, macOS, BSDs)
+
+Lazy migration: every accessor checks the legacy ``~/.claude/...``
+location on first call. If the legacy file/dir exists and the new
+path does not, the legacy content is copied across. The legacy
+entry is left in place so a downgrade can still read it; eager
+cleanup invoked from ``Dev10x:upgrade-cleanup`` and ``Dev10x:doctor``
+removes the legacy entries once parity is confirmed.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import os
+import shutil
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+from dev10x.domain.claude_paths import ClaudeDir
+
+CONFIG_HOME_ENV_VAR = "DEV10X_CONFIG_HOME"
+XDG_CONFIG_HOME_ENV_VAR = "XDG_CONFIG_HOME"
+
+_log = logging.getLogger(__name__)
+
+
+def _platform_default_root() -> Path:
+    if sys.platform == "win32":
+        appdata = os.environ.get("APPDATA")
+        if appdata:
+            return Path(appdata) / "Dev10x"
+    xdg = os.environ.get(XDG_CONFIG_HOME_ENV_VAR)
+    if xdg:
+        return Path(xdg) / "Dev10x"
+    return Path.home() / ".config" / "Dev10x"
+
+
+@functools.cache
+def _resolve_path(*, override: str | None, segments: tuple[str, ...]) -> Path:
+    base = Path(override).expanduser() if override else _platform_default_root()
+    return base.joinpath(*segments) if segments else base
+
+
+def _copy(*, source: Path, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if source.is_dir():
+        shutil.copytree(source, destination, dirs_exist_ok=True)
+    else:
+        shutil.copy2(source, destination)
+
+
+def migrate_path(*, legacy: Path, current: Path) -> bool:
+    """Copy ``legacy`` to ``current`` when only the legacy path exists.
+
+    Returns True when a copy happened. Leaves the legacy path in
+    place so a downgrade can still read it; eager cleanup deletes
+    the legacy entry once parity is confirmed.
+    """
+    if current.exists() or not legacy.exists():
+        return False
+    _log.info("Migrating Dev10x config: %s -> %s", legacy, current)
+    _copy(source=legacy, destination=current)
+    return True
+
+
+class Dev10xConfigDir:
+    """Cached accessors for canonical Dev10x config paths.
+
+    ``DEV10X_CONFIG_HOME`` overrides the root. Each accessor runs
+    lazy migration from the legacy ``~/.claude/`` location on first
+    call — see :func:`migrate_path`.
+    """
+
+    @classmethod
+    def _resolve(cls, *segments: str) -> Path:
+        return _resolve_path(
+            override=os.environ.get(CONFIG_HOME_ENV_VAR),
+            segments=segments,
+        )
+
+    @classmethod
+    def reset_cache(cls) -> None:
+        """Clear the path resolution cache. Call in test teardown."""
+        _resolve_path.cache_clear()
+
+    @classmethod
+    def home(cls) -> Path:
+        return cls._resolve()
+
+    @classmethod
+    def version_yaml(cls) -> Path:
+        return _with_lazy_migration(cls._resolve("version.yml"), _legacy_version_yaml)
+
+    @classmethod
+    def projects_yaml(cls) -> Path:
+        return _with_lazy_migration(cls._resolve("projects.yaml"), _legacy_projects_yaml)
+
+    @classmethod
+    def platforms_yaml(cls) -> Path:
+        return _with_lazy_migration(cls._resolve("platforms.yaml"), _legacy_platforms_yaml)
+
+    @classmethod
+    def slack_config_yaml(cls) -> Path:
+        return _with_lazy_migration(
+            cls._resolve("slack-config.yaml"),
+            _legacy_slack_config_yaml,
+        )
+
+    @classmethod
+    def slack_review_config_yaml(cls) -> Path:
+        return _with_lazy_migration(
+            cls._resolve("slack-config-code-review-requests.yaml"),
+            _legacy_slack_review_config_yaml,
+        )
+
+    @classmethod
+    def upgrade_cleanup_projects_yaml(cls) -> Path:
+        return _with_lazy_migration(
+            cls._resolve("upgrade-cleanup-projects.yaml"),
+            _legacy_upgrade_cleanup_projects_yaml,
+        )
+
+    @classmethod
+    def github_bot_dir(cls) -> Path:
+        return _with_lazy_migration(cls._resolve("github-bot"), _legacy_github_bot_dir)
+
+    @classmethod
+    def github_app_yaml(cls) -> Path:
+        return _with_lazy_migration(
+            cls._resolve("github-bot", "github-app.yaml"),
+            _legacy_github_app_yaml,
+        )
+
+    @classmethod
+    def playbooks_dir(cls) -> Path:
+        return _with_lazy_migration(cls._resolve("playbooks"), _legacy_playbooks_dir)
+
+
+def _with_lazy_migration(current: Path, legacy_provider: Callable[[], Path]) -> Path:
+    migrate_path(legacy=legacy_provider(), current=current)
+    return current
+
+
+# Legacy path providers — wrapped in callables so test overrides of
+# ClaudeDir env vars propagate on every call.
+_legacy_version_yaml = ClaudeDir.dev10x_version_yaml
+_legacy_projects_yaml = ClaudeDir.memory_projects_yaml
+_legacy_platforms_yaml = ClaudeDir.platforms_yaml
+_legacy_slack_config_yaml = ClaudeDir.slack_config_yaml
+_legacy_slack_review_config_yaml = ClaudeDir.slack_review_config_yaml
+_legacy_upgrade_cleanup_projects_yaml = ClaudeDir.upgrade_cleanup_projects_yaml
+_legacy_github_bot_dir = ClaudeDir.github_bot_dir
+_legacy_github_app_yaml = ClaudeDir.github_app_yaml
+
+
+def _legacy_playbooks_dir() -> Path:
+    return ClaudeDir.memory_dev10x_dir() / "playbooks"
+
+
+def _migration_pairs() -> list[tuple[Path, Path]]:
+    """Build (legacy, current) pairs without triggering lazy migration."""
+    return [
+        (_legacy_version_yaml(), Dev10xConfigDir._resolve("version.yml")),
+        (_legacy_projects_yaml(), Dev10xConfigDir._resolve("projects.yaml")),
+        (_legacy_platforms_yaml(), Dev10xConfigDir._resolve("platforms.yaml")),
+        (_legacy_slack_config_yaml(), Dev10xConfigDir._resolve("slack-config.yaml")),
+        (
+            _legacy_slack_review_config_yaml(),
+            Dev10xConfigDir._resolve("slack-config-code-review-requests.yaml"),
+        ),
+        (
+            _legacy_upgrade_cleanup_projects_yaml(),
+            Dev10xConfigDir._resolve("upgrade-cleanup-projects.yaml"),
+        ),
+        (_legacy_github_bot_dir(), Dev10xConfigDir._resolve("github-bot")),
+        (
+            _legacy_github_app_yaml(),
+            Dev10xConfigDir._resolve("github-bot", "github-app.yaml"),
+        ),
+        (_legacy_playbooks_dir(), Dev10xConfigDir._resolve("playbooks")),
+    ]
+
+
+def migrate_all() -> list[Path]:
+    """Eagerly migrate every known legacy file. Returns paths copied."""
+    migrated: list[Path] = []
+    for legacy, current in _migration_pairs():
+        if migrate_path(legacy=legacy, current=current):
+            migrated.append(current)
+    return migrated
+
+
+def stale_legacy_paths() -> list[Path]:
+    """Return legacy paths that still exist (doctor uses this to nudge)."""
+    return [legacy for legacy, _ in _migration_pairs() if legacy.exists()]
+
+
+__all__ = [
+    "CONFIG_HOME_ENV_VAR",
+    "Dev10xConfigDir",
+    "migrate_all",
+    "migrate_path",
+    "stale_legacy_paths",
+]

--- a/src/dev10x/domain/install_version.py
+++ b/src/dev10x/domain/install_version.py
@@ -23,7 +23,7 @@ from pathlib import Path
 
 import yaml
 
-from dev10x.domain.claude_paths import ClaudeDir
+from dev10x.domain.dev10x_paths import Dev10xConfigDir
 
 
 def read_plugin_version(*, plugin_root: Path | None = None) -> str | None:
@@ -52,7 +52,7 @@ def read_applied_version(*, version_yaml: Path | None = None) -> str | None:
     Returns ``None`` when ``~/.claude/Dev10x/version.yml`` is absent or
     does not contain a ``plugin_version`` string.
     """
-    path = version_yaml or ClaudeDir.dev10x_version_yaml()
+    path = version_yaml or Dev10xConfigDir.version_yaml()
     if not path.is_file():
         return None
     try:
@@ -75,7 +75,7 @@ def write_applied_version(
 
     Creates parent directories as needed. Returns the path written.
     """
-    path = version_yaml or ClaudeDir.dev10x_version_yaml()
+    path = version_yaml or Dev10xConfigDir.version_yaml()
     path.parent.mkdir(parents=True, exist_ok=True)
     timestamp = (now or datetime.now(UTC)).isoformat()
     payload = {"plugin_version": plugin_version, "upgraded_at": timestamp}
@@ -89,7 +89,7 @@ def install_state() -> InstallState:
     Combines the running plugin version, the applied version on disk,
     and whether the userspace config directory exists at all.
     """
-    config_present = ClaudeDir.dev10x_config_dir().is_dir()
+    config_present = Dev10xConfigDir.home().is_dir()
     plugin_version = read_plugin_version()
     applied_version = read_applied_version() if config_present else None
     return InstallState(

--- a/src/dev10x/github/app_auth.py
+++ b/src/dev10x/github/app_auth.py
@@ -1,9 +1,11 @@
 """GitHub App authentication for posting agent-generated content.
 
-Loads an opt-in App configuration from
-``~/.claude/Dev10x/github-app.yaml`` and mints short-lived
-installation tokens for the configured repository. The tokens are
-cached per-repo until shortly before their expiry.
+Loads an opt-in App configuration from the Dev10x config directory
+(``~/.config/Dev10x/github-bot/github-app.yaml`` on Linux/macOS,
+``%APPDATA%/Dev10x/github-bot/github-app.yaml`` on Windows, or via
+``DEV10X_CONFIG_HOME`` override) and mints short-lived installation
+tokens for the configured repository. The tokens are cached per-repo
+until shortly before their expiry.
 
 When configuration is absent, malformed, or the token exchange
 fails, ``get_bot_token`` returns ``None`` so callers can fall back
@@ -21,10 +23,10 @@ from pathlib import Path
 
 import yaml
 
-from dev10x.domain.claude_paths import ClaudeDir
+from dev10x.domain.dev10x_paths import Dev10xConfigDir
 from dev10x.subprocess_utils import async_run
 
-DEFAULT_CONFIG_PATH = ClaudeDir.github_app_yaml()
+DEFAULT_CONFIG_PATH = Dev10xConfigDir.github_app_yaml()
 
 
 @dataclass(frozen=True)

--- a/src/dev10x/hooks/session_dispatch.py
+++ b/src/dev10x/hooks/session_dispatch.py
@@ -110,7 +110,7 @@ def build_install_check_context() -> str:
     state = install_state()
     if state.needs_bootstrap:
         return (
-            "Dev10x config folder is missing at ~/.claude/Dev10x.\n"
+            "Dev10x config folder is missing at ~/.config/Dev10x.\n"
             "Run `/Dev10x:upgrade-cleanup` to bootstrap the userspace install."
         )
     if state.needs_upgrade:

--- a/src/dev10x/platform/registry.py
+++ b/src/dev10x/platform/registry.py
@@ -7,10 +7,10 @@ from pathlib import Path
 
 import yaml
 
-from dev10x.domain.claude_paths import ClaudeDir
+from dev10x.domain.dev10x_paths import Dev10xConfigDir
 from dev10x.domain.file_locks import atomic_write_text
 
-REGISTRY_FILE = ClaudeDir.platforms_yaml()
+REGISTRY_FILE = Dev10xConfigDir.platforms_yaml()
 
 
 @dataclass(frozen=True)

--- a/src/dev10x/skills/permission/clean_project_files.py
+++ b/src/dev10x/skills/permission/clean_project_files.py
@@ -23,8 +23,9 @@ from pathlib import Path
 import yaml
 
 from dev10x.domain.claude_paths import ClaudeDir
+from dev10x.domain.dev10x_paths import Dev10xConfigDir
 
-USERSPACE_CONFIG = ClaudeDir.upgrade_cleanup_projects_yaml()
+USERSPACE_CONFIG = Dev10xConfigDir.upgrade_cleanup_projects_yaml()
 PLUGIN_CONFIG = (
     Path(__file__).resolve().parents[4] / "skills" / "upgrade-cleanup" / "projects.yaml"
 )

--- a/src/dev10x/skills/permission/merge_worktree_permissions.py
+++ b/src/dev10x/skills/permission/merge_worktree_permissions.py
@@ -18,9 +18,9 @@ from pathlib import Path
 
 import yaml
 
-from dev10x.domain.claude_paths import ClaudeDir
+from dev10x.domain.dev10x_paths import Dev10xConfigDir
 
-USERSPACE_CONFIG = ClaudeDir.upgrade_cleanup_projects_yaml()
+USERSPACE_CONFIG = Dev10xConfigDir.upgrade_cleanup_projects_yaml()
 PLUGIN_CONFIG = (
     Path(__file__).resolve().parents[4] / "skills" / "upgrade-cleanup" / "projects.yaml"
 )

--- a/src/dev10x/skills/permission/update_paths.py
+++ b/src/dev10x/skills/permission/update_paths.py
@@ -5,9 +5,10 @@ Modes:
   - ensure-base: Add missing base permissions from projects.yaml
   - generalize: Replace session-specific args with wildcard patterns
 
-Config lookup order:
-  1. ~/.claude/memory/Dev10x/projects.yaml (persistent user config)
-  2. ~/.claude/skills/Dev10x:upgrade-cleanup/projects.yaml (userspace)
+Config lookup order (post-GH-215):
+  1. ~/.config/Dev10x/projects.yaml (XDG; legacy ~/.claude/memory/Dev10x/)
+  2. ~/.config/Dev10x/upgrade-cleanup-projects.yaml (XDG; legacy
+     ~/.claude/skills/Dev10x:upgrade-cleanup/projects.yaml)
   3. ${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/projects.yaml (plugin default)
 
 CLI entry point: ``dev10x permission update-paths`` (and siblings).
@@ -21,9 +22,10 @@ from pathlib import Path
 import yaml
 
 from dev10x.domain.claude_paths import ClaudeDir
+from dev10x.domain.dev10x_paths import Dev10xConfigDir
 
-MEMORY_CONFIG = ClaudeDir.memory_projects_yaml()
-USERSPACE_CONFIG = ClaudeDir.upgrade_cleanup_projects_yaml()
+MEMORY_CONFIG = Dev10xConfigDir.projects_yaml()
+USERSPACE_CONFIG = Dev10xConfigDir.upgrade_cleanup_projects_yaml()
 PLUGIN_CONFIG = (
     Path(__file__).resolve().parents[4] / "skills" / "upgrade-cleanup" / "projects.yaml"
 )

--- a/tests/commands/test_permission_record_upgrade.py
+++ b/tests/commands/test_permission_record_upgrade.py
@@ -10,12 +10,15 @@ import yaml
 from click.testing import CliRunner
 
 from dev10x.commands.permission import record_upgrade
-from dev10x.domain.claude_paths import CLAUDE_HOME_ENV_VAR, ClaudeDir
+from dev10x.domain.claude_paths import CLAUDE_HOME_ENV_VAR
+from dev10x.domain.dev10x_paths import CONFIG_HOME_ENV_VAR, Dev10xConfigDir
 
 
 @pytest.fixture
 def claude_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
     monkeypatch.setenv(CLAUDE_HOME_ENV_VAR, str(tmp_path))
+    monkeypatch.setenv(CONFIG_HOME_ENV_VAR, str(tmp_path / "config_dev10x"))
+    Dev10xConfigDir.reset_cache()
     return tmp_path
 
 
@@ -35,7 +38,7 @@ def test_writes_plugin_version_to_version_yaml(
 
     result = CliRunner().invoke(record_upgrade, [])
     assert result.exit_code == 0
-    payload = yaml.safe_load(ClaudeDir.dev10x_version_yaml().read_text())
+    payload = yaml.safe_load(Dev10xConfigDir.version_yaml().read_text())
     assert payload["plugin_version"] == "0.72.0"
 
 
@@ -48,7 +51,7 @@ def test_explicit_version_overrides_plugin_json(
 
     result = CliRunner().invoke(record_upgrade, ["--version", "9.9.9"])
     assert result.exit_code == 0
-    payload = yaml.safe_load(ClaudeDir.dev10x_version_yaml().read_text())
+    payload = yaml.safe_load(Dev10xConfigDir.version_yaml().read_text())
     assert payload["plugin_version"] == "9.9.9"
 
 

--- a/tests/domain/test_dev10x_paths.py
+++ b/tests/domain/test_dev10x_paths.py
@@ -1,0 +1,174 @@
+"""Tests for Dev10x XDG config paths and lazy/eager migration (GH-215)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dev10x.domain.claude_paths import CLAUDE_HOME_ENV_VAR, ClaudeDir
+from dev10x.domain.dev10x_paths import (
+    CONFIG_HOME_ENV_VAR,
+    Dev10xConfigDir,
+    migrate_all,
+    migrate_path,
+    stale_legacy_paths,
+)
+
+
+@pytest.fixture
+def isolated_dirs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> tuple[Path, Path]:
+    legacy_root = tmp_path / "claude"
+    new_root = tmp_path / "config_dev10x"
+    monkeypatch.setenv(CLAUDE_HOME_ENV_VAR, str(legacy_root))
+    monkeypatch.setenv(CONFIG_HOME_ENV_VAR, str(new_root))
+    ClaudeDir.reset_cache()
+    Dev10xConfigDir.reset_cache()
+    yield legacy_root, new_root
+    ClaudeDir.reset_cache()
+    Dev10xConfigDir.reset_cache()
+
+
+@pytest.mark.parametrize(
+    "accessor,expected_suffix",
+    [
+        ("home", ""),
+        ("version_yaml", "version.yml"),
+        ("projects_yaml", "projects.yaml"),
+        ("platforms_yaml", "platforms.yaml"),
+        ("slack_config_yaml", "slack-config.yaml"),
+        ("slack_review_config_yaml", "slack-config-code-review-requests.yaml"),
+        ("upgrade_cleanup_projects_yaml", "upgrade-cleanup-projects.yaml"),
+        ("github_bot_dir", "github-bot"),
+        ("github_app_yaml", "github-bot/github-app.yaml"),
+        ("playbooks_dir", "playbooks"),
+    ],
+)
+def test_accessors_resolve_under_override(
+    isolated_dirs: tuple[Path, Path],
+    accessor: str,
+    expected_suffix: str,
+) -> None:
+    _, new_root = isolated_dirs
+    path = getattr(Dev10xConfigDir, accessor)()
+    expected = new_root / expected_suffix if expected_suffix else new_root
+    assert path == expected
+
+
+def test_default_root_uses_dot_config_dev10x(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(CONFIG_HOME_ENV_VAR, raising=False)
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.delenv("APPDATA", raising=False)
+    monkeypatch.setattr("sys.platform", "linux")
+    Dev10xConfigDir.reset_cache()
+    assert Dev10xConfigDir.home() == Path.home() / ".config" / "Dev10x"
+
+
+def test_xdg_config_home_is_honored(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.delenv(CONFIG_HOME_ENV_VAR, raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setattr("sys.platform", "linux")
+    Dev10xConfigDir.reset_cache()
+    assert Dev10xConfigDir.home() == tmp_path / "xdg" / "Dev10x"
+    Dev10xConfigDir.reset_cache()
+
+
+def test_windows_uses_appdata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.delenv(CONFIG_HOME_ENV_VAR, raising=False)
+    monkeypatch.setattr("sys.platform", "win32")
+    monkeypatch.setenv("APPDATA", str(tmp_path / "AppData"))
+    Dev10xConfigDir.reset_cache()
+    assert Dev10xConfigDir.home() == tmp_path / "AppData" / "Dev10x"
+    Dev10xConfigDir.reset_cache()
+
+
+def test_migrate_path_copies_file_when_only_legacy_exists(tmp_path: Path) -> None:
+    legacy = tmp_path / "old" / "file.yaml"
+    current = tmp_path / "new" / "file.yaml"
+    legacy.parent.mkdir()
+    legacy.write_text("hello: world")
+    assert migrate_path(legacy=legacy, current=current) is True
+    assert current.read_text() == "hello: world"
+    assert legacy.exists(), "legacy file must remain for downgrade safety"
+
+
+def test_migrate_path_skips_when_current_exists(tmp_path: Path) -> None:
+    legacy = tmp_path / "old" / "file.yaml"
+    current = tmp_path / "new" / "file.yaml"
+    legacy.parent.mkdir()
+    current.parent.mkdir()
+    legacy.write_text("old")
+    current.write_text("new")
+    assert migrate_path(legacy=legacy, current=current) is False
+    assert current.read_text() == "new"
+
+
+def test_migrate_path_skips_when_legacy_missing(tmp_path: Path) -> None:
+    legacy = tmp_path / "old" / "absent.yaml"
+    current = tmp_path / "new" / "absent.yaml"
+    assert migrate_path(legacy=legacy, current=current) is False
+    assert not current.exists()
+
+
+def test_migrate_path_copies_directory(tmp_path: Path) -> None:
+    legacy = tmp_path / "old" / "playbooks"
+    current = tmp_path / "new" / "playbooks"
+    legacy.mkdir(parents=True)
+    (legacy / "a.yaml").write_text("a")
+    (legacy / "b.yaml").write_text("b")
+    assert migrate_path(legacy=legacy, current=current) is True
+    assert (current / "a.yaml").read_text() == "a"
+    assert (current / "b.yaml").read_text() == "b"
+
+
+def test_lazy_migration_runs_on_accessor(isolated_dirs: tuple[Path, Path]) -> None:
+    legacy_root, new_root = isolated_dirs
+    legacy = ClaudeDir.memory_projects_yaml()
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text("payload: 1")
+    current = Dev10xConfigDir.projects_yaml()
+    assert current.read_text() == "payload: 1"
+
+
+def test_migrate_all_copies_every_known_pair(
+    isolated_dirs: tuple[Path, Path],
+) -> None:
+    legacy_version = ClaudeDir.dev10x_version_yaml()
+    legacy_version.parent.mkdir(parents=True, exist_ok=True)
+    legacy_version.write_text("plugin_version: 0.0.0")
+    legacy_platforms = ClaudeDir.platforms_yaml()
+    legacy_platforms.parent.mkdir(parents=True, exist_ok=True)
+    legacy_platforms.write_text("[]")
+
+    migrated = migrate_all()
+    new_paths = {p.name for p in migrated}
+    assert "version.yml" in new_paths
+    assert "platforms.yaml" in new_paths
+    assert Dev10xConfigDir.version_yaml().read_text() == "plugin_version: 0.0.0"
+
+
+def test_stale_legacy_paths_reports_only_existing(
+    isolated_dirs: tuple[Path, Path],
+) -> None:
+    legacy_version = ClaudeDir.dev10x_version_yaml()
+    legacy_version.parent.mkdir(parents=True, exist_ok=True)
+    legacy_version.write_text("plugin_version: 0.0.0")
+    stale = stale_legacy_paths()
+    assert legacy_version in stale
+    assert ClaudeDir.platforms_yaml() not in stale
+
+
+def test_migrate_all_is_idempotent(isolated_dirs: tuple[Path, Path]) -> None:
+    legacy = ClaudeDir.dev10x_version_yaml()
+    legacy.parent.mkdir(parents=True, exist_ok=True)
+    legacy.write_text("plugin_version: 1.0.0")
+    first = migrate_all()
+    second = migrate_all()
+    assert len(first) == 1
+    assert second == []

--- a/tests/domain/test_install_version.py
+++ b/tests/domain/test_install_version.py
@@ -7,7 +7,8 @@ from pathlib import Path
 import pytest
 import yaml
 
-from dev10x.domain.claude_paths import CLAUDE_HOME_ENV_VAR, ClaudeDir
+from dev10x.domain.claude_paths import CLAUDE_HOME_ENV_VAR
+from dev10x.domain.dev10x_paths import CONFIG_HOME_ENV_VAR, Dev10xConfigDir
 from dev10x.domain.install_version import (
     InstallState,
     install_state,
@@ -20,6 +21,8 @@ from dev10x.domain.install_version import (
 @pytest.fixture
 def claude_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
     monkeypatch.setenv(CLAUDE_HOME_ENV_VAR, str(tmp_path))
+    monkeypatch.setenv(CONFIG_HOME_ENV_VAR, str(tmp_path / "config_dev10x"))
+    Dev10xConfigDir.reset_cache()
     return tmp_path
 
 
@@ -62,7 +65,7 @@ def test_read_applied_version_returns_recorded_value(claude_home: Path) -> None:
 
 
 def test_read_applied_version_rejects_non_string(claude_home: Path) -> None:
-    path = ClaudeDir.dev10x_version_yaml()
+    path = Dev10xConfigDir.version_yaml()
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(yaml.safe_dump({"plugin_version": 0.72}))
     assert read_applied_version() is None
@@ -89,14 +92,14 @@ def test_install_state_needs_bootstrap_when_config_missing(
 def test_install_state_needs_upgrade_when_version_missing(
     claude_home: Path, plugin_root: Path
 ) -> None:
-    ClaudeDir.dev10x_config_dir().mkdir(parents=True)
+    Dev10xConfigDir.home().mkdir(parents=True)
     state = install_state()
     assert state.needs_bootstrap is False
     assert state.needs_upgrade is True
 
 
 def test_install_state_current_when_versions_match(claude_home: Path, plugin_root: Path) -> None:
-    ClaudeDir.dev10x_config_dir().mkdir(parents=True)
+    Dev10xConfigDir.home().mkdir(parents=True)
     write_applied_version(plugin_version="0.72.0")
     state = install_state()
     assert state.needs_bootstrap is False
@@ -106,7 +109,7 @@ def test_install_state_current_when_versions_match(claude_home: Path, plugin_roo
 def test_install_state_needs_upgrade_when_versions_differ(
     claude_home: Path, plugin_root: Path
 ) -> None:
-    ClaudeDir.dev10x_config_dir().mkdir(parents=True)
+    Dev10xConfigDir.home().mkdir(parents=True)
     write_applied_version(plugin_version="0.71.0")
     state = install_state()
     assert state.needs_upgrade is True

--- a/tests/hooks/test_session_start_hooks.py
+++ b/tests/hooks/test_session_start_hooks.py
@@ -106,12 +106,15 @@ class TestSessionInstallCheck:
     def test_silent_when_install_current(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        from dev10x.domain.claude_paths import CLAUDE_HOME_ENV_VAR, ClaudeDir
+        from dev10x.domain.claude_paths import CLAUDE_HOME_ENV_VAR
+        from dev10x.domain.dev10x_paths import CONFIG_HOME_ENV_VAR, Dev10xConfigDir
         from dev10x.domain.install_version import write_applied_version
         from dev10x.hooks.session_dispatch import build_install_check_context
 
         monkeypatch.setenv(CLAUDE_HOME_ENV_VAR, str(tmp_path))
-        ClaudeDir.dev10x_config_dir().mkdir(parents=True)
+        monkeypatch.setenv(CONFIG_HOME_ENV_VAR, str(tmp_path / "config_dev10x"))
+        Dev10xConfigDir.reset_cache()
+        Dev10xConfigDir.home().mkdir(parents=True)
         plugin_root = tmp_path / "plugin"
         (plugin_root / ".claude-plugin").mkdir(parents=True)
         (plugin_root / ".claude-plugin" / "plugin.json").write_text(
@@ -126,9 +129,12 @@ class TestSessionInstallCheck:
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         from dev10x.domain.claude_paths import CLAUDE_HOME_ENV_VAR
+        from dev10x.domain.dev10x_paths import CONFIG_HOME_ENV_VAR, Dev10xConfigDir
         from dev10x.hooks.session_dispatch import build_install_check_context
 
         monkeypatch.setenv(CLAUDE_HOME_ENV_VAR, str(tmp_path))
+        monkeypatch.setenv(CONFIG_HOME_ENV_VAR, str(tmp_path / "config_dev10x"))
+        Dev10xConfigDir.reset_cache()
         monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
 
         ctx = build_install_check_context()
@@ -138,12 +144,15 @@ class TestSessionInstallCheck:
     def test_guides_upgrade_on_version_mismatch(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        from dev10x.domain.claude_paths import CLAUDE_HOME_ENV_VAR, ClaudeDir
+        from dev10x.domain.claude_paths import CLAUDE_HOME_ENV_VAR
+        from dev10x.domain.dev10x_paths import CONFIG_HOME_ENV_VAR, Dev10xConfigDir
         from dev10x.domain.install_version import write_applied_version
         from dev10x.hooks.session_dispatch import build_install_check_context
 
         monkeypatch.setenv(CLAUDE_HOME_ENV_VAR, str(tmp_path))
-        ClaudeDir.dev10x_config_dir().mkdir(parents=True)
+        monkeypatch.setenv(CONFIG_HOME_ENV_VAR, str(tmp_path / "config_dev10x"))
+        Dev10xConfigDir.reset_cache()
+        Dev10xConfigDir.home().mkdir(parents=True)
         plugin_root = tmp_path / "plugin"
         (plugin_root / ".claude-plugin").mkdir(parents=True)
         (plugin_root / ".claude-plugin" / "plugin.json").write_text(
@@ -161,9 +170,12 @@ class TestSessionInstallCheck:
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
     ) -> None:
         from dev10x.domain.claude_paths import CLAUDE_HOME_ENV_VAR
+        from dev10x.domain.dev10x_paths import CONFIG_HOME_ENV_VAR, Dev10xConfigDir
         from dev10x.hooks.session_dispatch import session_install_check
 
         monkeypatch.setenv(CLAUDE_HOME_ENV_VAR, str(tmp_path))
+        monkeypatch.setenv(CONFIG_HOME_ENV_VAR, str(tmp_path / "config_dev10x"))
+        Dev10xConfigDir.reset_cache()
         monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
 
         session_install_check()


### PR DESCRIPTION
**When** Claude Code reorganizes its `~/.claude/` layout or a user installs Dev10x on a fresh machine, **I want to** keep Dev10x userspace config at a stable OS-standard location, **so I can** avoid Dev10x state breaking with every Claude home-dir change and so the plugin is no longer coupled to Claude's filesystem conventions.

---

[`b9d7f7dd`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/256/commits/b9d7f7dd2179af868095a54aa2bb6779a05490c4) ✨ GH-215 Enable Dev10x config at OS-standard XDG location
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/215

---