### PR TITLE
✨ M1 Enable spec-as-source-of-truth pipeline (SPDD)

### DIFF
--- a/references/skill-pipelines.md
+++ b/references/skill-pipelines.md
@@ -116,6 +116,74 @@ park → discover → resume
 
 ---
 
+### 6. Structured Spec Pipeline (SPDD-style)
+
+For tickets that earn the full
+[Spec-Driven Development](../docs/adr/0005-spdd-pipeline.md)
+loop: scope-with-REASONS, ADR if architectural, spec-first
+edits on behaviour change, refactor-resync of the spec, and
+the regular shipping tail. The `Dev10x:work-on` suitability
+gate (GH-174) routes good-fit tickets here automatically.
+
+```
+scope-with-reasons → adr (if architectural)
+  → spec-update gate → implement
+  → py-test (API) → py-test (unit)
+  → spec-sync gate before merge
+  → ...shipping pipeline...
+```
+
+| Step | Skill | Input | Output |
+|------|-------|-------|--------|
+| Scope with REASONS | [`Dev10x:ticket-scope`](../skills/ticket-scope/SKILL.md) | ticket ID | `docs/specs/<TICKET-ID>.md` with Entities / Norms / Safeguards rendered inline |
+| Record ADR (conditional) | [`Dev10x:adr`](../skills/adr/SKILL.md) | architectural decision | ADR document |
+| Spec-update gate (Golden Rule) | [`Dev10x:spec-update`](../skills/spec-update/SKILL.md) | behaviour change | Updated spec + regenerated code |
+| Implement | (no skill — agent generates from spec) | spec | Code |
+| Run API tests | [`Dev10x:py-test`](../skills/py-test/SKILL.md) | code | Pass / fail |
+| Run unit tests | [`Dev10x:py-test`](../skills/py-test/SKILL.md) | code | Pass / fail |
+| Spec-sync gate before merge | [`Dev10x:spec-sync`](../skills/spec-sync/SKILL.md) | spec + code | Resynced spec OR bail-to-spec-update |
+| Drift check (during review) | [`Dev10x:gh-pr-respond`](../skills/gh-pr-respond/SKILL.md) | PR | Drift report — blocks on behavioural drift |
+| Drift check (pre-merge) | [`Dev10x:git-groom`](../skills/git-groom/SKILL.md) | branch | Fail-close on behavioural drift |
+| Shipping tail | shipping-pipeline fragment | branch | Merged PR |
+
+**Enter at any step.** Each step is invocable on its own:
+
+- **Already scoped, need to update behaviour mid-flight?**
+  Enter at `Dev10x:spec-update`. The skill reads the existing
+  spec, walks you through the behaviour-change edits, then
+  re-invokes `Dev10x:work-on` to regenerate code from the
+  updated spec.
+- **Refactor without behaviour change?** Enter at
+  `Dev10x:spec-sync`. The skill detects structural drift and
+  regenerates only the spec's Architecture / Implementation
+  Steps / Code References sections.
+- **Drift check only (no edits)?** `Dev10x:spec-sync
+  --check-only <ticket-id>` returns the `DriftReport` from the
+  shared `dev10x.spec.drift_detector` module without touching
+  the spec.
+
+**Pipeline guarantees.**
+
+- One canonical drift detector (`dev10x.spec.drift_detector`)
+  is shared between `Dev10x:spec-update`, `Dev10x:spec-sync`,
+  `Dev10x:gh-pr-respond`, and `Dev10x:git-groom` — all four
+  agree byte-for-byte on what counts as drift.
+- Behavioural drift is fail-close at merge time
+  (`Dev10x:git-groom` Phase 0b). Structural drift is a
+  warning, not a blocker.
+- The pipeline is **opt-in per ticket**. Projects without
+  `docs/specs/<TICKET-ID>.md` files continue to use the
+  `feature` / `bugfix` plays unchanged; the drift checks
+  no-op silently when no spec is present.
+
+**Why this pipeline?** Per ADR 0005, the SPDD insight is that
+the spec is the prompt. Code generated from a drifted spec
+silently regresses behaviour the spec no longer describes. The
+pipeline keeps spec and code aligned at every gate so the
+generation-from-spec contract holds across sessions.
+
+---
+
 ## Standalone Invocation
 
 Each skill in a pipeline can be invoked independently. Prerequisites:

--- a/skills/gh-pr-respond/instructions.md
+++ b/skills/gh-pr-respond/instructions.md
@@ -346,6 +346,59 @@ across nested skills, breaking allow-rule matching.
 This prevents wasted turns from file-not-found errors when
 the agent reads files that exist only on the PR branch.
 
+## Preamble: Spec Drift Check (GH-173)
+
+Before responding to review comments, check whether the PR's
+changes have drifted from the canonical spec at
+`docs/specs/<TICKET-ID>.md`. If the ticket has no canonical
+spec, **no-op** — this guard only fires when SPDD-style scoping
+is in use.
+
+```python
+from pathlib import Path
+from dev10x.spec import detect_drift, DriftKind
+
+ticket_id = "<extracted from PR branch>"
+spec_path = Path(f"docs/specs/{ticket_id}.md")
+if spec_path.exists():
+    report = detect_drift(
+        spec_path=spec_path,
+        project_root=Path("."),
+    )
+    if report.has_behavioural:
+        # SURFACE AS BLOCKER — do not auto-fix.
+        ...
+    elif report.has_structural:
+        # SURFACE AS WARNING with Dev10x:spec-sync suggestion.
+        ...
+```
+
+**Behavioural drift is a blocker.** Surface to the user:
+
+> "Spec drift detected: behavioural drift in
+> `docs/specs/<TICKET-ID>.md`. Per the Golden Rule, fix the
+> prompt first. Invoke `Dev10x:spec-update` before responding
+> to review comments — otherwise fixup commits will compound
+> the drift."
+
+Stop the skill. Do not proceed to Mode A or Mode B until the
+user has either resolved the drift or explicitly opted to
+override (rare — used only when the reviewer's comment IS the
+spec update).
+
+**Structural drift is a warning.** Surface to the user, but
+allow the response flow to continue:
+
+> "Spec drift detected: structural drift in
+> `docs/specs/<TICKET-ID>.md`. The Architecture / Implementation
+> Steps sections lag the current code shape. Consider running
+> `Dev10x:spec-sync` after this PR merges."
+
+**No spec means no-op.** If `docs/specs/<TICKET-ID>.md` does
+not exist, skip this preamble silently and continue to Input
+Detection. Projects that haven't adopted SPDD scoping are
+unaffected.
+
 ## Input Detection
 
 Parse the input URL to determine the mode:

--- a/skills/git-groom/instructions.md
+++ b/skills/git-groom/instructions.md
@@ -112,7 +112,75 @@ agent-initiated grooming is blocked.
    Exit non-zero. Do NOT continue to Phase 1.
 
 4. If zero unresolved threads OR `invoker` indicates supervisor
-   session, proceed to Phase 1 normally.
+   session, proceed to Phase 0b normally.
+
+### Phase 0b Precondition: Pre-merge Spec Drift Check (GH-173)
+
+Before squashing or rewriting commit history, verify the
+canonical spec at `docs/specs/<TICKET-ID>.md` still matches the
+code on the branch. Grooming locks in whatever shape the branch
+has — if behavioural drift exists, the merge would land code
+that contradicts the spec, and every future agent generating
+from that spec would silently regenerate the wrong behaviour.
+
+**No-op rule.** If `docs/specs/<TICKET-ID>.md` does not exist,
+skip this phase silently. Projects that haven't adopted SPDD
+scoping continue as before.
+
+**Check:**
+
+```python
+from pathlib import Path
+from dev10x.spec import detect_drift
+
+ticket_id = "<extracted from branch>"
+spec_path = Path(f"docs/specs/{ticket_id}.md")
+if spec_path.exists():
+    report = detect_drift(
+        spec_path=spec_path,
+        project_root=Path("."),
+    )
+    if report.has_behavioural:
+        # FAIL-CLOSE — refuse to groom.
+        ...
+```
+
+**Fail-close on behavioural drift.** Print the same `BLOCKED:`
+contract used in Phase 0:
+
+```
+BLOCKED: groom-refused-spec-drift behavioural
+
+git-groom refused: spec drift detected at
+docs/specs/{TICKET-ID}.md. Behavioural drift means the code
+no longer matches the spec's Requirements / Acceptance Criteria
+/ Safeguards sections. Squashing pre-merge would lock the
+contradiction into history.
+
+Run `Dev10x:spec-update` to fix the spec first (Golden Rule:
+fix the prompt, then regenerate), then re-invoke git-groom.
+
+To override (rare — only when the spec is intentionally being
+retired with this merge), pass `--skip-spec-check` explicitly.
+```
+
+Exit non-zero. Do NOT continue to Phase 1.
+
+**Warn on structural drift.** Allow the groom to continue, but
+surface a warning that `Dev10x:spec-sync` should run before the
+next session:
+
+```
+WARNING: structural spec drift detected at
+docs/specs/{TICKET-ID}.md. The Architecture / Implementation
+Steps sections describe a different code shape. Consider running
+`Dev10x:spec-sync` after this merge so the next agent generating
+from this spec gets the right file layout.
+```
+
+This precondition uses the shared `dev10x.spec.drift_detector`
+module so `gh-pr-respond` and `git-groom` agree byte-for-byte
+on what counts as drift.
 
 ### Phase 1: Analyze Current State
 

--- a/skills/playbook/references/playbook.yaml
+++ b/skills/playbook/references/playbook.yaml
@@ -573,6 +573,84 @@ defaults:
           plan. If more investigation is needed, suggest
           creating a follow-up ticket.
 
+  structured-spec:
+    prompt: >
+      Use when a ticket is a good fit for SPDD-style scoping —
+      multi-component design, cross-layer changes, or API
+      additions. The Phase 1 suitability gate routes good-fit
+      tickets here; poor-fit tickets (single-file tweaks,
+      config-only changes, exploratory spikes) fall back to
+      the `feature` play. See `references/skill-pipelines.md`
+      "Structured Spec Pipeline" for the rationale.
+
+      The pipeline materializes ADR 0005's six-step SPDD loop
+      on top of existing skills:
+      scope-with-reasons → adr (if architectural) →
+      spec-update gate → implement → py-test (API) →
+      py-test (unit) → spec-sync gate before merge.
+    steps:
+      - subject: Set up workspace
+        type: detailed
+        prompt: >
+          Create a feature branch from develop. Skip if a matching
+          branch already exists.
+        skills: [Dev10x:ticket-branch]
+      - subject: Scope ticket with REASONS sections
+        type: detailed
+        prompt: >
+          Invoke Dev10x:ticket-scope. The skill renders Entities,
+          Norms, and Safeguards sections inline using the
+          autopopulator (`dev10x.scope.render_norms` /
+          `render_safeguards`). The saved spec at
+          docs/specs/<TICKET-ID>.md becomes the source of truth
+          for the rest of the pipeline.
+        skills: [Dev10x:ticket-scope]
+      - subject: Record ADR (if architectural decision involved)
+        type: detailed
+        prompt: >
+          When the spec introduces or changes an architectural
+          boundary, an ADR is required. Skip otherwise.
+        skills: [Dev10x:adr]
+        condition: if-architectural
+      - subject: Spec-update gate (Golden Rule)
+        type: detailed
+        prompt: >
+          Before implementing, check whether requirements shifted
+          since the spec was saved. If yes, run Dev10x:spec-update
+          (spec-first edit) and re-enter this step. If no, proceed
+          to Implement.
+        skills: [Dev10x:spec-update]
+        condition: if-requirements-shifted
+      - subject: Implement changes
+        type: epic
+        prompt: >
+          Generate code from the spec. The spec — not a custom
+          plan — IS the prompt. Each Implementation Step in the
+          spec becomes a concrete edit.
+      - subject: Verify — API tests
+        type: detailed
+        prompt: >
+          Run integration / API tests covering the spec's
+          Acceptance Criteria. Failures indicate the spec is
+          either wrong or under-implemented; do not silently
+          weaken assertions.
+        skills: [test]
+      - subject: Verify — unit tests
+        type: detailed
+        prompt: >
+          Run unit tests covering Implementation Steps. Aim for
+          100% coverage of new code, per project convention.
+        skills: [test]
+      - subject: Spec-sync gate before merge
+        type: detailed
+        prompt: >
+          Run Dev10x:spec-sync in check-only mode. Behavioural
+          drift blocks the pipeline (route back to spec-update).
+          Structural drift triggers a regenerate-and-commit pass
+          so the spec matches the final code shape.
+        skills: [Dev10x:spec-sync]
+      - fragment: shipping-pipeline
+
 # User overrides — added when user customizes a plan.
 # persist: true = reuse across sessions; false = one-time.
 # Example:

--- a/skills/spec-sync/SKILL.md
+++ b/skills/spec-sync/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: Dev10x:spec-sync
+invocation-name: Dev10x:spec-sync
+description: >
+  Inverse Golden Rule path: when code is refactored without
+  behaviour changes, update the canonical spec at
+  docs/specs/<TICKET-ID>.md to match the new code shape.
+  Regenerates Architecture / Implementation Steps / Code
+  References sections, leaves Requirements / Entities / Norms /
+  Safeguards untouched. Bails to Dev10x:spec-update if it detects
+  behavioural drift.
+  TRIGGER when: a structural refactor (rename, file move, signature
+  change) ships and the canonical spec must be re-aligned with the
+  new code shape.
+  DO NOT TRIGGER when: behaviour changes (use Dev10x:spec-update);
+  spec is missing (use Dev10x:ticket-scope); no canonical spec
+  workflow is in use (regular Dev10x:work-on applies).
+user-invocable: true
+allowed-tools:
+  - AskUserQuestion
+  - Read
+  - Edit
+  - Write
+  - Bash(git diff:*)
+  - Bash(git status:*)
+  - Skill
+  - TaskCreate
+  - TaskUpdate
+  - TaskList
+---
+
+# Dev10x:spec-sync — Refactor-Driven Spec Update
+
+## Overview
+
+When a refactor ships, the spec's Structure / Implementation
+Steps / Code References sections describe the **pre-refactor**
+shape — that's drift, even though no behaviour changed. This
+skill detects structural drift and regenerates those sections.
+
+If behavioural drift is detected, it **refuses to proceed** and
+delegates to `Dev10x:spec-update` (the spec-first path). Per
+ADR 0005, the shared `drift_detector` module (one canonical
+detector, two entry points) ensures both skills agree on what
+counts as drift.
+
+## Orchestration
+
+**REQUIRED: Create task at invocation.**
+
+1. `TaskCreate(subject="Sync spec with refactored code",
+   activeForm="Syncing spec to code")`
+
+## Interface Contract
+
+```
+INPUTS:
+  ticket_id: str               — e.g. GH-172, FEAT-300
+  spec_path: Path | None       — defaults to docs/specs/<TICKET-ID>.md
+  project_root: Path | None    — defaults to repo root (cwd)
+  check_only: bool             — true returns the drift report
+                                 without writing; default false
+
+OUTPUTS:
+  drift_report: DriftReport    — list of structural / behavioural
+                                 signals found
+  spec_updated: bool           — true if the spec was rewritten
+
+SIDE EFFECTS:
+  - Modifies docs/specs/<TICKET-ID>.md when check_only is false
+    and only structural drift exists
+```
+
+## Workflow
+
+### Step 1: Locate the Canonical Spec
+
+Resolve `spec_path` from `ticket_id` if not supplied:
+`docs/specs/<TICKET-ID>.md`. If missing, **STOP** and ask the
+user whether to run `Dev10x:ticket-scope` to create one.
+
+### Step 2: Run the Drift Detector
+
+Call the shared module:
+
+```python
+from pathlib import Path
+from dev10x.spec import detect_drift
+
+report = detect_drift(
+    spec_path=Path("docs/specs/<TICKET-ID>.md"),
+    project_root=Path("."),
+)
+```
+
+The report's `signals` list classifies each mismatch as
+`DriftKind.STRUCTURAL` or `DriftKind.BEHAVIOURAL`. The same
+detector is used by `Dev10x:spec-update` — both skills agree on
+what counts as drift.
+
+### Step 3: Branch on Drift Kind
+
+**REQUIRED: Call `AskUserQuestion`** when both kinds exist —
+plain text would silently default to "sync structural only" and
+let the behavioural drift slip through.
+
+| Report state | Action |
+|--------------|--------|
+| `not report.has_drift` | STOP — no work to do. Mark task completed. |
+| `report.has_behavioural` only | DELEGATE — `Skill("Dev10x:spec-update", ...)` and exit. |
+| `report.has_structural` only | PROCEED — Step 4 regenerates structural sections. |
+| Both kinds present | ASK the user (gate below) — proceed with structural-only sync, run spec-update first, or split into two steps. |
+
+**Gate options** (when both drift kinds are present):
+
+- **Run spec-update first (Recommended)** — Behavioural drift is
+  the more dangerous kind; resolve it before touching structure.
+- **Sync structural only, escalate behavioural** — Write the
+  structural updates and surface the behavioural signals as a
+  ticket comment / TODO for follow-up.
+- **Abort** — Investigate manually before either path runs.
+
+If `check_only=True`, **skip this gate** and return the report
+unchanged. The caller (e.g., `gh-pr-respond`, `git-groom`)
+decides what to do.
+
+### Step 4: Regenerate Structural Sections
+
+For each structural signal, locate the section it pertains to
+(`Architecture`, `Implementation Steps`, `Code References`) and:
+
+1. Re-derive the section's content from the current code (read
+   the referenced modules, inspect actual symbols, list current
+   file paths).
+2. Replace the section body using `Edit`. **Preserve sibling
+   sections** (Requirements / Acceptance Criteria / Entities /
+   Norms / Safeguards) byte-for-byte — those are the source of
+   truth and should never change in a refactor sync.
+
+### Step 5: Re-run the Detector
+
+After rewriting, call `detect_drift` again. If structural drift
+remains, surface it to the user — the regeneration was
+incomplete. Do not auto-loop.
+
+### Step 6: Mark Task Completed
+
+If the spec was updated, commit the change with the ticket ID
+and the gitmoji `📝` (docs). Per the project's git-commit
+convention, the title outcome-focuses on the spec, not the
+underlying refactor:
+
+> `📝 <TICKET-ID> Resync spec Architecture with refactored module layout`
+
+## Decision Gates
+
+This skill has **one REQUIRED `AskUserQuestion` gate** at Step 3
+when both drift kinds are present. See `.claude/rules/skill-gates.md`.
+
+## Integration Points
+
+- **`Dev10x:spec-update`** — inverse path (behaviour-first).
+  Shares `dev10x.spec.drift_detector`.
+- **`Dev10x:ticket-scope`** — creates the canonical spec.
+- **`Dev10x:gh-pr-respond`** (GH-173) — calls this skill in
+  `check_only=True` mode before applying review-comment fixups.
+- **`Dev10x:git-groom`** (GH-173) — pre-merge guard.
+
+## Anti-Patterns
+
+- ❌ Editing Requirements / Acceptance Criteria / Safeguards in
+  a structural sync — those sections are owned by
+  `Dev10x:spec-update`. Touching them here causes the
+  contradiction the shared detector exists to prevent.
+- ❌ Skipping the post-rewrite re-run (Step 5). Without the
+  re-check, the skill cannot prove the drift was actually fixed.
+- ❌ Calling this skill on a behavioural change "to update the
+  spec quickly". Behavioural changes must go through
+  `Dev10x:spec-update` so the spec is updated **before** the
+  code, not after.
+
+## References
+
+- ADR 0005 — SPDD pipeline rationale (canonical detector,
+  two entry points)
+- `src/dev10x/spec/drift_detector.py` — shared module
+- `references/skill-pipelines.md` — Structured Spec Pipeline
+  (added in GH-175)

--- a/skills/spec-sync/evals/evals.json
+++ b/skills/spec-sync/evals/evals.json
@@ -1,0 +1,117 @@
+{
+  "skill_name": "Dev10x:spec-sync",
+  "eval_dimensions": [
+    {
+      "name": "structural-drift-detection",
+      "description": "Skill flags missing file references in Architecture / Implementation Steps"
+    },
+    {
+      "name": "behavioural-bail",
+      "description": "Skill refuses to proceed on behavioural drift and delegates to Dev10x:spec-update"
+    },
+    {
+      "name": "preserve-source-of-truth-sections",
+      "description": "Requirements / Acceptance Criteria / Entities / Norms / Safeguards are never modified during a sync"
+    },
+    {
+      "name": "check-only-mode",
+      "description": "check_only=True returns the report without writing or asking"
+    },
+    {
+      "name": "mixed-drift-gate",
+      "description": "When both kinds exist, AskUserQuestion fires (not plain text)"
+    }
+  ],
+  "evals": [
+    {
+      "scenario": "pure structural drift — refactor only",
+      "input": {
+        "ticket_id": "GH-172",
+        "drift": {
+          "structural": ["src/foo/old_path.py"],
+          "behavioural": []
+        }
+      },
+      "expected": {
+        "spec_updated": true,
+        "spec_update_invoked": false,
+        "untouched_sections": [
+          "Acceptance Criteria",
+          "Entities",
+          "Norms",
+          "Safeguards"
+        ]
+      },
+      "assertions": [
+        {
+          "check": "file_modified",
+          "path_pattern": "docs/specs/*.md",
+          "assertion": "structural-drift-detection"
+        }
+      ]
+    },
+    {
+      "scenario": "behavioural drift only — bail to spec-update",
+      "input": {
+        "ticket_id": "GH-172",
+        "drift": {
+          "structural": [],
+          "behavioural": ["missing acceptance criterion"]
+        }
+      },
+      "expected": {
+        "spec_updated": false,
+        "spec_update_invoked": true
+      },
+      "assertions": [
+        {
+          "check": "skill_invoked",
+          "name": "Dev10x:spec-update",
+          "assertion": "behavioural-bail"
+        }
+      ]
+    },
+    {
+      "scenario": "mixed drift fires gate",
+      "input": {
+        "ticket_id": "GH-172",
+        "drift": {
+          "structural": ["src/a.py"],
+          "behavioural": ["missing safeguard"]
+        }
+      },
+      "expected": {
+        "ask_user_question_calls": 1
+      },
+      "assertions": [
+        {
+          "check": "tool_called",
+          "tool": "AskUserQuestion",
+          "assertion": "mixed-drift-gate"
+        }
+      ]
+    },
+    {
+      "scenario": "check-only mode returns report silently",
+      "input": {
+        "ticket_id": "GH-172",
+        "check_only": true,
+        "drift": {
+          "structural": ["src/a.py"],
+          "behavioural": []
+        }
+      },
+      "expected": {
+        "spec_updated": false,
+        "ask_user_question_calls": 0,
+        "drift_report_returned": true
+      },
+      "assertions": [
+        {
+          "check": "no_destructive_action",
+          "assertion": "check-only-mode"
+        }
+      ]
+    }
+  ]
+}

--- a/skills/spec-update/SKILL.md
+++ b/skills/spec-update/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: Dev10x:spec-update
+invocation-name: Dev10x:spec-update
+description: >
+  Enforce SPDD's "fix the prompt first" Golden Rule for logic
+  changes. When the user wants to change behaviour (not refactor),
+  walk them through editing the canonical spec at
+  docs/specs/<TICKET-ID>.md FIRST, then re-invoke
+  Dev10x:work-on to regenerate code from the updated spec. Refuses
+  to proceed if the user tries to edit code directly without a
+  spec update.
+  TRIGGER when: requirements shift mid-implementation and the
+  canonical spec exists; user describes a behaviour change for a
+  ticket that already has docs/specs/<TICKET-ID>.md.
+  DO NOT TRIGGER when: refactor without behavior change (use
+  Dev10x:spec-sync instead); ticket has no canonical spec (regular
+  Dev10x:work-on applies); user is creating a new spec for the
+  first time (use Dev10x:ticket-scope).
+user-invocable: true
+allowed-tools:
+  - AskUserQuestion
+  - Read
+  - Edit
+  - Write
+  - Bash(git diff:*)
+  - Bash(git status:*)
+  - Skill
+  - TaskCreate
+  - TaskUpdate
+  - TaskList
+---
+
+# Dev10x:spec-update — Spec-First Behaviour Change
+
+## Overview
+
+Implements SPDD's [Golden Rule](https://github.com/Dev10x-Guru/Dev10x-Claude/blob/main/docs/adr/0005-spdd-pipeline.md):
+**when behaviour must change, fix the prompt first, then regenerate
+the code.** The spec at `docs/specs/<TICKET-ID>.md` is the source
+of truth — drifting code away from it silently corrupts future
+generation passes.
+
+This skill refuses to proceed if the user tries to edit code
+directly without first updating the spec.
+
+## Orchestration
+
+**REQUIRED: Create task at invocation.**
+
+1. `TaskCreate(subject="Update spec before regenerating code",
+   activeForm="Walking through spec edit")`
+
+Mark completed after Step 5 (re-invoke `Dev10x:work-on`) succeeds.
+
+## Interface Contract
+
+```
+INPUTS:
+  ticket_id: str           — e.g. GH-171, FEAT-300
+  change_description: str  — what behaviour must change
+  spec_path: Path | None   — defaults to docs/specs/<TICKET-ID>.md
+
+OUTPUTS:
+  regenerated: bool — true if Dev10x:work-on ran successfully
+
+SIDE EFFECTS:
+  - Modifies docs/specs/<TICKET-ID>.md
+  - Invokes Dev10x:work-on which may modify source files
+```
+
+## Workflow
+
+### Step 1: Locate the Canonical Spec
+
+Resolve `spec_path` from `ticket_id` if not supplied:
+`docs/specs/<TICKET-ID>.md`.
+
+If the file does not exist, **STOP**. Surface to the user:
+
+> "No canonical spec found at `docs/specs/<TICKET-ID>.md`. This
+> skill enforces spec-first behaviour changes — a missing spec
+> means there is no source of truth to update. Run
+> `Dev10x:ticket-scope` first to create one, then re-invoke
+> this skill."
+
+### Step 2: Classify the Change
+
+**REQUIRED: Call `AskUserQuestion`** (do NOT use plain text).
+Classify the change so the right path runs:
+
+- **Behaviour change (Recommended)** — Requirements / Acceptance
+  Criteria / Job Story / Safeguards change. This skill applies.
+- **Structural refactor** — Code shape changes, behaviour stable.
+  This skill bails out and delegates to `Dev10x:spec-sync`.
+- **New feature, no spec yet** — There is no spec to update. This
+  skill bails out and delegates to `Dev10x:ticket-scope`.
+
+If anything other than "Behaviour change" is selected, route to
+the named skill via `Skill(...)` and exit.
+
+### Step 3: Read the Current Spec
+
+`Read` the spec file. Surface to the user the sections most likely
+to need updates: Job Story, Requirements / Acceptance Criteria,
+Norms, Safeguards. The `## Implementation Steps` section is NOT
+the source of truth — it is downstream of the others.
+
+### Step 4: Walk the User Through the Spec Edit
+
+For each section identified in Step 3:
+
+1. Show the current content
+2. Ask what should change (free-form text or AskUserQuestion as
+   appropriate)
+3. Apply the edit with the `Edit` tool
+
+**Anti-pattern guard.** If the user tries to skip ahead and
+modify source code, **STOP**. Refuse with:
+
+> "Spec must be updated before code. The Golden Rule says: fix
+> the prompt, then regenerate. Editing code first creates drift
+> that the next generation pass will silently revert."
+
+### Step 5: Re-invoke `Dev10x:work-on`
+
+After the spec is saved:
+
+```
+Skill(skill="Dev10x:work-on", args="<ticket_id>")
+```
+
+`work-on` will pick up the updated spec and regenerate code from
+the new requirements. The structured-spec play (GH-174, when
+landed) routes through this skill automatically.
+
+### Step 6: Verify Code Matches Spec
+
+After regeneration, run `Dev10x:spec-sync` in **check-only mode**
+to confirm no structural drift remains:
+
+```
+Skill(skill="Dev10x:spec-sync", args="--check-only <ticket_id>")
+```
+
+If drift remains, surface it to the user. The session terminates
+with the supervisor's confirmation that the code now matches the
+updated spec.
+
+## Decision Gates
+
+This skill has **two REQUIRED `AskUserQuestion` gates**:
+
+1. **Step 2 — Change classification.** Routes between this skill,
+   `Dev10x:spec-sync`, and `Dev10x:ticket-scope`. Plain-text
+   substitution would silently default to "behaviour change" and
+   break the contract.
+2. **Step 4 — Per-section edit approval.** Whenever the proposed
+   edit is non-trivial, confirm before writing.
+
+See `.claude/rules/skill-gates.md` for the pattern.
+
+## Integration Points
+
+- **`Dev10x:ticket-scope`** — creates the canonical spec this
+  skill updates.
+- **`Dev10x:spec-sync`** — the inverse path (refactor-only).
+  Shares the `drift_detector` module (GH-172).
+- **`Dev10x:work-on`** — invoked at Step 5 to regenerate code
+  from the updated spec.
+- **`Dev10x:gh-pr-respond`** — runs drift check before applying
+  fixups (GH-173). If drift is found, the user is prompted to
+  invoke this skill.
+- **`Dev10x:git-groom`** — pre-merge drift check (GH-173) blocks
+  the merge if a behaviour change shipped without a spec update.
+
+## Anti-Patterns
+
+- ❌ Editing the spec **after** the code change (drift created,
+  not fixed).
+- ❌ Skipping Step 5 — without re-invoking `Dev10x:work-on`, the
+  code does not yet reflect the new spec.
+- ❌ Editing only Implementation Steps without touching Job
+  Story / Acceptance Criteria / Safeguards. Implementation Steps
+  are downstream of those sections; they are not the source of
+  truth.
+
+## References
+
+- ADR 0005 — SPDD pipeline rationale
+- `references/skill-pipelines.md` — Structured Spec Pipeline
+  section (added by GH-175)
+- `.claude/rules/skill-gates.md` — decision gate pattern

--- a/skills/spec-update/evals/evals.json
+++ b/skills/spec-update/evals/evals.json
@@ -1,0 +1,92 @@
+{
+  "skill_name": "Dev10x:spec-update",
+  "eval_dimensions": [
+    {
+      "name": "spec-first-enforcement",
+      "description": "Skill blocks code edits when no spec update has happened"
+    },
+    {
+      "name": "classification-gate",
+      "description": "Step 2 uses AskUserQuestion (not plain text) to classify the change"
+    },
+    {
+      "name": "missing-spec-handling",
+      "description": "Skill stops gracefully when docs/specs/<TICKET-ID>.md is absent"
+    },
+    {
+      "name": "regeneration-handoff",
+      "description": "After spec is updated, skill delegates to Dev10x:work-on for code regeneration"
+    },
+    {
+      "name": "drift-verification",
+      "description": "Skill runs Dev10x:spec-sync --check-only at the end to confirm code matches spec"
+    }
+  ],
+  "evals": [
+    {
+      "scenario": "behaviour change with existing spec",
+      "input": {
+        "ticket_id": "GH-171",
+        "change_description": "Discount codes must support per-customer usage limits, not just global limits"
+      },
+      "expected": {
+        "spec_file_modified": true,
+        "ask_user_question_calls": 1,
+        "work_on_invoked": true,
+        "spec_sync_check_run": true
+      },
+      "assertions": [
+        {
+          "check": "tool_called",
+          "tool": "AskUserQuestion",
+          "assertion": "classification-gate"
+        },
+        {
+          "check": "file_modified",
+          "path_pattern": "docs/specs/*.md",
+          "assertion": "spec-first-enforcement"
+        },
+        {
+          "check": "skill_invoked",
+          "name": "Dev10x:work-on",
+          "assertion": "regeneration-handoff"
+        }
+      ]
+    },
+    {
+      "scenario": "refactor classification routes to spec-sync",
+      "input": {
+        "ticket_id": "GH-171",
+        "change_description": "Rename DiscountService to PromotionService — no behavior changes"
+      },
+      "expected": {
+        "spec_file_modified": false,
+        "spec_sync_invoked": true
+      },
+      "assertions": [
+        {
+          "check": "skill_invoked",
+          "name": "Dev10x:spec-sync"
+        }
+      ]
+    },
+    {
+      "scenario": "spec missing aborts cleanly",
+      "input": {
+        "ticket_id": "GH-999",
+        "change_description": "anything"
+      },
+      "expected": {
+        "spec_file_modified": false,
+        "work_on_invoked": false,
+        "exit_message_contains": "ticket-scope"
+      },
+      "assertions": [
+        {
+          "check": "no_destructive_action",
+          "assertion": "missing-spec-handling"
+        }
+      ]
+    }
+  ]
+}

--- a/skills/ticket-scope/instructions.md
+++ b/skills/ticket-scope/instructions.md
@@ -234,12 +234,78 @@ the diverged structure breaks audits and PR generation.
 - Objective/Problem Statement
 - Technical Approach
 - Architecture (components, dependencies)
+- **Entities** (property + relationship schemas — REASONS)
 - Implementation Steps (with file paths)
 - Code References
 - Dependencies (tickets)
-- Risks and Mitigations
 - Acceptance Criteria
+- **Norms** (project rules — populated by autopopulator, REASONS)
+- **Safeguards** (invariants & validation, distinct from Risks —
+  REASONS)
+- Risks and Mitigations (rollout-only failures)
 - Story Points
+
+**REASONS coverage check:** The seven SPDD REASONS dimensions are
+Requirements, Approach, Structure, Operations, Entities, Norms,
+Safeguards. Map them to template sections:
+
+| REASONS dimension | Template section(s) |
+|-------------------|---------------------|
+| Requirements | Objective / Problem Statement / Acceptance Criteria |
+| Approach | Technical Approach |
+| Structure | Architecture |
+| Operations | Implementation Steps / Rollout |
+| Entities | **Entities** (new) |
+| Norms | **Norms** (new, autopopulator-driven) |
+| Safeguards | **Safeguards** (new) |
+
+If a saved scope is missing any of the three new headings, the
+spec is incomplete — `Dev10x:spec-sync` will flag it as drift.
+
+#### 5.3 Invoke the Norms / Safeguards Autopopulator (GH-170)
+
+Before writing the scope document, render the Norms and
+Safeguards section bodies from `.claude/rules/INDEX.md` and
+inject them inline. **Render at generation time, not at
+scope-save time** — re-render whenever the spec is fed back
+into a generation prompt so stale rule text never lies.
+
+Use the `dev10x.scope` Python API:
+
+```python
+from pathlib import Path
+from dev10x.scope import render_norms, render_safeguards
+
+affected = [
+    "src/payments/square/orders.py",
+    "src/payments/square/tests/test_orders.py",
+]
+
+norms_md = render_norms(
+    affected_files=affected,
+    index_path=Path(".claude/rules/INDEX.md"),
+)
+safeguards_md = render_safeguards(
+    affected_files=affected,
+    index_path=Path(".claude/rules/INDEX.md"),
+    claude_md_path=Path("CLAUDE.md"),
+    settings_paths=[
+        Path(".claude/settings.local.json"),
+        Path(".claude/settings.json"),
+    ],
+)
+```
+
+Inject `norms_md` directly under the `## Norms` heading and
+`safeguards_md` directly under the `## Safeguards` heading,
+replacing the placeholder bullets in the template. Manual
+additions (rules not in INDEX.md) belong **after** the
+auto-populated block, under a `**Manual additions**:` sub-heading
+preserved from the template.
+
+The renderer is idempotent — running it again with the same
+affected files produces byte-identical output, so re-rendering on
+each generation pass is safe.
 
 ### Phase 6: User Review
 

--- a/skills/ticket-scope/references/bug-fix-template.md
+++ b/skills/ticket-scope/references/bug-fix-template.md
@@ -163,6 +163,26 @@ Example:
 
 ---
 
+## Entities
+
+[Data shapes touched by this fix. For bug fixes, the entities are
+usually the existing types whose contracts were silently violated.
+Listing them helps `Dev10x:spec-sync` detect future drift.]
+
+**Affected entities:**
+
+| Entity | Property used | Bug touched |
+|--------|---------------|-------------|
+| `Customer` | `tax_exemption: TaxExemption` | Read path missing |
+| `WorkOrder` | tax calc honors `tax_exemption` | Correct already |
+| `SquareOrder` | tax lines | Was ignoring exemption |
+
+Bug fixes rarely introduce new entities. When they do (e.g., a
+new typed exception), list them here so the spec covers the new
+surface.
+
+---
+
 ## Rollout
 
 **Testing:**
@@ -187,6 +207,47 @@ Example:
 - Simple code revert if issues
 - No data to rollback
 - Low risk change
+
+---
+
+## Norms
+
+[Project rules and conventions this fix MUST follow. Populated by
+the Norms / Safeguards autopopulator (`Dev10x:ticket-scope`
+Phase 5).]
+
+**Auto-populated rules**:
+- [Placeholder — renderer walks `.claude/rules/INDEX.md` matching
+  affected files (e.g., `src/payments/square/**`)]
+
+**Manual additions**:
+- [e.g., "Square integration tests must use the recorded-cassette
+  fixture, not live API calls"]
+
+---
+
+## Safeguards
+
+[Invariants that must hold AFTER this fix ships. Distinct from the
+`## Rollout` section, which describes monitoring during deploy.
+Safeguards describe the **post-fix invariant** that the regression
+test pins down.]
+
+**Invariants:**
+- `SquareOrder.tax_total == WorkOrder.tax_total` for every order,
+  regardless of customer tax-exemption status
+- `OrderConverter._get_taxes()` reads `tax_exemption` from its
+  caller, never from a stale cache or globals
+
+**Validation rules:**
+- `TaxExemption` enum is exhaustive — `_get_taxes()` raises on
+  unknown variants instead of silently returning all taxes
+- Tax-exempt customer paths are covered by parametrized tests over
+  all three `TaxExemption` values
+
+**Authorization safeguards:**
+- Only the `WorkOrderRepository.tax_exemption()` path may set the
+  exemption on a Square order — no callers may pass it directly
 
 ---
 

--- a/skills/ticket-scope/references/business-feature-template.md
+++ b/skills/ticket-scope/references/business-feature-template.md
@@ -54,6 +54,28 @@ Example:
 - New column: `quotes_workorder.discount_code_id` (FK)
 - Migration: Auto-generated + custom for indexes
 
+### Entities
+
+[Data shapes introduced or modified by this change. Use this section to
+make property schemas and relationships explicit — the Architecture
+section names *which* components are affected; Entities names *what*
+data they carry.]
+
+**New entities:**
+
+| Entity | Properties | Relationships |
+|--------|-----------|---------------|
+| `DiscountCode` | `id`, `code` (unique), `amount`, `expiry`, `usage_limit`, `created_at` | M:N with `Quote` via `quotes_discountcode_usages` |
+
+**Modified entities:**
+
+| Entity | Changes |
+|--------|---------|
+| `WorkOrder` | Adds nullable `discount_code_id` FK to `DiscountCode` |
+
+Note any uniqueness constraints, indexes, ordering, or cardinality
+requirements that downstream code must preserve.
+
 ### Implementation Steps
 
 1. **Create DiscountCode Model**
@@ -130,6 +152,48 @@ Example:
 - [ ] Used codes are tracked (can't reuse single-use codes)
 - [ ] Admin can list and view active discount codes
 - [ ] Tests cover all edge cases (expired, invalid, usage limit)
+
+### Norms
+
+[Project rules and conventions this change MUST follow. The Norms /
+Safeguards autopopulator (`Dev10x:ticket-scope` Phase 5) renders the
+matched rules from `.claude/rules/INDEX.md` inline at scope-render
+time. Do NOT hand-copy rules here — list manual additions only.]
+
+**Auto-populated rules** (rendered at scope-generation time):
+- [Placeholder — `Dev10x:ticket-scope` Phase 5 renderer fills this
+  by walking `.claude/rules/INDEX.md` and path-matching against the
+  files in Architecture / Implementation Steps.]
+
+**Manual additions** (project conventions discovered during scoping
+that aren't in INDEX.md yet):
+- [e.g., "Discount-code copy must round-trip through i18n catalogue —
+  no hard-coded English strings"]
+
+Norms answer: *what must this code do to fit existing patterns?*
+
+### Safeguards
+
+[Invariants and validation rules that must hold AFTER this change
+ships. Distinct from `### Risks & Mitigation` below, which lists
+what could go wrong **during rollout**. Safeguards describe what
+must always be true **post-change**.]
+
+**Invariants:**
+- A `WorkOrder` can have at most one active `DiscountCode` applied
+- `DiscountCode.usage_count` must never exceed `usage_limit`
+- A discount cannot reduce the `WorkOrder` total below zero
+
+**Validation rules:**
+- `DiscountCode.code` matches `^[A-Z0-9-]{4,32}$`
+- `expiry` must be in the future when the code is created
+- `amount` must be positive
+
+**Authorization safeguards:**
+- Only `store_admin` role can create or deactivate discount codes
+- Customers cannot view raw `usage_count` of any code
+
+Safeguards answer: *what must always be true after this change?*
 
 ### Risks & Mitigation
 

--- a/skills/ticket-scope/references/technical-task-template.md
+++ b/skills/ticket-scope/references/technical-task-template.md
@@ -46,6 +46,25 @@ Example:
 
 ---
 
+## Entities
+
+[Data shapes introduced or modified by this change. For pure
+refactors, the entities are usually class hierarchies / interfaces,
+not database tables. List them anyway — downstream tooling
+(`Dev10x:spec-sync`) uses this section to detect structural drift.]
+
+**New / changed types:**
+
+| Type | Properties / Methods | Relationships |
+|------|---------------------|---------------|
+| `BaseRepository[T]` | `get`, `list`, `create`, `update`, `delete` (generic) | Parent of `PaymentRepository`, `TransactionRepository` |
+| `PaymentRepository` | Custom: `get_by_order_no` | Now extends `BaseRepository[PaymentDto]` |
+
+For refactors with no entity changes, write `No new entities; type
+parameter `T` of `BaseRepository` is the only new generic.`
+
+---
+
 ## Implementation Steps
 
 1. **Update BaseRepository with Generic CRUD**
@@ -164,6 +183,47 @@ Example:
 - [ ] Test coverage maintained at 100%
 - [ ] DI container registration works
 - [ ] Code review approved
+
+---
+
+## Norms
+
+[Project rules and conventions this change MUST follow. Populated
+by the Norms / Safeguards autopopulator from `.claude/rules/INDEX.md`
+at scope-render time. Do NOT hand-copy rules here — list manual
+additions only.]
+
+**Auto-populated rules** (filled by `Dev10x:ticket-scope` Phase 5):
+- [Placeholder — renderer walks `.claude/rules/INDEX.md` and
+  path-matches against affected files]
+
+**Manual additions**:
+- [e.g., "Generic type parameters must be `Protocol`s, not raw
+  `TypeVar`s, to satisfy mypy strict mode in this codebase"]
+
+---
+
+## Safeguards
+
+[Invariants and validation rules that must hold AFTER this change
+ships. Distinct from `## Technical Risks` (rollout failures) —
+Safeguards describe what must always be true **post-change**.]
+
+**Invariants:**
+- All `BaseRepository` subclasses preserve their pre-existing
+  public method signatures
+- DI container resolves `BaseRepository[T]` for every concrete
+  subclass registered before the refactor
+
+**Validation rules:**
+- Generic type parameter `T` must be a `pydantic.dataclass` (not
+  an arbitrary class) — enforced at registration time
+- `BaseRepository.get(id)` raises `EntityNotFound` (typed
+  exception) on miss, never returns `None`
+
+**Authorization safeguards:**
+- Refactor preserves existing repository-level permission checks
+  (no method becomes implicitly more permissive)
 
 ---
 

--- a/skills/work-on/instructions.md
+++ b/skills/work-on/instructions.md
@@ -175,6 +175,57 @@ to bundling. Phase 3 resolves the actual strategy (separate PRs vs
 single bundled PR with batches) using the Same-Milestone Heuristic
 and, if needed, the explicit strategy gate.
 
+### Structured-Spec Suitability Gate (GH-174)
+
+After classification, decide whether the ticket is a good fit for
+the SPDD-style `structured-spec` play. Run this gate per ticket
+source (not per session) — a session bundling several tickets may
+route some through `structured-spec` and others through `feature`.
+
+**Poor fit (skip the gate, fall back to default play):**
+
+- Single-file tweaks, config-only changes, dependency bumps
+- Exploratory spikes or research tickets
+- One-off scripts that won't be reused
+- Doc-only changes
+- Bug fixes whose root cause is named in the ticket body
+
+**Good fit (offer `structured-spec` at Phase 3):**
+
+- New features touching ≥ 3 modules
+- API additions (REST, GraphQL, gRPC)
+- Cross-layer changes (model + service + serializer + API)
+- Tickets that already have `docs/specs/<TICKET-ID>.md` —
+  treat this as a strong signal SPDD is in use for this project
+
+**Detection heuristics (apply in order):**
+
+1. If `docs/specs/<TICKET-ID>.md` exists for any source ticket,
+   set `structured_spec_candidate = true`.
+2. Else, count `## Files Changed` (or `Implementation Steps`)
+   entries in the ticket body. If ≥ 3 distinct top-level paths
+   are listed across files in different bounded contexts (e.g.,
+   `src/payments/` AND `src/quotes/` AND `src/api/`), set
+   `structured_spec_candidate = true`.
+3. Else, `structured_spec_candidate = false` — proceed to the
+   default play.
+
+**Phase 3 gate behaviour:**
+
+- When `structured_spec_candidate = true`, **REQUIRED: Call
+  `AskUserQuestion`** in Phase 3 with options:
+  - **Use structured-spec play (Recommended)** — full SPDD pipeline
+    with scope-with-reasons → spec-update gate → implement →
+    spec-sync gate before merge.
+  - **Use the default play** — feature / bugfix / etc.
+- At `friction_level: adaptive`, auto-select the **Recommended**
+  option and skip the prompt.
+- When the candidate flag is false, the gate does not fire — the
+  default play applies silently.
+
+Store the decision in the Phase 1 output as `play_override`. Phase
+3 uses it to resolve which play to instantiate.
+
 ### Ambiguous Input Fallback (GH-886)
 
 When ALL inputs classify as `note` (no URLs, ticket IDs, or PR
@@ -792,6 +843,45 @@ in `TaskList`).
 4.3  [detailed] Document findings and next steps
 4.4  [detailed] Decide: create ticket, fix now, or done
 ```
+
+**Structured-spec (SPDD pipeline, GH-174):**
+
+Selected when the Phase 1 suitability gate (see § Structured-Spec
+Suitability Gate) marks the ticket as good-fit. Routes through
+`Dev10x:ticket-scope` (with REASONS autopopulator),
+`Dev10x:spec-update` / `Dev10x:spec-sync` gates, and the regular
+shipping pipeline tail.
+
+```
+4.1  [detailed] Set up workspace                 → Dev10x:ticket-branch
+4.2  [detailed] Scope ticket with REASONS        → Dev10x:ticket-scope
+4.3  [detailed] Record ADR (if architectural)    → Dev10x:adr
+4.4  [detailed] Spec-update gate (Golden Rule)   → Dev10x:spec-update
+4.5  [epic]     Implement changes
+4.6  [detailed] Verify — API tests               → test
+4.7  [detailed] Verify — unit tests              → test
+4.8  [detailed] Spec-sync gate before merge      → Dev10x:spec-sync
+4.9  [detailed] Code review                      → Dev10x:review
+4.10 [detailed] Commit outstanding changes       → Dev10x:git-commit
+4.11 [detailed] Create draft PR                  → Dev10x:gh-pr-create
+4.12 [detailed] Monitor CI                       → Dev10x:gh-pr-monitor
+4.13 [epic]     Apply fixups                     → Dev10x:gh-pr-respond
+4.14 [detailed] Groom commit history             → Dev10x:git-groom
+4.15 [detailed] Update PR description            → Dev10x:gh-pr-create
+4.16 [detailed] Request review                   → Dev10x:gh-pr-request-review
+4.17 [detailed] Verify acceptance criteria
+```
+
+The structured-spec play differs from `feature` in two ways:
+
+1. **Scope step uses REASONS sections** — `Dev10x:ticket-scope`
+   renders Entities / Norms / Safeguards via the autopopulator
+   (GH-170) so the saved spec at `docs/specs/<TICKET-ID>.md` is
+   the single source of truth.
+2. **Two drift-detection gates bracket Implement** — the
+   spec-update gate (4.4) catches behaviour changes mid-flight;
+   the spec-sync gate (4.8) catches structural drift before
+   merge. Both use `dev10x.spec.drift_detector` so they agree.
 
 ### Supervisor Approval Gate
 

--- a/src/dev10x/scope/__init__.py
+++ b/src/dev10x/scope/__init__.py
@@ -1,0 +1,23 @@
+"""Scope-document autopopulator (GH-170).
+
+Renders Norms and Safeguards sections inline into ticket-scope
+documents by walking ``.claude/rules/INDEX.md`` and path-matching
+discovered rule files against the scope's affected files.
+
+Per ADR 0005: render at generation time, not at scope-save time —
+re-render whenever the spec is fed into a generation prompt so
+stale rule text never lies.
+"""
+
+from __future__ import annotations
+
+from dev10x.scope.index_parser import RuleEntry, parse_index
+from dev10x.scope.norms_renderer import render_norms
+from dev10x.scope.safeguards_renderer import render_safeguards
+
+__all__ = [
+    "RuleEntry",
+    "parse_index",
+    "render_norms",
+    "render_safeguards",
+]

--- a/src/dev10x/scope/_matcher.py
+++ b/src/dev10x/scope/_matcher.py
@@ -1,0 +1,29 @@
+"""Shared path-matching helper for norms/safeguards renderers (GH-170).
+
+Uses ``fnmatch`` semantics over POSIX paths. ``**`` is treated as
+``*`` after a one-time substitution, matching the loose convention
+INDEX.md uses (e.g. ``**/*.py``).
+"""
+
+from __future__ import annotations
+
+from fnmatch import fnmatch
+
+from dev10x.scope.index_parser import RuleEntry
+
+
+def select_matching(
+    *,
+    entries: list[RuleEntry],
+    affected_files: list[str],
+) -> list[RuleEntry]:
+    """Return entries whose any pattern matches any affected file."""
+
+    matched: list[RuleEntry] = []
+    for entry in entries:
+        for pattern in entry.patterns:
+            normalized = pattern.replace("**/", "*/").replace("**", "*")
+            if any(fnmatch(path, pattern) or fnmatch(path, normalized) for path in affected_files):
+                matched.append(entry)
+                break
+    return matched

--- a/src/dev10x/scope/index_parser.py
+++ b/src/dev10x/scope/index_parser.py
@@ -1,0 +1,95 @@
+"""Parse ``.claude/rules/INDEX.md`` routing table into rule entries.
+
+The INDEX.md file declares a path-aware routing table that maps
+file-pattern globs to rule files and review agents. The
+autopopulator (``render_norms`` / ``render_safeguards``) walks
+this table to discover which rules apply to a scope's affected
+files.
+
+Format expected (Markdown table, GH-flavored):
+
+    | File Pattern | Primary Agent | Required References |
+    |---|---|---|
+    | `**/*.py`, `**/*.sh` | reviewer-generic, ... | ... |
+
+This parser is intentionally lenient — INDEX.md is hand-edited
+and the goal is robust matching, not strict schema validation.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class RuleEntry:
+    """One rule discovered from INDEX.md.
+
+    ``patterns`` are fnmatch-style globs lifted from the table's
+    "File Pattern" column. ``source`` is the table row's main
+    reference (rule file path or agent spec) — used as the
+    rendered Markdown link target.
+    """
+
+    patterns: tuple[str, ...]
+    source: str
+    description: str
+
+
+_TABLE_ROW_RE = re.compile(r"^\|(.+)\|\s*$")
+_BACKTICK_RE = re.compile(r"`([^`]+)`")
+
+
+def parse_index(*, index_path: Path) -> list[RuleEntry]:
+    """Return rule entries lifted from INDEX.md's routing tables.
+
+    Raises ``FileNotFoundError`` if ``index_path`` does not exist —
+    callers (renderers) should catch and fall back to an empty
+    "no matched rules" rendering.
+    """
+
+    text = index_path.read_text()
+    entries: list[RuleEntry] = []
+    in_table = False
+    saw_header_separator = False
+
+    for line in text.splitlines():
+        match = _TABLE_ROW_RE.match(line)
+        if not match:
+            in_table = False
+            saw_header_separator = False
+            continue
+
+        cells = [cell.strip() for cell in match.group(1).split("|")]
+
+        if not in_table:
+            if any("File Pattern" in cell for cell in cells):
+                in_table = True
+                saw_header_separator = False
+            continue
+
+        if not saw_header_separator:
+            if all(set(cell) <= {"-", ":", " "} for cell in cells):
+                saw_header_separator = True
+            continue
+
+        if len(cells) < 2:
+            continue
+
+        patterns = tuple(_BACKTICK_RE.findall(cells[0]))
+        if not patterns:
+            continue
+
+        source = cells[1] if len(cells) > 1 else ""
+        description = cells[2] if len(cells) > 2 else ""
+        entries.append(
+            RuleEntry(
+                patterns=patterns,
+                source=source.strip(),
+                description=description.strip(),
+            )
+        )
+
+    return entries

--- a/src/dev10x/scope/norms_renderer.py
+++ b/src/dev10x/scope/norms_renderer.py
@@ -1,0 +1,63 @@
+"""Render the Norms section of a ticket-scope document (GH-170).
+
+Norms are project rules that the change MUST follow — style,
+naming, testing, and pattern conventions discoverable from
+``.claude/rules/INDEX.md``.
+
+Per ADR 0005: render at generation time, not at scope-save time.
+The caller passes the scope's affected-files list; the renderer
+walks INDEX.md, path-matches, and emits Markdown ready to inject
+under the ``## Norms`` heading.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dev10x.scope._matcher import select_matching
+from dev10x.scope.index_parser import parse_index
+
+_HEADER = (
+    "<!-- Auto-populated by dev10x.scope.norms_renderer at scope-render time. -->"
+    "\nMatched project rules (from `.claude/rules/INDEX.md`):"
+)
+_EMPTY_BODY = "No project rules matched the affected files for this scope."
+
+
+def render_norms(
+    *,
+    affected_files: list[str],
+    index_path: Path,
+    rules_root: Path | None = None,
+) -> str:
+    """Return Markdown for the Norms section.
+
+    ``rules_root`` (default: parent of ``index_path``) is the
+    directory used to build relative links to matched rule files
+    so they remain navigable from the rendered scope document.
+    """
+
+    if rules_root is None:
+        rules_root = index_path.parent
+
+    try:
+        entries = parse_index(index_path=index_path)
+    except FileNotFoundError:
+        return _EMPTY_BODY
+
+    matched = select_matching(entries=entries, affected_files=affected_files)
+    if not matched:
+        return _EMPTY_BODY
+
+    lines = [_HEADER, ""]
+    seen: set[str] = set()
+    for entry in matched:
+        key = entry.source
+        if key in seen:
+            continue
+        seen.add(key)
+        patterns = ", ".join(f"`{p}`" for p in entry.patterns)
+        lines.append(f"- **{entry.source}** — applies to {patterns}")
+        if entry.description:
+            lines.append(f"  - {entry.description}")
+    return "\n".join(lines)

--- a/src/dev10x/scope/safeguards_renderer.py
+++ b/src/dev10x/scope/safeguards_renderer.py
@@ -1,0 +1,143 @@
+"""Render the Safeguards section of a ticket-scope document (GH-170).
+
+Safeguards are invariants and validation rules that must hold
+AFTER the change ships. Sources:
+
+1. ``.claude/rules/INDEX.md`` rules whose source path matches
+   security / validation / schema keywords
+2. ``CLAUDE.md`` lines that contain safeguard-shaped guidance
+   (security, validation, never/must keywords)
+3. Hook deny rules from ``.claude/settings.local.json`` /
+   ``.claude/settings.json``
+
+Per ADR 0005: render at generation time. Callers inject the
+returned Markdown under the ``## Safeguards`` heading.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from dev10x.scope._matcher import select_matching
+from dev10x.scope.index_parser import parse_index
+
+_HEADER = "<!-- Auto-populated by dev10x.scope.safeguards_renderer at scope-render time. -->"
+_EMPTY = "No safeguards matched. Manual additions only."
+
+_SAFEGUARD_KEYWORDS = (
+    "security",
+    "validation",
+    "schema",
+    "gate",
+    "deny",
+    "never",
+    "must",
+    "auth",
+    "permission",
+    "safety",
+)
+_NEVER_LINE_RE = re.compile(
+    r"^\s*[-*]?\s*\*?\*?(Never|Must|Always|Do not|Don't|MUST|NEVER)\b",
+    flags=re.IGNORECASE,
+)
+
+
+def render_safeguards(
+    *,
+    affected_files: list[str],
+    index_path: Path,
+    claude_md_path: Path | None = None,
+    settings_paths: list[Path] | None = None,
+) -> str:
+    """Return Markdown for the Safeguards section."""
+
+    parts: list[str] = [_HEADER, ""]
+    has_content = False
+
+    rule_lines = _matched_rule_lines(affected_files=affected_files, index_path=index_path)
+    if rule_lines:
+        has_content = True
+        parts.append("**Rule-based safeguards** (from `.claude/rules/INDEX.md`):")
+        parts.extend(rule_lines)
+        parts.append("")
+
+    if claude_md_path is not None:
+        claude_lines = _claude_md_safeguards(path=claude_md_path)
+        if claude_lines:
+            has_content = True
+            parts.append("**CLAUDE.md guidance**:")
+            parts.extend(claude_lines)
+            parts.append("")
+
+    if settings_paths:
+        deny_lines = _hook_deny_rules(paths=settings_paths)
+        if deny_lines:
+            has_content = True
+            parts.append("**Hook deny rules** (commands blocked at runtime):")
+            parts.extend(deny_lines)
+            parts.append("")
+
+    if not has_content:
+        return _EMPTY
+
+    return "\n".join(parts).rstrip()
+
+
+def _matched_rule_lines(
+    *,
+    affected_files: list[str],
+    index_path: Path,
+) -> list[str]:
+    try:
+        entries = parse_index(index_path=index_path)
+    except FileNotFoundError:
+        return []
+
+    matched = select_matching(entries=entries, affected_files=affected_files)
+    seen: set[str] = set()
+    out: list[str] = []
+    for entry in matched:
+        haystack = f"{entry.source} {entry.description}".lower()
+        if not any(kw in haystack for kw in _SAFEGUARD_KEYWORDS):
+            continue
+        if entry.source in seen:
+            continue
+        seen.add(entry.source)
+        patterns = ", ".join(f"`{p}`" for p in entry.patterns)
+        out.append(f"- **{entry.source}** — enforces safeguards for {patterns}")
+    return out
+
+
+def _claude_md_safeguards(*, path: Path) -> list[str]:
+    if not path.exists():
+        return []
+    out: list[str] = []
+    for line in path.read_text().splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if _NEVER_LINE_RE.match(stripped):
+            out.append(f"- {stripped.lstrip('-* ').rstrip()}")
+        if len(out) >= 10:
+            break
+    return out
+
+
+def _hook_deny_rules(*, paths: list[Path]) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for path in paths:
+        if not path.exists():
+            continue
+        try:
+            data = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        deny = data.get("permissions", {}).get("deny", [])
+        for rule in deny:
+            if isinstance(rule, str) and rule not in seen:
+                seen.add(rule)
+                out.append(f"- `{rule}`")
+    return out

--- a/src/dev10x/spec/__init__.py
+++ b/src/dev10x/spec/__init__.py
@@ -1,0 +1,22 @@
+"""Spec drift detection for the SPDD pipeline (GH-172).
+
+Shared module between Dev10x:spec-update (behaviour-first) and
+Dev10x:spec-sync (refactor-first). One canonical drift detector,
+two entry points — per ADR 0005 risk mitigation.
+"""
+
+from __future__ import annotations
+
+from dev10x.spec.drift_detector import (
+    DriftKind,
+    DriftReport,
+    DriftSignal,
+    detect_drift,
+)
+
+__all__ = [
+    "DriftKind",
+    "DriftReport",
+    "DriftSignal",
+    "detect_drift",
+]

--- a/src/dev10x/spec/drift_detector.py
+++ b/src/dev10x/spec/drift_detector.py
@@ -1,0 +1,183 @@
+"""Detect drift between a canonical spec and the current code (GH-172).
+
+Two flavors of drift, classified per ADR 0005:
+
+* **Structural drift** — class/function names, file paths, signatures
+  changed in the code but not in the spec's
+  ``## Architecture`` / ``## Implementation Steps`` sections.
+  ``Dev10x:spec-sync`` regenerates only structural sections to
+  match.
+
+* **Behavioural drift** — requirements / acceptance criteria /
+  safeguards no longer match the code's contract. ``Dev10x:spec-sync``
+  refuses to proceed and delegates to ``Dev10x:spec-update``.
+
+The detector is intentionally heuristic — perfect classification
+requires AST + semantic analysis, which is out of scope here. It
+errs on the side of flagging anything ambiguous as
+``DriftKind.BEHAVIOURAL`` so the caller bails to the more careful
+``Dev10x:spec-update`` path.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+
+
+class DriftKind(StrEnum):
+    """Classification of one drift signal.
+
+    ``STRUCTURAL`` may be auto-fixed by ``Dev10x:spec-sync``.
+    ``BEHAVIOURAL`` requires ``Dev10x:spec-update`` (spec-first
+    edit + regenerate). ``NONE`` is the only "no drift" signal
+    callers should treat as "all good".
+    """
+
+    NONE = "none"
+    STRUCTURAL = "structural"
+    BEHAVIOURAL = "behavioural"
+
+
+@dataclass(frozen=True)
+class DriftSignal:
+    kind: DriftKind
+    section: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class DriftReport:
+    signals: tuple[DriftSignal, ...] = field(default_factory=tuple)
+
+    @property
+    def has_drift(self) -> bool:
+        return any(s.kind is not DriftKind.NONE for s in self.signals)
+
+    @property
+    def has_behavioural(self) -> bool:
+        return any(s.kind is DriftKind.BEHAVIOURAL for s in self.signals)
+
+    @property
+    def has_structural(self) -> bool:
+        return any(s.kind is DriftKind.STRUCTURAL for s in self.signals)
+
+
+_FILE_REF_RE = re.compile(r"`([a-zA-Z0-9_/.\-]+\.[a-zA-Z0-9]+)`")
+_CALLABLE_REF_RE = re.compile(r"`([A-Za-z_][A-Za-z0-9_]*)\s*\(")
+_HEADING_RE = re.compile(r"^(#+)\s+(.+?)\s*$")
+
+
+def detect_drift(
+    *,
+    spec_path: Path,
+    project_root: Path,
+) -> DriftReport:
+    """Compare the spec at ``spec_path`` against current code.
+
+    Returns a ``DriftReport`` listing every detected mismatch.
+    A spec that does not exist yields a single
+    ``DriftKind.BEHAVIOURAL`` signal so callers fail closed.
+    """
+
+    if not spec_path.exists():
+        return DriftReport(
+            signals=(
+                DriftSignal(
+                    kind=DriftKind.BEHAVIOURAL,
+                    section="<spec>",
+                    detail=f"spec file missing: {spec_path}",
+                ),
+            )
+        )
+
+    sections = _split_sections(spec_path.read_text())
+    signals: list[DriftSignal] = []
+    signals.extend(_structural_signals(sections=sections, project_root=project_root))
+    signals.extend(_behavioural_signals(sections=sections, project_root=project_root))
+    return DriftReport(signals=tuple(signals))
+
+
+def _split_sections(text: str) -> dict[str, str]:
+    """Return a {heading: body} map keyed by the heading text."""
+
+    sections: dict[str, str] = {}
+    current_heading = "<preamble>"
+    current_lines: list[str] = []
+    for line in text.splitlines():
+        match = _HEADING_RE.match(line)
+        if match:
+            sections[current_heading] = "\n".join(current_lines)
+            current_heading = match.group(2).strip()
+            current_lines = []
+        else:
+            current_lines.append(line)
+    sections[current_heading] = "\n".join(current_lines)
+    return sections
+
+
+def _structural_signals(
+    *,
+    sections: dict[str, str],
+    project_root: Path,
+) -> list[DriftSignal]:
+    """Flag missing-file references in Implementation Steps / Architecture."""
+
+    signals: list[DriftSignal] = []
+    for heading in ("Architecture", "Implementation Steps", "Code References"):
+        body = sections.get(heading, "")
+        for path in _FILE_REF_RE.findall(body):
+            candidate = project_root / path
+            if not candidate.exists():
+                signals.append(
+                    DriftSignal(
+                        kind=DriftKind.STRUCTURAL,
+                        section=heading,
+                        detail=f"spec references missing file `{path}`",
+                    )
+                )
+    return signals
+
+
+def _behavioural_signals(
+    *,
+    sections: dict[str, str],
+    project_root: Path,
+) -> list[DriftSignal]:
+    """Flag missing acceptance criteria coverage and safeguard mismatches.
+
+    Heuristic — we look for callable references in Acceptance Criteria
+    or Safeguards sections and check whether ``project_root`` still
+    contains a definition for them.
+    """
+
+    signals: list[DriftSignal] = []
+    for heading in ("Acceptance Criteria", "Safeguards"):
+        body = sections.get(heading, "")
+        for name in set(_CALLABLE_REF_RE.findall(body)):
+            if not _name_defined_in_project(name=name, project_root=project_root):
+                signals.append(
+                    DriftSignal(
+                        kind=DriftKind.BEHAVIOURAL,
+                        section=heading,
+                        detail=f"spec mentions `{name}(...)` but no definition found",
+                    )
+                )
+    return signals
+
+
+def _name_defined_in_project(*, name: str, project_root: Path) -> bool:
+    """True if a `def <name>` or `class <name>` exists anywhere in src/."""
+
+    if not project_root.exists():
+        return False
+    pattern = re.compile(rf"^(?:def|class)\s+{re.escape(name)}\b", flags=re.MULTILINE)
+    for python_file in project_root.rglob("*.py"):
+        try:
+            if pattern.search(python_file.read_text()):
+                return True
+        except OSError:
+            continue
+    return False

--- a/tests/scope/test_index_parser.py
+++ b/tests/scope/test_index_parser.py
@@ -1,0 +1,75 @@
+"""Unit tests for dev10x.scope.index_parser (GH-170)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dev10x.scope.index_parser import RuleEntry, parse_index
+
+
+@pytest.fixture
+def index_file(tmp_path: Path) -> Path:
+    content = """# Routing
+
+Intro text.
+
+## File Patterns -> Agents -> References
+
+| File Pattern | Primary Agent | Required References |
+|---|---|---|
+| `**/*.py`, `**/*.sh` | reviewer-generic | review-checks-common.md |
+| `skills/**` | reviewer-skill | skill-naming.md |
+| `**/migrations/*.py` | reviewer-migration | (self-contained) |
+
+Trailing prose.
+"""
+    path = tmp_path / "INDEX.md"
+    path.write_text(content)
+    return path
+
+
+class TestParseIndex:
+    def test_returns_rule_entries(self, index_file: Path) -> None:
+        entries = parse_index(index_path=index_file)
+        assert len(entries) == 3
+        assert all(isinstance(e, RuleEntry) for e in entries)
+
+    def test_first_entry_patterns(self, index_file: Path) -> None:
+        entries = parse_index(index_path=index_file)
+        assert entries[0].patterns == ("**/*.py", "**/*.sh")
+
+    def test_source_extracted(self, index_file: Path) -> None:
+        entries = parse_index(index_path=index_file)
+        assert entries[0].source == "reviewer-generic"
+
+    def test_description_extracted(self, index_file: Path) -> None:
+        entries = parse_index(index_path=index_file)
+        assert entries[0].description == "review-checks-common.md"
+
+    def test_skills_pattern(self, index_file: Path) -> None:
+        entries = parse_index(index_path=index_file)
+        assert entries[1].patterns == ("skills/**",)
+        assert entries[1].source == "reviewer-skill"
+
+    def test_raises_on_missing_file(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            parse_index(index_path=tmp_path / "missing.md")
+
+    def test_empty_when_no_table(self, tmp_path: Path) -> None:
+        path = tmp_path / "empty.md"
+        path.write_text("# Title\n\nNo tables here.\n")
+        assert parse_index(index_path=path) == []
+
+    def test_skips_rows_without_patterns(self, tmp_path: Path) -> None:
+        path = tmp_path / "no-patterns.md"
+        path.write_text(
+            "| File Pattern | Primary Agent | Refs |\n"
+            "|---|---|---|\n"
+            "| no backticks here | x | y |\n"
+            "| `**/*.py` | good | ok |\n"
+        )
+        entries = parse_index(index_path=path)
+        assert len(entries) == 1
+        assert entries[0].source == "good"

--- a/tests/scope/test_norms_renderer.py
+++ b/tests/scope/test_norms_renderer.py
@@ -1,0 +1,75 @@
+"""Unit tests for dev10x.scope.norms_renderer (GH-170)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dev10x.scope.norms_renderer import render_norms
+
+
+@pytest.fixture
+def index_file(tmp_path: Path) -> Path:
+    path = tmp_path / "INDEX.md"
+    path.write_text(
+        "| File Pattern | Primary Agent | Required References |\n"
+        "|---|---|---|\n"
+        "| `**/*.py`, `**/*.sh` | reviewer-generic | "
+        "review-checks-common.md |\n"
+        "| `skills/**` | reviewer-skill | skill-naming.md |\n"
+        "| `**/migrations/*.py` | reviewer-migration | (self-contained) |\n"
+    )
+    return path
+
+
+class TestRenderNorms:
+    def test_matches_python_file(self, index_file: Path) -> None:
+        out = render_norms(affected_files=["src/foo/bar.py"], index_path=index_file)
+        assert "reviewer-generic" in out
+
+    def test_matches_skill_path(self, index_file: Path) -> None:
+        out = render_norms(
+            affected_files=["skills/git-commit/SKILL.md"],
+            index_path=index_file,
+        )
+        assert "reviewer-skill" in out
+
+    def test_renders_header(self, index_file: Path) -> None:
+        out = render_norms(affected_files=["src/foo.py"], index_path=index_file)
+        assert "Auto-populated by dev10x.scope.norms_renderer" in out
+
+    def test_no_matches_returns_empty_body(self, index_file: Path) -> None:
+        out = render_norms(affected_files=["docs/readme.txt"], index_path=index_file)
+        assert "No project rules matched" in out
+
+    def test_missing_index_returns_empty(self, tmp_path: Path) -> None:
+        out = render_norms(
+            affected_files=["src/foo.py"],
+            index_path=tmp_path / "missing.md",
+        )
+        assert "No project rules matched" in out
+
+    def test_dedupes_repeated_sources(self, tmp_path: Path) -> None:
+        idx = tmp_path / "INDEX.md"
+        idx.write_text(
+            "| File Pattern | Primary Agent | Refs |\n"
+            "|---|---|---|\n"
+            "| `**/*.py` | reviewer-generic | a |\n"
+            "| `**/*.sh` | reviewer-generic | a |\n"
+        )
+        out = render_norms(affected_files=["src/a.py", "src/b.sh"], index_path=idx)
+        assert out.count("reviewer-generic") == 1
+
+    def test_multiple_patterns_in_listing(self, index_file: Path) -> None:
+        out = render_norms(affected_files=["src/foo.py"], index_path=index_file)
+        assert "`**/*.py`" in out
+
+    def test_migrations_path_matches(self, index_file: Path) -> None:
+        out = render_norms(
+            affected_files=[
+                "src/app/migrations/0001_initial.py",
+            ],
+            index_path=index_file,
+        )
+        assert "reviewer-migration" in out

--- a/tests/scope/test_safeguards_renderer.py
+++ b/tests/scope/test_safeguards_renderer.py
@@ -1,0 +1,153 @@
+"""Unit tests for dev10x.scope.safeguards_renderer (GH-170)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dev10x.scope.safeguards_renderer import render_safeguards
+
+
+@pytest.fixture
+def index_file(tmp_path: Path) -> Path:
+    path = tmp_path / "INDEX.md"
+    path.write_text(
+        "| File Pattern | Primary Agent | Required References |\n"
+        "|---|---|---|\n"
+        "| `**/*.py` | reviewer-security | security scans |\n"
+        "| `skills/**` | reviewer-skill | skill-gates.md |\n"
+        "| `**/*.md` | reviewer-docs | docs only |\n"
+    )
+    return path
+
+
+@pytest.fixture
+def claude_md(tmp_path: Path) -> Path:
+    path = tmp_path / "CLAUDE.md"
+    path.write_text(
+        "# Header\n"
+        "\n"
+        "- Never commit secrets to the repo.\n"
+        "- Must validate input at boundaries.\n"
+        "- Normal informational line.\n"
+        "- Always wrap DB writes in transaction.atomic.\n"
+    )
+    return path
+
+
+@pytest.fixture
+def settings_file(tmp_path: Path) -> Path:
+    path = tmp_path / "settings.local.json"
+    path.write_text(
+        json.dumps(
+            {
+                "permissions": {
+                    "deny": [
+                        "Bash(rm -rf:*)",
+                        "Bash(curl http*)",
+                    ]
+                }
+            }
+        )
+    )
+    return path
+
+
+class TestRenderSafeguards:
+    def test_matches_security_rule(self, index_file: Path) -> None:
+        out = render_safeguards(affected_files=["src/foo.py"], index_path=index_file)
+        assert "reviewer-security" in out
+
+    def test_skips_non_safeguard_keywords(self, index_file: Path) -> None:
+        out = render_safeguards(affected_files=["docs/README.md"], index_path=index_file)
+        assert "reviewer-docs" not in out
+
+    def test_includes_skill_gates_rule(self, index_file: Path) -> None:
+        out = render_safeguards(
+            affected_files=["skills/git-commit/SKILL.md"],
+            index_path=index_file,
+        )
+        assert "reviewer-skill" in out
+
+    def test_empty_when_no_inputs(self, tmp_path: Path) -> None:
+        idx = tmp_path / "INDEX.md"
+        idx.write_text(
+            "| File Pattern | Primary Agent | Refs |\n"
+            "|---|---|---|\n"
+            "| `**/*.txt` | reviewer-docs | nothing |\n"
+        )
+        out = render_safeguards(affected_files=["src/foo.py"], index_path=idx)
+        assert "No safeguards matched" in out
+
+    def test_includes_claude_md_never_lines(self, index_file: Path, claude_md: Path) -> None:
+        out = render_safeguards(
+            affected_files=["src/foo.py"],
+            index_path=index_file,
+            claude_md_path=claude_md,
+        )
+        assert "Never commit secrets" in out
+        assert "Must validate input" in out
+
+    def test_skips_normal_claude_md_lines(self, index_file: Path, claude_md: Path) -> None:
+        out = render_safeguards(
+            affected_files=["src/foo.py"],
+            index_path=index_file,
+            claude_md_path=claude_md,
+        )
+        assert "Normal informational line" not in out
+
+    def test_includes_hook_deny_rules(self, index_file: Path, settings_file: Path) -> None:
+        out = render_safeguards(
+            affected_files=["src/foo.py"],
+            index_path=index_file,
+            settings_paths=[settings_file],
+        )
+        assert "Bash(rm -rf:*)" in out
+        assert "Bash(curl http*)" in out
+
+    def test_settings_missing_is_silent(self, index_file: Path, tmp_path: Path) -> None:
+        out = render_safeguards(
+            affected_files=["src/foo.py"],
+            index_path=index_file,
+            settings_paths=[tmp_path / "missing.json"],
+        )
+        assert "reviewer-security" in out
+
+    def test_settings_malformed_is_silent(self, index_file: Path, tmp_path: Path) -> None:
+        bad = tmp_path / "bad.json"
+        bad.write_text("not valid json {")
+        out = render_safeguards(
+            affected_files=["src/foo.py"],
+            index_path=index_file,
+            settings_paths=[bad],
+        )
+        assert "reviewer-security" in out
+
+    def test_index_missing_with_other_sources(self, tmp_path: Path, claude_md: Path) -> None:
+        out = render_safeguards(
+            affected_files=["src/foo.py"],
+            index_path=tmp_path / "missing.md",
+            claude_md_path=claude_md,
+        )
+        assert "Never commit secrets" in out
+
+    def test_completely_empty_returns_marker(self, tmp_path: Path) -> None:
+        out = render_safeguards(
+            affected_files=["src/foo.py"],
+            index_path=tmp_path / "missing.md",
+        )
+        assert out == "No safeguards matched. Manual additions only."
+
+    def test_dedupes_repeated_deny_rules(self, index_file: Path, tmp_path: Path) -> None:
+        a = tmp_path / "a.json"
+        a.write_text(json.dumps({"permissions": {"deny": ["Bash(rm:*)"]}}))
+        b = tmp_path / "b.json"
+        b.write_text(json.dumps({"permissions": {"deny": ["Bash(rm:*)"]}}))
+        out = render_safeguards(
+            affected_files=["src/foo.py"],
+            index_path=index_file,
+            settings_paths=[a, b],
+        )
+        assert out.count("Bash(rm:*)") == 1

--- a/tests/spec/test_drift_detector.py
+++ b/tests/spec/test_drift_detector.py
@@ -1,0 +1,96 @@
+"""Unit tests for dev10x.spec.drift_detector (GH-172)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dev10x.spec.drift_detector import DriftKind, detect_drift
+
+
+@pytest.fixture
+def project_root(tmp_path: Path) -> Path:
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "foo.py").write_text("def known_function():\n    pass\n")
+    (src / "models.py").write_text("class KnownModel:\n    pass\n")
+    return tmp_path
+
+
+def _write_spec(tmp_path: Path, body: str) -> Path:
+    spec = tmp_path / "spec.md"
+    spec.write_text(body)
+    return spec
+
+
+class TestDetectDrift:
+    def test_missing_spec_is_behavioural(self, tmp_path: Path, project_root: Path) -> None:
+        report = detect_drift(spec_path=tmp_path / "missing.md", project_root=project_root)
+        assert report.has_behavioural
+        assert report.signals[0].kind is DriftKind.BEHAVIOURAL
+
+    def test_no_drift_when_refs_resolve(self, tmp_path: Path, project_root: Path) -> None:
+        spec = _write_spec(
+            tmp_path,
+            "## Architecture\n\nUses `src/foo.py`.\n\n"
+            "## Acceptance Criteria\n\nCalls `known_function(`.\n",
+        )
+        report = detect_drift(spec_path=spec, project_root=project_root)
+        assert not report.has_drift
+
+    def test_structural_drift_on_missing_file(self, tmp_path: Path, project_root: Path) -> None:
+        spec = _write_spec(
+            tmp_path,
+            "## Architecture\n\nUses `src/gone.py`.\n",
+        )
+        report = detect_drift(spec_path=spec, project_root=project_root)
+        assert report.has_structural
+        assert not report.has_behavioural
+
+    def test_behavioural_drift_on_missing_callable(
+        self, tmp_path: Path, project_root: Path
+    ) -> None:
+        spec = _write_spec(
+            tmp_path,
+            "## Acceptance Criteria\n\nMust call `missing_callable(`.\n",
+        )
+        report = detect_drift(spec_path=spec, project_root=project_root)
+        assert report.has_behavioural
+
+    def test_both_drift_kinds_reported(self, tmp_path: Path, project_root: Path) -> None:
+        spec = _write_spec(
+            tmp_path,
+            "## Architecture\n\nUses `src/missing.py`.\n\n"
+            "## Safeguards\n\n`gone_method(` must be called.\n",
+        )
+        report = detect_drift(spec_path=spec, project_root=project_root)
+        assert report.has_structural
+        assert report.has_behavioural
+
+    def test_only_known_sections_scanned_for_files(
+        self, tmp_path: Path, project_root: Path
+    ) -> None:
+        spec = _write_spec(
+            tmp_path,
+            "## Random Notes\n\nWe used to have `src/legacy.py`.\n",
+        )
+        report = detect_drift(spec_path=spec, project_root=project_root)
+        assert not report.has_drift
+
+    def test_known_class_resolves(self, tmp_path: Path, project_root: Path) -> None:
+        spec = _write_spec(
+            tmp_path,
+            "## Safeguards\n\nRespect `KnownModel(`.\n",
+        )
+        report = detect_drift(spec_path=spec, project_root=project_root)
+        assert not report.has_behavioural
+
+    def test_signals_carry_section_and_detail(self, tmp_path: Path, project_root: Path) -> None:
+        spec = _write_spec(
+            tmp_path,
+            "## Architecture\n\nUses `src/missing.py`.\n",
+        )
+        report = detect_drift(spec_path=spec, project_root=project_root)
+        assert report.signals[0].section == "Architecture"
+        assert "missing.py" in report.signals[0].detail


### PR DESCRIPTION
**When** a ticket's requirements or refactor reshapes code mid-implementation, **the developer wants to** keep the canonical spec at `docs/specs/<TICKET-ID>.md` aligned with the code at every gate (review, pre-merge, regenerate-from-spec), **so future agents can** generate from the spec without silently regressing behaviour the spec no longer describes.

---

[`9914b20f`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/257/commits/9914b20fd7749dd00a0a05dff76806228c752267) ✨ M1 Enable spec-as-source-of-truth pipeline (SPDD)
Closes #169
Closes #170
Closes #171
Closes #172
Closes #173
Closes #174
Closes #175
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/milestone/2

---