### PR TITLE
🐛 GH-252 Stabilize skill self-checks and permission rules

### DIFF
--- a/skills/gh-pr-merge/instructions.md
+++ b/skills/gh-pr-merge/instructions.md
@@ -73,6 +73,31 @@ ones before proceeding. Do NOT shortcut to `gh pr merge` based on a
 single `gh pr view` JSON read — that is the regression this check
 exists to catch (GH-112).
 
+**Unskippable on every invocation (GH-253):** The `TaskList` call
+above runs ONCE per skill invocation, at Step 1, before any check
+or `gh pr merge` execution. It is not optional and it is not
+satisfied by a prior invocation's call. If you proceed past Step 1
+without calling `TaskList` in this invocation, HALT with the
+message: "gh-pr-merge Step 1 self-check skipped — restart from
+Step 1." Do not jump to Step 5 (`gh pr merge` / `merge_pr`) based
+on the agent's recollection that "the checks just passed" — those
+checks belong to a sibling skill's context, not this one.
+
+**Re-invocation contract:** Every invocation of `Dev10x:gh-pr-merge`
+re-runs the full skill body from Step 1, including all 8 pre-merge
+checks. Check results from a prior `Dev10x:gh-pr-monitor` phase,
+prior `Dev10x:verify-acc-dod` run, or earlier invocation of this
+same skill are NOT reusable. CI state, review comments, draft
+toggles, and force-push state can drift between invocations — the
+8 checks exist precisely to detect that drift.
+
+**"Re-run the skill" expansion:** When the supervisor says
+"execute the whole skill again", "re-run the skill", "run it once
+more", or any equivalent phrasing, treat that as a fresh invocation
+starting from Step 1 of this body — NOT as "resume from the last
+unfinished step" or "skip to the merge command". The full skill
+body, including all 8 checks, runs every time.
+
 Adaptive friction does NOT waive this skill body. The friction level
 only governs `AskUserQuestion` gates marked `(Recommended)`; the 8
 checks below still run. See `references/friction-levels.md` §

--- a/skills/upgrade-cleanup/projects.yaml
+++ b/skills/upgrade-cleanup/projects.yaml
@@ -22,6 +22,13 @@ include_user_settings: true
 # in every settings file.
 workspace_directories:
   - /tmp/Dev10x
+  # GH-254: skills read playbook overrides, plan-sync state, and
+  # plugin assets from these well-known locations. Without them,
+  # the additionalDirectories gate fires per-Read/Bash even when
+  # the underlying tool is allowed.
+  - ~/.claude/memory
+  - ~/.claude/plugins
+  - ~/.config/Dev10x
 
 # Base permissions that update-paths.py --ensure-base will add to every
 # settings.local.json if missing.  These are stable, version-independent

--- a/skills/work-on/instructions.md
+++ b/skills/work-on/instructions.md
@@ -908,23 +908,41 @@ plan gate in those cases.
 or use Claude Code's built-in plan mode.
 
 **REQUIRED: Call `AskUserQuestion`** when the plan was
-agent-generated (do NOT use plain text).
+agent-generated (do NOT use plain text), EXCEPT when the
+adaptive+solo-maintainer bypass below applies.
 
-**Adaptive friction behavior (GH-808, refined GH-158):** At
-adaptive level, the `AskUserQuestion` tool call MUST still
-emit so the user retains override capability — do not skip
-the gate. The agent auto-selects "Approve (Recommended)" and
-proceeds to Phase 4 only if the user does not override within
-the harness's interactive window. Skipping the gate as plain
-text (audit GH-158: ~45-minute response delay because the A/B
-choice was presented as prose, not a structured widget) is a
-compliance violation regardless of friction level.
+**Adaptive friction behavior (GH-808, GH-158, refined GH-252):**
 
-Implementation: always call `AskUserQuestion` below; treat
-adaptive as "auto-recommend, but block briefly for override"
-rather than "fire-and-forget approval".
+- At `friction_level: strict` or `friction_level: guided`,
+  the `AskUserQuestion` tool call ALWAYS fires.
+- At `friction_level: adaptive` WITHOUT `solo-maintainer` in
+  `active_modes`, the `AskUserQuestion` tool call MUST still
+  emit so the user retains override capability. The agent
+  auto-selects "Approve (Recommended)" and proceeds to Phase 4
+  only if the user does not override within the harness's
+  interactive window. Skipping the gate as plain text (audit
+  GH-158: ~45-minute response delay because the A/B choice was
+  presented as prose, not a structured widget) is a compliance
+  violation here.
+- At `friction_level: adaptive` AND `solo-maintainer` in
+  `active_modes`, the gate is bypassed entirely (GH-252) —
+  do not call `AskUserQuestion`, do not present the plan as
+  prose for approval. Auto-select "Approve (Recommended)" and
+  proceed directly to Phase 4. The friction profile already
+  resolves to a clear default; re-prompting on every
+  invocation creates the over-prompting regression documented
+  in GH-252 (Phase 3 fired a 4-option prompt on the second
+  invocation of the same session despite unchanged friction
+  context). The supervisor can still interrupt mid-execution
+  via the standard input channel.
 
-**All friction levels:** Call `AskUserQuestion`:
+This bypass applies only to **agent-generated** plans. When
+the user provides a numbered, actionable plan inline (per
+"Implicit approval bypass" below), no gate fires at any
+friction level.
+
+**Friction levels OTHER than `adaptive`+`solo-maintainer`:** Call
+`AskUserQuestion`:
 
 1. `AskUserQuestion(questions=[{question: "How would you like to proceed with the work plan?", header: "Plan", options: [{label: "Approve (Recommended)", description: "Start execution immediately"}, {label: "Edit", description: "Describe what to change (add/remove/reorder steps)"}], multiSelect: false}])`
 

--- a/src/dev10x/skills/permission/update_paths.py
+++ b/src/dev10x/skills/permission/update_paths.py
@@ -396,6 +396,35 @@ def scan_top_level_dirs(
     return present
 
 
+def build_marketplaces_read_rules(
+    *,
+    plugin_cache: str,
+    user_home: Path,
+) -> list[str]:
+    """Emit unversioned Read rules pointing at the marketplaces layout.
+
+    The runtime reads plugin skills from
+    ``~/.claude/plugins/marketplaces/<publisher>/skills/...`` (unversioned).
+    Versioned cache paths emitted by :func:`build_read_allow_rules` go
+    stale on every plugin upgrade (GH-254). Emit an unversioned rule
+    covering every skill at once so the Read allow-rule survives plugin
+    version bumps.
+
+    Returns ``~/`` and ``/home/<user>/`` twins covering the whole
+    marketplaces publisher tree.
+    """
+    publisher = extract_cache_publisher(plugin_cache)
+    if not publisher:
+        return []
+
+    home = user_home.expanduser().resolve()
+    rel = f".claude/plugins/marketplaces/{publisher}"
+    return [
+        f"Read(~/{rel}/**)",
+        f"Read({home}/{rel}/**)",
+    ]
+
+
 def build_read_allow_rules(
     *,
     plugin_root: Path,
@@ -975,6 +1004,16 @@ def ensure_reads(
     expected_rules = build_read_allow_rules(
         plugin_root=plugin_root,
         user_home=Path.home(),
+    )
+    # GH-254: emit unversioned marketplaces Read rules alongside the
+    # versioned cache rules. The runtime reads skills from the
+    # marketplaces tree, which is unversioned — pinning to cache
+    # versions guarantees the rule goes stale on every upgrade.
+    expected_rules.extend(
+        build_marketplaces_read_rules(
+            plugin_cache=config["plugin_cache"],
+            user_home=Path.home(),
+        )
     )
     if not expected_rules:
         messages.append(f"No Read rules to emit for {plugin_root}")

--- a/src/dev10x/validators/prefix_friction.py
+++ b/src/dev10x/validators/prefix_friction.py
@@ -88,6 +88,24 @@ SEMICOLON_CHAIN_RE = re.compile(
     rf"(?P<tail>{_CHAIN_HEAD_RE}\b.*)$"
 )
 
+# GH-258: shell loops wrap allowed commands and shift the effective
+# command prefix to the loop keyword (`for`, `while`, `until`).
+# `Bash(gh api:*)` does not match `for n in 1 2 3; do gh api ... ; done`
+# because the matcher sees `for` as the leading token. Same regression
+# family as `cd ... &&` chaining (DX007 existing rules) and `for/xargs`
+# wrappers documented in CLAUDE.md and `.claude/rules/hook-patterns.md`.
+# The proposed remedy is the parallel-Bash-tool-call pattern.
+_LOOP_KEYWORDS = ("for", "while", "until")
+SHELL_LOOP_HEAD_RE = re.compile(
+    r"^\s*(?P<keyword>for|while|until)\b[^;]*?;\s*do\b\s*(?P<body>.+?)(?:;\s*done\b.*)?$",
+    re.DOTALL,
+)
+XARGS_WRAP_RE = re.compile(r"\|\s*xargs\b(?P<rest>[^|;]*)")
+FIND_EXEC_WRAP_RE = re.compile(r"\bfind\b[^|;]*?-exec\s+(?P<rest>[^;]+?)(?:\\;|';'|\+)")
+_WRAPPED_INNER_TOKENS = frozenset(
+    {"gh", "git", "kubectl", "docker", "psql", "aws", "uv", "python", "python3"}
+)
+
 CD_REVPARSE_MSG = (
     '\u26a0\ufe0f  `cd "$(git rev-parse --show-toplevel)"` is unnecessary.\n\n'
     "Git commands already operate from the repo root regardless of CWD.\n"
@@ -178,6 +196,19 @@ SEMICOLON_CHAIN_MSG = (
     "Split into separate Bash tool calls instead.\n"
 )
 
+SHELL_LOOP_WRAP_MSG = (
+    "⚠️  Shell {wrapper} wraps an allowed command (`{inner}`) — permission friction risk.\n\n"
+    "Claude Code's allow-rule matcher keys on the leading token of the\n"
+    "command string. For `{wrapper}`, that token is `{wrapper}` — not\n"
+    "`{inner}`. So `Bash({inner}:*)` does NOT cover this call.\n\n"
+    "Use parallel Bash tool calls instead — one per iteration.\n"
+    "Tool calls in a single message run concurrently, which is faster\n"
+    "than a serial shell loop and each iteration matches its own\n"
+    "allow rule cleanly.\n\n"
+    "Example: send N separate Bash calls in one message, each running\n"
+    "`{inner} ...` with the iteration value substituted in.\n"
+)
+
 MERGE_BASE_MSG = (
     "\u26a0\ufe0f  $(git merge-base ...) subshell blocked \u2014 permission friction risk.\n\n"
     "The subshell shifts the effective command prefix, breaking allow-rule\n"
@@ -265,6 +296,10 @@ class PrefixFrictionValidator(ValidatorBase):
             # GH-119: shapes that bypass allow-rule prefix matching
             or ";" in cmd
             or re.search(r"\d?>(?:&\d|/\S+)", cmd) is not None
+            # GH-258: shell loops/xargs/find -exec wrap allowed commands
+            or any(re.search(rf"\b{kw}\b", cmd) for kw in _LOOP_KEYWORDS)
+            or "xargs" in cmd
+            or "-exec" in cmd
         )
 
     def validate(self, inp: HookInput) -> HookResult | None:
@@ -297,6 +332,10 @@ class PrefixFrictionValidator(ValidatorBase):
             return result
 
         result = self._check_semicolon_chain(command=inp.command)
+        if result:
+            return result
+
+        result = self._check_shell_loop_wrap(command=inp.command)
         if result:
             return result
 
@@ -418,6 +457,63 @@ class PrefixFrictionValidator(ValidatorBase):
                 tail_cmd=tail_cmd,
             )
         )
+
+    def _check_shell_loop_wrap(self, *, command: str) -> HookResult | None:
+        loop_match = SHELL_LOOP_HEAD_RE.match(command)
+        if loop_match:
+            inner = self._inner_command_from(body=loop_match.group("body"))
+            if inner:
+                return HookResult(
+                    message=SHELL_LOOP_WRAP_MSG.format(
+                        wrapper=loop_match.group("keyword"),
+                        inner=inner,
+                    ),
+                )
+
+        xargs_match = XARGS_WRAP_RE.search(command)
+        if xargs_match:
+            inner = self._first_non_flag_token(text=xargs_match.group("rest"))
+            if inner in _WRAPPED_INNER_TOKENS:
+                return HookResult(
+                    message=SHELL_LOOP_WRAP_MSG.format(wrapper="xargs", inner=inner),
+                )
+
+        find_match = FIND_EXEC_WRAP_RE.search(command)
+        if find_match:
+            inner = self._first_non_flag_token(text=find_match.group("rest"))
+            if inner in _WRAPPED_INNER_TOKENS:
+                return HookResult(
+                    message=SHELL_LOOP_WRAP_MSG.format(wrapper="find -exec", inner=inner),
+                )
+
+        return None
+
+    def _first_non_flag_token(self, *, text: str) -> str | None:
+        # Skip leading option flags and their values. Recognized
+        # value-taking short flags for `xargs` and `find -exec`.
+        value_flags = {"-I", "-n", "-P", "-J", "-L", "-E", "-d", "-s", "-name"}
+        tokens = text.strip().split()
+        idx = 0
+        while idx < len(tokens):
+            token = tokens[idx]
+            if token in value_flags:
+                idx += 2
+                continue
+            if token.startswith("-"):
+                idx += 1
+                continue
+            return token
+        return None
+
+    def _inner_command_from(self, *, body: str) -> str | None:
+        for clause in re.split(r"\s*(?:;|&&|\|\|)\s*", body):
+            tokens = clause.strip().split()
+            if not tokens:
+                continue
+            head = tokens[0]
+            if head in _WRAPPED_INNER_TOKENS:
+                return head
+        return None
 
     def _check_and_chaining(self, *, command: str) -> HookResult | None:
         if "&&" not in command:

--- a/tests/skills/upgrade-cleanup/test_ensure_reads.py
+++ b/tests/skills/upgrade-cleanup/test_ensure_reads.py
@@ -14,6 +14,7 @@ import pytest
 
 from dev10x.skills.permission.update_paths import (
     READ_TOP_LEVEL_DIRS,
+    build_marketplaces_read_rules,
     build_read_allow_rules,
     ensure_read_rules,
     scan_skill_directories,
@@ -253,3 +254,35 @@ class TestEnsureReadRules:
 
         assert count == 0
         assert messages == []
+
+
+class TestBuildMarketplacesReadRules:
+    """GH-254: emit unversioned marketplaces Read rules."""
+
+    def test_emits_unversioned_twin_rules(self, fake_home: Path) -> None:
+        rules = build_marketplaces_read_rules(
+            plugin_cache="~/.claude/plugins/cache/Dev10x-Guru/Dev10x",
+            user_home=fake_home,
+        )
+
+        assert any("plugins/marketplaces/Dev10x-Guru/**" in r for r in rules)
+        assert any(r.startswith("Read(~/") for r in rules)
+        assert any(r.startswith(f"Read({fake_home}/") for r in rules)
+
+    def test_no_version_segment_in_emitted_rules(self, fake_home: Path) -> None:
+        rules = build_marketplaces_read_rules(
+            plugin_cache="~/.claude/plugins/cache/Dev10x-Guru/Dev10x",
+            user_home=fake_home,
+        )
+
+        for rule in rules:
+            assert "/cache/" not in rule
+            assert "0.72.0" not in rule
+
+    def test_returns_empty_when_publisher_undetectable(self, fake_home: Path) -> None:
+        rules = build_marketplaces_read_rules(
+            plugin_cache="~/some/random/path",
+            user_home=fake_home,
+        )
+
+        assert rules == []

--- a/tests/validators/test_prefix_friction.py
+++ b/tests/validators/test_prefix_friction.py
@@ -412,3 +412,74 @@ class TestSemicolonChain:
         inp = _make_input(command=command)
         result = validator.validate(inp=inp)
         assert result is None
+
+
+class TestShellLoopWrap:
+    """GH-258: shell loops/xargs/find -exec wrap allowed commands."""
+
+    @pytest.fixture()
+    def validator(self) -> PrefixFrictionValidator:
+        return PrefixFrictionValidator()
+
+    @pytest.mark.parametrize(
+        ("command", "wrapper", "inner"),
+        [
+            (
+                "for n in 169 170 171; do gh api repos/x/y/issues/$n; done",
+                "for",
+                "gh",
+            ),
+            (
+                "while read line; do git log $line; done",
+                "while",
+                "git",
+            ),
+            (
+                "until [ -z $x ]; do kubectl get pods; done",
+                "until",
+                "kubectl",
+            ),
+            (
+                "echo a b c | xargs -I{} gh api {}",
+                "xargs",
+                "gh",
+            ),
+            (
+                r"find . -name '*.py' -exec git log {} \;",
+                "find -exec",
+                "git",
+            ),
+        ],
+    )
+    def test_blocks_shell_loop_wrap(
+        self,
+        validator: PrefixFrictionValidator,
+        command: str,
+        wrapper: str,
+        inner: str,
+    ) -> None:
+        inp = _make_input(command=command)
+        result = validator.validate(inp=inp)
+        assert result is not None
+        assert wrapper in result.message
+        assert inner in result.message
+        assert "parallel Bash tool calls" in result.message
+
+    def test_allows_loop_with_unrelated_body(
+        self,
+        validator: PrefixFrictionValidator,
+    ) -> None:
+        # Loop bodies whose inner head is not in the allowed-tokens set
+        # (e.g. plain `echo`) are out of scope — they're rarely the
+        # source of the documented friction.
+        inp = _make_input(command="for n in 1 2 3; do echo $n; done")
+        result = validator.validate(inp=inp)
+        assert result is None
+
+    def test_allows_xargs_with_unrelated_inner(
+        self,
+        validator: PrefixFrictionValidator,
+    ) -> None:
+        inp = _make_input(command="ls | xargs cat")
+        result = validator.validate(inp=inp)
+        assert result is None


### PR DESCRIPTION
**When** the Dev10x plugin reaches its second skill invocation in a session (or upgrades to a new version), **I want to** keep self-check guardrails firing and permission rules pointing at the right paths, **so I can** trust that the 8-check pre-merge gate, the Phase 3 friction profile, and the per-skill Read rules all behave the same way they did on the first invocation.

---

[`72e848cc`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/259/commits/72e848cce0bf21e4bae68a93626363dd6b75b3f4) 🐛 GH-252 Stabilize skill self-checks and permission rules
Closes #252
Closes #253
Closes #254
Closes #258
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/252

---