### PR TITLE
🐛 GH-274 Restore Dev10x:py-test after hook hard-block regression

### DIFF
--- a/src/dev10x/validators/command-skill-map.yaml
+++ b/src/dev10x/validators/command-skill-map.yaml
@@ -427,20 +427,25 @@ rules:
       - pytest
       - python -m pytest
       - uv run pytest
-    hook_block: true
+    hook_block: false
     compensations:
       - type: use-skill
-        skill: test
+        skill: Dev10x:py-test
         guardrails: 100% coverage gate, concise pass/fail summaries, cwd-aware uv run wrapping
         fallback: >
-          If the test skill is unavailable, run pytest with coverage
+          If Skill(Dev10x:py-test) is unavailable, run pytest with coverage
           (`pytest --cov --cov-report=term-missing`) and verify 100%
           coverage on changed files manually.
     reason: >
       Bare pytest invocations bypass the test skill's coverage gate
       and concise summary formatting. Audit (GH-155) caught 4 bare
       pytest calls before commits/PR with no coverage verification.
-      The test skill ensures consistent coverage reporting.
+
+      Advisory only (hook_block: false) — the hard-block flipped in
+      GH-155 broke Dev10x:py-test itself, which internally invokes
+      `uv run pytest --cov ...` and hit the same hook recursively.
+      Restoring advisory behavior pending the skill-context-aware
+      hook protocol (GH-271 Phase 8).
 
   - name: gh-pr-comment-reply
     matcher: Bash


### PR DESCRIPTION
**When** I invoke `Dev10x:py-test` to run a test suite, **I want** the skill to actually run `uv run pytest --cov ...` as documented, **so** I can verify coverage before commits without the agent reaching for `DEV10X_SKIP_CMD_VALIDATION=` as a workaround.

---

[`ab90f983`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/275/commits/ab90f983badb9e9453104e007eac3e0ce3f6d55e) 🐛 GH-274 Restore Dev10x:py-test after hook hard-block regression
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/274

---