### PR TITLE
✨ GH-267 GH-268 Enable routed gh pr view and issue state changes

### DIFF
--- a/.claude/rules/mcp-tools.md
+++ b/.claude/rules/mcp-tools.md
@@ -88,6 +88,9 @@ supporting each tool:
 | `issue_get` | `cli` | PR #126 | v0.25.0+ |
 | `issue_comments` | `cli` | PR #126 | v0.25.0+ |
 | `issue_create` | `cli` | PR #552 | v0.44.0+ |
+| `issue_close` | `cli` | GH-268 | v0.74.0+ |
+| `issue_reopen` | `cli` | GH-268 | v0.74.0+ |
+| `pr_get` | `cli` | GH-267 | v0.74.0+ |
 | `pr_comments` | `cli` | PR #126 | v0.25.0+ |
 | `pr_comment_reply` | `cli` | PR #399 | v0.37.0+ |
 | `pr_issue_comment` | `cli` | GH-205 | v0.72.0+ |
@@ -209,8 +212,11 @@ the MCP server is unavailable.
 | `gh issue view` | `mcp__plugin_Dev10x_cli__issue_get` |
 | `gh issue create` | `mcp__plugin_Dev10x_cli__issue_create` |
 | `gh issue edit` | `mcp__plugin_Dev10x_cli__issue_edit` |
+| `gh issue close` | `mcp__plugin_Dev10x_cli__issue_close` |
+| `gh issue reopen` | `mcp__plugin_Dev10x_cli__issue_reopen` |
 | `gh issue comment` | `mcp__plugin_Dev10x_cli__issue_comment` |
 | `gh issue list` | `mcp__plugin_Dev10x_cli__issue_list` (advisory) |
+| `gh pr view` | `mcp__plugin_Dev10x_cli__pr_get` |
 | `gh api .../milestones POST` | `mcp__plugin_Dev10x_cli__milestone_create` |
 | `gh pr edit` | `mcp__plugin_Dev10x_cli__update_pr` |
 | `gh pr create` | `Dev10x:gh-pr-create` (wraps `create_pr`) |

--- a/skills/gh-context/scripts/gh-issue-close.sh
+++ b/skills/gh-context/scripts/gh-issue-close.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# gh-issue-close.sh — Close a GitHub issue (GH-268).
+#
+# Usage:
+#   gh-issue-close.sh NUMBER [REPO] [REASON] [COMMENT_FILE]
+#
+# REASON: "completed" or "not_planned" (defaults to "completed")
+# COMMENT_FILE: optional path to file containing a final closing comment.
+#
+# Output: JSON {number, state, url}.
+
+set -euo pipefail
+
+NUMBER="${1:?Usage: gh-issue-close.sh NUMBER [REPO] [REASON] [COMMENT_FILE]}"
+REPO="${2:-$(gh repo view --json nameWithOwner -q '.nameWithOwner')}"
+REASON="${3:-completed}"
+COMMENT_FILE="${4:-}"
+
+args=("issue" "close" "$NUMBER" "--repo" "$REPO" "--reason" "$REASON")
+if [[ -n "$COMMENT_FILE" ]]; then
+    args+=("--comment" "$(cat "$COMMENT_FILE")")
+fi
+
+gh "${args[@]}" >/dev/null
+
+URL=$(gh issue view "$NUMBER" --repo "$REPO" --json url -q '.url')
+printf '{"number": %s, "state": "closed", "url": "%s"}\n' "$NUMBER" "$URL"

--- a/skills/gh-context/scripts/gh-issue-reopen.sh
+++ b/skills/gh-context/scripts/gh-issue-reopen.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# gh-issue-reopen.sh — Reopen a closed GitHub issue (GH-268).
+#
+# Usage:
+#   gh-issue-reopen.sh NUMBER [REPO]
+#
+# Output: JSON {number, state, url}.
+
+set -euo pipefail
+
+NUMBER="${1:?Usage: gh-issue-reopen.sh NUMBER [REPO]}"
+REPO="${2:-$(gh repo view --json nameWithOwner -q '.nameWithOwner')}"
+
+gh issue reopen "$NUMBER" --repo "$REPO" >/dev/null
+
+URL=$(gh issue view "$NUMBER" --repo "$REPO" --json url -q '.url')
+printf '{"number": %s, "state": "open", "url": "%s"}\n' "$NUMBER" "$URL"

--- a/skills/gh-context/scripts/gh-pr-get.sh
+++ b/skills/gh-context/scripts/gh-pr-get.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# gh-pr-get.sh — Fetch GitHub PR details as JSON (GH-267).
+#
+# Usage:
+#   gh-pr-get.sh NUMBER [REPO]
+#
+# If REPO is omitted, detects from current directory.
+#
+# Output: JSON with number, title, body, state, baseRefName, headRefName,
+# merged, mergedAt, closedAt, labels, milestone, assignees, author, url.
+
+set -euo pipefail
+
+NUMBER="${1:?Usage: gh-pr-get.sh NUMBER [REPO]}"
+REPO="${2:-$(gh repo view --json nameWithOwner -q '.nameWithOwner')}"
+
+gh pr view "$NUMBER" --repo "$REPO" \
+    --json number,title,body,state,baseRefName,headRefName,merged,mergedAt,closedAt,labels,milestone,assignees,author,url

--- a/src/dev10x/github/__init__.py
+++ b/src/dev10x/github/__init__.py
@@ -122,6 +122,31 @@ async def pr_detect(*, arg: str) -> Result[dict[str, Any]]:
     return ok(parse_key_value_output(result.stdout))
 
 
+async def pr_get(
+    *,
+    number: int,
+    repo: str | None = None,
+) -> Result[dict[str, Any]]:
+    """Get GitHub PR details as a structured payload (GH-267).
+
+    Wraps ``gh pr view --json …`` so agents have a routed alternative
+    to the hook-blocked ``gh pr view`` invocation.
+    """
+    args = [str(number)]
+    if repo:
+        args.append(repo)
+    result = await async_run_script(
+        "skills/gh-context/scripts/gh-pr-get.sh",
+        *args,
+    )
+    if result.returncode != 0:
+        return err(result.stderr.strip())
+    try:
+        return ok(json.loads(result.stdout))
+    except json.JSONDecodeError:
+        return ok(parse_key_value_output(result.stdout))
+
+
 async def issue_get(
     *,
     number: int,
@@ -924,6 +949,87 @@ async def issue_edit(
     return ok(
         {
             "number": number,
+            "url": f"https://github.com/{repo_result.value}/issues/{number}",
+        }
+    )
+
+
+async def issue_close(
+    *,
+    number: int,
+    reason: str = "completed",
+    comment: str | None = None,
+    repo: str | None = None,
+) -> Result[dict[str, Any]]:
+    """Close a GitHub issue (GH-268).
+
+    Wraps ``gh issue close N --reason <reason> [--comment <body>]``.
+
+    Args:
+        number: Issue number to close.
+        reason: ``"completed"`` (default) or ``"not_planned"``.
+        comment: Optional final closing comment (Markdown supported).
+        repo: Repository (owner/repo). Auto-detected if omitted.
+
+    Returns:
+        On success: ``{"number": int, "state": "closed", "url": str}``.
+    """
+    if reason not in ("completed", "not_planned"):
+        return err(f"reason must be 'completed' or 'not_planned', got: {reason}")
+
+    args = ["gh", "issue", "close", str(number), "--reason", reason]
+    if repo:
+        args.extend(["--repo", repo])
+    if comment is not None:
+        args.extend(["--comment", comment])
+
+    result = await async_run(args=args, timeout=30)
+    if result.returncode != 0:
+        return err(result.stderr.strip())
+
+    repo_result = await _resolve_repo(repo)
+    if isinstance(repo_result, ErrorResult):
+        return ok({"number": number, "state": "closed", "url": result.stdout.strip()})
+    return ok(
+        {
+            "number": number,
+            "state": "closed",
+            "url": f"https://github.com/{repo_result.value}/issues/{number}",
+        }
+    )
+
+
+async def issue_reopen(
+    *,
+    number: int,
+    repo: str | None = None,
+) -> Result[dict[str, Any]]:
+    """Reopen a closed GitHub issue (GH-268).
+
+    Wraps ``gh issue reopen N``.
+
+    Args:
+        number: Issue number to reopen.
+        repo: Repository (owner/repo). Auto-detected if omitted.
+
+    Returns:
+        On success: ``{"number": int, "state": "open", "url": str}``.
+    """
+    args = ["gh", "issue", "reopen", str(number)]
+    if repo:
+        args.extend(["--repo", repo])
+
+    result = await async_run(args=args, timeout=30)
+    if result.returncode != 0:
+        return err(result.stderr.strip())
+
+    repo_result = await _resolve_repo(repo)
+    if isinstance(repo_result, ErrorResult):
+        return ok({"number": number, "state": "open", "url": result.stdout.strip()})
+    return ok(
+        {
+            "number": number,
+            "state": "open",
             "url": f"https://github.com/{repo_result.value}/issues/{number}",
         }
     )

--- a/src/dev10x/mcp/server_cli.py
+++ b/src/dev10x/mcp/server_cli.py
@@ -60,6 +60,30 @@ async def pr_detect(arg: str, cwd: str | None = None) -> dict:
 
 
 @server.tool()
+async def pr_get(number: int, repo: str | None = None, cwd: str | None = None) -> dict:
+    """Get GitHub PR details (GH-267).
+
+    Symmetric to ``issue_get`` — closes the ``gh pr view`` permission-
+    friction gap.
+
+    Args:
+        number: PR number.
+        repo: Repository (owner/repo). If omitted, uses current repo.
+        cwd: Effective working directory (GH-979).
+
+    Returns:
+        Dictionary with keys: number, title, body, state, baseRefName,
+        headRefName, merged, mergedAt, closedAt, labels, milestone,
+        assignees, author, url.
+    """
+    from dev10x import github as gh
+    from dev10x.subprocess_utils import use_cwd
+
+    with use_cwd(cwd):
+        return (await gh.pr_get(number=number, repo=repo)).to_dict()
+
+
+@server.tool()
 async def issue_get(number: int, repo: str | None = None, cwd: str | None = None) -> dict:
     """Get GitHub issue details.
 
@@ -573,6 +597,69 @@ async def issue_edit(
                 repo=repo,
             )
         ).to_dict()
+
+
+@server.tool()
+async def issue_close(
+    number: int,
+    reason: str = "completed",
+    comment: str | None = None,
+    repo: str | None = None,
+    cwd: str | None = None,
+) -> dict:
+    """Close a GitHub issue (GH-268).
+
+    Wraps `gh issue close N --reason <reason>` plus an optional
+    `--comment` body. Closes the `gh issue close` permission-friction
+    gap so skills like work-on can finalise epic closure.
+
+    Args:
+        number: Issue number to close.
+        reason: "completed" (default) or "not_planned".
+        comment: Optional final closing comment (Markdown supported).
+        repo: Repository (owner/repo). Auto-detected if omitted.
+        cwd: Effective working directory (GH-979).
+
+    Returns:
+        Dictionary with keys: number, state ("closed"), url.
+    """
+    from dev10x import github as gh
+    from dev10x.subprocess_utils import use_cwd
+
+    with use_cwd(cwd):
+        return (
+            await gh.issue_close(
+                number=number,
+                reason=reason,
+                comment=comment,
+                repo=repo,
+            )
+        ).to_dict()
+
+
+@server.tool()
+async def issue_reopen(
+    number: int,
+    repo: str | None = None,
+    cwd: str | None = None,
+) -> dict:
+    """Reopen a closed GitHub issue (GH-268).
+
+    Wraps `gh issue reopen N`. Symmetric to `issue_close`.
+
+    Args:
+        number: Issue number to reopen.
+        repo: Repository (owner/repo). Auto-detected if omitted.
+        cwd: Effective working directory (GH-979).
+
+    Returns:
+        Dictionary with keys: number, state ("open"), url.
+    """
+    from dev10x import github as gh
+    from dev10x.subprocess_utils import use_cwd
+
+    with use_cwd(cwd):
+        return (await gh.issue_reopen(number=number, repo=repo)).to_dict()
 
 
 @server.tool()

--- a/src/dev10x/validators/command-skill-map.yaml
+++ b/src/dev10x/validators/command-skill-map.yaml
@@ -186,6 +186,62 @@ rules:
       Direct gh pr checks --watch exits on first result; the skill
       loops, fixes CI failures, addresses comments, and requests review.
 
+  - name: gh-pr-view
+    matcher: Bash
+    patterns:
+      - gh pr view
+    except: []
+    hook_block: true
+    compensations:
+      - type: use-tool
+        tool: mcp__plugin_Dev10x_cli__pr_get
+        guardrails: structured responses, no Bash permission friction
+        description: >
+          If the MCP server is unavailable, use gh pr view directly
+          and parse the JSON output manually with --json flag.
+    reason: >
+      Direct gh pr view requires Bash permission approval on every
+      call. The MCP tool provides structured JSON (number, title,
+      body, state, baseRefName, headRefName, merged, mergedAt,
+      closedAt, labels, milestone, assignees, author, url) and
+      avoids permission friction.
+
+  - name: gh-issue-close
+    matcher: Bash
+    patterns:
+      - gh issue close
+    except: []
+    hook_block: true
+    compensations:
+      - type: use-tool
+        tool: mcp__plugin_Dev10x_cli__issue_close
+        guardrails: structured responses, no Bash permission friction
+        description: >
+          If the MCP server is unavailable, use gh issue close N
+          --reason <completed|not_planned> directly.
+    reason: >
+      Direct gh issue close changes issue state and requires per-call
+      Bash permission. The MCP tool accepts reason and optional
+      closing comment and avoids friction.
+
+  - name: gh-issue-reopen
+    matcher: Bash
+    patterns:
+      - gh issue reopen
+    except: []
+    hook_block: true
+    compensations:
+      - type: use-tool
+        tool: mcp__plugin_Dev10x_cli__issue_reopen
+        guardrails: structured responses, no Bash permission friction
+        description: >
+          If the MCP server is unavailable, use gh issue reopen N
+          directly.
+    reason: >
+      Direct gh issue reopen changes issue state and requires per-call
+      Bash permission. The MCP tool returns structured responses and
+      avoids friction.
+
   - name: gh-issue-view
     matcher: Bash
     patterns:

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -1706,3 +1706,159 @@ class TestGenerateCommitList:
 
         assert isinstance(result, ErrorResult)
         assert "no commits" in result.error
+
+
+class TestPrGet:
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run_script", new_callable=AsyncMock)
+    async def test_parses_pr_json(self, mock_run: AsyncMock) -> None:
+        mock_run.return_value = _completed(
+            stdout=json.dumps(
+                {
+                    "number": 42,
+                    "title": "Fix things",
+                    "state": "OPEN",
+                    "merged": False,
+                    "url": "https://github.com/owner/repo/pull/42",
+                }
+            )
+        )
+
+        result = await gh.pr_get(number=42, repo="owner/repo")
+
+        assert isinstance(result, SuccessResult)
+        assert result.value["number"] == 42
+        assert result.value["state"] == "OPEN"
+        called_args = mock_run.call_args.args
+        assert "skills/gh-context/scripts/gh-pr-get.sh" in called_args[0]
+        assert "42" in called_args
+        assert "owner/repo" in called_args
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run_script", new_callable=AsyncMock)
+    async def test_returns_error_on_script_failure(self, mock_run: AsyncMock) -> None:
+        mock_run.return_value = _completed(returncode=1, stderr="not found")
+
+        result = await gh.pr_get(number=999)
+
+        assert isinstance(result, ErrorResult)
+        assert "not found" in result.error
+
+
+class TestIssueClose:
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run", new_callable=AsyncMock)
+    async def test_closes_with_default_reason(
+        self,
+        mock_run: AsyncMock,
+        mock_resolve_repo: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(stdout="")
+
+        result = await gh.issue_close(number=42, repo="owner/repo")
+
+        assert isinstance(result, SuccessResult)
+        assert result.value == {
+            "number": 42,
+            "state": "closed",
+            "url": "https://github.com/owner/repo/issues/42",
+        }
+        called_args = mock_run.call_args.kwargs["args"]
+        assert called_args[:6] == [
+            "gh",
+            "issue",
+            "close",
+            "42",
+            "--reason",
+            "completed",
+        ]
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run", new_callable=AsyncMock)
+    async def test_accepts_not_planned_reason(
+        self,
+        mock_run: AsyncMock,
+        mock_resolve_repo: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(stdout="")
+
+        result = await gh.issue_close(number=1, reason="not_planned", repo="owner/repo")
+
+        assert isinstance(result, SuccessResult)
+        called_args = mock_run.call_args.kwargs["args"]
+        assert "not_planned" in called_args
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_reason(self) -> None:
+        result = await gh.issue_close(number=1, reason="abandoned")
+
+        assert isinstance(result, ErrorResult)
+        assert "completed" in result.error and "not_planned" in result.error
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run", new_callable=AsyncMock)
+    async def test_passes_comment_when_provided(
+        self,
+        mock_run: AsyncMock,
+        mock_resolve_repo: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(stdout="")
+
+        result = await gh.issue_close(
+            number=7,
+            comment="Done — see PR #99",
+            repo="owner/repo",
+        )
+
+        assert isinstance(result, SuccessResult)
+        called_args = mock_run.call_args.kwargs["args"]
+        assert "--comment" in called_args
+        assert "Done — see PR #99" in called_args
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run", new_callable=AsyncMock)
+    async def test_returns_error_on_failure(
+        self,
+        mock_run: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(returncode=1, stderr="not found")
+
+        result = await gh.issue_close(number=999)
+
+        assert isinstance(result, ErrorResult)
+        assert "not found" in result.error
+
+
+class TestIssueReopen:
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run", new_callable=AsyncMock)
+    async def test_reopens_issue(
+        self,
+        mock_run: AsyncMock,
+        mock_resolve_repo: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(stdout="")
+
+        result = await gh.issue_reopen(number=42, repo="owner/repo")
+
+        assert isinstance(result, SuccessResult)
+        assert result.value == {
+            "number": 42,
+            "state": "open",
+            "url": "https://github.com/owner/repo/issues/42",
+        }
+        called_args = mock_run.call_args.kwargs["args"]
+        assert called_args[:4] == ["gh", "issue", "reopen", "42"]
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run", new_callable=AsyncMock)
+    async def test_returns_error_on_failure(
+        self,
+        mock_run: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(returncode=1, stderr="not found")
+
+        result = await gh.issue_reopen(number=999)
+
+        assert isinstance(result, ErrorResult)
+        assert "not found" in result.error

--- a/tests/mcp/test_cli_server.py
+++ b/tests/mcp/test_cli_server.py
@@ -948,6 +948,116 @@ class TestIssueGet:
         assert "error" in result
 
 
+class TestPrGet:
+    @pytest.mark.asyncio
+    @patch("dev10x.github.pr_get", new_callable=AsyncMock)
+    async def test_delegates_to_github_module(
+        self,
+        mock_fn: AsyncMock,
+    ) -> None:
+        mock_fn.return_value = ok(
+            {
+                "number": 42,
+                "title": "T",
+                "state": "OPEN",
+                "merged": False,
+            }
+        )
+
+        result = await cli_server.pr_get(number=42, repo="o/r")
+
+        assert result["number"] == 42
+        assert result["state"] == "OPEN"
+        assert mock_fn.call_args.kwargs == {"number": 42, "repo": "o/r"}
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.pr_get", new_callable=AsyncMock)
+    async def test_returns_error_on_failure(
+        self,
+        mock_fn: AsyncMock,
+    ) -> None:
+        mock_fn.return_value = err("Not Found")
+
+        result = await cli_server.pr_get(number=999)
+
+        assert "error" in result
+
+
+class TestIssueClose:
+    @pytest.mark.asyncio
+    @patch("dev10x.github.issue_close", new_callable=AsyncMock)
+    async def test_delegates_to_github_module(
+        self,
+        mock_fn: AsyncMock,
+    ) -> None:
+        mock_fn.return_value = ok({"number": 1, "state": "closed", "url": "https://example/1"})
+
+        result = await cli_server.issue_close(
+            number=1,
+            reason="not_planned",
+            repo="o/r",
+        )
+
+        assert result["state"] == "closed"
+        assert mock_fn.call_args.kwargs == {
+            "number": 1,
+            "reason": "not_planned",
+            "comment": None,
+            "repo": "o/r",
+        }
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.issue_close", new_callable=AsyncMock)
+    async def test_passes_comment(
+        self,
+        mock_fn: AsyncMock,
+    ) -> None:
+        mock_fn.return_value = ok({"number": 1, "state": "closed", "url": "https://example/1"})
+
+        await cli_server.issue_close(number=1, comment="thanks", repo="o/r")
+
+        assert mock_fn.call_args.kwargs["comment"] == "thanks"
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.issue_close", new_callable=AsyncMock)
+    async def test_returns_error_on_failure(
+        self,
+        mock_fn: AsyncMock,
+    ) -> None:
+        mock_fn.return_value = err("Not Found")
+
+        result = await cli_server.issue_close(number=999)
+
+        assert "error" in result
+
+
+class TestIssueReopen:
+    @pytest.mark.asyncio
+    @patch("dev10x.github.issue_reopen", new_callable=AsyncMock)
+    async def test_delegates_to_github_module(
+        self,
+        mock_fn: AsyncMock,
+    ) -> None:
+        mock_fn.return_value = ok({"number": 1, "state": "open", "url": "https://example/1"})
+
+        result = await cli_server.issue_reopen(number=1, repo="o/r")
+
+        assert result["state"] == "open"
+        assert mock_fn.call_args.kwargs == {"number": 1, "repo": "o/r"}
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.issue_reopen", new_callable=AsyncMock)
+    async def test_returns_error_on_failure(
+        self,
+        mock_fn: AsyncMock,
+    ) -> None:
+        mock_fn.return_value = err("Not Found")
+
+        result = await cli_server.issue_reopen(number=999)
+
+        assert "error" in result
+
+
 class TestIssueComments:
     @pytest.mark.asyncio
     @patch("dev10x.github.issue_comments", new_callable=AsyncMock)
@@ -1262,6 +1372,18 @@ CWD_HANDLERS: list[tuple[str, dict]] = [
     (
         "plan_sync_archive",
         {},
+    ),
+    (
+        "pr_get",
+        {"number": 1},
+    ),
+    (
+        "issue_close",
+        {"number": 1},
+    ),
+    (
+        "issue_reopen",
+        {"number": 1},
     ),
 ]
 


### PR DESCRIPTION
**When** I am finishing PR shipping or epic closure in a Dev10x skill flow, **I want to** route through MCP wrappers symmetric to `issue_get`/`issue_edit` for read-only PR metadata and issue state transitions, **so I can** complete those workflows without reaching for raw `gh` CLI or `DEV10X_SKIP_CMD_VALIDATION` bypasses.

---

[`1bf098f0`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/277/commits/1bf098f0ce98d1b53744970b8637d70f9a671777) ✨ GH-267 Enable routed gh pr view and issue state changes

Closes #267
Closes #268
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/267

---