### PR TITLE
✨ GH-238 Route pytest through run_tests MCP wrapper

### DIFF
--- a/.claude/rules/mcp-tools.md
+++ b/.claude/rules/mcp-tools.md
@@ -101,6 +101,7 @@ supporting each tool:
 | `create_pr` | `cli` | PR #191 | v0.30.0+ |
 | `update_pr` | `cli` | GH-60 | v0.70.0+ |
 | `merge_pr` | `cli` | GH-232 | v0.73.0+ |
+| `run_tests` | `cli` | GH-238 | v0.74.0+ |
 | `milestone_close` | `cli` | GH-187 | v0.71.0+ |
 | `milestone_create` | `cli` | GH-220 | v0.73.0+ |
 | `issue_edit` | `cli` | GH-220 | v0.73.0+ |

--- a/skills/py-test/SKILL.md
+++ b/skills/py-test/SKILL.md
@@ -11,6 +11,7 @@ description: >
 user-invocable: true
 invocation-name: Dev10x:py-test
 allowed-tools:
+  - mcp__plugin_Dev10x_cli__run_tests
   - Bash(pytest:*)
   - Bash(uv:*)
 ---
@@ -34,12 +35,30 @@ failures.
 
 ### Step 1: Run Tests
 
+**Preferred — MCP tool** (works in every session, including
+worktrees where `pytest` is not on PATH and the Bash hook blocks
+every direct invocation form, GH-238):
+
+```
+mcp__plugin_Dev10x_cli__run_tests()
+```
+
+Pass extra pytest args via the `args` parameter, e.g.
+`args=["src/dev10x/runner/"]` or `args=["-k", "name"]`. The tool
+returns a structured payload: `returncode`, `summary`, `passed`,
+`failed`, `skipped`, `coverage_percent`, `failed_tests`,
+`missing_coverage`, `stdout`, `stderr`. The subprocess is
+launched from the MCP server so the PreToolUse hook does not
+apply.
+
+**Fallback — Bash** (only when the MCP server is unavailable):
+
 ```bash
 pytest --cov --cov-report=term-missing
 ```
 
-**Worktree sessions:** When the session CWD is inside a worktree
-(`.git` is a file, not a directory), prefix with `uv run`:
+Inside a worktree (`.git` is a file, not a directory), prefix
+with `uv run`:
 
 ```bash
 uv run pytest --cov --cov-report=term-missing

--- a/src/dev10x/mcp/server_cli.py
+++ b/src/dev10x/mcp/server_cli.py
@@ -1683,5 +1683,44 @@ async def record_upgrade(version: str | None = None) -> dict:
     return {"version": resolved, "path": str(path)}
 
 
+@server.tool()
+async def run_tests(
+    args: list[str] | None = None,
+    coverage: bool = True,
+    timeout: int = 600,
+    cwd: str | None = None,
+) -> dict:
+    """Run pytest with coverage via ``uv run`` (GH-238).
+
+    Symmetric to ``merge_pr``/``create_pr``/``push_safe``: the
+    subprocess is launched from the MCP server so the PreToolUse
+    hook that blocks raw ``pytest`` / ``uv run pytest`` Bash
+    invocations does not apply. This makes the documented test
+    gate reachable from worktree sessions where ``pytest`` is not
+    on PATH and every direct invocation form is hook-blocked.
+
+    Args:
+        args: Extra pytest arguments appended after coverage flags.
+            Example: ``["src/dev10x/runner/"]`` or ``["-k", "name"]``.
+        coverage: When True (default), add
+            ``--cov --cov-report=term-missing``.
+        timeout: Subprocess timeout in seconds (default 600).
+        cwd: Effective working directory (GH-979).
+
+    Returns:
+        Dictionary with keys: returncode (int), summary (str),
+        passed (int), failed (int), skipped (int), errors (int),
+        coverage_percent (int | None), failed_tests (list[dict]),
+        missing_coverage (list[dict]), stdout (str), stderr (str).
+        A non-zero ``returncode`` is *not* an MCP-level error —
+        callers read ``returncode`` and ``failed_tests`` to decide.
+    """
+    from dev10x import runner
+    from dev10x.subprocess_utils import use_cwd
+
+    with use_cwd(cwd):
+        return (await runner.run_tests(args=args, coverage=coverage, timeout=timeout)).to_dict()
+
+
 def main() -> None:
     server.run()

--- a/src/dev10x/runner/__init__.py
+++ b/src/dev10x/runner/__init__.py
@@ -1,0 +1,139 @@
+"""Test runner module — invokes ``pytest`` via ``uv run`` from MCP.
+
+Provides a structured entry point for the ``Dev10x:py-test`` skill so
+the test gate works inside worktree sessions where ``pytest`` is not
+on PATH and the Bash PreToolUse hook blocks every direct invocation
+form (``pytest``, ``python -m pytest``, ``uv run pytest``). Because
+the subprocess is launched from the MCP server, the Bash hook does
+not apply (GH-238, mirrors the GH-232 ``merge_pr`` pattern).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from dev10x.domain.common.result import Result, err, ok
+from dev10x.subprocess_utils import async_run
+
+_SUMMARY_RE = re.compile(
+    r"=+\s+(\d+\s+(?:passed|failed|skipped|error|errors)"
+    r"(?:,\s+\d+\s+(?:passed|failed|skipped|error|errors))*)"
+    r"\s+in\s+[\d.]+s\s+=+",
+    re.MULTILINE,
+)
+_COUNT_RE = re.compile(r"(\d+)\s+(passed|failed|skipped|error|errors)")
+_COVERAGE_TOTAL_RE = re.compile(
+    r"^TOTAL\s+\d+\s+\d+(?:\s+\d+\s+\d+)?\s+(\d+)%",
+    re.MULTILINE,
+)
+_FAILED_LINE_RE = re.compile(r"^FAILED\s+(\S+)(?:\s+-\s+(.*))?$", re.MULTILINE)
+_MISSING_LINE_RE = re.compile(
+    r"^(src/\S+\.py)\s+\d+\s+\d+(?:\s+\d+\s+\d+)?\s+(\d+)%\s+(.+)$",
+    re.MULTILINE,
+)
+
+
+async def run_tests(
+    *,
+    args: list[str] | None = None,
+    coverage: bool = True,
+    timeout: float = 600,
+) -> Result[dict[str, Any]]:
+    """Run pytest via ``uv run`` and return a structured summary.
+
+    Args:
+        args: Extra pytest arguments appended after the coverage flags.
+        coverage: When True, add ``--cov --cov-report=term-missing``.
+        timeout: Subprocess timeout in seconds (default 10 minutes).
+
+    Returns:
+        ok({
+            "returncode": int,
+            "summary": str,            # e.g. "150 passed"
+            "passed": int,
+            "failed": int,
+            "skipped": int,
+            "errors": int,
+            "coverage_percent": int | None,
+            "failed_tests": [{"id": str, "message": str | None}, ...],
+            "missing_coverage": [{"file": str, "percent": int, "lines": str}, ...],
+            "stdout": str,
+            "stderr": str,
+        })
+
+        err(...) only when ``uv`` itself is missing or the subprocess
+        times out. A non-zero pytest returncode is *not* an MCP-level
+        error — the caller reads ``returncode`` and ``failed_tests``.
+    """
+    extra = list(args) if args else []
+    cmd = ["uv", "run", "pytest"]
+    if coverage:
+        cmd += ["--cov", "--cov-report=term-missing"]
+    cmd += ["--tb=short", "--color=no"]
+    cmd += extra
+
+    try:
+        proc = await async_run(args=cmd, timeout=timeout)
+    except FileNotFoundError:
+        return err(
+            "uv not found on PATH — install uv or call pytest via the "
+            "test skill's documented fallback."
+        )
+
+    if proc.returncode == -1 and "timed out" in proc.stderr.lower():
+        return err(
+            f"pytest timed out after {timeout:.0f}s",
+            stdout=proc.stdout,
+            stderr=proc.stderr,
+        )
+
+    parsed = _parse(proc.stdout)
+    payload: dict[str, Any] = {
+        "returncode": proc.returncode,
+        "stdout": proc.stdout,
+        "stderr": proc.stderr,
+        **parsed,
+    }
+    return ok(payload)
+
+
+def _parse(stdout: str) -> dict[str, Any]:
+    """Extract structured test results from pytest stdout."""
+    counts = {"passed": 0, "failed": 0, "skipped": 0, "errors": 0}
+    summary = ""
+
+    match = _SUMMARY_RE.search(stdout)
+    if match:
+        summary = match.group(1).strip()
+        for count, label in _COUNT_RE.findall(summary):
+            key = "errors" if label.startswith("error") else label
+            counts[key] = int(count)
+
+    cov_match = _COVERAGE_TOTAL_RE.search(stdout)
+    coverage_percent: int | None = int(cov_match.group(1)) if cov_match else None
+
+    failed_tests = [
+        {"id": test_id, "message": message or None}
+        for test_id, message in _FAILED_LINE_RE.findall(stdout)
+    ]
+
+    missing_coverage = [
+        {"file": path, "percent": int(percent), "lines": lines.strip()}
+        for path, percent, lines in _MISSING_LINE_RE.findall(stdout)
+        if int(percent) < 100
+    ]
+
+    return {
+        "summary": summary,
+        "passed": counts["passed"],
+        "failed": counts["failed"],
+        "skipped": counts["skipped"],
+        "errors": counts["errors"],
+        "coverage_percent": coverage_percent,
+        "failed_tests": failed_tests,
+        "missing_coverage": missing_coverage,
+    }
+
+
+__all__ = ["run_tests"]

--- a/tests/runner/test_run_tests.py
+++ b/tests/runner/test_run_tests.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dev10x import runner
+from dev10x.domain.common.result import ErrorResult, SuccessResult
+
+
+def _completed(
+    *,
+    returncode: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=[],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+PASS_STDOUT = (
+    "============================= test session starts =============================\n"
+    "collected 150 items\n"
+    "tests/test_foo.py::test_bar PASSED\n"
+    "---------- coverage: platform linux, python 3.12.0 -----------\n"
+    "Name                  Stmts   Miss  Cover   Missing\n"
+    "---------------------------------------------------\n"
+    "src/dev10x/foo.py        20      0   100%\n"
+    "---------------------------------------------------\n"
+    "TOTAL                    20      0   100%\n"
+    "============================= 150 passed in 2.34s =============================\n"
+)
+
+FAIL_STDOUT = (
+    "============================= test session starts =============================\n"
+    "FAILED tests/test_foo.py::test_bar - AssertionError: expected 1, got 2\n"
+    "FAILED tests/test_baz.py::test_qux\n"
+    "---------- coverage: platform linux, python 3.12.0 -----------\n"
+    "Name                  Stmts   Miss  Cover   Missing\n"
+    "---------------------------------------------------\n"
+    "src/dev10x/foo.py        20      2    90%   12-13\n"
+    "---------------------------------------------------\n"
+    "TOTAL                    20      2    90%\n"
+    "===================== 148 passed, 2 failed in 3.21s ======================\n"
+)
+
+
+class TestRunTests:
+    @pytest.mark.asyncio
+    @patch("dev10x.runner.async_run", new_callable=AsyncMock)
+    async def test_invokes_uv_run_pytest_with_coverage_by_default(
+        self,
+        mock_run: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(stdout=PASS_STDOUT)
+
+        result = await runner.run_tests()
+
+        assert isinstance(result, SuccessResult)
+        called_args = mock_run.call_args.kwargs["args"]
+        assert called_args[:3] == ["uv", "run", "pytest"]
+        assert "--cov" in called_args
+        assert "--cov-report=term-missing" in called_args
+        assert "--tb=short" in called_args
+        assert "--color=no" in called_args
+
+    @pytest.mark.asyncio
+    @patch("dev10x.runner.async_run", new_callable=AsyncMock)
+    async def test_appends_extra_args_after_coverage_flags(
+        self,
+        mock_run: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(stdout=PASS_STDOUT)
+
+        await runner.run_tests(args=["-k", "test_foo", "src/dev10x/runner/"])
+
+        called_args = mock_run.call_args.kwargs["args"]
+        assert called_args[-3:] == ["-k", "test_foo", "src/dev10x/runner/"]
+
+    @pytest.mark.asyncio
+    @patch("dev10x.runner.async_run", new_callable=AsyncMock)
+    async def test_omits_coverage_flags_when_disabled(
+        self,
+        mock_run: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(stdout=PASS_STDOUT)
+
+        await runner.run_tests(coverage=False)
+
+        called_args = mock_run.call_args.kwargs["args"]
+        assert "--cov" not in called_args
+        assert "--cov-report=term-missing" not in called_args
+
+    @pytest.mark.asyncio
+    @patch("dev10x.runner.async_run", new_callable=AsyncMock)
+    async def test_parses_passing_summary_and_coverage(
+        self,
+        mock_run: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(stdout=PASS_STDOUT)
+
+        result = await runner.run_tests()
+
+        assert isinstance(result, SuccessResult)
+        payload = result.value
+        assert payload["returncode"] == 0
+        assert payload["passed"] == 150
+        assert payload["failed"] == 0
+        assert payload["coverage_percent"] == 100
+        assert payload["failed_tests"] == []
+        assert payload["missing_coverage"] == []
+        assert payload["summary"].startswith("150 passed")
+
+    @pytest.mark.asyncio
+    @patch("dev10x.runner.async_run", new_callable=AsyncMock)
+    async def test_parses_failed_tests_and_missing_coverage(
+        self,
+        mock_run: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(returncode=1, stdout=FAIL_STDOUT)
+
+        result = await runner.run_tests()
+
+        assert isinstance(result, SuccessResult)
+        payload = result.value
+        assert payload["returncode"] == 1
+        assert payload["passed"] == 148
+        assert payload["failed"] == 2
+        assert payload["coverage_percent"] == 90
+        assert {f["id"] for f in payload["failed_tests"]} == {
+            "tests/test_foo.py::test_bar",
+            "tests/test_baz.py::test_qux",
+        }
+        first = next(
+            f for f in payload["failed_tests"] if f["id"] == "tests/test_foo.py::test_bar"
+        )
+        assert first["message"] == "AssertionError: expected 1, got 2"
+        assert payload["missing_coverage"] == [
+            {"file": "src/dev10x/foo.py", "percent": 90, "lines": "12-13"},
+        ]
+
+    @pytest.mark.asyncio
+    @patch("dev10x.runner.async_run", new_callable=AsyncMock)
+    async def test_nonzero_returncode_is_not_an_mcp_error(
+        self,
+        mock_run: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(returncode=1, stdout=FAIL_STDOUT)
+
+        result = await runner.run_tests()
+
+        assert isinstance(result, SuccessResult)
+
+    @pytest.mark.asyncio
+    @patch("dev10x.runner.async_run", new_callable=AsyncMock)
+    async def test_timeout_returns_error(
+        self,
+        mock_run: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(
+            returncode=-1,
+            stderr="Process timed out",
+        )
+
+        result = await runner.run_tests(timeout=5)
+
+        assert isinstance(result, ErrorResult)
+        assert "timed out" in result.error.lower()
+
+    @pytest.mark.asyncio
+    @patch("dev10x.runner.async_run", new_callable=AsyncMock)
+    async def test_missing_uv_returns_error(
+        self,
+        mock_run: AsyncMock,
+    ) -> None:
+        mock_run.side_effect = FileNotFoundError("uv")
+
+        result = await runner.run_tests()
+
+        assert isinstance(result, ErrorResult)
+        assert "uv" in result.error


### PR DESCRIPTION
**When** I run `Dev10x:py-test` from a Dev10x worktree session, **I want to** invoke pytest with coverage through a hook-safe path, **so I can** ship code with the documented test gate without falling back to the forbidden `DEV10X_SKIP_CMD_VALIDATION` escape hatch.

---

[`f2cd1a7d`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/278/commits/f2cd1a7d02bb2082ea41cb86cfdfaab2d2bb6bb6) ✨ GH-238 Route pytest through run_tests MCP wrapper

Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/238

---
