### PR TITLE
📝 Consolidate four bot lessons PRs into one

### DIFF
--- a/.claude/agents/reviewer-generic.md
+++ b/.claude/agents/reviewer-generic.md
@@ -42,6 +42,16 @@ domain-specific reviewers).
     verify that session-guidance.md or .claude/rules/* are updated
     with the same pattern name, reason, and alternative. Mismatch
     between code behavior and documentation causes user confusion.
+9c. **Hook refactoring behavior equivalence** — when a PR modifies
+    the core hook dispatcher (ValidatorChain, filter logic, exception
+    handling), explicitly verify that the new implementation preserves
+    all observed behaviors of the old: single validator exception does
+    not prevent subsequent validators from running; validation results
+    are emitted in registration order; PermissionDenied correction
+    short-circuits at first non-None result; HOOK_DEBUG logging
+    captures the same details; disabled/filtered validators are never
+    imported. Compare hook.py integration points before/after and flag
+    as WARNING if behavior changes without explicit PR body justification.
 10. **New class without test suite** — when a PR adds a new `.py`
     file with production logic (classes or functions), or adds
     behavior methods to an existing model, check whether a

--- a/.claude/rules/INDEX.md
+++ b/.claude/rules/INDEX.md
@@ -87,6 +87,7 @@ Always apply `references/review-checks-common.md`.
 | `model-tiers.md` | Model assignments, tier framework, per-project overrides | `model-selection.md` rule, playbook system | Referenced, not auto-loaded |
 | `skill-pipelines.md` | Skill composition pipelines, standalone invocation | `Dev10x:work-on` skill, pipeline documentation | Referenced, not auto-loaded |
 | `config-resolution.md` | 3-tier config paths, project mapping format | All playbook/settings skills | Referenced, not auto-loaded |
+| `testing-patterns.md` | Pytest fixture composition, async handlers, parametrized tests | Code reviews, test authoring | Referenced, not auto-loaded |
 | `pr-backlog-deferral.md` | Deferring non-blocking review findings to a backlog | `Dev10x:gh-pr-review` skill, code review CI | Referenced, not auto-loaded |
 
 ## Agent Specs (`.claude/agents/`)

--- a/.claude/rules/INDEX.md
+++ b/.claude/rules/INDEX.md
@@ -87,6 +87,7 @@ Always apply `references/review-checks-common.md`.
 | `model-tiers.md` | Model assignments, tier framework, per-project overrides | `model-selection.md` rule, playbook system | Referenced, not auto-loaded |
 | `skill-pipelines.md` | Skill composition pipelines, standalone invocation | `Dev10x:work-on` skill, pipeline documentation | Referenced, not auto-loaded |
 | `config-resolution.md` | 3-tier config paths, project mapping format | All playbook/settings skills | Referenced, not auto-loaded |
+| `pr-backlog-deferral.md` | Deferring non-blocking review findings to a backlog | `Dev10x:gh-pr-review` skill, code review CI | Referenced, not auto-loaded |
 
 ## Agent Specs (`.claude/agents/`)
 

--- a/.claude/rules/performance.md
+++ b/.claude/rules/performance.md
@@ -34,3 +34,23 @@ If startup exceeds 200ms, profile with:
 uv run python -X importtime -c "from dev10x.cli import cli" \
   2>&1 | sort -t: -k2 -n | tail -20
 ```
+
+## Validator Lazy Import Behavior (GH-82)
+
+The ValidatorRegistry defers importing validator modules until
+`registry.active()` is called, avoiding the import cost of all
+validators on every hook invocation.
+
+**Trade-off**: Metadata assertion errors (rule_id drift, profile
+mismatch) surface at hook-run time (when validators are instantiated),
+not at startup.
+
+**Monitor**: If hook latency increases during PreToolUse or PermissionDenied
+invocations, profile with `HOOK_DEBUG=1 dev10x validate-bash echo hi` and
+compare against prior measurements. Lazy imports reduce amortized cost per
+hook invocation; eager loading of all validator modules would regress
+initialization time across all PreToolUse events.
+
+**If regression**: Evaluate eager-loading validator metadata only (specs
+loaded at startup for assertion checks, module imports deferred until
+`ValidatorChain.run()`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,9 @@ allowed-tools:
   - Bash(${CLAUDE_PLUGIN_ROOT}/skills/<name>/scripts/:*)
 ```
 
+When a skill delegates to an `instructions.md` file, verify `allowed-tools:` in
+SKILL.md covers ALL external tool calls in both SKILL.md AND instructions.md.
+
 Missing declarations cause per-invocation approval friction — users cannot
 invoke the skill without approving tool access each time. See
 `.claude/rules/mcp-tools.md` for MCP vs. direct script trade-offs.

--- a/references/git-pr.md
+++ b/references/git-pr.md
@@ -177,6 +177,11 @@ Detailed context for reviewers without bloating the Slack preview.
 
 For commit format and branch naming, see `git-commits.md`.
 
+### Backlog Items and Deferred Findings
+
+For deferring non-blocking review findings, see
+[`pr-backlog-deferral.md`](pr-backlog-deferral.md).
+
 ## Consolidation PRs
 
 When a PR consolidates multiple directories, features, or components, the JTBD

--- a/references/pr-backlog-deferral.md
+++ b/references/pr-backlog-deferral.md
@@ -1,0 +1,12 @@
+# Backlog Items and Deferred Findings
+
+If review uncovers non-blocking improvements (WARNINGs) that should be
+deferred, mention them in a comment with a clear backlog reference:
+
+```
+[Backlog: GH-197] skill-reinforcement/SKILL.md exceeds 200-line budget.
+Plan for next iteration: extract Step 3b (lines 124-145) into
+references/audit-procedure.md.
+```
+
+This keeps review momentum while documenting future work clearly.

--- a/references/testing-patterns.md
+++ b/references/testing-patterns.md
@@ -1,0 +1,153 @@
+# Pytest Fixture Composition Patterns
+
+Proven patterns for testing code that depends on multiple system resources
+(home directory, temporary working directories, environment variables).
+
+## Nested Context Managers for Isolated State
+
+When testing code with multiple system dependencies, compose fixtures to
+patch all dependencies at once without leaking state between tests.
+
+**Pattern:**
+
+```python
+@pytest.fixture
+def patched_workdir(workdir: Path, fake_home: Path):
+    """Redirect default workdir + Path.home() so commands operate in tmp_path."""
+    def _workdir() -> Path:
+        return workdir
+    with (
+        patch("dev10x.commands.permission._investigator_workdir", _workdir),
+        patch("dev10x.commands.permission.Path.home", return_value=fake_home),
+    ):
+        yield workdir
+```
+
+**Why this works:**
+- All patches are scoped to the fixture's context manager lifetime
+- Tests using `patched_workdir` automatically get both patches applied
+- On fixture cleanup, all patches are reverted (no test-to-test leakage)
+- Future tests don't inherit state or side effects from prior tests
+
+**Anti-pattern** (patches exit before test runs):
+```python
+# ❌ BAD
+@pytest.fixture
+def workdir():
+    with patch(...):
+        pass  # Patch exits here, before test runs!
+    return Path(...)
+```
+
+## Temporary Path Helpers for CLI Testing
+
+When testing Click CLI commands that read/write to temporary directories,
+use helper fixtures to create isolated temporary state:
+
+```python
+@pytest.fixture
+def fake_home(tmp_path: Path) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".claude").mkdir()
+    return home
+```
+
+Then pass both `fake_home` and `tmp_path` to dependent fixtures so tests
+can create multiple isolated directories without conflicts.
+
+**Use case**: CLI commands that write to `~/.claude/` or other user-scoped
+paths need a controlled home directory to avoid polluting the developer's
+actual home directory.
+
+## Multi-Layer Fixture Composition
+
+For complex test scenarios with 3+ dependencies, build fixtures in layers:
+
+```python
+@pytest.fixture
+def temp_state(tmp_path: Path):
+    """Create temp directory structure."""
+    return tmp_path / "state"
+
+@pytest.fixture
+def fake_home(temp_state: Path) -> Path:
+    """Create isolated home directory within temp_state."""
+    home = temp_state / "home"
+    home.mkdir(parents=True)
+    return home
+
+@pytest.fixture
+def patched_env(fake_home: Path):
+    """Patch environment to use isolated home."""
+    with patch.dict(os.environ, {"HOME": str(fake_home)}):
+        yield fake_home
+```
+
+This composition allows tests to:
+- Use `temp_state` for minimal temp setup
+- Use `fake_home` when home directory patching is needed
+- Use `patched_env` for full environment isolation
+
+Each fixture has a single responsibility; tests request what they need.
+
+## Parametrized Test Matrix Completeness
+
+When a PR uses `@pytest.mark.parametrize` to test a set of related items,
+ensure the test matrix is exhaustive:
+
+1. **Count items in parametrize list** — e.g., `@pytest.mark.parametrize("handler_name", ["detect_tracker", "pr_detect", ...])`
+2. **Count items in actual codebase** — grep for all handler names in `servers/cli_server.py`
+3. **Flag divergence as WARNING** — suggests incomplete coverage
+
+**Example**: If parametrized test validates "all 19 CWD-sensitive handlers
+must invoke use_cwd(cwd)", verify the list includes all 19. Adding new
+handlers without updating the parametrize list causes silent regressions.
+
+## Mock Call Signature Verification
+
+When mocking functions and verifying calls, go beyond `call_count`:
+
+```python
+# Good: verifies specific arguments
+mock_api.assert_called_once()
+assert mock_api.call_args.kwargs["as_bot"] is True
+assert mock_api.call_args.args[0] == "issue_id"
+
+# Weak: only checks it was called
+assert mock_api.called
+```
+
+**Checklist**:
+- Verify `call_args` contains all required parameters
+- Check both positional args (`args`) and keyword args (`kwargs`)
+- Test both success and failure scenarios
+- Avoid assertions that only check `call_count == 1` without verifying arguments
+
+## Async Handler Error Path Coverage
+
+For async handlers wrapping synchronous operations (GitHub API, git commands):
+
+**Test matrix**:
+1. Success path: returncode 0, stdout contains expected output
+2. Failure path: returncode != 0, stderr contains error message
+3. Empty success: returncode 0, stdout is empty (verify handler doesn't crash)
+4. Malformed response: handler can't parse output (graceful error)
+
+**Assertions**:
+```python
+# Success case
+result = await handler(...)
+assert isinstance(result, SuccessResult)
+assert "expected_field" in result.data
+
+# Error case
+result = await handler(...)
+assert isinstance(result, ErrorResult)
+assert "error_context" in str(result.error)
+```
+
+**Common gaps to watch**:
+- Error test missing (success-only coverage)
+- Error message not validated (just checking `"error" in result`)
+- Stderr content lost during error wrapping (context lost)


### PR DESCRIPTION
**When** the lessons bot opens multiple narrow PRs from prior PR retrospectives, **I want to** consolidate the surviving deliverables into one reviewable PR, **so I can** review and merge the documentation improvements in a single pass without juggling four scaffolding-heavy bot PRs.

Bundle members (one atomic commit each):
- GH-202 Document backlog-deferral pattern in PR guidelines
- GH-130 Formalize hook refactor and lazy-import documentation (applies the two patches embedded in #130 to their real targets; the LESSONS_LEARNED_IMPLEMENTATION.md / lessons_learned_report.md / *.patch scaffolding is intentionally not carried over)
- GH-124 Document pytest fixture and async handler patterns
- GH-104 Clarify allowed-tools scope spans instructions.md

Supersedes #202 #130 #124 #104 — those have been closed with a link back to this PR.

---

[`aa725e4c`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/279/commits/aa725e4c3128b13b1eeef570022c9fb607664594) 📝 GH-202 Document backlog-deferral pattern in PR guidelines
[`765f03bc`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/279/commits/765f03bc69ab559dbcc17efe19fcb725acc8ba8a) 📝 GH-130 Formalize hook refactor and lazy-import documentation
[`9e835d96`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/279/commits/9e835d969841a6af92910409ef8a6288c2e69b01) 📝 GH-124 Document pytest fixture and async handler patterns
[`c1c81097`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/279/commits/c1c8109786cd5b4b15470130c07128ed5c023ff7) 📝 GH-104 Clarify allowed-tools scope spans instructions.md

Fixes: none — consolidates #202 #130 #124 #104