### PR TITLE
📝 GH-223 Ensure no-checkpoints rule travels with auto-advance

### DIFF
--- a/references/eval-criteria.md
+++ b/references/eval-criteria.md
@@ -89,7 +89,7 @@ Dimensions are orthogonal quality axes (not sequential steps). Examples:
 - `classify` — input type identification (URL, ID, free text)
 - `gather` — parallel subagent context gathering
 - `plan` — task list generation with mandatory elements
-- `execute` — auto-advance + batched decisions
+- `execute` — auto-advance + batched decisions (no checkpoints under adaptive friction)
 - `task-structure` — 4 phase-level tasks + dependencies
 - `workspace` — early workspace decision (main repo vs. worktree)
 

--- a/references/friction-levels.md
+++ b/references/friction-levels.md
@@ -109,6 +109,49 @@ friction levels, including adaptive).
 
 Gates without `ALWAYS_ASK` auto-resolve at adaptive level.
 
+### "No checkpoints" rule
+
+Adaptive friction means **no checkpoints** between steps. A
+checkpoint is any pause where the agent waits for an implicit
+"ok, continue" from the user. Under adaptive friction, the
+approved plan is the authorization to proceed through every
+remaining step until the plan completion gate.
+
+**What counts as a checkpoint (forbidden under adaptive):**
+
+- Trailing "Ready to proceed?" / "Should I continue?" prompts
+- Summarising progress and stopping when the next step is
+  unambiguous
+- Pausing after a commit, push, or skill completion to await
+  acknowledgement
+- Inserting an `AskUserQuestion` gate that is not marked
+  `ALWAYS_ASK` and is not in the documented gate list for the
+  current skill
+
+**What is NOT a checkpoint (allowed at every friction level):**
+
+- `ALWAYS_ASK` gates — destructive operations, true ambiguity,
+  irreversible state changes
+- Batched A/B decisions per the queue pattern in
+  `references/task-orchestration.md` (collect, advance, ask
+  once when ALL tasks are blocked)
+- Hard blockers — unrecoverable CI, missing credentials, merge
+  conflicts requiring human judgment
+- The single Plan Completion Gate at end of plan
+- Documented gates in a skill's instructions that fire at every
+  friction level (e.g., merge-anyway overrides in
+  `Dev10x:gh-pr-merge`)
+
+**Detection signal:** If you are about to output "Ready to
+proceed to the next step?" or "Continue with the shipping
+pipeline?" under `friction_level: adaptive`, STOP. That is a
+checkpoint. Skip the question and execute the next step.
+
+**Cross-cutting reinforcement:** Every skill's `**Auto-advance:**`
+line ends with "— no checkpoints under adaptive friction." so
+the rule travels with the orchestration contract regardless of
+which skill is in flight.
+
 ## Acceptance Criteria (verify-acc-dod)
 
 | Level | Automated checks | Manual checks | Decision gate |

--- a/references/orchestration/auto-advance.md
+++ b/references/orchestration/auto-advance.md
@@ -3,11 +3,14 @@
 This rule applies to ALL skills, regardless of tier. It is the
 single most important orchestration pattern.
 
-**Always auto-advance.** Complete a step or task, immediately
-start the next. Never pause to ask "should I continue?", "ready
-for the next step?", or wait for the user to say "go" / "next" /
-"continue". The invocation of the skill is the authorization to
-proceed through all its steps.
+**Always auto-advance — no checkpoints under adaptive friction.**
+Complete a step or task, immediately start the next. Never pause
+to ask "should I continue?", "ready for the next step?", or wait
+for the user to say "go" / "next" / "continue". The invocation of
+the skill is the authorization to proceed through all its steps.
+See `references/friction-levels.md` § "No checkpoints" rule for
+the canonical definition of what counts as a checkpoint vs. a
+legitimate gate or dependency wait.
 
 ```
 TaskUpdate(taskId=current, status="completed")

--- a/references/orchestration/task-tracking.md
+++ b/references/orchestration/task-tracking.md
@@ -56,6 +56,10 @@ blocks read as examples; numbered lists read as instructions.
 
 Tiers guide HOW MUCH orchestration a skill adds, not WHETHER
 it participates. All tiers use TaskCreate + auto-advance.
+Under `friction_level: adaptive`, auto-advance carries the
+"no checkpoints" contract from `references/friction-levels.md`
+across every tier — implicit "ready to proceed?" pauses are
+forbidden in Full, Standard, and Minimal alike.
 
 | Tier | When | Additional patterns | Example skills |
 |------|------|---------------------|----------------|

--- a/skills/ddd/SKILL.md
+++ b/skills/ddd/SKILL.md
@@ -39,7 +39,7 @@ Storming, Software Archetypes, and architecture stress testing.
 
 This skill follows `references/task-orchestration.md` patterns.
 
-**Auto-advance:** Complete each step, immediately start the next.
+**Auto-advance:** Complete each step, immediately start the next — no checkpoints under adaptive friction.
 Only pause when batching questions per the process rules.
 
 **REQUIRED: Create tasks before ANY work.** After determining

--- a/skills/fanout/instructions.md
+++ b/skills/fanout/instructions.md
@@ -26,7 +26,8 @@ dependency or conflict is detected.
 This skill follows `references/task-orchestration.md` patterns.
 
 **Auto-advance:** Complete each item, immediately start the
-next. Never pause between items to ask "should I continue?"
+next — no checkpoints under adaptive friction. Never pause
+between items to ask "should I continue?"
 
 **REQUIRED: Create tasks before ANY work.** Execute
 `TaskCreate` calls at startup — one per phase:
@@ -614,6 +615,21 @@ status `in_progress`. If any exist (e.g., Phase 4 monitor agents
 still running), do NOT proceed — wait for all agents to complete.
 The completion gate must not fire while monitors are still
 tracking CI or merges.
+
+**This wait is NOT a checkpoint.** Under adaptive friction, "no
+checkpoints" means no implicit pauses for the user to acknowledge
+progress between steps. It does not mean "skip waiting for
+genuine async work to finish". Background agents finishing CI
+monitoring and merge confirmation are hard dependencies of the
+Phase 5 verification gate, not optional acknowledgements. The
+distinction:
+
+- Checkpoint (forbidden): "Phase 4 dispatched — ready to verify?"
+- Dependency wait (required): `TaskList` polling until all
+  in-progress agents return their results
+
+See `references/friction-levels.md` § "No checkpoints" rule for
+the full taxonomy.
 
 **Enforcement loop:**
 1. Call `TaskList`

--- a/skills/gh-pr-create/instructions.md
+++ b/skills/gh-pr-create/instructions.md
@@ -13,7 +13,7 @@ PR in your browser.
 This skill follows `references/task-orchestration.md` patterns
 (Tier: Standard).
 
-**Auto-advance:** Complete each step and immediately start the next.
+**Auto-advance:** Complete each step and immediately start the next — no checkpoints under adaptive friction.
 Never pause between steps to ask "should I continue?".
 
 **REQUIRED: Create tasks before ANY work.** Execute these

--- a/skills/gh-pr-fixup/SKILL.md
+++ b/skills/gh-pr-fixup/SKILL.md
@@ -49,7 +49,7 @@ validated the comment and will handle reply/resolution yourself.
 
 This skill follows `references/task-orchestration.md` patterns.
 
-**Auto-advance:** Complete each step, immediately start the next.
+**Auto-advance:** Complete each step, immediately start the next — no checkpoints under adaptive friction.
 Never pause to ask "should I continue?" between steps.
 
 **REQUIRED: Create tasks before ANY work.** Execute these

--- a/skills/gh-pr-merge/instructions.md
+++ b/skills/gh-pr-merge/instructions.md
@@ -433,13 +433,24 @@ Remote branch deleted: yes/no
 
 ## Auto-Advance Behavior
 
-This skill is designed to auto-advance in shipping pipelines.
-After a successful merge, the calling skill should proceed
-immediately to the next step (typically acceptance criteria
-verification). No confirmation gate after merge.
+This skill is designed to auto-advance in shipping pipelines —
+**no checkpoints under adaptive friction**. After a successful
+merge, the calling skill proceeds immediately to the next step
+(typically acceptance criteria verification). There is NO
+confirmation gate after merge: a trailing "PR merged — ready to
+verify acceptance?" is a checkpoint and is forbidden under
+adaptive friction. The merge is a step in the no-checkpoints
+shipping sequence, not a natural stopping point.
 
 If merge fails (e.g., branch protection rules), report the
-error and let the calling skill decide how to proceed.
+error and let the calling skill decide how to proceed. A
+genuine merge failure is a hard blocker, not a checkpoint —
+treat it accordingly.
+
+The ALWAYS_ASK "merge anyway" override (Check 2 failure path)
+is the only documented in-skill pause, and only fires when the
+auto-fix loop is exhausted. See `references/friction-levels.md`
+§ "No checkpoints" rule for the canonical definition.
 
 ## Important Notes
 

--- a/skills/gh-pr-monitor/instructions.md
+++ b/skills/gh-pr-monitor/instructions.md
@@ -19,7 +19,7 @@ on its own to revert reviewer-directed code.
 
 This skill follows `references/task-orchestration.md` patterns.
 
-**Auto-advance:** Complete each phase, immediately start the next.
+**Auto-advance:** Complete each phase, immediately start the next — no checkpoints under adaptive friction.
 Never pause to ask "should I continue?" between phases.
 
 **REQUIRED: Create tasks at session start.** The supervisor

--- a/skills/gh-pr-respond/instructions.md
+++ b/skills/gh-pr-respond/instructions.md
@@ -10,7 +10,7 @@ directly unless you are handling the full pipeline yourself.
 
 This skill follows `references/task-orchestration.md` patterns.
 
-**Auto-advance:** Complete each step, immediately start the next.
+**Auto-advance:** Complete each step, immediately start the next — no checkpoints under adaptive friction.
 Never pause to ask "should I continue?" between steps.
 
 **REQUIRED: Create tasks before ANY work.** Execute these

--- a/skills/gh-pr-review/SKILL.md
+++ b/skills/gh-pr-review/SKILL.md
@@ -43,7 +43,7 @@ branch before creating a PR.
 This skill follows `references/task-orchestration.md` patterns
 (Tier: Standard).
 
-**Auto-advance:** Complete each step and immediately start the next.
+**Auto-advance:** Complete each step and immediately start the next — no checkpoints under adaptive friction.
 Never pause between steps to ask "should I continue?".
 
 **REQUIRED: Create tasks before ANY work.** Execute these

--- a/skills/gh-pr-triage/SKILL.md
+++ b/skills/gh-pr-triage/SKILL.md
@@ -74,7 +74,7 @@ re-enter via this skill. See `Dev10x:gh-pr-respond/instructions.md`
 
 This skill follows `references/task-orchestration.md` patterns.
 
-**Auto-advance:** Complete each step, immediately start the next.
+**Auto-advance:** Complete each step, immediately start the next — no checkpoints under adaptive friction.
 Never pause to ask "should I continue?" between steps.
 
 **REQUIRED: Create tasks before ANY work.** Execute these

--- a/skills/git-commit-split/instructions.md
+++ b/skills/git-commit-split/instructions.md
@@ -8,7 +8,7 @@ Split monolithic git commits into atomic, cohesive commits that follow Clean Arc
 
 This skill follows `references/task-orchestration.md` patterns.
 
-**Auto-advance:** Complete each phase, immediately start the next.
+**Auto-advance:** Complete each phase, immediately start the next — no checkpoints under adaptive friction.
 Never pause between phases to ask "should I continue?".
 
 **REQUIRED: Create tasks before ANY work.** Execute these

--- a/skills/git-commit/instructions.md
+++ b/skills/git-commit/instructions.md
@@ -25,7 +25,7 @@ This skill creates properly formatted git commits following project conventions:
 This skill follows `references/task-orchestration.md` patterns
 (Tier: Standard).
 
-**Auto-advance:** Complete each step and immediately start the next.
+**Auto-advance:** Complete each step and immediately start the next — no checkpoints under adaptive friction.
 Never pause between steps to ask "should I continue?".
 
 **REQUIRED: Create tasks before ANY work.** Execute these

--- a/skills/git-groom/instructions.md
+++ b/skills/git-groom/instructions.md
@@ -19,7 +19,8 @@ Read that file for full context on auto-advance and batched
 decision queues.
 
 **Auto-advance:** Complete each phase and immediately start the
-next. Never pause between phases to ask "should I continue?".
+next — no checkpoints under adaptive friction. Never pause
+between phases to ask "should I continue?".
 
 **REQUIRED: Create tasks before ANY work.** Execute these
 `TaskCreate` calls at startup:

--- a/skills/investigate/SKILL.md
+++ b/skills/investigate/SKILL.md
@@ -26,7 +26,7 @@ allowed-tools:
 
 This skill follows `references/task-orchestration.md` patterns.
 
-**Auto-advance:** Complete each step, immediately start the next.
+**Auto-advance:** Complete each step, immediately start the next — no checkpoints under adaptive friction.
 Never pause to ask "should I continue?" between steps.
 
 **Playbook-driven modes:**

--- a/skills/permission-investigator/SKILL.md
+++ b/skills/permission-investigator/SKILL.md
@@ -114,8 +114,9 @@ For **every cell** in the matrix, run this loop:
 
 4. Move to the next cell.
 
-**Auto-advance:** Do not pause between cells. The matrix is
-complete when every cell has a recorded outcome.
+**Auto-advance:** Do not pause between cells — no checkpoints
+under adaptive friction. The matrix is complete when every cell
+has a recorded outcome.
 
 ## Phase 3: Aggregate
 

--- a/skills/plugin-maintenance/SKILL.md
+++ b/skills/plugin-maintenance/SKILL.md
@@ -59,7 +59,7 @@ Read the args string passed to the skill:
 ## Orchestration
 
 This skill follows `references/task-orchestration.md` patterns.
-**Auto-advance:** complete each step, immediately start the next.
+**Auto-advance:** complete each step, immediately start the next — no checkpoints under adaptive friction.
 Run dry-run before applying — no pause between steps.
 
 **REQUIRED: Create tasks before ANY work.** The task list depends

--- a/skills/project-audit/SKILL.md
+++ b/skills/project-audit/SKILL.md
@@ -53,7 +53,7 @@ prioritized improvement backlog with milestones and blocking chains.
 
 This skill follows `references/task-orchestration.md` patterns.
 
-**Auto-advance:** Complete each phase, immediately start the next.
+**Auto-advance:** Complete each phase, immediately start the next — no checkpoints under adaptive friction.
 Only pause at the Phase 2 selection gate and Phase 4 synthesis
 review.
 

--- a/skills/project-scope/SKILL.md
+++ b/skills/project-scope/SKILL.md
@@ -58,7 +58,7 @@ description and produces a complete project structure in the tracker.
 This skill follows `references/task-orchestration.md` patterns
 (Tier: Standard).
 
-**Auto-advance:** Complete each phase and immediately start the next.
+**Auto-advance:** Complete each phase and immediately start the next — no checkpoints under adaptive friction.
 Never pause between phases to ask "should I continue?".
 
 **REQUIRED: Create tasks before ANY work.** Execute these

--- a/skills/py-test-flaky/instructions.md
+++ b/skills/py-test-flaky/instructions.md
@@ -14,7 +14,7 @@
 
 This skill follows `references/task-orchestration.md` patterns.
 
-**Auto-advance:** Complete each step, immediately start the next.
+**Auto-advance:** Complete each step, immediately start the next — no checkpoints under adaptive friction.
 Never pause between steps except at documented decision gates.
 
 **REQUIRED: Create tasks before ANY work.** Execute these

--- a/skills/qa-self/instructions.md
+++ b/skills/qa-self/instructions.md
@@ -17,7 +17,7 @@ Linear.
 
 This skill follows `references/task-orchestration.md` patterns.
 
-**Auto-advance:** Complete each phase, immediately start the next.
+**Auto-advance:** Complete each phase, immediately start the next — no checkpoints under adaptive friction.
 Never pause between phases to ask "should I continue?".
 
 **REQUIRED: Create tasks before ANY work.** Execute these

--- a/skills/request-review/SKILL.md
+++ b/skills/request-review/SKILL.md
@@ -28,7 +28,7 @@ This skill follows `references/task-orchestration.md` patterns.
 
 Mark completed when done: `TaskUpdate(taskId, status="completed")`
 
-**Auto-advance:** Complete each step, immediately start the next.
+**Auto-advance:** Complete each step, immediately start the next — no checkpoints under adaptive friction.
 
 ## Flow
 

--- a/skills/review-fix/SKILL.md
+++ b/skills/review-fix/SKILL.md
@@ -45,7 +45,8 @@ This skill follows `references/task-orchestration.md` patterns
 (Tier: Standard).
 
 **Auto-advance:** Complete each finding and immediately start the
-next. Never pause between findings.
+next — no checkpoints under adaptive friction. Never pause
+between findings.
 
 **REQUIRED: Create tasks before ANY work.** Execute at startup:
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -78,7 +78,7 @@ applies to the `simplify` step that follows review.
 This skill follows `references/task-orchestration.md` patterns
 (Tier: Standard).
 
-**Auto-advance:** Complete each step and immediately start the next.
+**Auto-advance:** Complete each step and immediately start the next — no checkpoints under adaptive friction.
 Never pause between steps to ask "should I continue?".
 
 **REQUIRED: Create tasks before ANY work.** Execute these

--- a/skills/scope/instructions.md
+++ b/skills/scope/instructions.md
@@ -12,7 +12,7 @@ architecture design workflows. Not directly invocable — extended by:
 
 This skill follows `references/task-orchestration.md` patterns.
 
-**Auto-advance:** Complete each phase, immediately start the next.
+**Auto-advance:** Complete each phase, immediately start the next — no checkpoints under adaptive friction.
 Never pause between phases.
 
 **REQUIRED: Create tasks before ANY work.** Execute these

--- a/skills/session-wrap-up/SKILL.md
+++ b/skills/session-wrap-up/SKILL.md
@@ -53,7 +53,7 @@ each one to the right discovery context.
 
 This skill follows `references/task-orchestration.md` patterns.
 
-**Auto-advance:** Complete each step, immediately start the next.
+**Auto-advance:** Complete each step, immediately start the next — no checkpoints under adaptive friction.
 Never pause to ask "should I continue?" between steps.
 
 **REQUIRED: Create tasks before ANY work.** Execute these

--- a/skills/skill-audit/instructions.md
+++ b/skills/skill-audit/instructions.md
@@ -7,7 +7,7 @@ user corrections, and process improvements worth persisting into skill definitio
 
 This skill follows `references/task-orchestration.md` patterns.
 
-**Auto-advance:** Complete each phase, immediately start the next.
+**Auto-advance:** Complete each phase, immediately start the next — no checkpoints under adaptive friction.
 Never pause between phases.
 
 ### Deferral (GH-219)

--- a/skills/ticket-scope/instructions.md
+++ b/skills/ticket-scope/instructions.md
@@ -21,7 +21,7 @@ This skill follows `references/task-orchestration.md` patterns
 (Tier: Standard). It extends the base `scope` skill's orchestration
 with Linear-specific tasks.
 
-**Auto-advance:** Complete each phase and immediately start the next.
+**Auto-advance:** Complete each phase and immediately start the next — no checkpoints under adaptive friction.
 Never pause between phases to ask "should I continue?".
 
 **REQUIRED: Create tasks before ANY work.** Execute these

--- a/skills/work-on/evals/evals.json
+++ b/skills/work-on/evals/evals.json
@@ -489,6 +489,12 @@
           "signals": ["auto-advance", "no pause"]
         },
         {
+          "id": "no-checkpoints-under-adaptive",
+          "text": "Under friction_level: adaptive, runs the shipping pipeline as a no-checkpoints sequence — no trailing 'Ready to proceed?' between commit, PR, CI, groom, update, ready, merge",
+          "check": "behavioral",
+          "signals": ["no checkpoints", "adaptive friction", "shipping pipeline atomic"]
+        },
+        {
           "id": "acceptance-verified-last",
           "text": "Acceptance criteria verification is the final action in the execution",
           "check": "behavioral",

--- a/skills/work-on/instructions.md
+++ b/skills/work-on/instructions.md
@@ -1280,7 +1280,9 @@ See `references/task-orchestration.md` for the full pattern.
 **Complete a task → immediately start the next.** Do not pause
 between tasks to ask "should I continue?" or wait for the user
 to say "go" / "next" / "continue". The approved plan is the
-authorization to proceed.
+authorization to proceed — **no checkpoints under adaptive
+friction**. See `references/friction-levels.md` § "No checkpoints"
+rule for the canonical definition of what counts as a checkpoint.
 
 **Auto-advance on commits:** After creating a commit, immediately
 proceed to the next task. Never pause to show the commit or ask
@@ -1311,13 +1313,20 @@ GH-477 showed the monitor was not invoked for 12+ hours after
 PR creation, requiring 9 user prompts. The monitor is part of
 the shipping pipeline, not an optional convenience.
 
-**Shipping pipeline is atomic:** Once the main implementation
-and verification are done, the remaining shipping steps (code
-review → commit → PR → CI → groom → update → ready → merge)
-form an atomic sequence. Auto-advance through ALL of them
-without pausing for user input. Do NOT stop after posting
-review replies, after creating the PR, or after grooming —
-continue until the plan completion gate or a genuine blocker.
+**Shipping pipeline is atomic — no-checkpoints sequence:** Once
+the main implementation and verification are done, the remaining
+shipping steps (code review → commit → PR → CI → groom → update
+→ ready → merge) form an atomic, no-checkpoints sequence. Auto-
+advance through ALL of them without pausing for user input. Under
+`friction_level: adaptive` this sequence runs end-to-end with
+zero interruptions other than `ALWAYS_ASK` gates. Do NOT stop
+after posting review replies, after creating the PR, after CI
+goes green, or after grooming — continue until the plan
+completion gate or a genuine blocker (unrecoverable CI,
+unresolved human review thread, merge conflict needing judgment).
+A trailing "Ready to proceed to the next step?" between any of
+these shipping steps is a checkpoint and is forbidden under
+adaptive friction.
 
 **Batched Decision Queue:** When a task hits a genuine A/B
 decision, do NOT interrupt the user immediately. Instead:
@@ -1407,15 +1416,19 @@ delegation ensures consistent behavior, proper tool declarations,
 and reusable orchestration. Bypassing delegation by inlining the
 skill's logic breaks these guarantees.
 
-**Unattended mode compliance:** Auto-advance pressure in
-unattended mode makes it tempting to perform operations directly
-(e.g., `git checkout -b` instead of `Dev10x:ticket-branch`,
-inline review instead of `Dev10x:review`). This is still a
-violation — unattended mode changes the *pace*, not the *rules*.
-If you catch yourself about to skip a `Skill()` call, stop and
-invoke the skill. Refer to the **Skill Routing Enforcement**
-table above — it lists every action that MUST use a skill
-wrapper regardless of execution mode.
+**Unattended mode compliance — no checkpoints, but no shortcuts
+either:** Auto-advance pressure in unattended mode makes it
+tempting to perform operations directly (e.g., `git checkout -b`
+instead of `Dev10x:ticket-branch`, inline review instead of
+`Dev10x:review`). This is still a violation — "no checkpoints
+under adaptive friction" eliminates implicit pauses between steps;
+it does NOT license raw-CLI substitutions for skill wrappers.
+Unattended mode changes the *pace*, not the *rules*. If you catch
+yourself about to skip a `Skill()` call, stop and invoke the
+skill. Refer to the **Skill Routing Enforcement** table above —
+it lists every action that MUST use a skill wrapper regardless of
+execution mode. The two rules compose: auto-advance between steps,
+but always through the correct skill.
 
 **Mandatory delegation flag:** When a playbook step has
 `skills:` entries, delegation is mandatory — not advisory.


### PR DESCRIPTION
**When** running a long Dev10x pipeline in AFK adaptive mode, **I want to** see every auto-advance directive explicitly reinforce "no checkpoints", **so I can** return to a fully-executed pipeline instead of one paused mid-sequence for an implicit confirmation.

---

[`791436de`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/284/commits/791436de4ff05c9449cbda43356e128fe238491f) 📝 GH-223 Ensure no-checkpoints rule travels with auto-advance
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/223

---