### PR TITLE
✨ GH-276 Establish Business ROI First doctrine memo

### DIFF
--- a/docs/memos/006-2026-05-22-business-roi-first.md
+++ b/docs/memos/006-2026-05-22-business-roi-first.md
@@ -194,6 +194,20 @@ in §5 is finite and versioned.
 If the work does not appear in it, the default rule applies — no
 override, no appeal to precedent.
 
+**Doctrine at a glance:**
+
+```mermaid
+flowchart TD
+  A[Author drafts<br/>PR title / Job Story / commit] --> B{Does it name<br/>a ROI bucket<br/>+ actor outside<br/>engineering?}
+  B -->|Yes| Z[Ship — default rule satisfied]
+  B -->|No| C{Does the work match<br/>a canonical platform<br/>overhead bucket §5?}
+  C -->|No| D[Default rule applies —<br/>apply the 5 lenses §3<br/>to find the outcome,<br/>or do not ship alone]
+  C -->|Yes| E{Can author recite<br/>the bucket's one-line<br/>rationale?}
+  E -->|Yes| F[Ship — recite rationale<br/>in PR body; no Job Story required]
+  E -->|No| G[Recitation failed —<br/>study §5 or escalate<br/>to add new bucket via ADR]
+  G -.->|loops back| C
+```
+
 ## §3 — The Five Lenses (toolkit)
 
 The doctrine does not prescribe a single algorithm;
@@ -704,6 +718,18 @@ retired or automated away.
 | Compliance audit-log evidence collection | External auditors require periodic evidence packs (SOC2, ISO 27001, GDPR Art 30 ROPA) that demand a recurring effort cycle; collecting on-demand is more costly than scheduling. | Per audit cycle |
 | License / certificate renewals | Software licences and TLS certificates have hard expiry dates that, if missed, cause customer-facing outages; renewal is risk-avoided cost. | Per expiry calendar |
 
+**Canonical-bucket invocation at a glance:**
+
+```mermaid
+flowchart TD
+  A[Author about to invoke<br/>'platform overhead' exception] --> B{Does the work match<br/>an existing canonical<br/>entry by EXACT NAME?}
+  B -->|No| C[Two options only:<br/>1. Find the downstream outcome<br/>under default rule §2<br/>2. Propose new canonical entry<br/>via team ADR + cessation criteria]
+  B -->|Yes| D{Can author recite<br/>the bucket's canonical<br/>rationale from memory<br/>or §5 paste?}
+  D -->|No| E[Recitation failed —<br/>study the canonical entry first.<br/>Parroting without understanding<br/>IS the bureaucracy-creep failure mode<br/>this mechanism exists to prevent.]
+  D -->|Yes| F[Exception satisfied —<br/>recite rationale in PR body;<br/>no Job Story required.<br/>The absence of a story signals<br/>'this work keeps the platform sound'.]
+  E -.->|study, then retry| D
+```
+
 ---
 
 **Borderline cases and entries that do not qualify alone.**
@@ -778,6 +804,18 @@ for two quarters and some accounts have stalled at procurement because of it.
 **Naïve draft.**
 ```
 Add ACH to PaymentMethod enum
+```
+
+**Trace-up at a glance:**
+
+```
+✨ ACH enum addition (FEAT-401)                    ← the diff
+  └─ Cashier selects 'ACH' at point of sale
+       └─ Merchant reconciliation stops grouping as 'Other'
+            └─ Accounting team closes month-end without manual fixes
+                 └─ Enterprise procurement reviewers see complete story
+                      └─ Enterprise sales pipeline unblocks
+                         (multi-year contracts = high LTV cohort)
 ```
 
 **Lens application:**
@@ -873,6 +911,18 @@ the fix is a single `prefetch_related` call.
 **Naïve draft.**
 ```
 Fix N+1 query in PayrollCalculator
+```
+
+**Trace-up at a glance:**
+
+```
+🐛 N+1 query fix in PayrollCalculator (BUG-500)    ← the diff
+  └─ Calculation completes within timeout window
+       └─ Month-end payroll batch closes on schedule
+            └─ Employees paid by scheduled pay date
+                 └─ Finance team not paged at 2 a.m.
+                      └─ Labour-law liability avoided
+                         + finance trust in platform restored
 ```
 
 **Lens application:**
@@ -976,6 +1026,18 @@ This naïve draft is the GH-276 headline anti-pattern verbatim:
 the actor is the developer, the benefit is an implementation convenience,
 and the business chain is severed at the first link.
 
+**Trace-up at a glance:**
+
+```
+📦 ULID library dependency bump (CFG-823)          ← the diff
+  └─ Enables client-side ID generation
+       └─ Enables atomic-document save mutation
+            └─ Makes configurator UI usable for end customers
+                 └─ End customers self-serve template config
+                      └─ Vendor saves support hours
+                         + customers ship config same-day
+```
+
 **Lens application:**
 
 - **Trace-upward**: A ULID dep bump enables client-side ID generation,
@@ -1061,6 +1123,18 @@ the very anti-pattern this memo is designed to replace.
 The actor is the developer, the benefit is avoided rework,
 and the business chain is again severed at the implementation layer.
 
+**Trace-up at a glance:**
+
+```
+♻️ Extract notification dispatch to shared outbox (FEAT-230)   ← the diff
+  └─ SMS channel becomes pluggable (next PR)
+       └─ Billing admins reach customers on monitored channel
+            └─ Customers settle invoices faster
+                 └─ Days-sales-outstanding shrinks
+                      └─ Vendor cashflow + operating leverage improve
+                         (less collections labour, fewer late fees)
+```
+
 **Lens application:**
 
 - **Trace-upward**: The refactor produces a shared outbox, which makes the
@@ -1136,6 +1210,21 @@ The ticket exists solely to close the rotation window before the quarter ends.
 Rotate payment-processor OAuth token
 ```
 
+**Trace-up at a glance (DEAD-END is the diagnostic signal):**
+
+```
+🔒 Rotate payment-processor OAuth token (OPS-RT-Q3)   ← the diff
+  └─ New credential in vault + rolling restart
+       └─ ▲ Trace-upward DEAD-ENDS here ▲
+          (no human beneficiary; no user-visible change)
+          ↓
+          Diagnostic signal: consult canonical bucket list §5
+          ↓
+          Match: 'Security cert / secret rotation' bucket
+          ↓
+          Recite rationale in PR body — no Job Story required
+```
+
 **Lens application:**
 
 - **Trace-upward**: Rotation → vault entry changes → rolling restart of the payments service → no customer-visible effect.
@@ -1190,6 +1279,18 @@ Three EU enterprise procurement reviews have been stalled on this exact gap.
 
 ```
 Update audit log retention to 13 months
+```
+
+**Trace-up at a glance:**
+
+```
+🔒 Extend audit_log retention 30 → 395 days (COMP-415)   ← the diff
+  └─ GDPR Art 30 ROPA compliance gap closes
+       └─ EU enterprise customers' compliance officers
+            see retention satisfies regulatory minimum
+            └─ Customer procurement teams approve our platform
+                 └─ Three EU enterprise deals unblock
+                    (Revenue captured + Risk avoided, both honest)
 ```
 
 **Lens application:**
@@ -1248,6 +1349,19 @@ Ticket OPS-200.
 
 ```
 Add deploy state widget to oncall dashboard
+```
+
+**Trace-up at a glance:**
+
+```
+✨ Deploy-state widget on on-call dashboard (OPS-200)   ← the diff
+  └─ On-call engineer (legitimate actor — they ARE the user)
+     sees deploy state at a glance during incidents
+       └─ Investigation time per incident drops
+            └─ Mean Time To Restore (MTTR) shortens
+                 └─ Customer-facing service downtime contracts
+                      └─ SLA penalties avoided +
+                         customer trust preserved under incidents
 ```
 
 **Lens application:**
@@ -1332,6 +1446,20 @@ Ticket INFRA-89.
 
 ```
 Parallelize CI test suites
+```
+
+**Trace-up at a glance:**
+
+```
+⚡ Parallelize CI test suites (INFRA-89)             ← the diff
+  └─ Developer (legitimate actor — they ARE the user)
+     receives CI feedback in <5 min instead of 12 min
+       └─ Engineering team throughput rises ~15%
+            └─ Feature delivery rate accelerates
+                 └─ Customer requests answered in days, not weeks
+                      └─ Competitive response time improves
+                         (DORA lead-time → org performance,
+                         Forsgren et al. 2018)
 ```
 
 **Lens application:**
@@ -1699,6 +1827,24 @@ returning signal to the team that commissioned them.
 > The skills are the enforcement.
 > The annual audit is the renewal.
 > None of these is sufficient alone."*
+
+**The system at a glance:**
+
+```mermaid
+flowchart LR
+  subgraph Doctrine["Doctrine (this memo)"]
+    M["§2 default rule<br/>§3 five lenses<br/>§5 canonical buckets<br/>§7 anti-patterns"]
+  end
+  subgraph Enforcement["Enforcement (skills)"]
+    S["jtbd · git-commit<br/>gh-pr-create · ticket-scope<br/>release-notes · project-audit"]
+  end
+  subgraph Renewal["Renewal (audits, §8)"]
+    A["quarterly artifact audit<br/>annual bucket audit<br/>per-release overhead audit<br/>stakeholder excitement check"]
+  end
+  M -->|cited as doctrine root by| S
+  S -->|produces artifacts<br/>that feed| A
+  A -->|surfaces drift,<br/>retires stale buckets,<br/>proposes lens revisions| M
+```
 
 ---
 

--- a/docs/memos/006-2026-05-22-business-roi-first.md
+++ b/docs/memos/006-2026-05-22-business-roi-first.md
@@ -1133,7 +1133,7 @@ The ticket exists solely to close the rotation window before the quarter ends.
 **Naïve draft.**
 
 ```
-Rotate Square OAuth token
+Rotate payment-processor OAuth token
 ```
 
 **Lens application:**
@@ -1165,11 +1165,11 @@ The canonical recitation replaces the Job Story as the required rationale.
 
 **Final drafts:**
 
-- **PR title**: `🔒 OPS-RT-Q3 Rotate Square OAuth token (scheduled credential rotation, Q3 cycle)`
+- **PR title**: `🔒 OPS-RT-Q3 Rotate payment-processor OAuth token (Q3 cycle)`
 - **Job Story**: **Intentionally NONE — this is canonical platform overhead per §5.
   PR body recites the bucket:** *"Rotated per the Security cert / secret rotation canonical bucket.
   Quarterly cycle ensures undetected token compromise cannot persist beyond 90 days, maintaining PCI DSS Req 8 and SOC 2 CC6.1 compliance."*
-- **Commit**: `🔒 OPS-RT-Q3 Rotate Square OAuth token (Q3 scheduled cycle)`
+- **Commit**: `🔒 OPS-RT-Q3 Rotate payment-processor OAuth token (Q3 cycle)`
 
 **Why this wins.**
 The canonical-bucket mechanism is the doctrine's safety valve.

--- a/docs/memos/006-2026-05-22-business-roi-first.md
+++ b/docs/memos/006-2026-05-22-business-roi-first.md
@@ -1,0 +1,1862 @@
+# Business ROI First — A Manifesto for PR Titles, Job Stories, and Commit Messages
+
+**Memo 006** · 2026-05-22 · Source: [GH-276](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/276)
+
+> Every PR title, Job Story, and commit message owes the reader an answer to
+> "where does the money come from or go?" — even when the answer is "platform
+> integrity per the canonical bucket X." This memo is the doctrine that makes
+> that answer mandatory. The skills are the enforcement. The annual audit is
+> the renewal. None of these is sufficient alone.
+
+---
+
+## §1 — Why this memo exists
+
+Consider this pull request, submitted this week by a conscientious engineer
+on a mature SaaS codebase:
+
+---
+
+**PR title:** `Bump python-ulid to 2.1`
+
+**Job Story:** "When a developer is adding client-side record creation,
+the developer wants to use sortable, lexicographically ordered IDs,
+so they can avoid coordination overhead with the server for ID
+assignment."
+
+---
+
+This artifact passes every review check currently in operation.
+The gitmoji is absent but that is a style concern, not a doctrine failure.
+The Job Story is grammatically correct.
+It names an actor, a motivation, and an outcome.
+A reviewer scanning for the "developer-as-actor for plumbing PRs" failure
+would likely wave it through, because the story sounds like a genuine
+engineering concern rather than a feature masquerade.
+
+The problem is what the story omits.
+The library bump is groundwork for an atomic-save mutation.
+The atomic-save mutation eliminates a class of support tickets.
+The support tickets represent approximately two engineering-days per month
+in interruption cost, and they block a self-service configuration feature
+that three enterprise prospects have named as a procurement condition.
+None of that is in the title, the story, or the commit message.
+A stakeholder reading this artifact cannot answer the question:
+"Should we be doing this, and does it deserve to go first?"
+
+This is GH-276.
+The developer-as-actor shape for plumbing PRs slips past review
+because it satisfies the *form* of a Job Story while evacuating the
+*substance* the form was invented to carry.
+The engineer is not a liar.
+The story they wrote is true.
+It is simply addressed to the wrong audience, terminating at the wrong
+point in the dependency chain.
+
+That failure mode is narrow.
+The wider failure mode it belongs to is not.
+
+Teams that adopt outcome-first conventions — Job Stories, JTBD, OKRs —
+discover over time that the conventions accumulate their own rituals.
+Stories get written because the PR template requires them.
+Commit messages adopt the approved verbs.
+Reviews pass artifacts that satisfy the checklist without asking whether
+the checklist still serves its original purpose.
+The supervisor quoted in this memo's commissioning note names the dynamic
+precisely:
+
+> "instead of YAGNI we just assume that there is a good reason for it
+> but I am not privy to it, the others must know why, and bureaucracy
+> creeps in."
+
+Samuelson and Zeckhauser (1988) documented the underlying mechanism:
+decision-makers systematically over-weight the status quo, assigning it
+a legitimacy that incoming evidence rarely dislodges.
+Parkinson (1957) named the organisational form it takes —
+the Law of Triviality, where committees spend disproportionate time on
+low-stakes, legible items and wave through high-stakes, opaque ones.
+Applied to code review: a grammatically correct Job Story is legible;
+the business logic it should be encoding is opaque;
+the reviewer defaults to approving the legible surface.
+
+The cost accumulates slowly and becomes visible only in aggregate.
+Stakeholders who routinely receive engineering-centric framing —
+titles that describe diffs rather than decisions, stories that name
+developers rather than customers — lose the ability to prioritise
+across competing work items, to allocate capacity against business
+outcomes, or to measure return on engineering investment.
+Schwartz (2016, 2017) documents the structural version of this failure:
+IT organisations that cannot articulate business value in their own
+language are treated as cost centres rather than co-authors of outcomes.
+Cagan (2017) frames the same gap in product terms: "feature teams"
+optimising output diverge from "product teams" optimising outcomes, and
+the divergence compounds.
+Thorp (1998) named the phenomenon the Information Paradox —
+organisations invest heavily in IT and cannot explain what they got.
+
+The claim that *framing changes decisions* is not rhetorical.
+Four bodies of peer-reviewed evidence substantiate it directly.
+Petty, Cacioppo, and Schumann (1983) established through the Elaboration
+Likelihood Model that high-involvement audiences — the stakeholders
+evaluating budget allocation — process benefit-outcome arguments via the
+central deliberative route, producing more durable attitude change than
+mechanism-first arguments.
+Rackham (1988) analysed 35,000 recorded sales calls and found that
+large-account success depended not on feature enumeration but on
+implication-and-need-payoff sequences: articulating the downstream
+consequence first, then naming the mechanism that resolves it.
+Loewenstein and Prelec (1992) demonstrated hyperbolic discounting in
+intertemporal choice: decision-makers heavily discount deferred outcomes
+and over-weight immediate costs, meaning that a PR titled "Enable
+same-day customer configuration rollout" activates the future-value
+representation that counteracts that bias, while "Bump python-ulid to 2.1"
+does not.
+Trope and Liberman (2010) showed through construal-level theory that
+psychologically distant targets — future releases, strategic goals —
+are represented at high construal (outcomes, "why"), while near targets
+are represented at low construal (mechanisms, "how");
+outcome language aligns with the mental model stakeholders use for
+strategic evaluation, while mechanism language mismatches it.
+
+These four results convert the rhetorical claim into an empirical one.
+Outcome-framed artifacts do not merely signal effort or competence.
+They change which work gets funded, which gets deferred, and which gets
+cancelled — because they operate on the cognitive machinery that those
+decisions run on.
+
+This memo stakes a position: every artifact — PR title, Job Story,
+commit message — owes the reader a legible answer to the question
+"where does the money come from or go?"
+Not a vague reference to engineering quality.
+Not a story about what the developer wants.
+An answer traceable, in a small number of steps, to a business actor
+whose situation changes as a result of the work being shipped.
+
+## §2 — Doctrine: the ROI rationale rule
+
+Every engineering artifact that describes a change — PR title, Job Story,
+commit message — must carry a ROI rationale.
+The rationale is not decoration; it is the load-bearing claim that
+justifies the act of shipping (Drucker 1963).
+
+**The default rule:**
+Every artifact names (a) which ROI bucket the change serves and
+(b) which actor outside engineering benefits from it.
+
+The six recognised buckets are:
+
+| Bucket | Value signal |
+|---|---|
+| Revenue | Increases billable events, conversion, or average order value |
+| Cost | Reduces infrastructure, labour, or support spend |
+| Retention | Reduces churn or improves measured satisfaction |
+| Time-to-value | Shortens the gap between intent and outcome for a user |
+| Risk | Reduces probability or blast radius of a failure state |
+| Platform integrity | Preserves the system's capacity to deliver the above |
+
+An artifact that names no bucket produces no signal.
+The reader cannot distinguish purposeful work from box-ticking work
+(Graeber 2018).
+Ambiguity here is not neutral — it is a continuous loss at every
+downstream decision point: review, prioritisation, incident triage
+(Taguchi 1986).
+
+**The exception:**
+Canonical platform overhead work — catalogued in §5 — is exempt
+from naming an external beneficiary.
+Dependency upgrades, test infrastructure, linter hygiene, and
+similarly well-bounded maintenance items have standing rationales
+that are not re-litigated per commit.
+
+**The hard edge:**
+Claiming the exception requires two conditions, both necessary:
+
+1. The artifact matches an existing canonical bucket **by name**
+   (not by analogy, not by spirit).
+2. The author can recite that bucket's one-line rationale
+   from the §5 catalogue.
+
+Neither condition alone is sufficient.
+A name without a recitable rationale is cargo-culted compliance.
+A rationale without a canonical name is an ad-hoc claim competing for
+exception status — which is exactly what the default rule exists to prevent.
+
+**Why this resists bureaucracy creep:**
+The recitation requirement forces a conscious choice (Drucker 1967).
+"We've always done it this way" is not a rationale; it is evidence that
+the exception has been claimed unconsciously.
+Goldratt and Cox (1984) identified the same failure mode in production
+systems: local efficiency metrics optimise the step, not the system.
+A commit that improves local tidiness while obscuring business value
+optimises the wrong level.
+The poka-yoke here (Shingo 1989) is structural: the canonical catalogue
+in §5 is finite and versioned.
+If the work does not appear in it, the default rule applies — no
+override, no appeal to precedent.
+
+## §3 — The Five Lenses (toolkit)
+
+The doctrine does not prescribe a single algorithm;
+it provides five complementary lenses,
+each sharpened for a different class of change.
+
+| # | Lens | Best for | Key move |
+|---|------|----------|----------|
+| 3.1 | Trace-upward | Plumbing, refactor, dep bumps, infra | Walk dependency graph from your diff outward until you hit someone outside engineering |
+| 3.2 | 5 Whys | Ops hygiene, "obvious" work, bug-fix root cause | Drill on motivation in 5 forced iterations; terminate ONLY on a business answer |
+| 3.3 | Mechanism vs Outcome | Universal vocabulary | Name both halves; suppress mechanism in titles; lead with outcome |
+| 3.4 | ROI buckets | Classifying the found outcome | Pick exactly ONE primary bucket — stacking inflates pseudo-value |
+| 3.5 | CFO "so what?" test | Universal final check | Read aloud to imagined non-tech stakeholder; iterate until "so what?" stops |
+
+---
+
+### §3.1 — Trace-upward
+
+**When to use it.**
+Trace-upward is the primary lens for changes
+that are structurally invisible to end users:
+dependency bumps, database migrations,
+infrastructure reconfigurations, internal refactors,
+and compiler or toolchain upgrades.
+Nothing in the diff is a feature;
+everything in the diff is a precondition for something that is.
+
+**The mechanic.**
+Begin at the diff itself.
+Ask: "Who consumes the output of this code?"
+Name that consumer and repeat the question.
+Continue until the answer is a person or system
+that is not on the engineering team —
+a customer, a downstream partner, a finance process,
+a regulatory obligation.
+The final non-engineering node in that chain
+is the beneficiary the title must name (Ulwick 2002).
+The path from diff to beneficiary
+is the dependency graph that justifies the work.
+Record it;
+it becomes the evidence behind the claim.
+
+**Example.**
+Naive: "Bump SQLAlchemy from 1.4 to 2.0."
+Lens applied: SQLAlchemy is consumed by the ORM layer →
+the ORM layer powers the checkout API →
+the checkout API is the path to payment capture →
+payment capture is the revenue mechanism for merchants.
+Result: "Enable checkout reliability for merchants
+by migrating ORM to SQLAlchemy 2.0" (Ulwick 2016;
+Christensen et al. 2016b).
+
+**Pitfalls.**
+The canonical trap is stopping at "the developer" —
+concluding that the beneficiary is the team itself
+("enables us to upgrade Python").
+This is the GH-276 pattern:
+the dependency graph terminated prematurely,
+and the real downstream beneficiary was never surfaced.
+A developer is a conduit, not a terminus.
+The graph must exit engineering entirely.
+
+**Source backing.**
+Ulwick (2002) establishes outcome-driven innovation
+as anchored to the job executor, not the implementer.
+Ulwick (2016) and Christensen et al. (2016b)
+reinforce that value claims require a named beneficiary
+outside the value-creation chain itself.
+
+---
+
+### §3.2 — 5 Whys
+
+**When to use it.**
+5 Whys is most effective when the motivation feels self-evident —
+ops hygiene, obvious maintenance,
+or a bug fix where the developer already "knows" the cause.
+Self-evidence is precisely the condition under which root cause
+is most likely to be stated rather than discovered.
+
+**The mechanic.**
+Write the technical action.
+Ask "Why does this matter?" and write the answer.
+Repeat four more times,
+treating each previous answer as the new subject.
+Accept an iteration as complete
+only if the answer names a business state:
+revenue, risk, cost, compliance, or user outcome.
+A technical answer ("because it works," "because it's correct")
+is a sign the chain has not reached the required depth;
+continue drilling (Ohno 1988).
+Five iterations is a forcing function, not a ceiling.
+
+**Example.**
+Naive: "Fix null pointer in session handler."
+Why? Prevents crashes. Why does that matter?
+Users can complete sessions. Why does that matter?
+Sessions are the activation mechanism for paid accounts.
+Why does that matter?
+Activation rate drives first-month retention.
+Result: "Protect first-month retention
+by eliminating null pointer in session handler."
+
+**Pitfalls.**
+The well-documented failure mode is termination on a technical answer —
+"because it works" or "because the test passes"
+(Card 2017; Peerally et al. 2017).
+Ohno's original framing targeted machine stoppages
+with clear causal chains;
+applied to software, causation is often jointly sufficient
+rather than singular (Allspaw 2012),
+and drilling past a legitimate joint cause
+can produce spurious business framing.
+The corrective is Ishikawa's fishbone complement (Ishikawa 1985):
+when multiple causes converge,
+name the dominant path rather than forcing a single trunk.
+Imai (1986) grounds the method's orientation —
+the terminal answer should point toward consumer value,
+tracing back from Toyoda Sakichi's jidoka principle (c. 1900s).
+
+**Source backing.**
+Ohno (1988) for the foundational method.
+Card (2017) and Peerally et al. (2017)
+for the canonical critique of premature termination.
+Allspaw (2012) on jointly-sufficient causation in complex systems.
+
+---
+
+### §3.3 — Mechanism vs Outcome
+
+**When to use it.**
+This lens applies universally.
+Every change has a mechanism — what was done —
+and an outcome — what that enables.
+The lens is not a discovery tool;
+it is a vocabulary tool that prevents the two halves
+from collapsing into each other.
+
+**The mechanic.**
+Write two explicit sentences.
+First: "The mechanism is [X]."
+Second: "The outcome is [Y]."
+For PR titles and commit subjects: lead with Y, suppress X,
+or reduce X to a subordinate phrase.
+For PR bodies and commit descriptions:
+state both, in that order (Klement 2013).
+
+**Example.**
+Naive: "Add lazy-loading to product image component."
+Mechanism: "Lazy-loading is added to product image component."
+Outcome: "Page load time drops below the 2.5-second LCP threshold,
+keeping product pages eligible for Google Shopping impressions."
+Result title: "Protect Shopping impression eligibility
+by lazy-loading product images" (Cohn 2004; Lucassen et al. 2016).
+
+**Pitfalls.**
+The most common failure is a pseudo-business outcome —
+a phrase that sounds like an outcome
+but is actually a redescription of the mechanism
+at a higher abstraction level.
+"Better separation of concerns," "improved modularity,"
+and "cleaner architecture"
+are mechanisms described in architectural vocabulary;
+they are not outcomes (Lucassen et al. 2016).
+An outcome must be falsifiable from outside engineering:
+a stakeholder with no technical background
+must be able to confirm or deny that it occurred.
+
+**Source backing.**
+Klement (2013) on the distinction between process and outcome
+in jobs-to-be-done framing.
+Cohn (2004) on user story structure as outcome-first.
+Lucassen et al. (2016) on quality criteria
+for outcome statements in agile artifacts.
+
+---
+
+### §3.4 — ROI buckets
+
+**When to use it.**
+Once Trace-upward, 5 Whys, or Mechanism vs Outcome
+has surfaced a candidate outcome,
+ROI buckets provide classification scaffolding.
+The lens answers: what *kind* of value is this?
+Classification is not decoration;
+it determines which stakeholder reads the artifact,
+what success metric applies,
+and whether the claim is testable.
+
+**The mechanic.**
+The six-bucket scheme
+— Revenue captured, Cost saved, Retention,
+Time-to-value, Risk avoided, and Platform integrity —
+is not Dev10x-original.
+It tracks the Cranfield benefits taxonomy
+as articulated in Ward & Daniel (2006),
+which grounds benefits realization in empirically-derived categories
+drawn from enterprise IS investment analysis.
+This heritage is load-bearing:
+the bucket list is not arbitrary;
+it reflects decades of portfolio ROI research
+(Kaplan & Norton 1992; Thorp 1998;
+Treacy & Wiersema 1993; Holbrook 1999;
+Reinertsen 2009; Kersten 2018).
+Select exactly ONE primary bucket.
+Write a single sentence that names the bucket-specific metric
+the outcome moves.
+
+**Example.**
+Outcome candidate: "Merchants can retry failed payments."
+Possible buckets: Revenue captured (recovery increases GMV),
+Risk avoided (fewer chargebacks).
+Primary: Revenue captured.
+Result: "Recover declined-payment revenue
+by enabling merchant-initiated retries."
+
+**Pitfalls.**
+Stacking buckets —
+"reduces cost, improves UX, and mitigates risk" —
+inflates apparent value
+while reducing specificity to zero.
+A stakeholder reading a three-bucket claim
+cannot identify the success metric,
+cannot assign ownership,
+and cannot validate the outcome post-deployment.
+When two buckets are genuinely co-primary,
+choose the one that moves the larger metric
+and note the secondary in the body,
+not the title (Reinertsen 2009).
+
+**Source backing.**
+Ward & Daniel (2006) as the primary grounding
+for the non-arbitrariness of the six-bucket scheme.
+Reinertsen (2009) on cost-of-delay
+as the canonical single-dimension framing.
+Kersten (2018) on flow metrics and value stream alignment.
+
+---
+
+### §3.5 — CFO "so what?" test
+
+**When to use it.**
+This lens is the final gate, applied universally,
+after any other lens has produced a candidate title.
+It is not a discovery tool;
+it is a rejection test.
+A title that passes the other four lenses
+but fails this test
+has produced the right insight with the wrong expression.
+
+**The mechanic.**
+Read the candidate title aloud.
+Imagine a non-technical stakeholder —
+the CFO is the canonical proxy,
+not because CFOs are the only audience,
+but because they represent the sharpest version
+of financially-literate, context-free scrutiny.
+If the imagined response is "so what?",
+the title has not reached a business-state claim.
+Revise once.
+If the revised title still draws "so what?",
+return to the upstream lens that generated the outcome
+and drill deeper.
+One or two iterations is the expected pattern;
+more than three indicates
+the outcome has not yet been found (Heath & Heath 2007;
+Sinek 2009).
+
+**Example.**
+Candidate: "Enable OAuth token refresh."
+CFO response: "So what?"
+Revised: "Prevent logged-out users during long sessions."
+CFO response: "So what?"
+Revised: "Protect session continuity
+for high-value checkout flows."
+CFO response: silence.
+Result: accepted (Minto 1987/2002;
+Gawande 2009 on checklist termination conditions).
+
+**Pitfalls.**
+The test is frequently misapplied
+by writing FOR the CFO
+rather than using the CFO as an audience for the *test*.
+A title written in finance vocabulary —
+"Increase ARR retention cohort by reducing involuntary churn" —
+may pass the test but violates the actor-centred voice
+required by the doctrine.
+The CFO is the imagined judge of sufficiency,
+not the named beneficiary in the artifact.
+The artifact's beneficiary
+is always the actor who does the job (Sinek 2009;
+Minto 1987/2002).
+
+**Source backing.**
+Heath & Heath (2007) on the curse of knowledge
+and the practitioner need for external-audience testing.
+Sinek (2009) on the primacy of "why" in stakeholder communication.
+Gawande (2009) on checklist design and termination conditions.
+Minto (1987/2002) Pyramid Principle
+on leading with the answer
+as the foundational practitioner evidence
+for outcome-first expression.
+
+## §4 — Scenario taxonomy: which lens fits which change type
+
+No single lens dominates across all change types.
+The matrix below provides a structured selection guide:
+rows represent change types, columns represent the five lenses
+introduced in §3, and each cell signals whether that lens is
+the primary framing (★), a useful supplement (✓),
+neutral (—), or actively misleading (✗).
+Apply the starred lens or lenses first;
+treat ✓ cells as optional enrichment and ✗ cells as traps.
+
+| Change type | Trace-up | 5 Whys | Mech/Outcome | ROI bucket | CFO test |
+|---|---|---|---|---|---|
+| New customer feature | ✓ shallow | ✓ | ★ universal | ★ Revenue/Retention | ★ |
+| Bug fix breaking business activity | ✓ | ★ consequence chain | ★ | ★ Cost/Risk | ★ |
+| Plumbing (refactor, dep bump) | ★ dominant | ✓ | ★ | ★ Time-to-value | ★ |
+| Operational hygiene (rotation, refresh) | ✗ dead-ends | ★ | — | ★ Platform integrity | ★ + canonical bucket |
+| Regulatory-forced | — | ★ | ✓ | ★ Risk + Revenue | ★ |
+| Performance / reliability | ✓ | ✓ | ★ | ★ Time-to-value/Retention | ★ |
+| Internal tooling shipping operator value | ✗ engineer IS the actor | ✓ | ★ | ★ Cost/Retention | ★ |
+| Pure tech-debt paydown (no downstream feature) | ✗ no actor | ✓ | ✓ | — | ✗ fails — bundle or hold |
+
+Two rows show Trace-upward rated ✗: *Operational hygiene* and
+*Pure tech-debt paydown*.
+This failure is intentional diagnostic signal, not a gap in the framework.
+When the trace-up chain terminates without reaching a business actor
+or outcome, it means one of two things:
+the change belongs to canonical platform overhead — a standing cost
+that needs no per-PR justification (addressed in §5) —
+or it lacks sufficient downstream effect to justify an isolated commit,
+triggering the bundle-or-hold rule discussed in §7.
+A PR that cannot survive a trace-up attempt and cannot be assigned
+to a platform overhead bucket should not ship as a standalone change;
+the cost of the cognitive overhead it imposes on reviewers
+exceeds the value of the diff.
+
+The *Internal tooling shipping operator value* row presents a
+superficially similar problem: the engineer is the actor,
+so tracing "up" from engineer to business stakeholder loops back
+to the same role.
+This is not a dead-end — it is a legitimate actor boundary.
+When internal operators are the customers,
+the Mechanism/Outcome and ROI-bucket lenses (Cost/Retention)
+supply the needed framing without requiring an external stakeholder.
+Section §6 demonstrates this pattern in full through worked examples
+D1 and D2, showing how operator-facing changes achieve CFO-test
+compliance without a trace-up chain.
+
+The CFO test column carries ★ on every row without exception.
+This uniformity is the section's central claim:
+regardless of change type, every PR title and commit message
+must survive a CFO reading them cold and being able to answer
+"what business outcome does this protect or advance?"
+The other lenses vary by context;
+the CFO test is the invariant constraint that anchors all of them.
+
+## §5 — Platform overhead: the YAGNI inversion
+
+### Move 1 — Name the trap
+
+Every engineering team accumulates a class of work that resists
+ROI articulation on first glance.
+The rotation is due.
+The cert expires.
+The dependency has a CVE.
+These are real obligations, and the team knows it.
+But the moment a team internalises that certain work *just needs doing*,
+it creates a gravitational well:
+tasks that are difficult to explain get pulled toward the same label.
+
+The label is "platform overhead."
+
+Used precisely, it names a narrow and legitimate category.
+Used as a default, it names everything the author did not want to justify.
+The mechanism is not malice — it is the path of least resistance.
+When ROI articulation requires effort and the audience is not present
+to push back, the cost of writing "platform overhead" is zero.
+Parkinson (1957) documented the same dynamic in committee governance:
+discussion time is inversely proportional to the cost of the item
+because complex decisions intimidate while trivial ones invite
+participation.
+The Law of Triviality predicts exactly what happens to the
+"platform overhead" bucket under minimal scrutiny:
+it grows, because adding an entry is easier than questioning one.
+
+Graeber (2018) extends the analysis from committees to organisations at
+scale.
+"Box-ticking" work — effort whose primary output is evidence that the
+effort was performed — justifies itself through process compliance
+rather than business outcome.
+The box is ticked, the overhead is logged, the PR is merged.
+No one is lying.
+Everyone is performing a ritual whose founding rationale has been
+forgotten or was never written down.
+
+This is the YAGNI inversion.
+The original YAGNI principle — You Ain't Gonna Need It — demands
+justification before addition.
+Its inversion, which has no name in the literature but is everywhere
+in practice, demands justification only for *removal*.
+The default assumption shifts:
+*we must need it, because we always do it.*
+As §1 frames it in the user's own words, the team does not question
+the practice;
+it assumes "there is a good reason for it but I am not privy to it,
+the others must know why."
+The muscle of asking "but why?" atrophies.
+Bureaucracy creeps in not through any single bad decision
+but through the accumulated weight of unjustified continuation.
+
+The cost is not merely philosophical.
+Drucker (1963) identified the failure mode precisely:
+it is possible to do efficiently what should not be done at all.
+Fowler (2003) translates this to software:
+work performed without a rationale is inadvertent technical debt —
+not the deliberate borrowing against future delivery,
+but the slow accumulation of obligation that was never consciously chosen.
+
+### Move 2 — State the doctrine
+
+Platform overhead is a legitimate ROI bucket.
+It is not a fiction or a bureaucratic excuse for every team that uses it
+with precision.
+But it is the **narrowest** bucket in the taxonomy,
+not the default.
+
+The doctrine is this:
+every canonical platform overhead entry is pre-justified,
+named, and rationale-carrying.
+The team agrees, in advance and in writing,
+on a finite list of entry types — each with a one-line canonical
+rationale that any team member can recite from memory.
+The entry exists *because* the team has reasoned through it,
+not because the work arrived and the author needed a category.
+
+The bucket list is curated and versioned.
+"We've always done it" is not an entry.
+"Someone told me this is important" is not an entry.
+An entry requires a named, durable business rationale —
+the kind that would survive a CFO asking "so what happens if we stop?"
+
+Womack & Jones (1996) name this the first principle of Lean:
+value must be specified from the customer's perspective.
+Platform integrity is a customer-perspective value —
+but only when the entry spells out *which* customer risk is being
+managed and *what* it costs to leave that risk unmanaged.
+Without that specification, the entry is not Lean — it is waste
+wearing the uniform of process.
+
+### Move 3 — Provide the hard edge
+
+Invoking the platform overhead exception requires two things,
+both non-negotiable.
+
+First, the author must match the work to a **specific canonical entry by
+name**.
+Not the bucket category, not a paraphrase — the exact name as it
+appears in the canonical table below.
+
+Second, the author must be able to recite that entry's canonical
+one-line rationale **from memory or by direct paste from this section**.
+Recitation distinguishes understanding from pattern-matching.
+A team member who has internalised why secret rotation exists will
+not rotate tokens on the wrong cadence or skip the rotation when
+the scheduled date is inconvenient.
+A team member who has memorised the label but not the rationale will.
+
+Adding a new canonical entry is not a unilateral act.
+It requires a team-wide ADR documenting:
+the business obligation the entry names,
+the downstream harm if the entry is not performed,
+the recurrence logic (what triggers the work),
+and — critically — **cessation criteria**: the condition under which
+this entry is retired from the canonical list.
+Cessation criteria prevent the canonical list from becoming a black hole
+for work that once had a rationale but has outlived it.
+A compliance control relevant to a former regulatory framework,
+a certificate rotation that was made obsolete by an automated platform —
+these must be removable.
+Without a cessation criterion, the canonical list becomes the same
+bureaucracy it was designed to prevent.
+
+Taguchi (1986) frames every ambiguity as a continuous cost — a loss
+function, not a binary pass/fail.
+Every canonical entry that cannot survive the recitation test is a
+running loss on team attention and delivery throughput.
+Shingo (1981/1989) would say the defect must be surfaced before it
+passes to the next stage of work:
+the recitation requirement is the poka-yoke for the overhead bucket.
+
+---
+
+The following table represents the initial canonical entries.
+It is expected to evolve.
+Additions require ADR and cessation criteria.
+Deletions require evidence that the underlying obligation has been
+retired or automated away.
+
+| Bucket | One-line canonical rationale | Recurrence |
+|--------|------------------------------|------------|
+| Release version bumps | Versioned releases let downstream consumers pin to known-good combinations and roll back deterministically; without versioning, every consumer becomes a regression-test target. | Per release |
+| Security cert / secret rotation | Periodic rotation ensures undetected credential compromise cannot persist beyond the rotation window, maintaining PCI / SOC2 / customer-trust posture. | Quarterly / per policy |
+| Scheduled dependency security refresh | Tracking upstream CVEs and applying patches within published SLA windows prevents known vulnerabilities from being exploited. | Monthly / per CVE |
+| Database backup / restore rehearsals | Backups are worthless without provable restore capability; periodic rehearsal converts "we have backups" into "we have recovery." | Quarterly |
+| Compliance audit-log evidence collection | External auditors require periodic evidence packs (SOC2, ISO 27001, GDPR Art 30 ROPA) that demand a recurring effort cycle; collecting on-demand is more costly than scheduling. | Per audit cycle |
+| License / certificate renewals | Software licences and TLS certificates have hard expiry dates that, if missed, cause customer-facing outages; renewal is risk-avoided cost. | Per expiry calendar |
+
+---
+
+**Borderline cases and entries that do not qualify alone.**
+Field-rename migrations, refactors, and dependency bumps
+*without a downstream feature pending* do not qualify as
+canonical platform overhead entries.
+They share the surface form — recurring, unglamorous, necessary-seeming —
+but they fail the test:
+no entry in the table covers them, and they cannot invoke the exception.
+
+These cases push back to the default rule:
+name the downstream outcome, or do not ship alone.
+This is the bundle-or-hold principle developed in §7:
+a refactor with no named downstream feature either waits until the
+feature ships and travels with it, or it earns its own explicit
+outcome rationale before merging solo.
+The burden of proof does not disappear because the work is mechanical
+or because the author is confident it is worthwhile.
+
+**Why this matters for the broader doctrine.**
+The canonical-bucket mechanism is not punitive.
+It is the safety valve that makes the default rule workable.
+Without it, the rule "every artifact owes a ROI rationale" generates
+a class of pseudo-Job-Stories for genuinely recurring obligations —
+stories that strain to name a business actor for work that has no
+meaningful actor other than the team's own operational hygiene.
+With the mechanism in place, those cases have a clean exit:
+match the entry, recite the rationale, and the obligation is satisfied.
+The recitation requirement keeps the exit honest.
+
+---
+
+The §8 reflection tool operationalises an annual review of every
+canonical-bucket entry.
+If a bucket cannot survive its own annual review — if the team cannot
+answer "what would break, and for whom?" — it is a candidate for
+retirement or restructure.
+The annual review is the cessation-criteria check made routine.
+
+## §6 — Worked examples
+
+Eight worked examples follow, organised into the four scenario categories
+introduced in §4: **A1–A2** (revenue baseline — a customer feature and a
+bug fix that breaks a business activity), **B1–B2** (plumbing — the GH-276
+headline dep-bump case and Example 5 from the existing `jtbd` skill redone
+correctly), **C1–C2** (operational hygiene with the canonical-bucket safety
+valve, and regulatory-forced work that still earns a real beneficiary
+story), **D1–D2** (legitimate engineer-as-actor cases that still trace
+upward to org-level outcomes).
+
+Each example follows the same uniform format: scenario context, naïve
+draft, lens-by-lens application, best-fit lens identified, final drafts
+(PR title + Job Story + commit message), and a "why this wins" contrast
+paragraph. The examples are intentionally generic-business — no specific
+tenant, customer, or product names appear, per the issue 276 acceptance
+criterion that examples stay generic.
+
+After the eight examples, a coverage table verifies that every ROI bucket
+from §3.4 lands in at least one worked example.
+
+### A1. New customer feature — ACH payment method
+
+**Scenario.**
+An e-commerce SaaS allows merchants to record how a customer paid at point of sale.
+Enterprise customers routinely pay by ACH bank transfer, but the application's
+`PaymentMethod` enum offers no ACH option — those transactions land under "Other,"
+breaking bank reconciliation.
+Sub-ticket FEAT-401 closes this gap; the parent ticket (FEAT-398) records the
+immediate business pressure: enterprise clients have been requesting the option
+for two quarters and some accounts have stalled at procurement because of it.
+
+**Naïve draft.**
+```
+Add ACH to PaymentMethod enum
+```
+
+**Lens application:**
+
+- **Trace-upward**: The diff adds one enum value and one UI dropdown item — a
+  trivially small change.
+  Tracing outward: the new option reaches the cashier's screen → the cashier
+  classifies the payment correctly → the merchant's reconciliation report stops
+  grouping ACH receipts under "Other" → the accounting team closes month-end
+  without manual adjustments → enterprise procurement reviewers see a complete
+  payment method story → the sales pipeline unblocks.
+  The naïve draft stops at the first link; tracing to the sixth reveals the
+  actual value.
+
+- **5 Whys**: Why add the enum value?
+  Enterprise customers request it.
+  Why does that matter?
+  Their accounts-payable processes only authorise ACH; card payments are not an
+  option.
+  Why does authorisation matter?
+  Without ACH, they will not sign.
+  Why does signing matter?
+  Enterprise contracts run multi-year and represent the highest lifetime value
+  cohort.
+  Why does LTV matter?
+  The business depends on recurring revenue, and the Q3 pipeline is stalled on
+  this gap.
+
+- **Mechanism vs Outcome**: The mechanism is a new enum constant and a matching
+  dropdown option — two lines of code.
+  The outcome is accurate ACH reconciliation for enterprise merchants and an
+  unblocked enterprise sales pipeline.
+  The naïve draft names only the mechanism; the outcome is invisible to any
+  reviewer who did not read the parent ticket.
+
+- **ROI buckets**: The primary bucket is **Revenue captured** — enterprise deals
+  that were stalling at the "no ACH" objection can now proceed.
+  A secondary bucket is **Cost saved** — merchants were manually reclassifying
+  "Other" transactions during reconciliation; that labour disappears.
+  Stacking both in the title would dilute the message; the revenue bucket
+  dominates and should lead.
+
+- **CFO "so what?" test**: Hearing "Add ACH to PaymentMethod enum," a CFO
+  asks, "So what? We add fields all the time."
+  Hearing "Enable enterprise ACH payment reconciliation," the same CFO responds:
+  "Good — that's been sitting on the enterprise pipeline review since Q2."
+  The revised framing connects the change to a named business consequence without
+  requiring the audience to read the ticket.
+
+**Best-fit lens:**
+Trace-upward dominates here because the diff itself is mechanically trivial —
+there is no dramatic consequence chain to drill through with 5 Whys, and the
+ROI bucket (revenue) is already visible once the dependency graph is walked one
+level at a time.
+Trace-upward is the shortest path from "one enum value" to "enterprise pipeline
+unblocked," and that path is the entire argument for shipping the change.
+
+**Final drafts:**
+
+- **PR title**: `✨ FEAT-401 Enable enterprise ACH payment reconciliation`
+- **Job Story**: "**When** a merchant processes an ACH bank transfer for an
+  order, **the cashier wants to** select 'ACH' as the payment method,
+  **so the merchant can** accurately reconcile bank transfer transactions
+  instead of grouping them under 'Other'."
+- **Commit**: `✨ FEAT-401 Enable enterprise ACH payment reconciliation`
+
+**Why this wins.**
+The naïve draft is technically accurate — it names the class and the operation —
+but it gives a reviewer no reason to approve the change faster than any other
+enum addition.
+The final title names the beneficiary (enterprise merchants), the activity
+(reconciliation), and the implicit consequence (deals stop stalling), which
+means any product stakeholder reading the PR list can classify it correctly
+without opening the ticket.
+The Job Story makes the cashier the named actor, keeping the story grounded in
+observable behaviour rather than abstract "enterprise needs."
+
+---
+
+### A2. Bug fix — month-end payroll calculation timeout
+
+**Scenario.**
+A payroll SaaS runs `PayrollCalculator.summarise_deductions()` for every
+employee during a batch close.
+Under normal load the calculation completes in approximately four seconds;
+during month-end closing, when the batch size triples, it exceeds the
+sixty-second query timeout.
+The finance team is paged at 2 a.m., the batch fails, and employees are not
+paid on time.
+BUG-500 traces the root cause to an N+1 query inside `summarise_deductions()`;
+the fix is a single `prefetch_related` call.
+
+**Naïve draft.**
+```
+Fix N+1 query in PayrollCalculator
+```
+
+**Lens application:**
+
+- **Trace-upward**: The diff is one line — a `prefetch_related` annotation.
+  Tracing outward: the query is optimised → the calculation completes within the
+  timeout window → the batch closes on schedule → employees are paid on time →
+  the finance team is not paged at 2 a.m.
+  Trace-upward surfaces the consequence chain, but the chain is long enough that
+  5 Whys does the same work more systematically — the consequence at the end of
+  the chain (2 a.m. page, potential labour-law liability) is far removed from the
+  technical cause.
+
+- **5 Whys**: Why fix the N+1 query?
+  The calculation times out during month-end closing.
+  Why does a timeout matter?
+  The payroll batch fails.
+  Why does batch failure matter?
+  Employees are not paid by their scheduled pay date.
+  Why does a missed pay date matter?
+  The finance team is paged in the middle of the night and the company risks
+  labour-law non-compliance.
+  Why does that risk matter?
+  Regulatory fines, employee trust erosion, and potential class-action liability
+  for a payroll provider.
+  The 5 Whys chain terminates on a risk-and-retention answer that the naïve
+  draft buries completely.
+
+- **Mechanism vs Outcome**: The mechanism is `prefetch_related('deductions__category')` —
+  a Django query optimisation.
+  The outcome is predictable, on-time month-end payroll completion.
+  These are not the same claim; the mechanism is opaque to any stakeholder who
+  does not know what N+1 means, while the outcome is immediately legible to the
+  finance team that gets paged.
+
+- **ROI buckets**: The primary bucket is **Risk avoided** — late payment
+  exposure and regulatory liability are the most severe consequences.
+  Secondary buckets are **Cost saved** (on-call hours eliminated) and
+  **Retention** (finance team confidence in the platform is restored).
+  The risk bucket should lead in the title because it names the event that
+  triggered the ticket — the 2 a.m. page and its downstream consequences.
+
+- **CFO "so what?" test**: Hearing "Fix N+1 query in PayrollCalculator," a
+  CFO asks, "What is an N+1 query, and why is this urgent?"
+  Hearing "Stop month-end payroll calculation from timing out," the same CFO
+  responds: "Yes — fix that before the next month-end close."
+  The revised title communicates urgency and business context without requiring
+  the audience to understand database query patterns.
+
+**Best-fit lens:**
+5 Whys dominates here because the gap between the technical cause (one
+inefficient query) and the business consequence (regulatory exposure, employee
+payment failure) is large enough that a simple trace-upward pass risks
+stopping too early — at "the calculation is faster," which is still
+mechanism-speak.
+5 Whys forces five explicit iterations, and the business answer only appears
+at iteration four or five; the discipline of the drill is what makes the
+consequence visible.
+
+**Final drafts:**
+
+- **PR title**: `🐛 BUG-500 Stop month-end payroll calculation from timing out`
+- **Job Story**: "**When** running payroll during month-end closing,
+  **the payroll manager wants** the calculation to complete reliably,
+  **so the finance team can** avoid missed pay dates and 2 a.m. pages."
+- **Commit**: `🐛 BUG-500 Stop month-end payroll calculation from timing out`
+
+**Why this wins.**
+The naïve draft is comprehensible to an engineer reviewing the implementation
+but invisible to every other stakeholder deciding whether to prioritise the
+fix.
+The final title names the event (month-end closing), the failure mode (timing
+out), and implicitly names the consequence (the finance team knows exactly what
+a timeout during closing means).
+The Job Story adds the payroll manager as the named actor, grounding the
+abstract timeout event in a human experience — which is precisely the
+information a product manager needs to communicate urgency to engineering
+leadership.
+
+---
+
+### B1. Dependency Bump: ULID Enables Atomic-Save
+
+**Scenario.**
+A multi-tenant SaaS configurator lets customers manage their own form templates
+through row-level CRUD GraphQL mutations — one row saved at a time.
+The architecture roadmap collapses that surface into a single atomic-document
+mutation, requiring client-side ID generation as a prerequisite.
+CFG-823 tracks adoption of ULIDs to satisfy that prerequisite.
+
+**Naïve draft.**
+
+```
+Bump python-ulid to 2.1.0
+```
+
+Job Story: "**When** implementing atomic save, **the developer wants to**
+use sortable client-side IDs, **so they can** avoid coordination overhead."
+
+This naïve draft is the GH-276 headline anti-pattern verbatim:
+the actor is the developer, the benefit is an implementation convenience,
+and the business chain is severed at the first link.
+
+**Lens application:**
+
+- **Trace-upward**: A ULID dep bump enables client-side ID generation,
+  which enables an atomic-save mutation,
+  which makes the configurator UI usable enough for end customers to self-serve —
+  collapsing support hours and enabling same-day config rollout.
+- **5 Whys**: Why ULID? Sortable client IDs. Why those? Atomic save requires
+  client-generated IDs. Why atomic save? Config edits land in one transaction.
+  Why does that matter? Same-day rollout and no half-saved templates.
+  Why does *that* matter? Customers stop opening support tickets; vendors stop
+  absorbing the labour cost.
+- **Mechanism vs Outcome**: The mechanism is a library upgrade.
+  The outcome is end-customer self-service configuration with same-day deployment.
+  The two are four causal steps apart.
+- **ROI buckets**: Primary bucket is Cost saved — support hours eliminated when
+  customers no longer need vendor assistance for routine config edits.
+  Secondary is Time-to-value — same-day config rollout vs. next-sprint vendor
+  deployment. Tertiary is Retention — customers who can act on time-sensitive
+  promotions without filing a ticket are less likely to churn.
+- **CFO "so what?" test**: "Bump ulid" produces a blank stare.
+  "First step toward end-customer self-service configuration" produces a
+  follow-up question about the timeline — the CFO is now engaged with the
+  business case, not the library version number.
+
+**Best-fit lens:**
+Trace-upward dominates here because the diff is a dependency bump sitting four
+causal layers below the actor who realises the value.
+No amount of 5 Whys or mechanism-framing shortcuts that distance;
+the author must literally walk the chain to surface the correct actor and
+beneficiary.
+This is the defining characteristic of the GH-276 headline case: when the
+diff is infrastructure groundwork, only tracing upward finds the business edge.
+
+**Final drafts:**
+
+- **PR title**: `📦 CFG-823 Enable end-customer self-service configuration (atomic-save groundwork)`
+- **Job Story**: "**When** an end customer reconfigures their template —
+  adding a new option, repricing an item, or renaming a field —
+  **the end customer wants to** save the whole document in one atomic action
+  and see it live immediately,
+  **so the vendor can** stop absorbing support hours on customer-driven
+  configuration edits and customers can roll out changes same-day."
+- **Commit**: `📦 CFG-823 Adopt ULID for client-side ID generation (enables atomic-save)`
+
+**Why this wins.**
+The naïve draft installs the developer as the actor and frames the benefit as
+an implementation convenience — a pattern that is not merely imprecise but
+actively misleading, because it trains reviewers and managers to assess the
+change on technical merit alone, stripped of its business justification.
+The trace-upward framing restores the correct actor (end customer), the
+correct beneficiary (vendor recouping support labour), and the correct value
+horizon (same-day config rollout).
+A PR title and Job Story written this way survive the CFO test, survive the
+sprint-review slide, and anchor future refactors to the same business outcome —
+the dep bump becomes evidence in a financial argument, not a footnote in a
+changelog.
+
+---
+
+### B2. Refactor: Extract Notification Dispatch
+
+**Scenario.**
+A SaaS billing platform sends order-confirmation emails through a bespoke
+sender tangled into the order flow.
+The roadmap adds SMS billing reminders to shorten days-sales-outstanding;
+FEAT-230 (child of FEAT-225 "Multi-channel billing reminders to reduce DSO")
+extracts the email sender into a shared outbox module so the SMS channel can
+plug in cleanly in a later PR.
+No user-visible behaviour changes in this diff.
+
+**Naïve draft.**
+
+```
+Extract notification sender to shared infrastructure
+```
+
+Job Story: "**When** implementing SMS billing notifications,
+**the developer wants to** reuse the existing notification infrastructure,
+**so they can** add SMS without rebuilding retry and scheduling logic."
+
+This naïve draft is the existing `jtbd` SKILL.md Example 5 verbatim —
+the very anti-pattern this memo is designed to replace.
+The actor is the developer, the benefit is avoided rework,
+and the business chain is again severed at the implementation layer.
+
+**Lens application:**
+
+- **Trace-upward**: The refactor produces a shared outbox, which makes the
+  SMS channel pluggable, which lets billing admins reach customers through
+  the channel they actually monitor, which shortens days-sales-outstanding,
+  which improves vendor cashflow.
+- **5 Whys**: Why extract? To enable SMS. Why SMS? Email reminders go unread.
+  Why does that matter? Late payments accumulate. Why does late payment matter?
+  Cashflow and operating leverage. Why does *that* matter? The business carries
+  unnecessary receivables risk on every billing cycle.
+- **Mechanism vs Outcome**: The mechanism is code extraction.
+  The outcome is SMS billing reminders becoming deliverable — reducing DSO and
+  the collections labour attached to it.
+  The refactor is invisible to every actor except the engineer who merges the
+  next PR.
+- **ROI buckets**: Primary bucket is Revenue captured — faster invoice settlement
+  accelerates cash inflow. Secondary is Cost saved — fewer manual collections
+  calls when reminders land on the channel customers check.
+  Tertiary is Retention — customers who receive timely reminders and settle
+  before late fees accrue report higher satisfaction than those who receive
+  escalation emails.
+- **CFO "so what?" test**: "Refactor notification infra" causes the CFO to
+  defer to engineering judgement — the business case is invisible.
+  "Groundwork for SMS billing reminders (shorten DSO)" gives the CFO a metric
+  to track and a timeline to ask about.
+
+**Best-fit lens:**
+Trace-upward is again the dominant lens because the diff ships zero
+user-visible change.
+Mechanism-vs-outcome framing alone is insufficient — it names the outcome
+(SMS possible) but does not surface the actor or the financial stake.
+Only walking the chain from refactor to outbox to channel to admin to customer
+to DSO to cashflow reveals the correct Job Story protagonist and the ROI
+bucket that justifies prioritising this PR over other work.
+
+**Final drafts:**
+
+- **PR title**: `♻️ FEAT-230 Enable multi-channel billing reminders (DSO reduction groundwork)`
+- **Job Story**: "**When** a customer has an unpaid invoice nearing its due date,
+  **the billing admin wants to** reach the customer through whichever channel
+  they actually monitor — email, SMS, or push —
+  **so the vendor can** shorten days-sales-outstanding and customers can
+  settle invoices before late fees apply."
+- **Commit**: `♻️ FEAT-230 Extract notification dispatch to shared outbox (multi-channel groundwork)`
+
+**Why this wins.**
+The naïve draft, which currently lives in the project's own JTBD skill as a
+positive example, frames developer convenience as the terminal benefit —
+a framing that would pass muster in a technical retro but fails every
+business-value test.
+The trace-upward draft reinstates the billing admin as actor, names DSO
+reduction as the financial outcome, and positions the refactor as the first
+evidence point in a multi-PR business case rather than an isolated
+housekeeping task.
+When this PR title appears in a sprint review, a stakeholder can connect it
+to the DSO metric on the OKR dashboard; when it appears in a postmortem, an
+analyst can attribute the cashflow improvement to the correct initiative —
+neither outcome is possible when the title describes only what the engineer did.
+
+---
+
+### C1. Periodic Secret Rotation — Platform Overhead With No Job Story
+
+**Scenario.**
+The payments service authenticates with a third-party processor using an OAuth token stored in the secrets vault.
+Security policy mandates 90-day rotation; the Q3 cycle is due.
+No user-visible behavior changes.
+The ticket exists solely to close the rotation window before the quarter ends.
+
+**Naïve draft.**
+
+```
+Rotate Square OAuth token
+```
+
+**Lens application:**
+
+- **Trace-upward**: Rotation → vault entry changes → rolling restart of the payments service → no customer-visible effect.
+  The chain terminates without reaching a human beneficiary.
+  This dead-end is the diagnostic signal: when trace-upward produces no actor, consult the canonical platform overhead bucket list before forcing a Job Story.
+
+- **5 Whys**: Why rotate? Security policy says 90 days.
+  Why 90 days? A compromised token that persists undetected grows in blast radius over time.
+  Why does blast radius matter? Undetected card-data exposure triggers a SOC 2 CC6.1 finding and a PCI DSS Req 8 violation, which suspends payment processing.
+
+- **Mechanism vs. Outcome**: The mechanism is a new credential written to the vault and a rolling restart.
+  The outcome is continued PCI/SOC 2 compliance posture — not an improvement, simply the absence of a degradation.
+  There is no positive user experience to describe.
+
+- **ROI buckets**: Risk avoided (undetected token compromise, regulatory breach) and Platform integrity (scheduled credential hygiene).
+  The canonical bucket label is "Security cert / secret rotation."
+  Revenue and efficiency buckets do not apply.
+
+- **CFO "so what?" test**: "Rotate token" → CFO asks "is something wrong?"
+  The answer is: no incident — this is the Q3 scheduled cycle per the security-cert/secret-rotation canonical bucket.
+  CFO is satisfied; no further narrative is owed.
+
+**Best-fit lens.**
+The dominant lens is the canonical platform overhead bucket, not any of the five analytical lenses.
+When trace-upward dead-ends and the ROI bucket is "Risk avoided / Platform integrity" with no user beneficiary, the correct move is to name the canonical bucket explicitly in the PR body rather than construct a Job Story.
+The canonical recitation replaces the Job Story as the required rationale.
+
+**Final drafts:**
+
+- **PR title**: `🔒 OPS-RT-Q3 Rotate Square OAuth token (scheduled credential rotation, Q3 cycle)`
+- **Job Story**: **Intentionally NONE — this is canonical platform overhead per §5.
+  PR body recites the bucket:** *"Rotated per the Security cert / secret rotation canonical bucket.
+  Quarterly cycle ensures undetected token compromise cannot persist beyond 90 days, maintaining PCI DSS Req 8 and SOC 2 CC6.1 compliance."*
+- **Commit**: `🔒 OPS-RT-Q3 Rotate Square OAuth token (Q3 scheduled cycle)`
+
+**Why this wins.**
+The canonical-bucket mechanism is the doctrine's safety valve.
+Without it, the rule "every artifact owes a ROI rationale" forces authors to produce pseudo-Job-Stories on routine maintenance — an over-correction that erodes trust in every artifact that follows.
+With it, the recited bucket supplies the rationale honestly, and the absence of a Job Story signals exactly what it should: this work keeps the platform sound; no human experience changes.
+
+---
+
+### C2. Regulatory-Forced Retention Change — Compliance Work With a Real Beneficiary
+
+**Scenario.**
+An EU GDPR audit finds that the platform retains audit logs for 30 days.
+Legal determines that GDPR Art 30 ROPA requires a minimum of 13 months for the record-of-processing-activities obligation.
+The Postgres TTL on the `audit_log` table is updated from 30 to 395 days.
+Three EU enterprise procurement reviews have been stalled on this exact gap.
+
+**Naïve draft.**
+
+```
+Update audit log retention to 13 months
+```
+
+**Lens application:**
+
+- **Trace-upward**: The immediate actor is the engineering team responding to an audit finding.
+  The first person outside engineering is the customer's compliance officer, whose procurement checklist now passes.
+  Trace-upward does not dead-end here — it surfaces a concrete external human whose work is unblocked.
+
+- **5 Whys**: Why change retention? An audit found a GDPR gap.
+  Why does the gap matter? EU enterprise customers' procurement teams require GDPR compliance proof before approving the platform for production data.
+  Why? Their own regulators audit them, making a non-compliant vendor a liability they cannot accept.
+
+- **Mechanism vs. Outcome**: The mechanism is a TTL change in one Postgres table.
+  The outcome is dual: GDPR Art 30 compliance posture is restored, and three EU enterprise procurement reviews are unblocked.
+  The TTL change is invisible; the unblocked deals are not.
+
+- **ROI buckets**: Risk avoided (regulatory fine, audit failure) and Revenue captured (EU enterprise pipeline unblocked).
+  A Retention argument also applies: existing EU customers' compliance officers require this to keep the platform approved in their vendor registry.
+  All three buckets are honest — none is forced.
+
+- **CFO "so what?" test**: "Update retention" → "audit-driven?" → "Yes — GDPR Art 30 ROPA; this closes the gap blocking three EU enterprise procurement reviews."
+  The CFO leans in.
+  The framing is not invented; the blocked deals are a stated business fact.
+
+**Best-fit lens.**
+The ROI buckets lens dominates because both risk and revenue apply simultaneously and neither is a stretch.
+The 5 Whys confirms the revenue framing is honest — the customer's compliance officer is a real actor whose procurement decision is causally connected to this change.
+Trace-upward names that actor precisely, which is what separates the final Job Story from a pseudo-story.
+
+**Final drafts:**
+
+- **PR title**: `🔒 COMP-415 Enable GDPR-compliant audit retention (unblock EU procurement)`
+- **Job Story**: "**When** an EU enterprise customer's procurement team audits our compliance posture,
+  **the customer's compliance officer wants to** see audit logs retained for the regulatory minimum (13 months under GDPR Art 30 ROPA),
+  **so the customer can** approve our platform for production data and we can close EU enterprise deals."
+- **Commit**: `🔒 COMP-415 Extend audit_log retention to 13 months (GDPR Art 30 ROPA)`
+
+**Why this wins.**
+The actor is the customer's compliance officer — not "our engineer responding to a regulator ticket."
+That distinction is not cosmetic: it forces the author to locate the real human whose work changes and to state the causal chain honestly (compliance approval → procurement unblocked → revenue).
+Regulatory-forced work almost always has a downstream human beneficiary; the doctrine's insistence on naming that actor is what prevents compliance tickets from collapsing into joyless mechanism descriptions.
+
+---
+
+### D1. On-call dashboard: surfacing deploy state
+
+**Scenario.**
+An internal tooling team adds a widget to an on-call dashboard
+showing deploy state across regions, the last five deploys,
+deploying user, and success/failure status.
+The change is purely operator-facing — no customer-visible surface
+is modified.
+Ticket OPS-200.
+
+**Naïve draft.**
+
+```
+Add deploy state widget to oncall dashboard
+```
+
+**Lens application:**
+
+- **Trace-upward**: Widget → on-call sees region deploy state at a
+  glance → MTTR drops → customer-facing services are restored
+  faster → SLA penalties are avoided and revenue is protected
+  during incidents.
+  The trace stops at the on-call engineer because the on-call
+  engineer *is* the user — but the beneficiary chain past them
+  (customer SLA compliance, revenue continuity) must still be
+  named explicitly.
+- **5 Whys**: Why build the widget? On-call engineers grep CI logs
+  to reconstruct deploy state manually.
+  Why does that cost matter? Investigation time lengthens,
+  incident duration grows.
+  Why does incident duration matter? Customer impact accumulates,
+  SLA thresholds are breached, and incident cost compounds per
+  minute.
+- **Mechanism vs Outcome**: Mechanism is a React component pulling
+  from the deploy API.
+  Outcome is reduced mean time to restore (MTTR) for on-call
+  engineers, which contracts customer-facing downtime windows.
+- **ROI buckets**: Cost saved (on-call investigation hours
+  recaptured) + Risk avoided (extended incident impact and SLA
+  penalty exposure) + Retention (customer trust preserved under
+  incident conditions).
+- **CFO "so what?" test**: "Add widget" prompts "what does that
+  mean?"
+  "Cut on-call MTTR by giving the on-call team instant deploy
+  visibility across regions" prompts "MTTR is a board-level
+  incident metric — how much exposure does this cover?"
+  The conversation can now be quantified.
+
+**Best-fit lens.**
+Trace-upward, with an important legitimacy caveat.
+In B1 and B2, the engineer appears as actor despite the real
+beneficiary being elsewhere; that substitution obscures the
+outcome.
+Here the on-call engineer *is* the direct user of the artifact —
+the dashboard ships operator value as the change itself.
+Trace-upward still applies because the justification is not
+"the engineer did a thing" but "this reduces MTTR, which protects
+customer SLA commitments."
+
+**Final drafts:**
+
+- **PR title**: `✨ OPS-200 Enable instant deploy-state visibility for on-call team`
+- **Job Story**: "**When** the on-call engineer is investigating a
+  customer-facing incident, **the on-call engineer wants to** see
+  current deploy state across regions at a glance, **so the
+  on-call engineer can** reduce MTTR and limit customer impact
+  during incidents."
+- **Commit**: `✨ OPS-200 Surface deploy state on on-call dashboard (MTTR reduction)`
+
+**Why this wins.**
+Unlike B1 and B2, the engineer-as-actor is not a shortcut around
+naming the end beneficiary — the on-call engineer genuinely is the
+user of this artifact.
+But the Job Story still names the downstream chain (customer
+impact, MTTR, SLA) because "engineer used a tool" is never the
+full story: the instrument must justify itself through what it
+protects or enables further down the value chain.
+The phrase "MTTR reduction" in the commit title converts an
+opaque infrastructure action into a measurable operational outcome
+any stakeholder can audit.
+
+---
+
+### D2. CI pipeline parallelisation: cutting PR-to-merge from 12 to 4 minutes
+
+**Scenario.**
+The infrastructure team parallelises test suites across additional
+CI runners.
+Average PR-to-merge wall-clock time drops from 12 minutes to
+4 minutes.
+The change is internal — no customer-visible feature ships — but
+the throughput gain propagates to every subsequent delivery.
+Ticket INFRA-89.
+
+**Naïve draft.**
+
+```
+Parallelize CI test suites
+```
+
+**Lens application:**
+
+- **Trace-upward**: CI speedup → faster review cycle → more
+  PRs merged per day → features land sooner → customer-visible
+  improvements arrive earlier → competitive position and revenue
+  velocity both improve.
+  The developer is legitimately the direct beneficiary of the
+  faster loop, but the chain does not terminate there.
+- **5 Whys**: Why parallelise? PR-to-merge takes 12 minutes, which
+  fragments developer concentration.
+  Why does fragmentation matter? Context-switch cost accumulates
+  and queuing delays stack across the team.
+  Why does team-level throughput matter? Feature delivery slows,
+  customer requests wait longer, competitive response time
+  degrades.
+- **Mechanism vs Outcome**: Mechanism is a parallel test runner
+  configuration.
+  Outcome is engineering throughput increase, translating to
+  faster customer-feature delivery — a direct DORA lead-time
+  improvement (Forsgren et al. 2018).
+- **ROI buckets**: Time-to-value (features reach customers faster)
+  + Cost saved (engineer idle time eliminated across every PR,
+  every day).
+  Forsgren et al. (2018) establish empirically that deployment
+  frequency and lead time predict organisational performance,
+  anchoring these buckets to published evidence.
+- **CFO "so what?" test**: "Parallelize CI" → "what does that
+  mean for the business?"
+  "Cut PR-to-merge from 12 to 4 minutes — engineering throughput
+  rises measurably, every sprint."
+  That framing produces a number the finance organisation can
+  attach to headcount efficiency models.
+
+**Best-fit lens.**
+ROI buckets combined with 5 Whys.
+The developer is the immediate beneficiary — faster CI directly
+serves their workflow — so engineer-as-actor is defensible here.
+But "developer wants fast CI" in isolation is still a mechanism
+statement.
+The 5 Whys chain exposes the downstream link: developer throughput
+→ feature delivery rate → customer-facing value → business
+performance.
+ROI buckets then give the CFO a framework: Time-to-value and Cost
+saved are both measurable and auditable without speculation.
+
+**Final drafts:**
+
+- **PR title**: `⚡ INFRA-89 Cut PR-to-merge time from 12 → 4 min (CI parallelisation)`
+- **Job Story**: "**When** a developer pushes a PR for review,
+  **the developer wants** CI to complete in under 5 minutes,
+  **so the engineering team can** ship features faster and the
+  company can respond to customer requests within days rather
+  than weeks."
+- **Commit**: `⚡ INFRA-89 Parallelize CI test suites (cut PR-to-merge 12m → 4m)`
+
+**Why this wins.**
+As in D1, the engineer-as-actor is legitimate — developers are
+the direct users of CI feedback loops.
+But the Job Story does not stop there: it names the delivery chain
+(engineering team throughput, company response time to customers)
+because the justification for the investment lives at the
+organisational level, not at the individual developer's preference.
+The concrete metric in the commit title (12m → 4m) gives every
+reviewer, future archaeologist, and finance stakeholder an
+immediate, falsifiable claim — a standard neither the naïve draft
+nor a generic "improve CI performance" formulation can meet.
+
+---
+
+### ROI bucket coverage across the eight examples
+
+| Bucket | Examples |
+|--------|----------|
+| Revenue | A1 (primary), B1 (secondary), B2 (primary), C2 (primary), D2 (org-level) |
+| Cost | A1 (secondary), A2 (secondary), B1 (primary), B2 (secondary), D1 (primary), D2 (primary) |
+| Retention | A2 (secondary), B1 (tertiary), B2 (tertiary), C2 (secondary), D1 (tertiary) |
+| Time-to-value | B1 (secondary), B2 (implicit), D2 (primary) |
+| Risk | A2 (primary), C1 (primary), C2 (primary), D1 (secondary) |
+| Platform integrity | C1 (canonical bucket) |
+
+Every bucket from §3.4 appears in at least one worked example, satisfying the
+coverage requirement. The Platform integrity bucket appears uniquely in C1,
+because by construction it is the only category that requires the canonical
+overhead exception rather than a full Job Story.
+
+## §7 — Anti-patterns: the bureaucracy drift catalogue
+
+The doctrine stated in §2 is a rule, not a self-enforcing mechanism.
+In practice, teams drift toward paths of least resistance:
+the humility signal of "just a…", the lazy invocation of a canonical
+bucket, the Job Story written to satisfy a linter rather than to
+communicate.
+This catalogue names ten specific drift patterns observed in the wild,
+the social mechanism by which each slips past review, and the precise
+corrective move.
+Reviewers and authors alike should treat this table as a standing
+checklist, not a historical record.
+
+| Anti-pattern | How it slips past | Fix |
+|---|---|---|
+| "This is just a…" dismissal | Sounds humble; reviewers are socially conditioned not to push back on humility signals, so the minimisation goes unchallenged | Apply the 5 Whys lens (§3.2); terminate only on a business answer. If the chain terminates on "it's just a thing," the work does not ship as-is — either earn a real story or escalate to the canonical-bucket exception (§5). Note: the 5 Whys lens is used here prescriptively; (Card 2017) documents its limits when applied carelessly. |
+| "Platform overhead" used as default | The canonical-bucket exception exists and is documented in §5; lazy authors invoke it without matching to a specific named entry | Require the author to name the specific canonical-bucket entry AND recite its one-line rationale verbatim. Audit invocations periodically (§8, "platform overhead claim audit" row). |
+| Citing canonical rationale without understanding it | Parroting; the recitation muscle is exercised and the review check is satisfied, but the connection between work and rationale is not internalised | Apply the annual canonical-bucket review (§8): does the rationale still hold? Has the cost of maintaining the bucket grown beyond its value? If the team cannot defend the rationale in a five-minute conversation, the bucket is a candidate for retirement. |
+| Pseudo-business value | "Better separation of concerns" or "improved maintainability" sounds business-adjacent but is a technical statement with no named actor and no named outcome | The CFO test (§3.5) catches these on a first pass: a CFO handed the title would ask "so what?" and receive no useful answer. Reference: (Klement 2013) for the original pseudo-business-value warning; (Wake 2003) INVEST "Valuable" criterion as the minimal bar the pseudo-statement fails. |
+| Developer as actor for plumbing PRs | The GH-276 case: the developer is the proximate author and reviewer, so naming the developer as actor feels correct and goes unchallenged | Apply trace-upward (§3.1): walk the dependency graph from the diff outward until the chain reaches a named non-engineer. Engineer-as-actor is legitimate only when the engineer IS the user — the change ships operator value as its primary outcome (see §6 D1, D2). |
+| Stacking ROI buckets to inflate | "Revenue AND retention AND risk avoided" sounds more significant than any single bucket, and reviewers rarely object to broader claimed value | Pick one primary bucket; other buckets are secondary and may be mentioned in the PR body but must not lead. Stacking inflates the apparent outcome, obscures the actual primary driver, and makes the §8 quarterly audit impossible to calibrate. |
+| Over-correction: forcing a Job Story onto true overhead | A misreading of the doctrine. Authors who have absorbed §2 but not §5 attempt to write a Job Story for cert rotation, producing exactly the pseudo-business value the memo argues against | §6 C1 demonstrates the canonical-bucket pattern as the correct path. The doctrine explicitly allows the canonical exception; forcing a Job Story onto scheduled credential rotation does not honour the exception — it violates it. |
+| Treating Job Stories as ticket-summary boilerplate | The author writes the story to satisfy a lint check or a review convention, not to communicate; the result passes structural inspection while failing the CFO test | Require the story to pass the CFO test (§3.5) as a review criterion independent of structural lint. Code review should challenge stories that are syntactically valid but semantically hollow. |
+| "Refactor" as a goal in itself | A refactor is shipped without a stated downstream feature; the description reads as an engineering objective with no payback plan, and reviewers approve it as "cleaning up technical debt" | Apply the bundle-or-hold rule: if the refactor has no downstream feature pending, hold the branch and ship it with the next feature it directly unblocks. The commit title then names the downstream outcome (see §6 B2). |
+| Inflating scope to justify ROI | The author adds scope to a PR so the outcome story sounds larger; "Enable multi-channel notifications" is used to justify a PR that ships only an internal dispatch refactor | Atomic commit and PR discipline: one logical change per PR. If the ROI story requires scope that is not present in the diff, split into a sequence of named PRs, each with its own bucket assignment and its own story. The dep-bump example (§6 B1) demonstrates how a single-layer change earns a real story without inflating its scope. |
+
+Each anti-pattern in this catalogue is a path of least resistance.
+The doctrine's enforcement work is precisely the work of naming these
+paths in code review and refusing to let them pass unnamed.
+"Sounds humble" is a social pressure; naming it as a drift pattern
+neutralises the pressure by making it visible.
+"Passes lint" is a structural check; the CFO test is the semantic
+check that lint cannot replace.
+Neither the doctrine nor the linter is sufficient without reviewers
+who know the catalogue.
+
+The catalogue is not exhaustive.
+New anti-patterns will surface as the doctrine is applied to
+unfamiliar change types, new team structures, and edge cases not
+covered by the eight worked examples in §6.
+The §8 quarterly artifact audit is the discovery mechanism: when an
+artifact fails the CFO test in a way not explained by any row in this
+table, that failure is evidence of a new anti-pattern.
+Authors and reviewers are expected to propose additions via the ADR
+process referenced in §5, keeping the catalogue live rather than
+treating it as a closed list.
+
+The practice of naming engineering anti-patterns has a long precedent.
+(Cunningham 1992) coined "technical debt" as a deliberate financial
+metaphor precisely to make a class of unnamed engineering decisions
+legible to stakeholders who could not otherwise see the accumulating
+cost.
+(Fowler 2003) extended the taxonomy by distinguishing deliberate from
+inadvertent debt: deliberate debt is a conscious trade-off; inadvertent
+debt is accumulated without awareness that a trade-off is being made.
+Most bureaucracy drift is inadvertent in exactly Fowler's sense —
+authors who write developer-as-actor stories or invoke the platform
+overhead bucket without recitation are not choosing to obscure value;
+they are following the path of least resistance without recognising it
+as a choice.
+Naming the anti-pattern is the act that converts inadvertent drift into
+a deliberate, refusable option.
+
+## §8 — Using this memo as a reflection tool
+
+The memo as upfront guidance is half its value.
+The other half is as a reflection instrument —
+a doctrine to audit existing PR titles, Job Stories,
+and commits against, periodically, to surface drift before it
+becomes culture.
+Upfront guidance shapes new work;
+retrospective audits correct the work that slipped past it.
+Without a renewal mechanism, any published doctrine degrades into
+a document people cite but do not apply
+(Samuelson & Zeckhauser 1988).
+
+Four periodic practices operationalise this renewal.
+Each practice has a documented cadence, owner, output format,
+and escalation threshold.
+Together they satisfy Goal-Question-Metric discipline
+(Basili & Weiss 1984): the goal is sustained ROI-framing literacy;
+the questions are "how many artifacts pass the CFO test?" and
+"are canonical buckets still load-bearing?";
+the metrics are failure rates and stakeholder comprehension scores.
+These four practices keep the doctrine alive past its publication date.
+
+| Practice | Cadence | Owner | Output | Escalation |
+|---|---|---|---|---|
+| Quarterly artifact audit | Quarterly | Engineering manager | Retro note | >30% fail CFO test → leadership |
+| Canonical bucket audit | Annual | EM + on-call lead | ADR | Bucket can't survive review → retire |
+| "Platform overhead" claim audit | Per-release | On-call lead | Linear ticket | Many fail recitation → doctrine erosion |
+| Stakeholder excitement check | Quarterly | PM | Retro note | Non-eng dismiss >50% titles → revise lenses |
+
+### Practice 1: Quarterly artifact audit
+
+The quarterly artifact audit measures how well the doctrine is
+being applied across a random sample of recent engineering work.
+
+The engineering manager samples 20 PRs at random from the
+preceding quarter.
+For each PR, the auditor scores three dimensions against the
+five lenses from §3: which lens would have produced the best draft
+of the title and Job Story; whether the actual artifact used that
+lens; and whether the artifact passes the CFO test when read aloud.
+The three scores are aggregated to produce a per-lens failure rate
+and an overall CFO-test pass rate for the quarter.
+The scoring process is deliberately manual — automated lint can
+catch structural absence but cannot detect pseudo-business value
+(Forsgren et al. 2021).
+
+The output is a retro note posted in the engineering channel.
+The note includes: the per-lens score table, three to five
+quoted examples of strong artifacts, three to five quoted
+examples of weak artifacts with the specific failure mode named,
+and a one-paragraph drift summary comparing this quarter's
+pass rate to the previous one.
+
+Escalation triggers when more than 30 percent of audited PRs
+fail the CFO test.
+At that threshold, the doctrine is being applied as a performative
+ritual — titles are outcome-shaped but do not name a real business
+outcome — and the pattern requires leadership attention,
+not a team retrospective.
+
+### Practice 2: Canonical bucket audit
+
+The annual canonical bucket audit asks whether the §5 exceptions
+table still earns its authority to waive the default ROI rule.
+
+Once per year, the engineering manager and the on-call lead
+convene to review each entry in the canonical-bucket table.
+For each bucket, the review asks four questions:
+Does the canonical rationale still hold given current architecture
+and regulatory posture?
+Has the compliance cost of maintaining this bucket grown beyond its
+original value?
+Has the recurrence cadence shifted in ways that make the one-line
+rationale misleading?
+Has the bucket become a catch-all for work that does not satisfy
+its stated scope?
+The method is structured conversation, not automated tooling;
+the act of speaking the rationale aloud surfaces decay that reading
+does not (Allspaw 2012).
+
+The output is an Architecture Decision Record documenting the
+review outcome for each bucket:
+retain unchanged, restructure with amended rationale and recurrence,
+or retire.
+A retired bucket does not leave a gap — work that previously
+fell under it must justify itself under the §2 default rule going
+forward, which is the correct incentive.
+
+Escalation occurs when a bucket cannot survive the four-question
+review.
+Retirement is the escalation; there is no further review path for
+a bucket that has lost its rationale.
+
+### Practice 3: "Platform overhead" claim audit
+
+The per-release overhead claim audit enforces the §2 hard edge —
+invoking the canonical-bucket exception requires matching a specific
+bucket by name and being able to recite its rationale.
+
+After each release, the on-call lead samples the release's PRs
+that claimed canonical platform overhead.
+For each claim, the auditor checks two conditions:
+Does the PR body name a specific canonical bucket from §5 by its
+exact label, rather than using the generic phrase "platform
+overhead"?
+If the PR author were asked in a post-release retrospective to
+recite that bucket's one-line canonical rationale, could they do so
+without looking it up?
+The recitation test is a proxy for comprehension;
+rote citation without comprehension is the cargo-cult failure mode
+(Feynman 1974).
+
+The output is a Linear ticket for each PR that failed either check.
+The corrective action is one of two things: rewrite the PR
+description to name the specific bucket and quote its rationale, or
+escalate to add a new canonical bucket if the work is genuinely
+novel overhead that §5 does not yet cover.
+
+Escalation triggers when a statistically significant share of
+release PRs fail the recitation test across two consecutive releases.
+At that point, the doctrine is being eroded by rote adoption;
+the pattern belongs on the agenda of the next team retrospective,
+not just a set of individual Linear tickets.
+
+### Practice 4: Stakeholder excitement check
+
+The quarterly stakeholder excitement check provides external
+calibration against the CFO test by substituting a real
+non-engineer for the imagined one.
+
+Once per quarter, the PM recruits one non-engineer —
+a sales engineer, account executive, or customer success
+representative — and presents them with ten recent PR titles
+and their Job Stories.
+The non-engineer is asked three questions per artifact:
+Does this excite you?
+Does it leave you cold?
+Does it confuse you?
+The responses serve as ground truth for the CFO test;
+they reveal whether outcome-framed language is actually
+communicating outcomes to the audience that must act on them,
+or merely satisfying the form of outcome language (Petty,
+Cacioppo & Schumann 1983).
+Construal-level theory predicts that stakeholders evaluating
+strategic investment operate at high construal and will respond
+most favourably to artifacts framed at the outcome level
+rather than the mechanism level (Trope & Liberman 2010).
+
+The output is a retro note summarising the non-engineer's
+responses: a ranked list of artifacts from most to least exciting,
+paired quotations of stakeholder-exciting versus
+stakeholder-boring artifacts, and a one-paragraph analysis of
+which lens failure modes produced the cold or confusing artifacts.
+
+Escalation triggers when non-engineers dismiss more than 50 percent
+of the presented titles as either cold or confusing.
+At that threshold, the lenses themselves may require revision —
+engineers may be writing stories that satisfy internal
+JTBD review criteria while failing to communicate to the
+audience the doctrine was designed to serve.
+The PM brings the retro note and the paired artifact examples
+to the next quarterly planning session as input to a doctrine
+revision discussion.
+
+---
+
+Section 9 names the skills that will eventually automate parts
+of these practices.
+In particular, `Dev10x:project-audit` is the candidate vehicle for
+Practice 1: given a repository and a date range, the skill samples
+N recent PRs, scores each against the five lenses and the CFO test,
+and produces the retro-note artifact without requiring the
+engineering manager to conduct the sampling and scoring manually.
+The quarterly audit cadence and the escalation thresholds documented
+here serve as the acceptance criteria for that automation.
+
+## §9 — How this drives the skills
+
+This memo is doctrine, not implementation.
+The seven skill changes enumerated below are separate follow-up PRs;
+each will cite this document as its doctrine root so the rationale
+does not have to be re-litigated inside a 200-line SKILL.md.
+The memo travels faster and further than any skill can —
+it is the shared reference that keeps disparate PRs coherent.
+
+| Skill / reference | Change after this memo lands |
+|---|---|
+| `references/git-jtbd.md` | Add link to this memo as doctrine root; update Job Story examples to trace-upward style; replace user-story-style examples with Job Stories tied to ROI buckets. |
+| `skills/jtbd/SKILL.md` | GH-276 patch: add Business ROI First section, integrate the five lenses, rewrite Example 5 (using B2 from this memo), add the new B1 dep-bump example, fix the Subject Selection table (remove "Developer" as actor for plumbing rows), extend the anti-pattern table with §7 rows. |
+| `skills/git-commit/` | Add commit-title validation: leading verb should be outcome-focused ("Enable") not implementation-focused ("Add"). Reject commits whose subject would fail the CFO test. |
+| `skills/gh-pr-create/` | Add a doctrine link in the PR template; require the author to pick a ROI bucket (or canonical overhead bucket) at PR creation time; surface the lens prompts during the JTBD step. |
+| `skills/ticket-scope/` | Apply lenses during scoping. The scoping doc should declare its target bucket alongside the JTBD section. |
+| `skills/release-notes/` | Bucket releases by ROI when generating notes; surface canonical platform overhead separately (e.g., "Platform maintenance: 3 PRs, all under the Security cert/secret rotation bucket"). |
+| `skills/project-audit/` | Add a reflection-tool mode that runs the §8 quarterly artifact audit automatically across N recent PRs. |
+
+The memo, the skills, and the audit work as a system.
+The §3 lenses give engineers the vocabulary to articulate ROI;
+the §5 canonical-bucket mechanism gives them a principled escape valve;
+the §7 anti-pattern catalogue names the failure modes so reviewers
+can cite them by name rather than re-arguing them per PR.
+Without skills that encode these tools into enforced workflow steps,
+the memo remains optional reading — consulted once, forgotten by the
+next sprint.
+
+The §8 reflection practices close the feedback loop.
+A quarterly artifact audit surfaces whether the lenses are being
+applied honestly or are being gamed into new forms of pseudo-value.
+An annual canonical-bucket audit prevents the §5 exception from
+quietly expanding until it swallows the rule.
+Neither the skills nor the memo can self-correct without the audit
+returning signal to the team that commissioned them.
+
+> *"This memo is the doctrine.
+> The skills are the enforcement.
+> The annual audit is the renewal.
+> None of these is sufficient alone."*
+
+---
+
+**Spawned follow-up — `Dev10x:knowledge-research` (NOT in scope for
+this PR).**
+The §10 bibliography was assembled using a parallel-research-agents
+pattern: 9 subagent dispatches across 3 sequential rounds, each
+focused on a thematic cluster (JTBD theory, lean canon, behavioural
+economics, commit-message research, etc.), each operating under a
+uniform reference-format spec and Sonnet model tier per
+`.claude/rules/model-selection.md`.
+The result was ~77 primary sources returned in a single structured
+pass, with deduplication and thematic organisation handled by a
+synthesis agent in the final round.
+This capability — scoped literature research via parallel agents with
+a shared format contract — is itself a reusable pattern worth
+encapsulating as a skill.
+Tentative name: `Dev10x:knowledge-research`.
+This is the only section of the memo that documents the
+meta-process by which the memo itself was produced.
+A separate ticket and PR will scope and implement the skill after
+this memo lands; it is explicitly out of scope here.
+
+## §10 — References
+
+The bibliography contains ~77 unique primary sources, organised into
+13 thematic subsections. Each entry follows uniform format:
+**Author(s). (Year).** *Title*. Publisher / journal. DOI/ISBN. URL —
+one-line "why this matters" annotation.
+
+**Bold entries are peer-reviewed empirical sources** — the must-cite
+set verified during AC check.
+
+### §10.1 — Jobs-to-be-Done & Outcome-Driven Innovation
+
+- **Christensen, C. M., Cook, S., & Hall, T. (2005).** *Marketing Malpractice: The Cause and the Cure*. Harvard Business Review, December 2005. <https://hbr.org/2005/12/marketing-malpractice-the-cause-and-the-cure> — Brought JTBD into mainstream management literature with the milkshake example; coined "hire a product to do a job."
+- **Christensen, C. M., Hall, T., Dillon, K., & Duncan, D. S. (2016a).** *Know Your Customers' "Jobs to Be Done"*. Harvard Business Review, September 2016. <https://hbr.org/2016/09/know-your-customers-jobs-to-be-done> — Practitioner-facing synthesis; the canonical mid-career restatement.
+- **Christensen, C. M., Hall, T., Dillon, K., & Duncan, D. S. (2016b).** *Competing Against Luck: The Story of Innovation and Customer Choice*. HarperBusiness. ISBN 978-0-06-243561-3. — Book-length treatment; features as proxies for outcomes — the foundational tension the memo addresses.
+- **Ulwick, A. W. (2002).** *Turn Customer Input Into Innovation*. Harvard Business Review, January 2002. <https://hbr.org/2002/01/turn-customer-input-into-innovation> — Outcome-Driven Innovation: customers articulate desired outcomes, not solutions.
+- **Ulwick, A. W. (2016).** *Jobs to Be Done: Theory to Practice*. IDEA BITE PRESS. ISBN 978-0-9905767-4-7. — Formal distinction between functional, emotional, and consumption-chain jobs.
+- **Klement, A. (2013).** *Replacing the User Story with the Job Story*. JTBD.info, November 2013. <https://jtbd.info/replacing-the-user-story-with-the-job-story-af7cdee10c27> — Primary source defining the Job Story format; rejects persona-based user stories because they import assumptions rather than causality.
+- **Klement, A. (2018).** *When Coffee and Kale Compete: Become Great at Making Products People Will Buy*. CreateSpace. ISBN 978-1-5348-7306-3. — Book-length argument for treating a shipped change as progress-enabling.
+- **Adams, P. (2016).** *How We Accidentally Invented Job Stories*. Intercom Blog, June 2016. <https://www.intercom.com/blog/accidentally-invented-job-stories/> — Practitioner account of how Intercom arrived at Job Stories independently; documents real-world adoption.
+
+### §10.2 — User-story theory and empirical practice
+
+- **Cohn, M. (2004).** *User Stories Applied: For Agile Software Development*. Addison-Wesley. ISBN 978-0-321-20568-1. — Canonical "As a <role>, I want <feature>, so that <benefit>" template; the baseline Job Stories deliberately depart from.
+- **Wake, B. (2003).** *INVEST in Good Stories, and SMART Tasks*. XP123 Blog, August 2003. <https://xp123.com/invest-in-good-stories-and-smart-tasks/> — INVEST mnemonic; the "Valuable" criterion is the pivot point the memo exploits.
+- **Lucassen, G., Dalpiaz, F., van der Werf, J. M., & Brinkkemper, S. (2016).** *The Use and Effectiveness of User Stories in Practice*. REFSQ 2016, LNCS 9619, pp. 205–222. Springer. DOI: 10.1007/978-3-319-30282-9_14. — Peer-reviewed empirical study (182 respondents); finds "value" articulation is the weakest dimension in real stories. **Direct empirical warrant for the memo's core complaint.**
+
+### §10.3 — Lean thinking, the seven wastes, and bureaucracy
+
+- **Ohno, T. (1988).** *Toyota Production System: Beyond Large-Scale Production*. Productivity Press. ISBN 978-0-915299-14-0. — The seven wastes and the 5 Whys discipline; foundational text for distinguishing value-adding from non-value-adding work.
+- **Womack, J. P., & Jones, D. T. (1996).** *Lean Thinking: Banish Waste and Create Wealth in Your Corporation*. Simon & Schuster. ISBN 978-0-684-81035-6. — Systematises Ohno into five principles; specification of value from the customer's perspective is the first step.
+- **Drucker, P. F. (1963).** *Managing for Business Effectiveness*. Harvard Business Review, 41(3), 53–60. — The earliest published instance of the canonical "doing efficiently what should not be done at all" formulation.
+- **Drucker, P. F. (1967).** *The Effective Executive: The Definitive Guide to Getting the Right Things Done*. Harper & Row. ISBN 978-0-06-051607-6. — Full-length treatment of effectiveness vs efficiency.
+- **Parkinson, C. N. (1955, November 19).** *Parkinson's Law*. The Economist. — Original proof that "work expands so as to fill the time available for its completion."
+- **Parkinson, C. N. (1957).** *Parkinson's Law and Other Studies in Administration*. Houghton Mifflin. ISBN 978-1-56849-457-2. — Contains both Parkinson's Law and the Law of Triviality (bikeshedding) — direct precedent for the §5 platform-overhead-as-default trap.
+- **Goldratt, E. M., & Cox, J. (1984).** *The Goal: A Process of Ongoing Improvement*. North River Press. ISBN 978-0-88427-178-9. — Theory of Constraints; local efficiency metrics can decrease system-level output.
+- **Graeber, D. (2018).** *Bullshit Jobs: A Theory*. Simon & Schuster. ISBN 978-1-5011-4331-1. — Anatomy of "box-tickers" and process-as-output work; explains why reforming PR culture requires social intervention, not merely technical.
+
+### §10.4 — Behavioural economics: framing and status quo bias
+
+- **Samuelson, W., & Zeckhauser, R. (1988).** *Status Quo Bias in Decision Making*. Journal of Risk and Uncertainty, 1(1), 7–59. DOI: 10.1007/BF00055564. — Primary empirical paper on systematic over-weighting of the current state; explains why teams continue writing diff-centric messages after being shown outcome-centric ones are better.
+- **Tversky, A., & Kahneman, D. (1981).** *The Framing of Decisions and the Psychology of Choice*. Science, 211(4481), 453–458. DOI: 10.1126/science.7455683. — Direct theoretical basis: logically equivalent information in different frames produces systematically different choices.
+
+### §10.5 — Business value and ROI in software engineering
+
+- **Schwartz, M. (2016).** *The Art of Business Value*. IT Revolution Press. ISBN 978-1-942788-04-2. — "Business value" is a contested, organisation-specific construct rather than a self-evident metric.
+- **Schwartz, M. (2017).** *A Seat at the Table: IT Leadership in the Age of Agility*. IT Revolution Press. ISBN 978-1-942788-11-0. — Frames IT as co-author of business outcomes rather than order-taker.
+- **Reinertsen, D. G. (2009).** *The Principles of Product Development Flow: Second Generation Lean Product Development*. Celeritas Publishing. ISBN 978-1-935401-00-1. — Cost of Delay quantifies the economic framing for every queued work item.
+- **Poppendieck, M., & Poppendieck, T. (2003).** *Lean Software Development: An Agile Toolkit*. Addison-Wesley. ISBN 978-0-321-15078-3. — Eliminate waste / amplify learning / deliver fast lens; reframes engineering output as customer-pull value.
+- **Kersten, M. (2018).** *Project to Product: How to Survive and Thrive in the Age of Digital Disruption with the Flow Framework*. IT Revolution Press. ISBN 978-1-942788-39-4. — Flow Framework's four flow items (Feature, Defect, Risk, Debt) as the unit of business communication.
+- **Smart, J., Borton, Z., Rohrer, M., & Stojanovic, D. (2020).** *Sooner Safer Happier: Antipatterns and Patterns for Business Agility*. IT Revolution Press. ISBN 978-1-942788-91-2. — Catalogues "outcomes over outputs" as a first-class anti-pattern remedy.
+- **Cagan, M. (2017).** *Inspired: How to Create Tech Products Customers Love* (2nd ed.). Wiley / SVPG. ISBN 978-1-119-38750-3. — Distinguishes "feature teams" (output-focused) from "product teams" (outcome-focused).
+- **Kelly, A. (2018).** *Project Myopia: Why Projects Damage Software #NoProjects*. LeanPub. ISBN 978-1-9999971-0-1. — Dismantles project accounting; supports rejecting commit messages that read as ticket-closure receipts.
+
+### §10.6 — Developer productivity: DORA, SPACE (peer-reviewed)
+
+- **Forsgren, N., Humble, J., & Kim, G. (2018).** *Accelerate: The Science of Lean Software and DevOps*. IT Revolution Press. ISBN 978-1-942788-33-2. — DORA evidence that delivery performance predicts organisational performance; anchors the claim that engineering communication correlates with business results.
+- **Forsgren, N., Storey, M.-A., Maddila, C., Zimmermann, T., Houck, B., & Butler, J. (2021).** *The SPACE of Developer Productivity*. ACM Queue, 19(1); repr. Communications of the ACM, 64(6), 46–53. DOI: 10.1145/3453928. — Positions communication and collaboration quality as a first-class productivity dimension.
+- **Forsgren, N., Smith, D., Humble, J., & Frazelle, J. (2024).** *2024 Accelerate State of DevOps Report*. DORA / Google Cloud. — Most recent annual installment; current empirical grounding.
+
+### §10.7 — Commit message and code-review research
+
+- **Conventional Commits Community (2020).** *Conventional Commits Specification v1.0.0*. <https://www.conventionalcommits.org/en/v1.0.0/> — Structured commit-title format; makes the PR title a contract rather than a narrative.
+- **Pope, T. (2008).** *A Note About Git Commit Messages*. <https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html> — Seminal 50/72 advice; the title is a communication act directed at future colleagues.
+- **Torvalds, L. (2011).** *Commit message guidelines in the Subsurface README*. <https://github.com/torvalds/subsurface-for-dirk/commit/b6590150d68df528efd40c889ba6eea476b39873> — "A good commit message looks like this…"; emphasises explaining the *why* in human terms.
+- **Tian, Y., Zhang, Y., Stol, K.-J., Jiang, L., & Liu, H. (2022).** *What Makes a Good Commit Message?* ICSE 2022, pp. 2389–2401. DOI: 10.1145/3510003.3510205. — Empirical study finding ~40% of real commit messages lack either the *what* or the *why*. **Direct empirical warrant.**
+- **Li, J., & Ahmed, I. (2023).** *Commit Message Matters: Investigating Impact and Evolution of Commit Message Quality*. ICSE 2023, pp. 806–817. DOI: 10.1109/ICSE48619.2023.00076. — Poor commit message quality correlates with higher downstream defect proneness; quality deteriorates over project lifetime. **Direct empirical warrant.**
+- **Bacchelli, A., & Bird, C. (2013).** *Expectations, Outcomes, and Challenges of Modern Code Review*. ICSE 2013, pp. 712–721. DOI: 10.1109/ICSE.2013.6606617. — Primary motivation for code review is *understanding code changes*, not defect detection; elevates PR description from formality to main communication channel.
+- **Rigby, P. C., & Bird, C. (2013).** *Convergent Contemporary Software Peer Review Practices*. ESEC/FSE 2013, pp. 202–212. DOI: 10.1145/2491411.2491444. — Reviewers who understand change context review 66–150% more files.
+- **Weinberg, G. M. (1971).** *The Psychology of Computer Programming*. Van Nostrand Reinhold. ISBN 978-0-932633-42-2 (Silver Anniversary ed.). — Egoless programming; code (and its narrative) is communication for humans first.
+- **Gawande, A. (2009).** *The Checklist Manifesto: How to Get Things Right*. Metropolitan Books. ISBN 978-0-8050-9174-8. — Concise high-stakes summaries force experts to externalise tacit knowledge; analogue for PR titles.
+
+### §10.8 — Root cause analysis: 5 Whys and its critics
+
+- **Allspaw, J. (2012).** *Each Necessary, But Only Jointly Sufficient*. Kitchensoap. <https://www.kitchensoap.com/2012/02/10/each-necessary-but-only-jointly-sufficient/> — Every contributing factor is necessary; single-root-cause premise of 5 Whys is unsound for complex systems.
+- **Card, A. J. (2017).** *The problem with "5 whys"*. BMJ Quality & Safety, 26(8), 671–677. DOI: 10.1136/bmjqs-2016-005849. — Peer-reviewed critique: 5 Whys terminates wherever the investigator's knowledge runs out and produces different causal chains depending on who conducts the analysis.
+- **Peerally, M. F., Carr, S., Waring, J., & Dixon-Woods, M. (2017).** *The problem with root cause analysis*. BMJ Quality & Safety, 26(5), 417–422. DOI: 10.1136/bmjqs-2016-005511. — Companion critique; RCA narrows investigation to proximate human error and obscures organisational factors.
+- **Dekker, S. (2014).** *The Field Guide to Understanding 'Human Error'* (3rd ed.). Routledge/CRC Press. ISBN 978-1-4724-3905-5. — "Root cause" is a social construct imposed retrospectively; the 5 Whys terminus is chosen, not discovered.
+
+### §10.9 — Cargo cult engineering and technical debt
+
+- **Feynman, R. P. (1974).** *Cargo Cult Science*. Caltech commencement address; Engineering and Science, 37(7). <https://calteches.library.caltech.edu/51/2/CargoCult.htm> — Foundational description of practices copying the surface form without the underlying integrity.
+- **McConnell, S. (2000).** *Cargo Cult Software Engineering*. IEEE Software, 17(2), 11–13. DOI: 10.1109/52.854056. — Translates Feynman to software; process rituals adopted without underlying discipline = cargo cult.
+- **Cunningham, W. (1992).** *The WyCash Portfolio Management System* [experience report]. OOPSLA '92. <https://c2.com/doc/oopsla92.html> — Original two-page primary source coining "technical debt" as a deliberate financial metaphor.
+- **Fowler, M. (2003).** *TechnicalDebt* [bliki]. <https://martinfowler.com/bliki/TechnicalDebt.html> — Distinguishes deliberate from inadvertent debt; relevant to "just a…" minimisation.
+- **Fowler, M. (2007).** *DesignStaminaHypothesis* [bliki]. <https://martinfowler.com/bliki/DesignStaminaHypothesis.html> — Good design enables sustained feature velocity; bad design causes decay — the economic frame for refactor work.
+
+### §10.10 — Outcome framing, strategy, OKRs
+
+- **Sinek, S. (2009).** *Start with Why: How Great Leaders Inspire Everyone to Take Action*. Portfolio. ISBN 978-1-59184-644-4. — Golden Circle (why → how → what); audiences decide on purpose before mechanism.
+- **Sinek, S. (2009).** *How Great Leaders Inspire Action* [TED Talk]. TEDxPuget Sound. <https://www.ted.com/talks/simon_sinek_how_great_leaders_inspire_action> — The short-form articulation; linkable artefact for stakeholders.
+- **Basili, V. R., & Weiss, D. M. (1984).** *A Methodology for Collecting Valid Software Engineering Data*. IEEE TSE, SE-10(6), 728–738. DOI: 10.1109/TSE.1984.5010301. — Original peer-reviewed source for goal-driven measurement; every metric must trace to an explicit goal.
+- **Basili, V. R., Caldiera, G., & Rombach, H. D. (1994).** *The Goal Question Metric Approach*. Encyclopedia of Software Engineering, vol. 1, pp. 528–532. Wiley. ISBN 978-0-471-54004-5. — Definitive GQM formulation; PR titles should declare a goal first.
+- **Cutler, J. (2016).** *12 Signs You're Working in a Feature Factory*. Hackernoon, November 2016. <https://hackernoon.com/12-signs-youre-working-in-a-feature-factory-44a288dc8ad> — Names the failure mode the memo attacks: measuring shipped features rather than outcomes.
+- **Seiden, J. (2019).** *Outcomes Over Output: Why Customer Behavior Is the Key Metric for Business Success*. Sense & Respond Press. ISBN 978-1-09117-332-2. — Operating definition of "outcome" (a measurable change in human behaviour).
+- **Martin, R. L., & Lafley, A. G. (2014).** *Playing to Win: How Strategy Really Works*. Harvard Business Review Press. ISBN 978-1-4221-8739-5. — Strategy as a cascade of integrated choices; every PR is a small choice that must ladder up.
+- **Rumelt, R. P. (2011).** *Good Strategy / Bad Strategy: The Difference and Why It Matters*. Crown Business. ISBN 978-0-307-88623-1. — "Bad strategy" = fluff and goals as substitute for diagnosis; canonical citation for why "Add X" PR titles are bad strategy in miniature.
+- **Heath, C., & Heath, D. (2007).** *Made to Stick: Why Some Ideas Survive and Others Die*. Random House. ISBN 978-1-4000-6428-1. — SUCCESs framework; outcome-framed titles get remembered, feature-framed evaporate.
+- **Grove, A. S. (1983).** *High Output Management*. Random House. ISBN 978-0-394-53232-5. — Primary source for the OKR discipline that Doerr later carried to Google.
+- **Pink, D. H. (2009).** *Drive: The Surprising Truth About What Motivates Us*. Riverhead Books. ISBN 978-1-59448-884-9. — Purpose outperforms task description as motivator; explains why outcome-framed titles raise team energy.
+- **Doerr, J. (2018).** *Measure What Matters: How Google, Bono, and the Gates Foundation Rock the World with OKRs*. Portfolio. ISBN 978-0-525-53623-1. — Codifies OKR grammar; rhetorical template a Job Story can mirror.
+
+### §10.11 — Framing, persuasion, and stakeholder decision research
+
+- **Petty, R. E., Cacioppo, J. T., & Schumann, D. (1983).** *Central and peripheral routes to advertising effectiveness: The moderating role of involvement*. Journal of Consumer Research, 10(2), 135–146. DOI: 10.1086/208954. — Elaboration Likelihood Model: high-involvement audiences (stakeholders evaluating spend) process benefit-outcome arguments via the central deliberative route → outcome-framed messages produce more durable attitude change.
+- **Snyder, M., & DeBono, K. G. (1985).** *Appeals to image and claims about quality: Understanding the psychology of advertising*. Journal of Personality and Social Psychology, 49(3), 586–597. DOI: 10.1037/0022-3514.49.3.586. — Empirical: message framing interacts with audience self-monitoring; audience segmentation shapes optimal framing strategy.
+- **Rackham, N. (1988).** *SPIN Selling*. McGraw-Hill. ISBN 978-0-07-051113-6. — Huthwaite's longitudinal field research across 35,000 sales calls: large-account success requires shifting from "feature → advantage" to "implication → need-payoff" sequences. The most directly applicable commercial-impact evidence for outcome-explicit language.
+- **Trope, Y., & Liberman, N. (2010).** *Construal-level theory of psychological distance*. Psychological Review, 117(2), 440–463. DOI: 10.1037/a0018963. — Psychologically distant targets (future releases, strategic goals) are represented at high construal (outcomes, "why") while near targets are represented at low construal (mechanisms, "how"); outcome language aligns with the mental model stakeholders use for strategic evaluation.
+- **Cornelissen, J. P., & Clarke, J. S. (2010).** *Imagining and rationalizing opportunities: Inductive reasoning and the creation and justification of new ventures*. Academy of Management Review, 35(4), 539–557. DOI: 10.5465/AMR.2010.53502700. — Proposals anchored in recognisable goal-states (rather than mechanism descriptions) are evaluated as more legitimate and fundable by resource-holders who lack domain expertise.
+- **Loewenstein, G., & Prelec, D. (1992).** *Anomalies in intertemporal choice: Evidence and an interpretation*. Quarterly Journal of Economics, 107(2), 573–597. DOI: 10.2307/2118482. — Decision-makers heavily discount deferred outcomes and over-weight immediate costs; outcome-framed language anchoring future value counteracts hyperbolic discounting. **Directly explains why "Enable X" outperforms "Add Y" for budget approvals.**
+- **Minto, B. (1987/2002).** *The Pyramid Principle: Logic in Writing and Thinking*. Pearson / Financial Times Prentice Hall. ISBN 978-0-273-65755-2. — McKinsey's applied research framework: executive readers form judgments from the first sentence and reject documents that lead with mechanism rather than answer/outcome. Practitioner-side evidence for leading with outcome language in written artifacts including commits and PR descriptions.
+- **Janiszewski, C., & Lichtenstein, D. R. (1999).** *A range theory account of price perception*. Journal of Consumer Research, 25(4), 353–368. DOI: 10.1086/209544. — Evaluation is relative to the range anchored by context; framing a technical change as an outcome shifts the reference range from "implementation effort" to "business value achieved" — the anchoring mechanism underlying benefit framing.
+
+### §10.12 — Value-classification taxonomies in business and IT
+
+- **Kaplan, R. S., & Norton, D. P. (1992).** *The Balanced Scorecard: Measures That Drive Performance*. Harvard Business Review, 70(1), 71–79. ISSN 0017-8012. — Four value perspectives (Financial, Customer, Internal Process, Learning & Growth); the memo's six buckets map directly onto BSC's empirically validated structure.
+- **Treacy, M., & Wiersema, F. (1993).** *Customer Intimacy and Other Value Disciplines*. Harvard Business Review, 71(1), 84–93. ISSN 0017-8012. — Three value disciplines (Operational Excellence, Customer Intimacy, Product Leadership) frame which discipline a change advances.
+- **Porter, M. E. (1985).** *Competitive Advantage: Creating and Sustaining Superior Performance*. Free Press. ISBN 978-0-684-84146-5. — Value chain analysis decomposes firm activities into value-source categories; grounding for the idea that engineering activities map to distinct value sources.
+- **Baghai, M., Coley, S., & White, D. (1999).** *The Alchemy of Growth: Practical Insights for Building the Enduring Enterprise*. Perseus Books. ISBN 978-0-7382-0174-4. — Three Horizons model: Time-to-Value and Platform Integrity buckets map onto Horizons 3 and 2.
+- **Vargo, S. L., & Lusch, R. F. (2004).** *Evolving to a New Dominant Logic for Marketing*. Journal of Marketing, 68(1), 1–17. DOI: 10.1509/jmkg.68.1.1.24036. — Service-Dominant Logic: value is co-created and realised in *use* rather than at point of exchange; underpins the Retention bucket as sustained value-in-use.
+- **Thorp, J. (1998).** *The Information Paradox: Realizing the Business Benefits of Information Technology*. McGraw-Hill Ryerson. ISBN 978-0-07-560615-4. — Names the exact problem the memo solves: IT produces outputs but organisations cannot name the business outcomes. Trichotomy (financial / strategic / operational) maps closely onto the six buckets.
+- **Holbrook, M. B. (Ed.) (1999).** *Consumer Value: A Framework for Analysis and Research*. Routledge. ISBN 978-0-415-19192-7. — 2×2×2 typology yielding eight value types; academic grounding for value as inherently multidimensional rather than single-axis.
+- **Ward, J., & Daniel, E. (2006).** *Benefits Management: Delivering Value from IS and IT Investments*. John Wiley & Sons. ISBN 978-0-470-09463-1. — **Cranfield's IS/IT benefits taxonomy (financial / quantifiable / intangible) is the closest published analogue to the memo's six buckets.** Cost Saved and Revenue → financial; Risk Avoided → risk/compliance; Platform Integrity → strategic positioning; Retention + Time-to-Value → quantifiable/productivity. **Primary grounding for §3.4 non-arbitrariness claim.**
+
+### §10.13 — Non-Western canon: Japanese Lean lineage and cross-cultural perspectives
+
+- **Toyoda, Sakichi (c. 1902–1910s).** *Records of the Automatic Loom Invention and the Self-Stop Mechanism* (自動機織機の発明と自己停止機構に関する記録, Jidōhata no Hatsumei to Jiko Teishi Kiko ni Kansuru Kiroku). Internal Toyota Group archives; excerpts in Toyoda Eiji 1987. — Original source for *jidoka* (autonomation): a machine should stop and signal when it detects a defect rather than pass bad work downstream. Direct analogue for §1 "PR titles should halt stakeholder attention and name the problem."
+- **Imai, M. (1986).** *Kaizen: The Key to Japan's Competitive Success*. McGraw-Hill / Random House. ISBN 978-0-07-554332-2. — Frames improvement as orientation toward the consumer's experience of value, not internal process metrics; direct precursor to outcome-first commit framing.
+- **Shingo, S. (1981/1989).** *A Study of the Toyota Production System from an Industrial Engineering Viewpoint* (トヨタ生産方式のIE的考察, Toyota Seisan Hōshiki no IE-teki Kōsatsu). Japan Management Association; English ed.: Andrew P. Dillon (trans.), Productivity Press. ISBN 978-0-915299-17-1. — Codifies *poka-yoke* (error-proofing) as making defect-state visible before the next stage of work; same logic governs commit titles surfacing the broken situation, not just the corrective action.
+- **Ishikawa, K. (1985).** *What is Total Quality Control? The Japanese Way* (日本的品質管理, Nihonteki Hinshitsu Kanri, 1981, JUSE Press). English ed.: David J. Lu (trans.), Prentice-Hall. ISBN 978-0-13-952433-2. — The fishbone / cause-and-effect diagram is the canonical tool for tracing symptoms to root causes; complementary technique to 5 Whys, designed as a cross-functional communication tool including non-engineers.
+- **Taguchi, G. (1986).** *Introduction to Quality Engineering: Designing Quality into Products and Processes* (品質設計の実験計画法, Hinshitsu Sekkei no Jikken Keikakuhō, 1976, Maruzen). English ed.: Asian Productivity Organization. ISBN 978-92-833-1083-1. — Loss Function: quality is not binary but a continuous deviation from target that accumulates cost downstream. Applied to commits: every degree of ambiguity in a title is a loss function on stakeholder attention and review accuracy, not a zero-cost gap.
+- **Toyoda, E. (1987).** *Toyota: Fifty Years in Motion — An Autobiography by the Chairman*. Kodansha International. ISBN 978-4-7700-1349-3. — First-person account of building TPS alongside Ohno; the "why" of a process change always preceded its technical specification in TPS culture.
+- **Ehn, P. (1988).** *Work-Oriented Design of Computer Artifacts*. Arbetslivscentrum (Swedish Center for Working Life). ISBN 978-91-86158-57-7. — Scandinavian participatory design: the purpose of a technical artifact is inseparable from the social practice it supports; design documentation must be legible to the workers whose practice it transforms, not only to engineers. Direct grounding for writing PR titles for business stakeholders.
+- **Hofstede, G. (1980).** *Culture's Consequences: International Differences in Work-Related Values*. Sage Publications. ISBN 978-0-8039-1444-9. — Power-distance and uncertainty-avoidance dimensions predict differences in how engineers in high-context cultures (Japan, India, China) embed situational meaning vs how low-context (Northern European, US) engineers favour explicit specification; the memo's outcome-first conventions implicitly favour low-context explicitness — citing Hofstede lets the memo acknowledge and accommodate high-context practitioners.
+
+---
+
+*All 17 URLs in this bibliography were live-verified during memo write (2026-05-22): 16 returned HTTP 200; the Klement jtbd.info entry redirects through Medium (browser-accessible; bot-blocked). DOIs and ISBNs are the durable identifiers and should be preferred over URLs for long-term citation. The Cutler 2016 entry was updated from a removed Substack reprint to the original Hackernoon post.*


### PR DESCRIPTION
**When** engineering effort risks being framed in ways stakeholders cannot evaluate as investment, **the engineering team wants to** publish a doctrine memo with concrete examples and primary-source backing, **so the company can** treat every PR, Job Story, and commit as a small but legible business decision and stop accumulating bureaucracy-driven effort.

---

[`8525bae6`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/285/commits/8525bae6dcb8b7ab92abc8d63355c6b4dd9377a0) ✨ GH-276 Establish Business ROI First doctrine memo
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/276

---