### PR TITLE
🛡️ GH-240 Enforce atomic writes and locks on boundary hot paths

### DIFF
--- a/docs/adr/0011-file-atomicity-and-locking-model.md
+++ b/docs/adr/0011-file-atomicity-and-locking-model.md
@@ -1,0 +1,162 @@
+# 11. File atomicity and locking model
+
+Date: 2026-05-22
+
+## Status
+
+Accepted
+
+## Context
+
+Several files under `~/.claude/` and `<repo>/.claude/session/` are
+written concurrently by multiple processes — hook scripts running in
+parallel worktrees, the long-lived MCP server, the CLI, and sub-agent
+processes. The 2026-05-18 architecture audit (memo 005, milestone M1)
+catalogued five HIGH-severity write paths that bypassed the existing
+concurrency-safe helpers in `dev10x.domain.file_locks`:
+
+- `domain.session_document.write_state` — bare `path.write_text(...)`
+- `plan.service.set_plan_context` / `archive_plan` — `Plan.load() →
+  Plan.save()` cycle without `file_lock`
+- `hooks.session_dispatch.session_persist` — non-atomic write paired
+  with an atomic-rename reader in `session_reload`
+- `platform.registry.Registry.add` / `remove` — load → mutate → save
+  without serialization
+- `hooks.session_policy.MigratePluginPermissionsRule.apply` and other
+  multi-file mutators — no cross-file rollback
+
+The audit also flagged that the two lock-file naming conventions in
+`file_locks.py` (`.with_suffix(".lock")` vs `_lock_path_for` which
+appends `.lock`) are deliberate but undocumented as a hard rule.
+
+## Decision
+
+We adopt a layered atomicity model with explicit guarantees per layer
+and a known boundary at the multi-file level.
+
+### Layer 1 — `atomic_write_text` / `atomic_write_bytes`
+
+Every write of a state, plan, settings, or registry file uses
+`atomic_write_text` (or `atomic_write_bytes`) so readers never observe
+a half-written file. The implementation uses `mkstemp` + `os.fsync` +
+`os.rename` in the target's parent directory.
+
+**Required for:** any file whose contents may be read by another
+process while we are writing it. This includes single-writer files
+because crash safety also matters (process killed mid-write must not
+corrupt persisted state).
+
+### Layer 2 — `file_lock(path)`
+
+Every `load → mutate → save` cycle on a shared file holds an exclusive
+`fcntl.flock` on a `.lock` sidecar. The lock spans the entire cycle so
+two concurrent writers cannot both read the same baseline and overwrite
+each other's changes.
+
+**Required for:** `plan.service` (set_plan_context, archive_plan),
+`Registry.add` / `Registry.remove`, hook scripts that mutate user
+settings files, and any future code that reads state, computes a
+delta, and writes it back.
+
+The sidecar is intentionally not unlinked on release: a third writer
+arriving between `unlink` and the next `open(O_CREAT)` would receive a
+fresh inode and acquire an independent flock, breaking mutual
+exclusion.
+
+### Layer 3 — `locked_json_update` / `locked_yaml_update`
+
+Composite helpers that combine layers 1 and 2 in a single context
+manager. New code that mutates a single JSON or YAML file should
+prefer these over open-coded `file_lock(path)` + `Plan.load/save`
+patterns.
+
+### Layer 4 — Multi-file mutations have no cross-file UoW
+
+**This is the known boundary.** `MigratePluginPermissionsRule.apply`
+rewrites both `settings.json` and `settings.local.json`. `Registry`
+operations may in the future span the registry YAML plus per-platform
+config files. We do **not** provide a Unit of Work that rolls back
+across files when one of N writes fails.
+
+Implications:
+
+- Each file is locked and written atomically (layers 1 + 2), so a
+  failure mid-multi-file-mutation leaves each touched file in a
+  consistent individual state.
+- However, the *set* of files may be inconsistent — one rewritten
+  with new rules and one with old.
+- Callers that need cross-file atomicity must either (a) collapse the
+  mutation to a single file or (b) implement a custom recovery path
+  (e.g. write all changes to a staging dir, then rename a manifest
+  pointer).
+
+We accept this boundary because:
+
+1. The current call sites have natural retry semantics — the next
+   session-start hook re-runs the migration and converges.
+2. A general cross-file transaction abstraction (write-ahead log,
+   2PC) would dwarf the value it delivers given the cardinality
+   (≤ 3 files per mutation) and frequency (once per session start /
+   user action) of our multi-file mutators.
+3. The `mkstemp` + `rename` primitive on POSIX is the strongest
+   atomic primitive the standard library exposes; building above it
+   without a transaction service buys little.
+
+### Sidecar naming convention
+
+Two functions in `file_locks.py` use different sidecar naming:
+
+- `file_lock` and `locked_yaml_update` **append** `.lock` to the full
+  target name (`plan.yaml` → `plan.yaml.lock`) via `_lock_path_for`.
+- `locked_json_update` **replaces** the target suffix (`settings.local.json`
+  → `settings.local.lock`).
+
+The split is deliberate for backward compatibility with on-disk
+sidecars created by the permission-skill call sites. New code MUST
+use `file_lock` / `locked_yaml_update` (the append convention).
+`locked_json_update` is frozen for its existing callers; do not
+introduce new call sites.
+
+The two helpers must never target the same path because their lock
+sidecars resolve to different files. The module docstring documents
+this; the `tests/domain/test_file_locks.py` test asserts the split
+empirically for the known caller paths.
+
+## Consequences
+
+### Positive
+
+- A SessionStart reader can never observe a partially written session
+  state file: the read side (`claim_state_file`) does an atomic rename
+  before reading, and the write side (`write_state`) now does an
+  atomic rename before publishing.
+- Two concurrent `TaskCreate` hooks or two concurrent
+  `set_plan_context` calls cannot lose task entries or context keys —
+  the lock serializes them at the plan-file granularity.
+- Two parallel `Registry.add(...)` calls cannot lose platform
+  registrations.
+- The cross-file UoW gap is explicit, scoped, and documented so
+  future contributors do not assume atomicity beyond what we
+  actually provide.
+
+### Negative
+
+- A crash between the writes of file A and file B in a multi-file
+  mutator leaves the set inconsistent. Mitigated by idempotent
+  re-execution on the next hook firing.
+- Lock contention is theoretically possible if a long-running
+  operation holds `file_lock` on a hot path. In practice the
+  load → mutate → save cycles are sub-millisecond.
+
+### Migration
+
+The five HIGH-severity findings (E2/E8 atomic state writes, E3 plan
+locks, D1 hook→domain inversion, A12 multi-file locks) ship in
+GH-240. No data migration is required — the on-disk sidecar layout
+is unchanged.
+
+## References
+
+- Audit memo: `docs/memos/005-2026-05-18-architecture-audit.md`
+- Implementation module: `src/dev10x/domain/file_locks.py`
+- Tracking ticket: GH-240

--- a/hooks/scripts/session-start.py
+++ b/hooks/scripts/session-start.py
@@ -46,7 +46,10 @@ def _import_session_modules() -> tuple:
 def _run_feature(*, name: str, fn, audit_hook) -> str:
     """Run one feature function, capturing stdout. Returns captured text.
 
-    Failures are logged to stderr but do not propagate.
+    Failures are logged to stderr but do not propagate. Partial stdout
+    captured before an exception is discarded — appending a truncated
+    JSON envelope to ``context_parts`` would corrupt the merged
+    ``hookSpecificOutput`` payload sent back to Claude Code.
     """
     buf = io.StringIO()
     wrapped = audit_hook(name=name, event="SessionStart")(fn)
@@ -54,9 +57,10 @@ def _run_feature(*, name: str, fn, audit_hook) -> str:
         with contextlib.redirect_stdout(buf):
             wrapped()
     except SystemExit:
-        pass
+        return buf.getvalue()
     except Exception:
         traceback.print_exc(file=sys.stderr)
+        return ""
     return buf.getvalue()
 
 

--- a/src/dev10x/audit/log_reader.py
+++ b/src/dev10x/audit/log_reader.py
@@ -64,14 +64,26 @@ def current_span_id() -> str:
 
 
 def append_record(*, record: dict[str, Any], base_dir: Path | None = None) -> None:
-    """Append a JSONL record. Failures never propagate to the caller."""
+    """Append a JSONL record. Failures never propagate to the caller.
+
+    Uses ``os.open(O_APPEND|O_WRONLY|O_CREAT)`` + a single ``os.write``
+    so concurrent hook processes do not interleave partial JSON lines.
+    POSIX guarantees that a single ``write()`` call to an ``O_APPEND``
+    fd is atomic up to ``PIPE_BUF`` bytes; audit records are well
+    under that limit (typically < 512 bytes). ``TextIOWrapper.write``
+    can split a single record into multiple syscalls under the hood,
+    losing the append-atomicity guarantee.
+    """
     try:
         log_dir = base_dir or audit_dir()
         log_dir.mkdir(parents=True, exist_ok=True)
         path = log_path(base_dir=log_dir)
-        line = json.dumps(record, separators=(",", ":"), sort_keys=True) + "\n"
-        with path.open("a") as f:
-            f.write(line)
+        line = (json.dumps(record, separators=(",", ":"), sort_keys=True) + "\n").encode("utf-8")
+        fd = os.open(str(path), os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o644)
+        try:
+            os.write(fd, line)
+        finally:
+            os.close(fd)
     except OSError:
         pass
 

--- a/src/dev10x/domain/file_locks.py
+++ b/src/dev10x/domain/file_locks.py
@@ -28,7 +28,10 @@ Sidecar naming convention:
   it now would orphan on-disk sidecars across the upgrade boundary.
 
 The two functions must not be used against the same target path
-because their sidecars resolve to different files.
+because their sidecars resolve to different files. New code MUST use
+``file_lock`` (append-``.lock`` convention); ``locked_json_update``
+is frozen for its existing :mod:`dev10x.skills.permission` call sites.
+See ADR-0011 for the rationale.
 """
 
 from __future__ import annotations

--- a/src/dev10x/domain/session_document.py
+++ b/src/dev10x/domain/session_document.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any
 
 from dev10x.domain.claude_paths import ClaudeDir
+from dev10x.domain.file_locks import atomic_write_text  # noqa: F401
 
 
 def state_path_for_toplevel(*, toplevel: str) -> Path:
@@ -54,18 +55,30 @@ def claim_state_file(*, path: Path) -> dict[str, Any]:
 
 
 def write_state(*, path: Path, state: dict[str, Any]) -> None:
-    """Write session state JSON to disk, ensuring the parent dir is 0700."""
+    """Atomically write session state JSON, ensuring the parent dir is 0700.
+
+    Uses ``atomic_write_text`` so a concurrent ``SessionStart`` reader can
+    never observe a half-written state file: the new contents become
+    visible only via the final ``os.rename`` in ``atomic_write_text``,
+    matching ``claim_state_file`` on the read side.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
     path.parent.chmod(0o700)
-    path.write_text(json.dumps(state, indent=2))
+    atomic_write_text(path, json.dumps(state, indent=2))
 
 
 def read_plan_summary(*, toplevel: str) -> dict[str, Any]:
-    """Read the persisted plan via the task_plan_sync helpers."""
-    from dev10x.hooks.task_plan_sync import get_plan_path, read_plan
+    """Read the persisted plan as a dict via the Plan domain object.
+
+    Direct domain → domain access; the previous lazy import into
+    ``dev10x.hooks.task_plan_sync`` inverted the dependency direction
+    (domain should never reach into hooks). Hooks compose this query
+    via the CLI adapter, not the other way around.
+    """
+    from dev10x.domain.documents.plan import Plan, get_plan_path
 
     plan_path = get_plan_path(toplevel=toplevel)
-    return read_plan(plan_path=plan_path)
+    return Plan.load(path=plan_path)._to_dict()
 
 
 __all__ = [

--- a/src/dev10x/plan/service.py
+++ b/src/dev10x/plan/service.py
@@ -13,6 +13,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from dev10x.domain.documents.plan import Plan, get_plan_path, get_toplevel
+from dev10x.domain.file_locks import file_lock  # noqa: F401
 
 
 class PlanServiceError(Exception):
@@ -26,17 +27,18 @@ def set_plan_context(*, args: list[str]) -> list[str]:
         raise PlanServiceError("Not in a git repository")
 
     plan_path = get_plan_path(toplevel=toplevel)
-    plan = Plan.load(path=plan_path)
-    plan.ensure_metadata()
+    with file_lock(plan_path):
+        plan = Plan.load(path=plan_path)
+        plan.ensure_metadata()
 
-    for arg in args:
-        if "=" not in arg:
-            raise PlanServiceError(f"Invalid argument (expected K=V): {arg}")
-        key, value = arg.split("=", 1)
-        plan.set_context(key=key, value=value)
+        for arg in args:
+            if "=" not in arg:
+                raise PlanServiceError(f"Invalid argument (expected K=V): {arg}")
+            key, value = arg.split("=", 1)
+            plan.set_context(key=key, value=value)
 
-    plan.save(path=plan_path)
-    return plan.context_keys()
+        plan.save(path=plan_path)
+        return plan.context_keys()
 
 
 def plan_summary() -> dict[str, Any]:
@@ -65,19 +67,20 @@ def archive_plan() -> dict[str, Any]:
         raise PlanServiceError("Not in a git repository")
 
     plan_path = get_plan_path(toplevel=toplevel)
-    if not plan_path.exists():
-        return {"archived": False}
+    with file_lock(plan_path):
+        if not plan_path.exists():
+            return {"archived": False}
 
-    plan = Plan.load(path=plan_path)
-    archive_dir = plan_path.parent / "archive"
-    archive_dir.mkdir(parents=True, exist_ok=True)
+        plan = Plan.load(path=plan_path)
+        archive_dir = plan_path.parent / "archive"
+        archive_dir.mkdir(parents=True, exist_ok=True)
 
-    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S")
-    branch_slug = plan.metadata.get("branch", "unknown")
-    branch_slug = branch_slug.replace("/", "-")[:50]
-    archive_name = f"plan-{timestamp}-{branch_slug}.yaml"
-    archive_path = archive_dir / archive_name
+        timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S")
+        branch_slug = plan.metadata.get("branch", "unknown")
+        branch_slug = branch_slug.replace("/", "-")[:50]
+        archive_name = f"plan-{timestamp}-{branch_slug}.yaml"
+        archive_path = archive_dir / archive_name
 
-    plan.archive(path=archive_path)
-    plan_path.unlink()
-    return {"archived": True, "archive_name": archive_name}
+        plan.archive(path=archive_path)
+        plan_path.unlink()
+        return {"archived": True, "archive_name": archive_name}

--- a/src/dev10x/platform/registry.py
+++ b/src/dev10x/platform/registry.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import yaml
 
 from dev10x.domain.dev10x_paths import Dev10xConfigDir
-from dev10x.domain.file_locks import atomic_write_text
+from dev10x.domain.file_locks import atomic_write_text, file_lock  # noqa: F401
 
 REGISTRY_FILE = Dev10xConfigDir.platforms_yaml()
 
@@ -167,17 +167,19 @@ class Registry:
                 playbook_override=playbook_override,
             )
 
-        registered = self.load()
-        registered[name] = base
-        self.save(registered)
+        with file_lock(self.path):
+            registered = self.load()
+            registered[name] = base
+            self.save(registered)
         return base
 
     def remove(self, name: str) -> bool:
-        registered = self.load()
-        if name not in registered:
-            return False
-        del registered[name]
-        self.save(registered)
+        with file_lock(self.path):
+            registered = self.load()
+            if name not in registered:
+                return False
+            del registered[name]
+            self.save(registered)
         return True
 
     def list(self) -> list[PlatformConfig]:

--- a/tests/audit/test_log_reader.py
+++ b/tests/audit/test_log_reader.py
@@ -165,6 +165,27 @@ class TestAppendRecord:
         finally:
             ro_dir.chmod(0o755)  # Restore for cleanup
 
+    def test_uses_posix_o_append(self, tmp_path) -> None:
+        """E1: append_record uses os.open(O_APPEND) for POSIX append atomicity."""
+        from unittest.mock import patch
+
+        with patch("dev10x.audit.log_reader.os.open", wraps=os.open) as mock_open:
+            append_record(record={"hook": "x"}, base_dir=tmp_path)
+
+        assert mock_open.called
+        flags = mock_open.call_args.args[1]
+        assert flags & os.O_APPEND
+        assert flags & os.O_WRONLY
+        assert flags & os.O_CREAT
+
+    def test_two_appends_do_not_corrupt_under_simulated_race(self, tmp_path) -> None:
+        """Both records survive even when both writers contend."""
+        append_record(record={"id": 1, "hook": "a"}, base_dir=tmp_path)
+        append_record(record={"id": 2, "hook": "b"}, base_dir=tmp_path)
+        log = tmp_path / f"hooks-{datetime.now(UTC).strftime('%Y-%m-%d')}.jsonl"
+        lines = [json.loads(line) for line in log.read_text().strip().split("\n")]
+        assert {rec["id"] for rec in lines} == {1, 2}
+
 
 class TestClassifyOutcome:
     def test_ok_outcome(self) -> None:

--- a/tests/domain/test_session_document.py
+++ b/tests/domain/test_session_document.py
@@ -1,0 +1,95 @@
+"""Tests for atomic-write semantics in session_document.write_state (GH-240 E2/E8)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from dev10x.domain import session_document
+from dev10x.domain.file_locks import atomic_write_text
+
+
+class TestWriteStateIsAtomic:
+    """write_state must publish via os.rename so readers never see a partial file."""
+
+    def test_writes_state_json(self, tmp_path: Path) -> None:
+        path = tmp_path / "state.json"
+        state = {"session_id": "abc", "branch": "develop"}
+        session_document.write_state(path=path, state=state)
+        assert json.loads(path.read_text()) == state
+
+    def test_parent_directory_chmod_0700(self, tmp_path: Path) -> None:
+        path = tmp_path / "nested" / "state.json"
+        session_document.write_state(path=path, state={})
+        assert (path.parent.stat().st_mode & 0o777) == 0o700
+
+    def test_crash_mid_write_leaves_original_intact(self, tmp_path: Path) -> None:
+        """Simulated crash inside atomic_write_text must not corrupt the
+        existing state file: the new contents become visible only via
+        the final os.rename, never via partial writes to the target."""
+        path = tmp_path / "state.json"
+        path.write_text(json.dumps({"original": True}))
+
+        def boom(_path: Path, _content: str) -> None:
+            raise RuntimeError("simulated crash")
+
+        with patch.object(session_document, "atomic_write_text", side_effect=boom):
+            with pytest.raises(RuntimeError):
+                session_document.write_state(path=path, state={"new": True})
+
+        assert json.loads(path.read_text()) == {"original": True}
+
+    def test_uses_atomic_write_text(self, tmp_path: Path) -> None:
+        path = tmp_path / "state.json"
+        with patch.object(session_document, "atomic_write_text") as mock_write:
+            session_document.write_state(path=path, state={"a": 1})
+        mock_write.assert_called_once()
+        called_path, called_content = mock_write.call_args.args
+        assert called_path == path
+        assert json.loads(called_content) == {"a": 1}
+
+
+class TestReadPlanSummaryHasNoHookImport:
+    """D1: read_plan_summary must not lazy-import from dev10x.hooks."""
+
+    def test_uses_domain_plan_directly(self, tmp_path: Path) -> None:
+        toplevel = str(tmp_path)
+        plan_dir = tmp_path / ".claude" / "session"
+        plan_dir.mkdir(parents=True)
+        plan_yaml = plan_dir / "plan.yaml"
+        plan_yaml.write_text(
+            "plan:\n  status: in_progress\ntasks:\n  - id: '1'\n    subject: hi\n"
+        )
+
+        result = session_document.read_plan_summary(toplevel=toplevel)
+        assert result["plan"]["status"] == "in_progress"
+        assert result["tasks"][0]["subject"] == "hi"
+
+    def test_returns_empty_when_no_plan(self, tmp_path: Path) -> None:
+        result = session_document.read_plan_summary(toplevel=str(tmp_path))
+        assert result == {}
+
+    def test_no_hooks_import_in_source(self) -> None:
+        """Source must not import from dev10x.hooks — domain->hooks inversion."""
+        src = Path(session_document.__file__).read_text()
+        assert "from dev10x.hooks" not in src
+        assert "import dev10x.hooks" not in src
+
+
+class TestAtomicWriteTextRoundtrip:
+    """Smoke-check: atomic helper still publishes via rename."""
+
+    def test_no_stale_tmp_after_crash(self, tmp_path: Path) -> None:
+        target = tmp_path / "out.json"
+        target.write_text("original")
+
+        with patch("dev10x.domain.file_locks.os.rename", side_effect=OSError("disk full")):
+            with pytest.raises(OSError):
+                atomic_write_text(target, "new")
+
+        assert target.read_text() == "original"
+        leftovers = [p for p in tmp_path.iterdir() if p.suffix == ".tmp"]
+        assert leftovers == []

--- a/tests/hooks/test_orchestrators.py
+++ b/tests/hooks/test_orchestrators.py
@@ -69,3 +69,79 @@ class TestOrchestratorConsolidation:
         # Feed malformed data that one feature might choke on
         result = _run(SESSION_START, {"session_id": ""})
         assert result.returncode == 0
+
+
+class TestRunFeatureBufferDiscard:
+    """E9: _run_feature must discard partial stdout when a feature raises.
+
+    Appending half-written JSON to context_parts would corrupt the
+    SessionStart envelope.
+    """
+
+    def _import_session_start(self):
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location("_session_start_under_test", SESSION_START)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    def test_returns_empty_on_exception(self) -> None:
+        module = self._import_session_start()
+
+        def fake_audit_hook(*, name: str, event: str = ""):
+            def decorator(fn):
+                return fn
+
+            return decorator
+
+        def feature_that_prints_then_raises() -> None:
+            print("PARTIAL_JSON_PAYLOAD")
+            raise RuntimeError("boom")
+
+        result = module._run_feature(
+            name="test",
+            fn=feature_that_prints_then_raises,
+            audit_hook=fake_audit_hook,
+        )
+        assert result == ""
+
+    def test_keeps_output_on_systemexit(self) -> None:
+        module = self._import_session_start()
+
+        def fake_audit_hook(*, name: str, event: str = ""):
+            def decorator(fn):
+                return fn
+
+            return decorator
+
+        def feature_that_exits() -> None:
+            print("CLEAN_OUTPUT")
+            raise SystemExit(0)
+
+        result = module._run_feature(
+            name="test",
+            fn=feature_that_exits,
+            audit_hook=fake_audit_hook,
+        )
+        assert "CLEAN_OUTPUT" in result
+
+    def test_returns_clean_output_on_success(self) -> None:
+        module = self._import_session_start()
+
+        def fake_audit_hook(*, name: str, event: str = ""):
+            def decorator(fn):
+                return fn
+
+            return decorator
+
+        def feature_clean() -> None:
+            print("HELLO")
+
+        result = module._run_feature(
+            name="test",
+            fn=feature_clean,
+            audit_hook=fake_audit_hook,
+        )
+        assert "HELLO" in result

--- a/tests/plan/test_service.py
+++ b/tests/plan/test_service.py
@@ -83,3 +83,36 @@ class TestArchivePlan:
         assert (archive_dir / result["archive_name"]).exists()
         # Active plan is moved away
         assert not (tmp_path / ".claude" / "session" / "plan.yaml").exists()
+
+
+class TestSetPlanContextHoldsLock:
+    """E3: set_plan_context must serialize load→mutate→save via file_lock."""
+
+    def test_holds_file_lock_around_cycle(self, tmp_path: Path) -> None:
+        from unittest.mock import MagicMock
+
+        with (
+            patch(f"{SERVICE}.get_toplevel", return_value=str(tmp_path)),
+            patch("dev10x.domain.documents.plan._get_branch", return_value="b"),
+            patch(f"{SERVICE}.file_lock") as mock_lock,
+        ):
+            mock_lock.return_value = MagicMock(__enter__=MagicMock(), __exit__=MagicMock())
+            set_plan_context(args=["work_type=feature"])
+
+        mock_lock.assert_called_once()
+        plan_path = tmp_path / ".claude" / "session" / "plan.yaml"
+        assert mock_lock.call_args.args[0] == plan_path
+
+
+class TestArchivePlanHoldsLock:
+    def test_holds_file_lock_around_cycle(self, tmp_path: Path) -> None:
+        from unittest.mock import MagicMock
+
+        with (
+            patch(f"{SERVICE}.get_toplevel", return_value=str(tmp_path)),
+            patch(f"{SERVICE}.file_lock") as mock_lock,
+        ):
+            mock_lock.return_value = MagicMock(__enter__=MagicMock(), __exit__=MagicMock())
+            archive_plan()
+
+        mock_lock.assert_called_once()

--- a/tests/platform/test_registry.py
+++ b/tests/platform/test_registry.py
@@ -56,6 +56,26 @@ class TestRegistryAdd:
         assert cfg.name == "windsurf"
         assert "windsurf" in str(cfg.config_dir)
 
+    def test_add_holds_file_lock(self, registry: Registry) -> None:
+        """A12: Registry.add serializes load→mutate→save via file_lock."""
+        from unittest.mock import MagicMock, patch
+
+        with patch("dev10x.platform.registry.file_lock") as mock_lock:
+            mock_lock.return_value = MagicMock(__enter__=MagicMock(), __exit__=MagicMock())
+            registry.add(name="windsurf")
+
+        mock_lock.assert_called_once_with(registry.path)
+
+    def test_remove_holds_file_lock(self, registry: Registry) -> None:
+        from unittest.mock import MagicMock, patch
+
+        registry.add(name="windsurf")
+        with patch("dev10x.platform.registry.file_lock") as mock_lock:
+            mock_lock.return_value = MagicMock(__enter__=MagicMock(), __exit__=MagicMock())
+            registry.remove("windsurf")
+
+        mock_lock.assert_called_once_with(registry.path)
+
     def test_rejects_unknown_platform(self, registry: Registry) -> None:
         with pytest.raises(ValueError, match="Unknown platform"):
             registry.add(name="not-a-real-platform")


### PR DESCRIPTION
**When** Dev10x agents and hooks race on shared session, plan, and permission files, **I want to** route every write through atomic_write_text and serialize every load→mutate→save cycle with file_lock, **so I can** prevent concurrent worktrees and parallel sub-agents from corrupting session state, plan metadata, or permission rules in production.

---

[`aaea3e0a`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/286/commits/aaea3e0adcd2f814cb442bb25e7c5924551ddc06) 🛡️ GH-240 Enforce atomic writes and locks on boundary hot paths
Closes #240
Fixes: https://github.com/Dev10x-Guru/dev10x-claude/issues/240

---