### PR TITLE
♻️ GH-241 Enforce typed identifiers across plan and PR surfaces

### DIFF
--- a/skills/gh-pr-monitor/scripts/ci-check-status.py
+++ b/skills/gh-pr-monitor/scripts/ci-check-status.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.12"
-# dependencies = []
+# dependencies = ["pyyaml"]
 # ///
 """Thin shim — delegates to dev10x.skills.monitor.ci_check_status."""
 

--- a/src/dev10x/domain/common/branch_name.py
+++ b/src/dev10x/domain/common/branch_name.py
@@ -1,0 +1,93 @@
+"""BranchName value object — `username/TICKET-ID/[worktree/]slug` convention.
+
+The branch-naming convention is documented in .claude/rules but
+enforced nowhere. This value object provides parsing,
+convention validation, and protected-branch detection so MCP
+entry points and git helpers can validate inputs at the
+boundary. Audit finding C10 — 2026-05-18.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from dev10x.domain.common.ticket_id import TicketId
+
+PROTECTED_BRANCHES: frozenset[str] = frozenset(
+    {"main", "master", "develop", "development", "trunk"}
+)
+
+# Slug constraints — lower-case alphanumerics with hyphens/underscores.
+_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+_USERNAME_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+
+
+@dataclass(frozen=True)
+class BranchName:
+    raw: str
+    username: str | None = None
+    ticket: TicketId | None = None
+    worktree: str | None = None
+    slug: str | None = None
+
+    def __str__(self) -> str:
+        return self.raw
+
+    @property
+    def is_protected(self) -> bool:
+        return self.raw in PROTECTED_BRANCHES
+
+    @property
+    def follows_convention(self) -> bool:
+        return self.username is not None and self.ticket is not None and self.slug is not None
+
+    @classmethod
+    def parse(cls, value: str) -> BranchName:
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"Invalid branch name: {value!r}")
+        parts = value.split("/")
+        if len(parts) < 3 or len(parts) > 4:
+            return cls(raw=value)
+
+        username = parts[0]
+        ticket_str = parts[1]
+        if not _USERNAME_RE.match(username):
+            return cls(raw=value)
+        ticket = TicketId.try_parse(ticket_str)
+        if ticket is None:
+            return cls(raw=value)
+
+        if len(parts) == 3:
+            slug = parts[2]
+            worktree = None
+        else:
+            worktree = parts[2]
+            slug = parts[3]
+
+        if not _SLUG_RE.match(slug):
+            return cls(raw=value)
+        if worktree is not None and not _SLUG_RE.match(worktree):
+            return cls(raw=value)
+
+        return cls(
+            raw=value,
+            username=username,
+            ticket=ticket,
+            worktree=worktree,
+            slug=slug,
+        )
+
+    @classmethod
+    def try_parse(cls, value: str) -> BranchName | None:
+        try:
+            return cls.parse(value)
+        except (TypeError, ValueError):
+            return None
+
+    def validate_convention(self) -> None:
+        if not self.follows_convention:
+            raise ValueError(
+                f"Branch {self.raw!r} does not follow the "
+                f"'username/TICKET-ID/[worktree/]slug' convention."
+            )

--- a/src/dev10x/domain/common/repository_ref.py
+++ b/src/dev10x/domain/common/repository_ref.py
@@ -18,3 +18,10 @@ class RepositoryRef:
             msg = f"Invalid repository reference: {value!r}. Expected 'owner/name' format."
             raise ValueError(msg)
         return cls(owner=parts[0], name=parts[1])
+
+    @classmethod
+    def try_parse(cls, value: str) -> RepositoryRef | None:
+        try:
+            return cls.parse(value)
+        except (TypeError, ValueError):
+            return None

--- a/src/dev10x/domain/common/skill_name.py
+++ b/src/dev10x/domain/common/skill_name.py
@@ -1,0 +1,51 @@
+"""SkillName value object — `<namespace>:<slug>` skill identifier.
+
+Eliminates duplicate parsing scattered across `hooks/skill.py`
+(safe-path naming), `skills/permission/local_skill_approval.py`
+(namespace grouping), and `skills/audit/cli_friction.py`
+(directory lookup). Audit finding C4 — 2026-05-18.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SkillName:
+    namespace: str | None
+    slug: str
+
+    def __str__(self) -> str:
+        if self.namespace:
+            return f"{self.namespace}:{self.slug}"
+        return self.slug
+
+    @property
+    def short_name(self) -> str:
+        return self.slug
+
+    @property
+    def safe_path_name(self) -> str:
+        full = str(self)
+        # Replace `:` with `-`, then strip anything outside [A-Za-z0-9._-].
+        return re.sub(r"[^a-zA-Z0-9._-]", "", full.replace(":", "-"))
+
+    @classmethod
+    def parse(cls, value: str) -> SkillName:
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"Invalid skill name: {value!r}")
+        if ":" in value:
+            namespace, slug = value.split(":", 1)
+            if not namespace or not slug:
+                raise ValueError(f"Invalid namespaced skill name: {value!r}")
+            return cls(namespace=namespace, slug=slug)
+        return cls(namespace=None, slug=value)
+
+    @classmethod
+    def try_parse(cls, value: str) -> SkillName | None:
+        try:
+            return cls.parse(value)
+        except (TypeError, ValueError):
+            return None

--- a/src/dev10x/domain/common/ticket_id.py
+++ b/src/dev10x/domain/common/ticket_id.py
@@ -1,0 +1,55 @@
+"""TicketId value object — canonical `[A-Z]+-\\d+` ticket identifier.
+
+Eliminates duplicate regex literals previously scattered across
+`validators/commit_jtbd.py`, `skills/release/collect_prs.py`, and
+`skills/permission/merge_worktree_permissions.py` (audit finding
+C1 — 2026-05-18; also resolves I5).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+TICKET_ID_PATTERN = r"[A-Z]+-\d+"
+_FULL_RE = re.compile(rf"^{TICKET_ID_PATTERN}$")
+_SEARCH_RE = re.compile(TICKET_ID_PATTERN)
+
+
+@dataclass(frozen=True)
+class TicketId:
+    project: str
+    number: int
+
+    def __str__(self) -> str:
+        return f"{self.project}-{self.number}"
+
+    @classmethod
+    def parse(cls, value: str) -> TicketId:
+        if not isinstance(value, str) or not _FULL_RE.match(value):
+            msg = f"Invalid ticket id: {value!r}. Expected '[A-Z]+-<digits>'."
+            raise ValueError(msg)
+        project, number = value.rsplit("-", 1)
+        return cls(project=project, number=int(number))
+
+    @classmethod
+    def try_parse(cls, value: str) -> TicketId | None:
+        try:
+            return cls.parse(value)
+        except (TypeError, ValueError):
+            return None
+
+    @classmethod
+    def find_first(cls, text: str) -> TicketId | None:
+        match = _SEARCH_RE.search(text)
+        if not match:
+            return None
+        return cls.try_parse(match.group(0))
+
+    @classmethod
+    def find_all(cls, text: str) -> list[TicketId]:
+        return [
+            ticket
+            for match in _SEARCH_RE.finditer(text)
+            if (ticket := cls.try_parse(match.group(0))) is not None
+        ]

--- a/src/dev10x/domain/documents/plan.py
+++ b/src/dev10x/domain/documents/plan.py
@@ -2,7 +2,8 @@
 
 Replaces the raw dict[str, Any] threading in task_plan_sync.py
 with a cohesive domain object that owns its own persistence and
-mutation logic.
+mutation logic. Tasks are typed `Task` value objects (GH-241
+finding B1/B10) — load/save round-trip preserves all fields.
 """
 
 from __future__ import annotations
@@ -13,11 +14,12 @@ import re
 import tempfile
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+from dev10x.domain.documents.task import Task, TaskStatus
 
 
 def _now_iso() -> str:
@@ -50,13 +52,6 @@ def get_toplevel() -> str | None:
 def get_plan_path(*, toplevel: str) -> Path:
     """Resolve the canonical plan file path within a git toplevel."""
     return Path(toplevel) / ".claude" / "session" / "plan.yaml"
-
-
-class TaskStatus(StrEnum):
-    PENDING = "pending"
-    IN_PROGRESS = "in_progress"
-    COMPLETED = "completed"
-    DELETED = "deleted"
 
 
 @dataclass(frozen=True)
@@ -107,7 +102,19 @@ TASK_TRANSITIONS: dict[TaskStatus, TaskTransition] = {
 @dataclass
 class Plan:
     metadata: dict[str, Any] = field(default_factory=dict)
-    tasks: list[dict[str, Any]] = field(default_factory=list)
+    tasks: list[Task] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        # Accept raw dicts at construction so tests and legacy callers
+        # that pass `tasks=[{"id": ...}]` keep working — normalize to
+        # `Task` instances eagerly.
+        normalized: list[Task] = []
+        for item in self.tasks:
+            if isinstance(item, Task):
+                normalized.append(item)
+            elif isinstance(item, dict):
+                normalized.append(Task.from_dict(item))
+        self.tasks = normalized
 
     @classmethod
     def load(cls, *, path: Path) -> Plan:
@@ -119,9 +126,11 @@ class Plan:
                 data = {}
         else:
             data = {}
+        raw_tasks = data.get("tasks", []) or []
+        tasks = [Task.from_dict(t) for t in raw_tasks if isinstance(t, dict)]
         return cls(
             metadata=data.get("plan", {}),
-            tasks=data.get("tasks", []),
+            tasks=tasks,
         )
 
     def save(self, *, path: Path) -> None:
@@ -154,7 +163,7 @@ class Plan:
         if self.metadata:
             result["plan"] = self.metadata
         if self.tasks:
-            result["tasks"] = self.tasks
+            result["tasks"] = [t.to_dict() for t in self.tasks]
         return result
 
     def archive(self, *, path: Path) -> None:
@@ -182,6 +191,12 @@ class Plan:
             return []
         return list(context.keys())
 
+    def _find_index(self, *, task_id: str) -> int | None:
+        for idx, task in enumerate(self.tasks):
+            if task.id == task_id:
+                return idx
+        return None
+
     def handle_task_create(
         self,
         *,
@@ -192,24 +207,20 @@ class Plan:
         if not task_id:
             return False
 
-        task_entry: dict[str, Any] = {
-            "id": task_id,
-            "subject": tool_input.get("subject", ""),
-            "status": TaskStatus.PENDING.value,
-            "created_at": _now_iso(),
-        }
-        description = tool_input.get("description")
-        if description:
-            task_entry["description"] = description
-        metadata = tool_input.get("metadata")
-        if metadata:
-            task_entry["metadata"] = metadata
+        if any(t.id == task_id for t in self.tasks):
+            return False
 
-        existing_ids = {t.get("id") for t in self.tasks}
-        if task_id not in existing_ids:
-            self.tasks.append(task_entry)
-            return True
-        return False
+        metadata_raw = tool_input.get("metadata") or {}
+        task = Task(
+            id=task_id,
+            subject=tool_input.get("subject", ""),
+            status=TaskStatus.PENDING,
+            created_at=_now_iso(),
+            description=tool_input.get("description", "") or "",
+            metadata=dict(metadata_raw) if isinstance(metadata_raw, dict) else {},
+        )
+        self.tasks.append(task)
+        return True
 
     def handle_task_update(self, *, tool_input: dict[str, Any]) -> None:
         task_id = tool_input.get("taskId")
@@ -219,43 +230,35 @@ class Plan:
         raw_status = tool_input.get("status")
         target_status = _coerce_status(raw_status)
         if target_status is TaskStatus.DELETED:
-            self.tasks = [t for t in self.tasks if t.get("id") != task_id]
+            self.tasks = [t for t in self.tasks if t.id != task_id]
             return
 
-        for task in self.tasks:
-            if task.get("id") != task_id:
-                continue
-            if target_status is not None and not _is_valid_transition(
-                current=_coerce_status(task.get("status")),
-                target=target_status,
-            ):
+        idx = self._find_index(task_id=task_id)
+        if idx is None:
+            return
+
+        task = self.tasks[idx]
+        if target_status is not None:
+            if not _is_valid_transition(current=task.status, target=target_status):
                 # Reject invalid transitions silently; the hook must keep
                 # processing other updates rather than crashing on a stale
                 # status flip caused by clock skew or replay.
-                break
-            if target_status is not None:
-                task["status"] = target_status.value
-                transition = TASK_TRANSITIONS[target_status]
-                if transition.timestamp_field is not None:
-                    task[transition.timestamp_field] = _now_iso()
-            if "subject" in tool_input:
-                task["subject"] = tool_input["subject"]
-            if "description" in tool_input:
-                task["description"] = tool_input["description"]
-            if "metadata" in tool_input:
-                existing_meta = task.get("metadata", {})
-                for k, v in tool_input["metadata"].items():
-                    if v is None:
-                        existing_meta.pop(k, None)
-                    else:
-                        existing_meta[k] = v
-                if existing_meta:
-                    task["metadata"] = existing_meta
-            break
+                return
+            task = task.with_status(status=target_status, timestamp=_now_iso())
+
+        if "subject" in tool_input:
+            task = task.with_subject(subject=tool_input["subject"])
+        if "description" in tool_input:
+            task = task.with_description(description=tool_input["description"])
+        if "metadata" in tool_input:
+            updates = tool_input["metadata"]
+            if isinstance(updates, dict):
+                task = task.with_metadata_merged(updates=updates)
+
+        self.tasks[idx] = task
 
     def check_all_completed(self) -> None:
-        all_statuses = [t.get("status") for t in self.tasks]
-        if all_statuses and all(s == TaskStatus.COMPLETED.value for s in all_statuses):
+        if self.tasks and all(t.status is TaskStatus.COMPLETED for t in self.tasks):
             self.metadata["status"] = TaskStatus.COMPLETED.value
             self.metadata["completed_at"] = _now_iso()
 

--- a/src/dev10x/domain/documents/session_state.py
+++ b/src/dev10x/domain/documents/session_state.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
 
+from dev10x.domain.documents.task import Task, TaskStatus
+
 
 @dataclass(frozen=True)
 class SessionState:
@@ -86,34 +88,47 @@ class PlanSummary:
     branch: str = "unknown"
     last_synced: str = "unknown"
     context: PlanContext = field(default_factory=PlanContext)
-    tasks: list[dict[str, Any]] = field(default_factory=list)
+    tasks: list[Task] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        # Tolerate raw-dict task inputs from legacy callers and tests
+        # that construct PlanSummary directly. Frozen dataclass requires
+        # `object.__setattr__` to mutate the field.
+        normalized: list[Task] = []
+        for item in self.tasks:
+            if isinstance(item, Task):
+                normalized.append(item)
+            elif isinstance(item, dict):
+                normalized.append(Task.from_dict(item))
+        object.__setattr__(self, "tasks", normalized)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> PlanSummary:
         plan_meta = data.get("plan", {})
+        raw_tasks = data.get("tasks", []) or []
+        tasks = [Task.from_dict(t) for t in raw_tasks if isinstance(t, dict)]
         return cls(
             status=plan_meta.get("status", "unknown"),
             branch=plan_meta.get("branch", "unknown"),
             last_synced=plan_meta.get("last_synced", "unknown"),
             context=PlanContext.from_dict(data=plan_meta.get("context", {})),
-            tasks=data.get("tasks", []),
+            tasks=tasks,
         )
 
     @property
-    def pending_tasks(self) -> list[dict[str, Any]]:
-        return [t for t in self.tasks if t.get("status") not in ("completed", "deleted")]
+    def pending_tasks(self) -> list[Task]:
+        return [
+            t for t in self.tasks if t.status not in (TaskStatus.COMPLETED, TaskStatus.DELETED)
+        ]
 
     @property
-    def pending_decisions(self) -> list[dict[str, Any]]:
-        return [t for t in self.pending_tasks if t.get("metadata", {}).get("decision_needed")]
+    def pending_decisions(self) -> list[Task]:
+        return [t for t in self.pending_tasks if t.metadata.get("decision_needed")]
 
     def format_for_display(self) -> str:
-        completed = sum(1 for t in self.tasks if t.get("status") == "completed")
+        completed = sum(1 for t in self.tasks if t.status is TaskStatus.COMPLETED)
         total = len(self.tasks)
-        pending = [
-            f"  - [{t.get('status')}] #{t.get('id')} {t.get('subject')}"
-            for t in self.pending_tasks
-        ]
+        pending = [f"  - [{t.status.value}] #{t.id} {t.subject}" for t in self.pending_tasks]
 
         lines = [f"Persisted plan detected ({completed}/{total} tasks completed):"]
         lines.append(f"- Plan branch: {self.branch}")
@@ -143,14 +158,13 @@ class PlanSummary:
     @staticmethod
     def _format_pending_decisions(
         *,
-        decisions: list[dict[str, Any]],
+        decisions: list[Task],
     ) -> list[str]:
         lines: list[str] = []
         for t in decisions:
-            meta = t.get("metadata", {})
-            desc = meta.get("decision_needed", "")
-            options = meta.get("options", [])
-            line = f"  - #{t.get('id')} {t.get('subject')}: {desc}"
+            desc = t.metadata.get("decision_needed", "")
+            options = t.metadata.get("options", [])
+            line = f"  - #{t.id} {t.subject}: {desc}"
             if options:
                 line += f" (options: {', '.join(str(o) for o in options)})"
             lines.append(line)
@@ -159,8 +173,8 @@ class PlanSummary:
     def format_for_compaction(self) -> str:
         task_lines = []
         for t in self.tasks:
-            line = f"- [{t.get('status')}] #{t.get('id')} {t.get('subject')}"
-            meta = t.get("metadata", {})
+            line = f"- [{t.status.value}] #{t.id} {t.subject}"
+            meta = t.metadata
             if meta.get("type"):
                 line += f" ({meta['type']})"
             if meta.get("skills"):

--- a/src/dev10x/domain/documents/task.py
+++ b/src/dev10x/domain/documents/task.py
@@ -1,0 +1,96 @@
+"""Task value object for typed plan task entries.
+
+Replaces the `dict[str, Any]` task representation that propagated
+through `Plan`, `PlanSummary`, `DecisionGuidanceRule`, and
+`task_plan_sync` with ~15 string-key call sites (audit finding
+B1/B10 — 2026-05-18). YAML round-trip is preserved via
+`Task.from_dict` / `Task.to_dict`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from enum import StrEnum
+from typing import Any
+
+
+class TaskStatus(StrEnum):
+    PENDING = "pending"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    DELETED = "deleted"
+
+
+@dataclass(frozen=True)
+class Task:
+    id: str
+    subject: str = ""
+    status: TaskStatus = TaskStatus.PENDING
+    created_at: str = ""
+    description: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+    started_at: str = ""
+    completed_at: str = ""
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Task:
+        raw_status = data.get("status")
+        try:
+            status = TaskStatus(raw_status) if raw_status else TaskStatus.PENDING
+        except ValueError:
+            status = TaskStatus.PENDING
+        metadata = data.get("metadata") or {}
+        return cls(
+            id=str(data.get("id", "")),
+            subject=data.get("subject", ""),
+            status=status,
+            created_at=data.get("created_at", ""),
+            description=data.get("description", ""),
+            metadata=dict(metadata) if isinstance(metadata, dict) else {},
+            started_at=data.get("started_at", ""),
+            completed_at=data.get("completed_at", ""),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "id": self.id,
+            "subject": self.subject,
+            "status": self.status.value,
+        }
+        if self.created_at:
+            result["created_at"] = self.created_at
+        if self.description:
+            result["description"] = self.description
+        if self.metadata:
+            result["metadata"] = self.metadata
+        if self.started_at:
+            result["started_at"] = self.started_at
+        if self.completed_at:
+            result["completed_at"] = self.completed_at
+        return result
+
+    def with_status(self, *, status: TaskStatus, timestamp: str) -> Task:
+        if status is TaskStatus.IN_PROGRESS:
+            return replace(self, status=status, started_at=timestamp)
+        if status is TaskStatus.COMPLETED:
+            return replace(self, status=status, completed_at=timestamp)
+        return replace(self, status=status)
+
+    def with_subject(self, *, subject: str) -> Task:
+        return replace(self, subject=subject)
+
+    def with_description(self, *, description: str) -> Task:
+        return replace(self, description=description)
+
+    def with_metadata_merged(self, *, updates: dict[str, Any]) -> Task:
+        merged = dict(self.metadata)
+        for k, v in updates.items():
+            if v is None:
+                merged.pop(k, None)
+            else:
+                merged[k] = v
+        return replace(self, metadata=merged)
+
+    @property
+    def is_active(self) -> bool:
+        return self.status in (TaskStatus.PENDING, TaskStatus.IN_PROGRESS)

--- a/src/dev10x/git/__init__.py
+++ b/src/dev10x/git/__init__.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
+from dev10x.domain.common.branch_name import BranchName
 from dev10x.domain.common.result import Result, err, ok
 from dev10x.subprocess_utils import async_run_script, parse_key_value_output
 
@@ -68,6 +69,14 @@ async def create_worktree(
     base: str | None = None,
     path: str | None = None,
 ) -> Result[dict[str, Any]]:
+    branch_ref = BranchName.try_parse(branch)
+    if branch_ref is None:
+        return err(f"Invalid branch name: {branch!r}")
+    if branch_ref.is_protected:
+        return err(
+            f"Refusing to create worktree on protected branch {branch!r}. "
+            "Use a feature branch (username/TICKET-ID/[worktree/]slug)."
+        )
     wt_args = [branch]
 
     if base is not None:

--- a/src/dev10x/github/__init__.py
+++ b/src/dev10x/github/__init__.py
@@ -66,14 +66,19 @@ async def _gh_api(
 
 
 async def _bot_env(*, repo: str) -> dict[str, str] | None:
-    token = await get_bot_token(repo=repo)
+    try:
+        ref = RepositoryRef.parse(repo)
+    except ValueError:
+        return None
+    canonical_repo = str(ref)
+    token = await get_bot_token(repo=canonical_repo)
     if token is None:
         if AppConfig.load() is not None:
             logger.warning(
                 "GitHub App auth configured but bot token exchange failed for %s — "
                 "falling back to engineer credentials. Verify the App is installed "
                 "on the repo and the private key matches the app_id.",
-                repo,
+                canonical_repo,
             )
         return None
     return {**os.environ, "GH_TOKEN": token, "GITHUB_TOKEN": token}

--- a/src/dev10x/hooks/session_policy.py
+++ b/src/dev10x/hooks/session_policy.py
@@ -121,9 +121,7 @@ class DecisionGuidanceRule:
         summary = PlanSummary.from_dict(data=self.plan)
         decisions = summary.pending_decisions
         if not decisions:
-            has_remaining = any(
-                t.get("status") not in ("completed", "deleted") for t in summary.tasks
-            )
+            has_remaining = bool(summary.pending_tasks)
             if has_remaining:
                 return "Session resumed with tasks remaining. Auto-advance through the task list."
             return ""

--- a/src/dev10x/hooks/skill.py
+++ b/src/dev10x/hooks/skill.py
@@ -9,13 +9,13 @@ from __future__ import annotations
 
 import hashlib
 import json
-import re
 import subprocess
 import sys
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from dev10x.domain.claude_paths import ClaudeDir
+from dev10x.domain.common.skill_name import SkillName
 from dev10x.domain.git_context import GitContext
 
 _git = GitContext()
@@ -40,7 +40,10 @@ def skill_tmpdir(data: dict | None = None) -> None:
     if not skill_name:
         return
 
-    safe_name = re.sub(r"[^a-zA-Z0-9._-]", "", skill_name.replace(":", "-"))
+    parsed = SkillName.try_parse(skill_name)
+    if parsed is None:
+        return
+    safe_name = parsed.safe_path_name
     if safe_name:
         Path(f"/tmp/Dev10x/{safe_name}").mkdir(parents=True, exist_ok=True)
 

--- a/src/dev10x/skills/monitor/ci_check_status.py
+++ b/src/dev10x/skills/monitor/ci_check_status.py
@@ -51,6 +51,8 @@ import subprocess
 import sys
 import time
 
+from dev10x.domain.common.repository_ref import RepositoryRef
+
 
 def fetch_mergeable(
     *,
@@ -233,10 +235,15 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    try:
+        repo = str(RepositoryRef.parse(args.repo))
+    except ValueError as exc:
+        parser.error(str(exc))
+
     if args.wait:
         result = poll_until_terminal(
             pr_number=args.pr,
-            repo=args.repo,
+            repo=repo,
             required_only=args.required_only,
             poll_interval=args.poll_interval,
             initial_wait=args.initial_wait,
@@ -245,12 +252,12 @@ def main() -> None:
     else:
         checks = fetch_checks(
             pr_number=args.pr,
-            repo=args.repo,
+            repo=repo,
             required_only=args.required_only,
         )
         mergeable = fetch_mergeable(
             pr_number=args.pr,
-            repo=args.repo,
+            repo=repo,
         )
         result = compute_verdict(checks=checks, mergeable=mergeable)
 

--- a/src/dev10x/skills/monitor/pr_notify.py
+++ b/src/dev10x/skills/monitor/pr_notify.py
@@ -37,6 +37,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from dev10x.domain.common.repository_ref import RepositoryRef
+
 
 def gh_json(args: list[str]) -> Any:
     result = subprocess.run(
@@ -95,6 +97,9 @@ def split_title_jtbd(pr_title: str) -> tuple[str, str | None]:
 
 
 def _repo_name(repo: str) -> str:
+    ref = RepositoryRef.try_parse(repo)
+    if ref is not None:
+        return ref.name
     return repo.split("/")[-1]
 
 
@@ -484,6 +489,10 @@ def main() -> None:
     )
 
     args = parser.parse_args()
+    try:
+        args.repo = str(RepositoryRef.parse(args.repo))
+    except ValueError as exc:
+        parser.error(str(exc))
     commands = {
         "prepare": cmd_prepare,
         "send": cmd_send,

--- a/src/dev10x/skills/permission/local_skill_approval.py
+++ b/src/dev10x/skills/permission/local_skill_approval.py
@@ -23,6 +23,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from dev10x.domain.claude_paths import ClaudeDir
+from dev10x.domain.common.skill_name import SkillName
 
 SKILL_NAME_RE = re.compile(
     r"^\s*name:\s*['\"]?(?P<name>[A-Za-z0-9:_\-]+)['\"]?\s*$",
@@ -40,7 +41,8 @@ class LocalSkill:
 
     @property
     def short_name(self) -> str:
-        return self.name.split(":", 1)[-1]
+        parsed = SkillName.try_parse(self.name)
+        return parsed.short_name if parsed else self.name
 
 
 @dataclass
@@ -79,7 +81,8 @@ def enumerate_local_skills(*, skills_root: Path | None = None) -> list[LocalSkil
         if not match:
             continue
         name = match.group("name")
-        namespace = name.split(":", 1)[0] if ":" in name else None
+        parsed = SkillName.try_parse(name)
+        namespace = parsed.namespace if parsed else None
         skills.append(
             LocalSkill(name=name, directory=skill_md.parent, namespace=namespace),
         )

--- a/src/dev10x/skills/permission/merge_worktree_permissions.py
+++ b/src/dev10x/skills/permission/merge_worktree_permissions.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 import yaml
 
+from dev10x.domain.common.ticket_id import TICKET_ID_PATTERN
 from dev10x.domain.dev10x_paths import Dev10xConfigDir
 
 USERSPACE_CONFIG = Dev10xConfigDir.upgrade_cleanup_projects_yaml()
@@ -33,7 +34,7 @@ NOISE_PATTERNS = [
     re.compile(r"Bash\(else "),
     re.compile(r"Bash\(fi\b"),
     re.compile(r"GROOM_SEQ_FILE="),
-    re.compile(r'"[A-Z]+-\d+"'),
+    re.compile(rf'"{TICKET_ID_PATTERN}"'),
     re.compile(r"detect-tracker\.sh\s+\S"),
     re.compile(r"gh-issue-get\.sh\s+\d"),
     re.compile(r"gh-pr-detect\.sh\s+\d"),

--- a/src/dev10x/skills/release/collect_prs.py
+++ b/src/dev10x/skills/release/collect_prs.py
@@ -32,6 +32,8 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from dev10x.domain.common.ticket_id import TICKET_ID_PATTERN
+
 GITMOJI_CATEGORIES: dict[str, str] = {
     "✨": "feature",
     "🐛": "bugfix",
@@ -59,7 +61,8 @@ JTBD_PATTERN: re.Pattern[str] = re.compile(
     re.DOTALL,
 )
 
-DEFAULT_TICKET_PATTERN = r"[A-Z]+-\d+"
+
+DEFAULT_TICKET_PATTERN = TICKET_ID_PATTERN
 
 
 @dataclass

--- a/src/dev10x/validators/commit_jtbd.py
+++ b/src/dev10x/validators/commit_jtbd.py
@@ -18,6 +18,7 @@ from typing import ClassVar
 
 from dev10x.domain import HookInput, HookResult
 from dev10x.domain.common.result import ErrorResult, Result, err, ok
+from dev10x.domain.common.ticket_id import TICKET_ID_PATTERN
 from dev10x.domain.profile_tier import ProfileTier
 from dev10x.validators.base import ValidatorBase
 
@@ -87,8 +88,9 @@ BLOCK_MSG = (
     "Update the commit message in the temp file and retry."
 )
 
+
 GIT_COMMIT_RE = re.compile(r"\bgit\s+commit\b")
-TICKET_RE = re.compile(r"^[A-Z]+-\d+\s+")
+TICKET_RE = re.compile(rf"^{TICKET_ID_PATTERN}\s+")
 
 BYPASS_GITMOJI: frozenset[str] = frozenset({"🔖", "📝", "🔀"})
 

--- a/tests/domain/common/test_branch_name.py
+++ b/tests/domain/common/test_branch_name.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import pytest
+
+from dev10x.domain.common.branch_name import BranchName
+
+
+class TestParseConvention:
+    def test_parses_regular_branch(self) -> None:
+        branch = BranchName.parse("janusz/GH-241/value-objects")
+
+        assert branch.username == "janusz"
+        assert branch.ticket is not None
+        assert str(branch.ticket) == "GH-241"
+        assert branch.worktree is None
+        assert branch.slug == "value-objects"
+        assert branch.follows_convention is True
+
+    def test_parses_worktree_branch(self) -> None:
+        branch = BranchName.parse("janusz/PAY-1/app-pos-7/fix-timeout")
+
+        assert branch.username == "janusz"
+        assert str(branch.ticket) == "PAY-1"
+        assert branch.worktree == "app-pos-7"
+        assert branch.slug == "fix-timeout"
+        assert branch.follows_convention is True
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "develop",
+            "main",
+            "feature-branch",
+            "username/notaticket/slug",
+            "janusz/GH-1/Bad-Slug",
+            "janusz/GH-1/wt/bad slug",
+            "too/many/slashes/here/wow",
+        ],
+    )
+    def test_non_conforming_branches_do_not_follow_convention(self, raw: str) -> None:
+        branch = BranchName.parse(raw)
+
+        assert branch.follows_convention is False
+
+
+class TestProtected:
+    @pytest.mark.parametrize("name", ["main", "master", "develop", "trunk"])
+    def test_protected_branches(self, name: str) -> None:
+        assert BranchName.parse(name).is_protected is True
+
+    def test_feature_branch_not_protected(self) -> None:
+        assert BranchName.parse("janusz/GH-1/work").is_protected is False
+
+
+class TestParseRejection:
+    def test_parse_empty_raises(self) -> None:
+        with pytest.raises(ValueError):
+            BranchName.parse("")
+
+    def test_try_parse_returns_none_for_empty(self) -> None:
+        assert BranchName.try_parse("") is None
+
+
+class TestValidateConvention:
+    def test_passes_for_conforming(self) -> None:
+        BranchName.parse("janusz/GH-1/slug").validate_convention()
+
+    def test_raises_for_non_conforming(self) -> None:
+        with pytest.raises(ValueError):
+            BranchName.parse("develop").validate_convention()

--- a/tests/domain/common/test_skill_name.py
+++ b/tests/domain/common/test_skill_name.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import pytest
+
+from dev10x.domain.common.skill_name import SkillName
+
+
+class TestParse:
+    def test_parses_namespaced(self) -> None:
+        name = SkillName.parse("Dev10x:git-commit")
+
+        assert name.namespace == "Dev10x"
+        assert name.slug == "git-commit"
+        assert str(name) == "Dev10x:git-commit"
+
+    def test_parses_unnamespaced(self) -> None:
+        name = SkillName.parse("simple-skill")
+
+        assert name.namespace is None
+        assert name.slug == "simple-skill"
+        assert str(name) == "simple-skill"
+
+    @pytest.mark.parametrize("raw", ["", ":slug", "ns:", None])
+    def test_rejects_invalid(self, raw: object) -> None:
+        with pytest.raises((TypeError, ValueError)):
+            SkillName.parse(raw)  # type: ignore[arg-type]
+
+
+class TestProperties:
+    def test_short_name_returns_slug(self) -> None:
+        assert SkillName.parse("Dev10x:git-commit").short_name == "git-commit"
+
+    def test_safe_path_name_replaces_colon(self) -> None:
+        assert SkillName.parse("Dev10x:git-commit").safe_path_name == "Dev10x-git-commit"
+
+    def test_safe_path_name_strips_unsafe_chars(self) -> None:
+        # Construct directly to bypass parse validation
+        name = SkillName(namespace="Dev10x", slug="bad/skill name!")
+
+        assert name.safe_path_name == "Dev10x-badskillname"
+
+
+class TestTryParse:
+    def test_returns_none_for_invalid(self) -> None:
+        assert SkillName.try_parse("") is None
+
+    def test_returns_skill_for_valid(self) -> None:
+        name = SkillName.try_parse("foo")
+
+        assert name is not None
+        assert name.slug == "foo"

--- a/tests/domain/common/test_ticket_id.py
+++ b/tests/domain/common/test_ticket_id.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import pytest
+
+from dev10x.domain.common.ticket_id import TICKET_ID_PATTERN, TicketId
+
+
+class TestParse:
+    @pytest.mark.parametrize(
+        "raw,project,number",
+        [
+            ("GH-15", "GH", 15),
+            ("PAY-133", "PAY", 133),
+            ("TEAM-1", "TEAM", 1),
+        ],
+    )
+    def test_parses_canonical_form(self, raw: str, project: str, number: int) -> None:
+        ticket = TicketId.parse(raw)
+
+        assert ticket.project == project
+        assert ticket.number == number
+        assert str(ticket) == raw
+
+    @pytest.mark.parametrize(
+        "raw",
+        ["", "gh-15", "GH15", "GH-", "-15", "GH-12X", "GH-12-extra"],
+    )
+    def test_rejects_invalid_forms(self, raw: str) -> None:
+        with pytest.raises(ValueError):
+            TicketId.parse(raw)
+
+    def test_rejects_non_string(self) -> None:
+        with pytest.raises(ValueError):
+            TicketId.parse(None)  # type: ignore[arg-type]
+
+
+class TestTryParse:
+    def test_returns_ticket_on_success(self) -> None:
+        ticket = TicketId.try_parse("GH-1")
+
+        assert ticket is not None
+        assert ticket.number == 1
+
+    def test_returns_none_on_failure(self) -> None:
+        assert TicketId.try_parse("invalid") is None
+
+
+class TestFindFirst:
+    def test_finds_embedded_ticket(self) -> None:
+        ticket = TicketId.find_first("Fixes GH-42 today")
+
+        assert ticket == TicketId(project="GH", number=42)
+
+    def test_returns_none_when_absent(self) -> None:
+        assert TicketId.find_first("no ticket here") is None
+
+
+class TestFindAll:
+    def test_returns_all_tickets(self) -> None:
+        tickets = TicketId.find_all("GH-1 and TEAM-2 and PAY-3")
+
+        assert [str(t) for t in tickets] == ["GH-1", "TEAM-2", "PAY-3"]
+
+    def test_returns_empty_list_when_none(self) -> None:
+        assert TicketId.find_all("nothing") == []
+
+
+def test_pattern_exposed_as_string() -> None:
+    assert TICKET_ID_PATTERN == r"[A-Z]+-\d+"

--- a/tests/domain/documents/test_task.py
+++ b/tests/domain/documents/test_task.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import pytest
+
+from dev10x.domain.documents.task import Task, TaskStatus
+
+
+class TestTaskFromDict:
+    def test_parses_minimal_dict(self) -> None:
+        task = Task.from_dict({"id": "1"})
+
+        assert task.id == "1"
+        assert task.status is TaskStatus.PENDING
+        assert task.metadata == {}
+
+    def test_parses_full_dict(self) -> None:
+        task = Task.from_dict(
+            {
+                "id": "5",
+                "subject": "Do thing",
+                "status": "in_progress",
+                "created_at": "2026-01-01",
+                "description": "Details",
+                "metadata": {"type": "epic"},
+                "started_at": "2026-01-02",
+                "completed_at": "",
+            }
+        )
+
+        assert task.id == "5"
+        assert task.subject == "Do thing"
+        assert task.status is TaskStatus.IN_PROGRESS
+        assert task.description == "Details"
+        assert task.metadata == {"type": "epic"}
+        assert task.started_at == "2026-01-02"
+
+    def test_falls_back_to_pending_for_unknown_status(self) -> None:
+        task = Task.from_dict({"id": "1", "status": "bogus"})
+
+        assert task.status is TaskStatus.PENDING
+
+    def test_coerces_id_to_str(self) -> None:
+        task = Task.from_dict({"id": 42})
+
+        assert task.id == "42"
+
+    def test_treats_non_dict_metadata_as_empty(self) -> None:
+        task = Task.from_dict({"id": "1", "metadata": "not-a-dict"})
+
+        assert task.metadata == {}
+
+
+class TestTaskToDict:
+    def test_omits_empty_optional_fields(self) -> None:
+        task = Task(id="1", subject="X")
+
+        result = task.to_dict()
+
+        assert result == {"id": "1", "subject": "X", "status": "pending"}
+
+    def test_includes_populated_fields(self) -> None:
+        task = Task(
+            id="1",
+            subject="X",
+            status=TaskStatus.COMPLETED,
+            created_at="ts",
+            description="d",
+            metadata={"k": "v"},
+            completed_at="t2",
+        )
+
+        result = task.to_dict()
+
+        assert result["status"] == "completed"
+        assert result["description"] == "d"
+        assert result["metadata"] == {"k": "v"}
+        assert result["completed_at"] == "t2"
+
+
+class TestTaskTransitions:
+    def test_with_status_in_progress_sets_started_at(self) -> None:
+        task = Task(id="1")
+
+        updated = task.with_status(status=TaskStatus.IN_PROGRESS, timestamp="now")
+
+        assert updated.status is TaskStatus.IN_PROGRESS
+        assert updated.started_at == "now"
+
+    def test_with_status_completed_sets_completed_at(self) -> None:
+        task = Task(id="1")
+
+        updated = task.with_status(status=TaskStatus.COMPLETED, timestamp="now")
+
+        assert updated.status is TaskStatus.COMPLETED
+        assert updated.completed_at == "now"
+
+    def test_with_status_pending_leaves_timestamps_empty(self) -> None:
+        task = Task(id="1")
+
+        updated = task.with_status(status=TaskStatus.PENDING, timestamp="now")
+
+        assert updated.started_at == ""
+        assert updated.completed_at == ""
+
+
+class TestTaskMerge:
+    def test_with_metadata_merged_adds_keys(self) -> None:
+        task = Task(id="1", metadata={"type": "epic"})
+
+        merged = task.with_metadata_merged(updates={"skills": ["test"]})
+
+        assert merged.metadata == {"type": "epic", "skills": ["test"]}
+
+    def test_with_metadata_merged_removes_none_keys(self) -> None:
+        task = Task(id="1", metadata={"type": "epic", "old": "v"})
+
+        merged = task.with_metadata_merged(updates={"old": None})
+
+        assert merged.metadata == {"type": "epic"}
+
+
+class TestTaskIsActive:
+    @pytest.mark.parametrize(
+        "status,expected",
+        [
+            (TaskStatus.PENDING, True),
+            (TaskStatus.IN_PROGRESS, True),
+            (TaskStatus.COMPLETED, False),
+            (TaskStatus.DELETED, False),
+        ],
+    )
+    def test_is_active(self, status: TaskStatus, expected: bool) -> None:
+        assert Task(id="1", status=status).is_active is expected

--- a/tests/domain/test_plan.py
+++ b/tests/domain/test_plan.py
@@ -14,6 +14,7 @@ from dev10x.domain.documents.plan import (
     _set_nested,
     get_plan_path,
 )
+from dev10x.domain.documents.task import Task
 
 
 class TestExtractTaskId:
@@ -69,6 +70,8 @@ class TestPlanLoad:
 
         assert plan.metadata["status"] == "in_progress"
         assert len(plan.tasks) == 1
+        assert plan.tasks[0].id == "1"
+        assert plan.tasks[0].status is TaskStatus.PENDING
 
     def test_returns_empty_for_missing_file(self, tmp_path: Path) -> None:
         plan = Plan.load(path=tmp_path / "nonexistent.yaml")
@@ -91,7 +94,7 @@ class TestPlanSave:
         path = tmp_path / "session" / "plan.yaml"
         plan = Plan(
             metadata={"status": "in_progress"},
-            tasks=[{"id": "1", "subject": "Test", "status": "pending"}],
+            tasks=[Task(id="1", subject="Test", status=TaskStatus.PENDING)],
         )
 
         plan.save(path=path)
@@ -99,6 +102,21 @@ class TestPlanSave:
 
         assert loaded.metadata["status"] == "in_progress"
         assert len(loaded.tasks) == 1
+        assert loaded.tasks[0].subject == "Test"
+
+    def test_round_trips_dict_tasks(self, tmp_path: Path) -> None:
+        # Legacy callers may still construct Plan with raw dict tasks —
+        # post_init normalizes them to Task instances.
+        path = tmp_path / "session" / "plan.yaml"
+        plan = Plan(
+            metadata={"status": "in_progress"},
+            tasks=[{"id": "1", "subject": "Test", "status": "pending"}],
+        )
+
+        plan.save(path=path)
+        loaded = Plan.load(path=path)
+
+        assert loaded.tasks[0].id == "1"
 
     def test_creates_parent_directories(self, tmp_path: Path) -> None:
         path = tmp_path / "deep" / "nested" / "plan.yaml"
@@ -129,8 +147,9 @@ class TestPlanHandleTaskCreate:
 
         assert result is True
         assert len(plan.tasks) == 1
-        assert plan.tasks[0]["id"] == "1"
-        assert plan.tasks[0]["subject"] == "Do thing"
+        assert plan.tasks[0].id == "1"
+        assert plan.tasks[0].subject == "Do thing"
+        assert plan.tasks[0].description == "Details"
 
     def test_returns_false_for_unparseable_result(self, plan: Plan) -> None:
         result = plan.handle_task_create(
@@ -142,7 +161,7 @@ class TestPlanHandleTaskCreate:
         assert len(plan.tasks) == 0
 
     def test_skips_duplicate_ids(self, plan: Plan) -> None:
-        plan.tasks = [{"id": "1", "subject": "Existing", "status": "pending"}]
+        plan.tasks = [Task(id="1", subject="Existing", status=TaskStatus.PENDING)]
 
         result = plan.handle_task_create(
             tool_input={"subject": "Duplicate"},
@@ -158,7 +177,7 @@ class TestPlanHandleTaskCreate:
             tool_result="Task #5 created successfully",
         )
 
-        assert plan.tasks[0]["metadata"] == {"type": "epic"}
+        assert plan.tasks[0].metadata == {"type": "epic"}
 
 
 class TestPlanHandleTaskUpdate:
@@ -167,47 +186,49 @@ class TestPlanHandleTaskUpdate:
         return Plan(
             metadata={"status": "in_progress"},
             tasks=[
-                {"id": "1", "subject": "First", "status": "pending"},
-                {"id": "2", "subject": "Second", "status": "pending"},
+                Task(id="1", subject="First", status=TaskStatus.PENDING),
+                Task(id="2", subject="Second", status=TaskStatus.PENDING),
             ],
         )
 
     def test_updates_status(self, plan: Plan) -> None:
         plan.handle_task_update(tool_input={"taskId": "1", "status": "in_progress"})
 
-        assert plan.tasks[0]["status"] == "in_progress"
-        assert "started_at" in plan.tasks[0]
+        assert plan.tasks[0].status is TaskStatus.IN_PROGRESS
+        assert plan.tasks[0].started_at != ""
 
     def test_marks_completed_with_timestamp(self, plan: Plan) -> None:
         plan.handle_task_update(tool_input={"taskId": "1", "status": "completed"})
 
-        assert plan.tasks[0]["status"] == "completed"
-        assert "completed_at" in plan.tasks[0]
+        assert plan.tasks[0].status is TaskStatus.COMPLETED
+        assert plan.tasks[0].completed_at != ""
 
     def test_deletes_task(self, plan: Plan) -> None:
         plan.handle_task_update(tool_input={"taskId": "1", "status": "deleted"})
 
         assert len(plan.tasks) == 1
-        assert plan.tasks[0]["id"] == "2"
+        assert plan.tasks[0].id == "2"
 
     def test_updates_subject(self, plan: Plan) -> None:
         plan.handle_task_update(tool_input={"taskId": "1", "subject": "Updated"})
 
-        assert plan.tasks[0]["subject"] == "Updated"
+        assert plan.tasks[0].subject == "Updated"
 
     def test_merges_metadata(self, plan: Plan) -> None:
-        plan.tasks[0]["metadata"] = {"type": "epic"}
+        plan.tasks[0] = plan.tasks[0].with_metadata_merged(updates={"type": "epic"})
 
         plan.handle_task_update(tool_input={"taskId": "1", "metadata": {"skills": ["test"]}})
 
-        assert plan.tasks[0]["metadata"] == {"type": "epic", "skills": ["test"]}
+        assert plan.tasks[0].metadata == {"type": "epic", "skills": ["test"]}
 
     def test_removes_metadata_key_with_none(self, plan: Plan) -> None:
-        plan.tasks[0]["metadata"] = {"type": "epic", "old": "value"}
+        plan.tasks[0] = plan.tasks[0].with_metadata_merged(
+            updates={"type": "epic", "old": "value"}
+        )
 
         plan.handle_task_update(tool_input={"taskId": "1", "metadata": {"old": None}})
 
-        assert plan.tasks[0]["metadata"] == {"type": "epic"}
+        assert plan.tasks[0].metadata == {"type": "epic"}
 
     def test_ignores_missing_task_id(self, plan: Plan) -> None:
         plan.handle_task_update(tool_input={})
@@ -220,8 +241,8 @@ class TestPlanCheckAllCompleted:
         plan = Plan(
             metadata={"status": "in_progress"},
             tasks=[
-                {"id": "1", "status": "completed"},
-                {"id": "2", "status": "completed"},
+                Task(id="1", status=TaskStatus.COMPLETED),
+                Task(id="2", status=TaskStatus.COMPLETED),
             ],
         )
 
@@ -234,8 +255,8 @@ class TestPlanCheckAllCompleted:
         plan = Plan(
             metadata={"status": "in_progress"},
             tasks=[
-                {"id": "1", "status": "completed"},
-                {"id": "2", "status": "pending"},
+                Task(id="1", status=TaskStatus.COMPLETED),
+                Task(id="2", status=TaskStatus.PENDING),
             ],
         )
 
@@ -337,23 +358,23 @@ class TestTaskTransitions:
     def test_completed_to_in_progress_rejected(self) -> None:
         plan = Plan(
             metadata={"status": "in_progress"},
-            tasks=[{"id": "1", "status": "completed", "completed_at": "old"}],
+            tasks=[Task(id="1", status=TaskStatus.COMPLETED, completed_at="old")],
         )
 
         plan.handle_task_update(tool_input={"taskId": "1", "status": "in_progress"})
 
-        assert plan.tasks[0]["status"] == "completed"
-        assert "started_at" not in plan.tasks[0]
+        assert plan.tasks[0].status is TaskStatus.COMPLETED
+        assert plan.tasks[0].started_at == ""
 
     def test_unknown_status_silently_skipped(self) -> None:
         plan = Plan(
             metadata={"status": "in_progress"},
-            tasks=[{"id": "1", "status": "pending"}],
+            tasks=[Task(id="1", status=TaskStatus.PENDING)],
         )
 
         plan.handle_task_update(tool_input={"taskId": "1", "status": "bogus"})
 
-        assert plan.tasks[0]["status"] == "pending"
+        assert plan.tasks[0].status is TaskStatus.PENDING
 
 
 class TestGetPlanPath:

--- a/tests/domain/test_session_state.py
+++ b/tests/domain/test_session_state.py
@@ -170,7 +170,7 @@ class TestPlanSummaryPendingTasks:
             ],
         )
 
-        ids = [t["id"] for t in summary.pending_tasks]
+        ids = [t.id for t in summary.pending_tasks]
 
         assert ids == ["1", "2"]
 
@@ -198,7 +198,7 @@ class TestPlanSummaryPendingDecisions:
         result = summary.pending_decisions
 
         assert len(result) == 1
-        assert result[0]["id"] == "1"
+        assert result[0].id == "1"
 
     def test_excludes_completed_tasks(self) -> None:
         summary = PlanSummary(


### PR DESCRIPTION
**When** Dev10x ships shipping-pipeline guardrails across plan tracking, GitHub APIs, and worktree creation, **I want to** parse identifiers once at the domain boundary and reuse the same parser everywhere, **so I can** stop scattered regex from drifting and stop dict-of-Any task payloads from masking shape bugs.

---

[`6b9d37a9`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/287/commits/6b9d37a99da4915a4c4947ceff1749eb5fb3b63f) ♻️ GH-241 Enforce typed identifiers across plan and PR surfaces
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/241

---