### PR TITLE
♻️ GH-272 Close three permission-friction gaps in tooling

### DIFF
--- a/.claude/rules/mcp-tools.md
+++ b/.claude/rules/mcp-tools.md
@@ -106,6 +106,8 @@ supporting each tool:
 | `milestone_create` | `cli` | GH-220 | v0.73.0+ |
 | `issue_edit` | `cli` | GH-220 | v0.73.0+ |
 | `issue_comment` | `cli` | GH-220 | v0.73.0+ |
+| `issue_comment_edit` | `cli` | GH-283 | v0.75.0+ |
+| `issue_comment_delete` | `cli` | GH-283 | v0.75.0+ |
 | `issue_list` | `cli` | GH-220 | v0.73.0+ |
 | `slack_thread_is_forward` | `cli` | GH-218 | v0.73.0+ |
 | `milestones_bulk_create` | `cli` | GH-222 | v0.73.0+ |

--- a/skills/diag-friction/SKILL.md
+++ b/skills/diag-friction/SKILL.md
@@ -131,6 +131,34 @@ for sources, allow-rule shapes, and the four-step audit procedure.
 The audit output feeds Step 4 — surface findings even when a
 skill match was also found.
 
+### Step 3c-pre: Inline-code structured-alternatives (GH-282)
+
+When the offending command starts with an inline-code prefix
+(`python -c`, `python3 -c`, `sh -c`, `bash -c`, `perl -e`,
+`ruby -e`, `node -e`, `deno eval`), the right recommendation is
+almost never "extract to `~/.claude/tools/`" — it's the canonical
+structured tool that already exists for the use case (jq, yq,
+yamllint, actionlint, curl, etc.).
+
+**Procedure:**
+
+1. `Read(file_path="${CLAUDE_PLUGIN_ROOT}/skills/diag-friction/references/structured-alternatives.yaml")`
+2. Check the offending command against `inline_code_prefixes`. If
+   no prefix matches, skip this step and proceed to Step 3c.
+3. Extract the inline code body (text between the quotes after the
+   `-c` / `-e` flag).
+4. Match the body against each entry's `detection_keywords`
+   (substring match; first hit wins).
+5. Surface the matched `tool` and `example` as the **primary**
+   recommendation in the "Use instead" section of Step 4.
+6. Fall back to the "Multi-step logic (fallback)" entry only when
+   no keyword matches across all other entries.
+
+Example match for `python -c "import yaml; yaml.safe_load(...)"`:
+the `yaml.safe_load` keyword hits the YAML-parsing entry, so the
+reinforcement names `yq` as the canonical alternative — not a
+tools-directory extraction.
+
 ### Step 3c: Detect structural friction (file upstream)
 
 When the hook itself is too aggressive, the command-skill map is

--- a/skills/diag-friction/references/structured-alternatives.yaml
+++ b/skills/diag-friction/references/structured-alternatives.yaml
@@ -1,0 +1,111 @@
+# Structured-alternatives knowledge base for Dev10x:diag-friction (GH-282).
+#
+# When a blocked command runs inline code (python -c, sh -c, node -e,
+# perl -e, ruby -e, bash -c), diag-friction matches the embedded code
+# body against detection_keywords below to recommend the canonical
+# structured tool instead of "extract to ~/.claude/tools/".
+#
+# First hit wins. Fall back to extract-to-tools only when no keyword
+# matches.
+
+alternatives:
+  - use_case: "JSON parsing or filtering"
+    detection_keywords:
+      - "json.loads"
+      - "json.dumps"
+      - "JSON.parse"
+      - "JSON.stringify"
+      - "import json"
+      - "require('json')"
+    tool: "jq"
+    example: "jq '<filter>' file.json"
+
+  - use_case: "JSON validation (parse-only, no output)"
+    detection_keywords:
+      - "json.tool"
+      - "validate json"
+    tool: "jq empty"
+    example: "jq empty file.json  # exits non-zero on parse error"
+
+  - use_case: "YAML parsing or filtering"
+    detection_keywords:
+      - "yaml.safe_load"
+      - "yaml.load"
+      - "import yaml"
+      - "require('js-yaml')"
+    tool: "yq"
+    example: "yq '<filter>' file.yml"
+
+  - use_case: "YAML validation"
+    detection_keywords:
+      - "yamllint"
+      - "validate yaml"
+    tool: "yamllint"
+    example: "yamllint file.yml"
+
+  - use_case: "GitHub Actions workflow validation"
+    detection_keywords:
+      - ".github/workflows/"
+      - "workflow_run"
+      - "actionlint"
+    tool: "actionlint"
+    example: "actionlint .github/workflows/"
+
+  - use_case: "TOML parsing or filtering"
+    detection_keywords:
+      - "import toml"
+      - "tomllib"
+      - "import tomllib"
+    tool: "tomlq"
+    example: "tomlq '<filter>' file.toml"
+
+  - use_case: "HTML scraping or selection"
+    detection_keywords:
+      - "BeautifulSoup"
+      - "lxml"
+      - "html.parser"
+    tool: "pup"
+    example: "pup '<selector>' < file.html"
+
+  - use_case: "XML parsing or filtering"
+    detection_keywords:
+      - "xml.etree"
+      - "lxml.etree"
+      - "xmlstarlet"
+    tool: "xq"
+    example: "xq '<filter>' file.xml"
+
+  - use_case: "HTTP requests"
+    detection_keywords:
+      - "requests.get"
+      - "requests.post"
+      - "urllib"
+      - "fetch("
+      - "http.client"
+    tool: "curl"
+    example: "curl -fsSL <url>"
+
+  - use_case: "Multi-step logic (fallback)"
+    # Empty keywords list means this entry matches only when no other
+    # use_case above matched. diag-friction recommends extracting to a
+    # standalone script.
+    detection_keywords: []
+    tool: "~/.claude/tools/<name>.py"
+    example: |
+      Extract to ~/.claude/tools/<name>.py with PEP 723 inline metadata:
+        #!/usr/bin/env -S uv run --script
+        # /// script
+        # dependencies = [...]
+        # ///
+
+# Detection prefixes — diag-friction enters structured-alternatives
+# matching when the blocked command begins with any of these.
+inline_code_prefixes:
+  - "python -c"
+  - "python3 -c"
+  - "sh -c"
+  - "bash -c"
+  - "perl -e"
+  - "ruby -e"
+  - "node -e"
+  - "deno eval"

--- a/skills/gh-pr-create/instructions.md
+++ b/skills/gh-pr-create/instructions.md
@@ -150,7 +150,7 @@ state. Parse `BRANCH_NAME` and `ISSUE` from the response.
 **MCP server unavailable.** If the tool is listed as "no longer
 available" in system-reminders, STOP and ask the user to reconnect
 via `/mcp` or a session restart. Do NOT fall back to the wrapper
-script or use `DEV10X_SKIP_CMD_VALIDATION` — see
+script or env-level bypasses — see
 `references/mcp-unavailable-escape-hatch.md`.
 
 **Fallback (script):** Only when the MCP server is healthy but the

--- a/skills/gh-pr-merge/SKILL.md
+++ b/skills/gh-pr-merge/SKILL.md
@@ -56,5 +56,4 @@ existing blocks on `git commit`, `git push`, and `git
 checkout -b`). The skill executes Step 5 via
 `mcp__plugin_Dev10x_cli__merge_pr` (GH-232) — symmetric to
 `create_pr` / `push_safe` — so the documented flow ships
-through a structured MCP tool instead of relying on the
-`DEV10X_SKIP_CMD_VALIDATION` escape hatch.
+through a structured MCP tool, not a caller-level bypass.

--- a/skills/gh-pr-merge/instructions.md
+++ b/skills/gh-pr-merge/instructions.md
@@ -387,10 +387,11 @@ mcp__plugin_Dev10x_cli__merge_pr(
 The MCP tool wraps `gh pr merge` inside the MCP server's
 subprocess, so the PreToolUse hook that blocks raw `gh pr
 merge` Bash invocations does not apply. This is the only
-authorized way to execute the merge — do NOT fall back to
-`DEV10X_SKIP_CMD_VALIDATION=true gh pr merge ...`, which is
-reserved for transient MCP-unavailability emergencies and
-not for the documented Step 5 flow.
+authorized way to execute the merge — do NOT fall back to a
+raw `gh pr merge` invocation or any caller-level env-bypass.
+Hook overrides for transient MCP unavailability live in the
+hook layer (see `.claude/rules/hook-patterns.md`), not at the
+skill caller.
 
 The tool returns `{pr_number, url, strategy, branch_deleted,
 repo}` on success and `{error: "..."}` on failure.

--- a/skills/gh-pr-monitor/instructions.md
+++ b/skills/gh-pr-monitor/instructions.md
@@ -97,7 +97,7 @@ with the PR argument (URL, bare number, or empty). Parse
 **MCP server unavailable.** If the tool is listed as "no longer
 available" in system-reminders, STOP and ask the user to reconnect
 via `/mcp` or a session restart. Do NOT fall back to the wrapper
-script or use `DEV10X_SKIP_CMD_VALIDATION` — see
+script or env-level bypasses — see
 `references/mcp-unavailable-escape-hatch.md`.
 
 **Fallback (script):** Only when the MCP server is healthy but the

--- a/skills/git-commit/instructions.md
+++ b/skills/git-commit/instructions.md
@@ -140,10 +140,10 @@ because a second scope appeared, the correct response is to:
    original scope.
 2. Re-invoke `Skill(Dev10x:git-commit)` for the new scope.
 
-**Do NOT use `DEV10X_SKIP_CMD_VALIDATION=true` as a workaround.**
-That flag is reserved for skill-internal exceptions, not caller
-escape hatches. See `references/commit-examples.md` for atomic
-commit guidance.
+**Do NOT reach for env-level hook bypasses as a workaround.** Hook
+overrides live in the hook layer, not at the skill caller — see
+`.claude/rules/hook-patterns.md`. See
+`references/commit-examples.md` for atomic commit guidance.
 
 ## Prerequisites Check
 

--- a/skills/git/SKILL.md
+++ b/skills/git/SKILL.md
@@ -66,10 +66,10 @@ this is the solo-maintainer escape valve.
 
 **Solo-maintainer rule of thumb:** when a hook denial says
 `Skill: Dev10x:git`, the fix is almost always to re-invoke
-`push_safe` with the right `protected_branches` list — not to
-set `DEV10X_SKIP_CMD_VALIDATION=true`. The skip-flag is reserved
-for skill-internal exceptions; bypassing it from outside the
-skill defeats the safety contract.
+`push_safe` with the right `protected_branches` list. Reach for
+the skill's documented escape paths — not env-level bypasses —
+when the wrapper itself blocks: hook overrides live in the hook
+layer (see `.claude/rules/hook-patterns.md`), not at the caller.
 
 If the call still blocks after adjusting `protected_branches`,
 read the returned `blocked_reason` field — it names the exact
@@ -80,8 +80,9 @@ you can adjust the call rather than escalating.
 is listed as "no longer available" in system-reminders, STOP and
 ask the user to reconnect via `/mcp` or a session restart. Do NOT
 fall back to the wrapper script (blocked by
-`validate-bash-command.py`) or use `DEV10X_SKIP_CMD_VALIDATION` —
-see `references/mcp-unavailable-escape-hatch.md`.
+`validate-bash-command.py`) or env-level bypasses — see
+`references/mcp-unavailable-escape-hatch.md` for the documented
+recovery path.
 
 ### Post-push CI monitoring (GH-117 #2)
 

--- a/skills/upgrade-cleanup/projects.yaml
+++ b/skills/upgrade-cleanup/projects.yaml
@@ -135,6 +135,8 @@ base_permissions:
   - "mcp__plugin_Dev10x_cli__pr_detect"
   - "mcp__plugin_Dev10x_cli__issue_get"
   - "mcp__plugin_Dev10x_cli__issue_comments"
+  - "mcp__plugin_Dev10x_cli__issue_comment_edit"
+  - "mcp__plugin_Dev10x_cli__issue_comment_delete"
   - "mcp__plugin_Dev10x_cli__issue_create"
   - "mcp__plugin_Dev10x_cli__pr_comments"
   - "mcp__plugin_Dev10x_cli__pr_comment_reply"

--- a/src/dev10x/github/__init__.py
+++ b/src/dev10x/github/__init__.py
@@ -1081,6 +1081,109 @@ async def issue_comment(
     return ok({"url": result.stdout.strip()})
 
 
+async def issue_comment_edit(
+    *,
+    comment_id: int,
+    body: str,
+    repo: str | None = None,
+) -> Result[dict[str, Any]]:
+    """Edit an existing GitHub issue or PR comment body (GH-283).
+
+    Symmetric to ``issue_comment`` (POST) but uses PATCH against
+    ``/repos/{owner}/{repo}/issues/comments/{id}``. Works on issue
+    comments *and* PR issue-level comments (same endpoint).
+
+    Body is written to a temp file to avoid heredoc/quoting issues at
+    the gh CLI boundary, matching the ``issue_comment`` pattern.
+
+    Args:
+        comment_id: Numeric ID of the comment to edit (from the
+            ``/comments/<id>`` URL fragment).
+        body: New body text (full replacement, not a delta).
+        repo: Repository (owner/repo). Auto-detected if omitted.
+
+    Returns:
+        On success: ``{"id": int, "body": str, "html_url": str}``.
+    """
+    import tempfile
+
+    repo_result = await _resolve_repo(repo)
+    if isinstance(repo_result, ErrorResult):
+        return repo_result
+    canonical_repo = str(repo_result.value)
+
+    fd = tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False, encoding="utf-8")
+    fd.write(body)
+    fd.close()
+    body_path = Path(fd.name)
+
+    endpoint = f"/repos/{canonical_repo}/issues/comments/{comment_id}"
+    args = [
+        "gh",
+        "api",
+        "-X",
+        "PATCH",
+        "-F",
+        f"body=@{body_path}",
+        endpoint,
+    ]
+
+    try:
+        result = await async_run(args=args, timeout=30)
+    finally:
+        body_path.unlink(missing_ok=True)
+
+    if result.returncode != 0:
+        return err(result.stderr.strip())
+
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return err(f"Invalid JSON from GitHub API: {result.stdout[:200]}")
+
+    return ok(
+        {
+            "id": payload.get("id", comment_id),
+            "body": payload.get("body", ""),
+            "html_url": payload.get("html_url", ""),
+        }
+    )
+
+
+async def issue_comment_delete(
+    *,
+    comment_id: int,
+    repo: str | None = None,
+) -> Result[dict[str, Any]]:
+    """Delete a GitHub issue or PR comment (GH-283).
+
+    Uses DELETE against ``/repos/{owner}/{repo}/issues/comments/{id}``.
+    Works on issue comments *and* PR issue-level comments.
+
+    Args:
+        comment_id: Numeric ID of the comment to delete.
+        repo: Repository (owner/repo). Auto-detected if omitted.
+
+    Returns:
+        On success: ``{"deleted": True, "comment_id": int}``.
+    """
+    repo_result = await _resolve_repo(repo)
+    if isinstance(repo_result, ErrorResult):
+        return repo_result
+    canonical_repo = str(repo_result.value)
+
+    endpoint = f"/repos/{canonical_repo}/issues/comments/{comment_id}"
+    result = await async_run(
+        args=["gh", "api", "-X", "DELETE", endpoint],
+        timeout=30,
+    )
+
+    if result.returncode != 0:
+        return err(result.stderr.strip())
+
+    return ok({"deleted": True, "comment_id": comment_id})
+
+
 async def issue_list(
     *,
     repo: str | None = None,

--- a/src/dev10x/mcp/server_cli.py
+++ b/src/dev10x/mcp/server_cli.py
@@ -697,6 +697,73 @@ async def issue_comment(
 
 
 @server.tool()
+async def issue_comment_edit(
+    comment_id: int,
+    body: str,
+    repo: str | None = None,
+    cwd: str | None = None,
+) -> dict:
+    """Edit an existing GitHub issue or PR comment body (GH-283).
+
+    Symmetric to `issue_comment` (POST) but uses PATCH against
+    `/repos/{owner}/{repo}/issues/comments/{id}`. Works on issue
+    comments and PR issue-level comments.
+
+    Args:
+        comment_id: Numeric ID of the comment to edit (from
+            /comments/<id> URL fragment).
+        body: New body text (full replacement; not a delta).
+        repo: Repository (owner/repo). Auto-detected if omitted.
+        cwd: Effective working directory (GH-979).
+
+    Returns:
+        Dictionary with keys: id, body, html_url.
+    """
+    from dev10x import github as gh
+    from dev10x.subprocess_utils import use_cwd
+
+    with use_cwd(cwd):
+        return (
+            await gh.issue_comment_edit(
+                comment_id=comment_id,
+                body=body,
+                repo=repo,
+            )
+        ).to_dict()
+
+
+@server.tool()
+async def issue_comment_delete(
+    comment_id: int,
+    repo: str | None = None,
+    cwd: str | None = None,
+) -> dict:
+    """Delete a GitHub issue or PR comment (GH-283).
+
+    Uses DELETE against `/repos/{owner}/{repo}/issues/comments/{id}`.
+    Works on issue comments and PR issue-level comments.
+
+    Args:
+        comment_id: Numeric ID of the comment to delete.
+        repo: Repository (owner/repo). Auto-detected if omitted.
+        cwd: Effective working directory (GH-979).
+
+    Returns:
+        Dictionary with keys: deleted (bool), comment_id (int).
+    """
+    from dev10x import github as gh
+    from dev10x.subprocess_utils import use_cwd
+
+    with use_cwd(cwd):
+        return (
+            await gh.issue_comment_delete(
+                comment_id=comment_id,
+                repo=repo,
+            )
+        ).to_dict()
+
+
+@server.tool()
 async def issue_list(
     repo: str | None = None,
     state: str = "open",

--- a/src/dev10x/skills/doctor/registry.py
+++ b/src/dev10x/skills/doctor/registry.py
@@ -16,6 +16,7 @@ from dev10x.skills.doctor.strategy import Strategy
 DEFAULT_STRATEGY_MODULES: tuple[str, ...] = (
     "dev10x.skills.doctor.strategies.mcp_vs_script_drift",
     "dev10x.skills.doctor.strategies.missing_linear_mcp_allow",
+    "dev10x.skills.doctor.strategies.forbidden_token_priming",
 )
 
 

--- a/src/dev10x/skills/doctor/strategies/forbidden_token_priming.py
+++ b/src/dev10x/skills/doctor/strategies/forbidden_token_priming.py
@@ -1,0 +1,112 @@
+"""Strategy: forbidden-token-priming (GH-272).
+
+Detects forbidden-token mentions in skill documentation that prime
+the agent to reproduce the very anti-pattern the docs warn against.
+
+The canonical case is ``DEV10X_SKIP_CMD_VALIDATION``: when the env
+var appears as a negative example in a SKILL.md or instructions.md
+("do NOT use this"), the literal token loads into the agent's
+context every time the skill is referenced. Agents reaching for the
+documented form are following the priming the plugin itself created.
+
+Mirrors ``mcp_vs_script_drift`` but generalises across an extensible
+token list. Hook-layer documentation paths (.claude/rules/, hooks/)
+are exempt — that is where the token MUST be documented for skill
+authors.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dev10x.skills.doctor.strategy import (
+    Context,
+    Finding,
+    Remediation,
+    Strategy,
+)
+
+FORBIDDEN_TOKENS: dict[str, str] = {
+    "DEV10X_SKIP_CMD_VALIDATION": (
+        "structural guidance referencing the skill's mktmp mechanism "
+        "or the documented escape path in .claude/rules/hook-patterns.md"
+    ),
+}
+
+EXEMPT_PATH_FRAGMENTS: tuple[str, ...] = (
+    "/.claude/rules/",
+    "/hooks/",
+    "/references/agents/",
+    "/strategies/forbidden_token_priming",
+)
+
+
+def _is_exempt(path: Path) -> bool:
+    path_str = str(path)
+    return any(fragment in path_str for fragment in EXEMPT_PATH_FRAGMENTS)
+
+
+def _scan_skill_docs(*, context: Context) -> list[Finding]:
+    findings: list[Finding] = []
+    plugin_root = context.plugin_cache_root
+    if plugin_root is None or not plugin_root.exists():
+        return findings
+
+    patterns = ("SKILL.md", "instructions.md")
+    for pattern in patterns:
+        for doc_path in plugin_root.rglob(pattern):
+            if _is_exempt(doc_path):
+                continue
+            try:
+                text = doc_path.read_text()
+            except (OSError, UnicodeDecodeError):
+                continue
+            for token, suggested_replacement in FORBIDDEN_TOKENS.items():
+                if token not in text:
+                    continue
+                findings.append(
+                    Finding(
+                        strategy_id="forbidden-token-priming",
+                        severity="drift",
+                        location=str(doc_path),
+                        evidence=(
+                            f"skill doc names forbidden token {token!r} — "
+                            "negative-example mention primes the wrong behavior"
+                        ),
+                        proposed_fix=(
+                            f"replace the literal mention with {suggested_replacement}; "
+                            "keep the env var's true documentation in the hook layer only"
+                        ),
+                        metadata={
+                            "token": token,
+                            "suggested_replacement": suggested_replacement,
+                        },
+                    )
+                )
+    return findings
+
+
+def detect(context: Context) -> list[Finding]:
+    return _scan_skill_docs(context=context)
+
+
+def remediate(finding: Finding) -> Remediation:
+    return Remediation(
+        kind="file_issue",
+        target=finding.location,
+        action={
+            "token": finding.metadata.get("token"),
+            "replacement": finding.metadata.get("suggested_replacement"),
+        },
+    )
+
+
+STRATEGY = Strategy(
+    id="forbidden-token-priming",
+    description=(
+        "Surface skill docs that name forbidden tokens as negative "
+        "examples, priming the agent to reach for them."
+    ),
+    detect=detect,
+    remediate=remediate,
+)

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -1155,6 +1155,140 @@ class TestIssueComment:
         assert isinstance(result, ErrorResult)
 
 
+class TestIssueCommentEdit:
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run", new_callable=AsyncMock)
+    async def test_edits_comment(
+        self,
+        mock_run: AsyncMock,
+        mock_resolve_repo: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(
+            stdout=json.dumps(
+                {
+                    "id": 99,
+                    "body": "updated body",
+                    "html_url": "https://github.com/owner/repo/issues/1#issuecomment-99",
+                }
+            )
+        )
+
+        result = await gh.issue_comment_edit(
+            comment_id=99,
+            body="updated body",
+            repo="owner/repo",
+        )
+
+        assert isinstance(result, SuccessResult)
+        assert result.value["id"] == 99
+        assert result.value["body"] == "updated body"
+        assert result.value["html_url"].endswith("issuecomment-99")
+        args_called = mock_run.call_args.kwargs["args"]
+        assert args_called[:5] == ["gh", "api", "-X", "PATCH", "-F"]
+        assert args_called[-1] == "/repos/owner/repo/issues/comments/99"
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run", new_callable=AsyncMock)
+    async def test_returns_error_when_repo_missing(
+        self,
+        mock_run: AsyncMock,
+    ) -> None:
+        with patch.object(
+            gh,
+            "_resolve_repo",
+            new_callable=AsyncMock,
+            return_value=ErrorResult(error="no repo"),
+        ):
+            result = await gh.issue_comment_edit(comment_id=99, body="x")
+
+        assert isinstance(result, ErrorResult)
+        assert "no repo" in result.error
+        mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run", new_callable=AsyncMock)
+    async def test_returns_error_on_api_failure(
+        self,
+        mock_run: AsyncMock,
+        mock_resolve_repo: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(returncode=1, stderr="404 Not Found")
+
+        result = await gh.issue_comment_edit(comment_id=99, body="x", repo="owner/repo")
+
+        assert isinstance(result, ErrorResult)
+        assert "Not Found" in result.error
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run", new_callable=AsyncMock)
+    async def test_returns_error_on_invalid_json(
+        self,
+        mock_run: AsyncMock,
+        mock_resolve_repo: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(stdout="not json")
+
+        result = await gh.issue_comment_edit(comment_id=99, body="x", repo="owner/repo")
+
+        assert isinstance(result, ErrorResult)
+        assert "Invalid JSON" in result.error
+
+
+class TestIssueCommentDelete:
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run", new_callable=AsyncMock)
+    async def test_deletes_comment(
+        self,
+        mock_run: AsyncMock,
+        mock_resolve_repo: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(stdout="")
+
+        result = await gh.issue_comment_delete(comment_id=99, repo="owner/repo")
+
+        assert isinstance(result, SuccessResult)
+        assert result.value == {"deleted": True, "comment_id": 99}
+        args_called = mock_run.call_args.kwargs["args"]
+        assert args_called == [
+            "gh",
+            "api",
+            "-X",
+            "DELETE",
+            "/repos/owner/repo/issues/comments/99",
+        ]
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run", new_callable=AsyncMock)
+    async def test_returns_error_when_repo_missing(
+        self,
+        mock_run: AsyncMock,
+    ) -> None:
+        with patch.object(
+            gh,
+            "_resolve_repo",
+            new_callable=AsyncMock,
+            return_value=ErrorResult(error="no repo"),
+        ):
+            result = await gh.issue_comment_delete(comment_id=99)
+
+        assert isinstance(result, ErrorResult)
+        mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run", new_callable=AsyncMock)
+    async def test_returns_error_on_api_failure(
+        self,
+        mock_run: AsyncMock,
+        mock_resolve_repo: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(returncode=1, stderr="403 Forbidden")
+
+        result = await gh.issue_comment_delete(comment_id=99, repo="owner/repo")
+
+        assert isinstance(result, ErrorResult)
+        assert "Forbidden" in result.error
+
+
 class TestIssueList:
     @pytest.mark.asyncio
     @patch("dev10x.github.async_run", new_callable=AsyncMock)

--- a/tests/skills/diag-friction/test_structured_alternatives.py
+++ b/tests/skills/diag-friction/test_structured_alternatives.py
@@ -1,0 +1,103 @@
+"""Schema tests for the structured-alternatives knowledge base (GH-282)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml", reason="pyyaml not installed")
+
+KB_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "skills"
+    / "diag-friction"
+    / "references"
+    / "structured-alternatives.yaml"
+)
+
+
+@pytest.fixture(scope="module")
+def kb_data() -> dict:
+    return yaml.safe_load(KB_PATH.read_text())
+
+
+class TestKnowledgeBaseSchema:
+    def test_kb_file_exists(self) -> None:
+        assert KB_PATH.is_file(), f"KB missing at {KB_PATH}"
+
+    def test_kb_has_alternatives_and_prefixes(self, kb_data: dict) -> None:
+        assert "alternatives" in kb_data
+        assert "inline_code_prefixes" in kb_data
+        assert isinstance(kb_data["alternatives"], list)
+        assert isinstance(kb_data["inline_code_prefixes"], list)
+
+    def test_every_alternative_has_required_fields(self, kb_data: dict) -> None:
+        required_fields = {"use_case", "detection_keywords", "tool", "example"}
+        for entry in kb_data["alternatives"]:
+            missing = required_fields - entry.keys()
+            assert not missing, f"Entry {entry.get('use_case')!r} missing fields: {missing}"
+            assert isinstance(entry["detection_keywords"], list)
+            assert isinstance(entry["tool"], str) and entry["tool"]
+            assert isinstance(entry["example"], str) and entry["example"]
+
+    def test_canonical_use_cases_are_present(self, kb_data: dict) -> None:
+        tools_by_use_case = {entry["use_case"]: entry["tool"] for entry in kb_data["alternatives"]}
+        # The GH-271 evidence #55 motivating cases — these MUST stay
+        # in the catalog so /Dev10x:diag-friction can surface them.
+        assert any("jq" == tool for tool in tools_by_use_case.values())
+        assert any("yq" == tool for tool in tools_by_use_case.values())
+        assert any("yamllint" == tool for tool in tools_by_use_case.values())
+        assert any("actionlint" == tool for tool in tools_by_use_case.values())
+        assert any("curl" == tool for tool in tools_by_use_case.values())
+
+    def test_fallback_entry_has_empty_keywords(self, kb_data: dict) -> None:
+        fallback_entries = [
+            entry for entry in kb_data["alternatives"] if entry["detection_keywords"] == []
+        ]
+        assert len(fallback_entries) == 1, "Exactly one fallback entry expected"
+        assert "tools" in fallback_entries[0]["tool"].lower() or (
+            "~/.claude" in fallback_entries[0]["tool"]
+        )
+
+    def test_inline_code_prefixes_cover_common_runtimes(
+        self,
+        kb_data: dict,
+    ) -> None:
+        prefixes = set(kb_data["inline_code_prefixes"])
+        # Motivating cases from the ticket
+        assert "python -c" in prefixes
+        assert "python3 -c" in prefixes
+        assert "sh -c" in prefixes
+        assert "node -e" in prefixes
+
+
+class TestSimulatedDetection:
+    """Smoke-test the documented Step 3c-pre matching algorithm."""
+
+    def _match(self, command_body: str, kb_data: dict) -> str:
+        for entry in kb_data["alternatives"]:
+            for keyword in entry["detection_keywords"]:
+                if keyword in command_body:
+                    return entry["tool"]
+        # Fallback path
+        for entry in kb_data["alternatives"]:
+            if entry["detection_keywords"] == []:
+                return entry["tool"]
+        raise AssertionError("KB missing fallback entry")
+
+    def test_yaml_safe_load_surfaces_yq(self, kb_data: dict) -> None:
+        body = "import yaml; yaml.safe_load(open('x.yml'))"
+        assert self._match(body, kb_data) == "yq"
+
+    def test_json_loads_surfaces_jq(self, kb_data: dict) -> None:
+        body = "import json; json.loads(open('x.json').read())"
+        assert self._match(body, kb_data) == "jq"
+
+    def test_unknown_body_falls_back_to_tools_extraction(
+        self,
+        kb_data: dict,
+    ) -> None:
+        body = "some bespoke business logic with no matchable keyword"
+        result = self._match(body, kb_data)
+        assert "tools" in result or "~/.claude" in result

--- a/tests/skills/doctor/test_forbidden_token_priming.py
+++ b/tests/skills/doctor/test_forbidden_token_priming.py
@@ -1,0 +1,136 @@
+"""Tests for the forbidden-token-priming strategy (GH-272)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+strategy_mod = pytest.importorskip(
+    "dev10x.skills.doctor.strategies.forbidden_token_priming",
+    reason="dev10x not installed",
+)
+from dev10x.skills.doctor.strategy import Context, Finding  # noqa: E402
+
+
+class TestDetect:
+    def test_skill_md_mentioning_forbidden_token_produces_finding(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        plugin_root = tmp_path / "plugin_cache"
+        skill_dir = plugin_root / "skills" / "example"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "Do NOT use DEV10X_SKIP_CMD_VALIDATION as a workaround.\n",
+        )
+
+        context = Context(plugin_cache_root=plugin_root)
+        findings = strategy_mod.detect(context=context)
+
+        assert len(findings) == 1
+        finding = findings[0]
+        assert finding.strategy_id == "forbidden-token-priming"
+        assert finding.severity == "drift"
+        assert finding.metadata["token"] == "DEV10X_SKIP_CMD_VALIDATION"
+
+    def test_instructions_md_mentioning_forbidden_token_produces_finding(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        plugin_root = tmp_path / "plugin_cache"
+        skill_dir = plugin_root / "skills" / "example"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "instructions.md").write_text(
+            "Reach for DEV10X_SKIP_CMD_VALIDATION only when ...\n",
+        )
+
+        context = Context(plugin_cache_root=plugin_root)
+        findings = strategy_mod.detect(context=context)
+
+        assert len(findings) == 1
+        assert "instructions.md" in findings[0].location
+
+    def test_hook_layer_docs_are_exempt(self, tmp_path: Path) -> None:
+        plugin_root = tmp_path / "plugin_cache"
+        rules_dir = plugin_root / ".claude" / "rules"
+        rules_dir.mkdir(parents=True)
+        (rules_dir / "SKILL.md").write_text(
+            "DEV10X_SKIP_CMD_VALIDATION is documented here for skill authors.\n",
+        )
+
+        context = Context(plugin_cache_root=plugin_root)
+        findings = strategy_mod.detect(context=context)
+
+        assert findings == []
+
+    def test_hooks_directory_is_exempt(self, tmp_path: Path) -> None:
+        plugin_root = tmp_path / "plugin_cache"
+        hooks_dir = plugin_root / "hooks" / "scripts"
+        hooks_dir.mkdir(parents=True)
+        (hooks_dir / "SKILL.md").write_text(
+            "If DEV10X_SKIP_CMD_VALIDATION is set, the hook short-circuits.\n",
+        )
+
+        context = Context(plugin_cache_root=plugin_root)
+        findings = strategy_mod.detect(context=context)
+
+        assert findings == []
+
+    def test_skill_md_without_forbidden_token_produces_no_finding(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        plugin_root = tmp_path / "plugin_cache"
+        skill_dir = plugin_root / "skills" / "example"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "Use the documented mktmp mechanism for temp paths.\n",
+        )
+
+        context = Context(plugin_cache_root=plugin_root)
+        findings = strategy_mod.detect(context=context)
+
+        assert findings == []
+
+    def test_empty_context_produces_no_findings(self) -> None:
+        findings = strategy_mod.detect(context=Context())
+        assert findings == []
+
+    def test_unreadable_file_is_skipped(self, tmp_path: Path) -> None:
+        plugin_root = tmp_path / "plugin_cache"
+        skill_dir = plugin_root / "skills" / "example"
+        skill_dir.mkdir(parents=True)
+        binary_path = skill_dir / "SKILL.md"
+        binary_path.write_bytes(b"\xff\xfe\x00\x00 DEV10X_SKIP_CMD_VALIDATION")
+
+        context = Context(plugin_cache_root=plugin_root)
+        findings = strategy_mod.detect(context=context)
+
+        assert findings == []
+
+
+class TestRemediate:
+    def test_finding_maps_to_file_issue_remediation(self) -> None:
+        finding = Finding(
+            strategy_id="forbidden-token-priming",
+            severity="drift",
+            location="/tmp/plugin/skills/x/SKILL.md",
+            evidence="skill doc names forbidden token 'DEV10X_SKIP_CMD_VALIDATION'",
+            proposed_fix="replace with structural guidance",
+            metadata={
+                "token": "DEV10X_SKIP_CMD_VALIDATION",
+                "suggested_replacement": "structural guidance",
+            },
+        )
+        remediation = strategy_mod.remediate(finding)
+        assert remediation.kind == "file_issue"
+        assert remediation.target == finding.location
+        assert remediation.action["token"] == "DEV10X_SKIP_CMD_VALIDATION"
+
+
+class TestStrategyConstant:
+    def test_strategy_constant_exposed(self) -> None:
+        assert strategy_mod.STRATEGY.id == "forbidden-token-priming"
+        assert callable(strategy_mod.STRATEGY.detect)
+        assert callable(strategy_mod.STRATEGY.remediate)


### PR DESCRIPTION
**When** the agent hits permission friction during routine GitHub comment edits, blocked inline-code commands, or `DEV10X_SKIP_CMD_VALIDATION`-primed skill docs, **I want to** close each friction surface in the plugin itself, **so the supervisor can** complete the documented workflow without seeing a fresh approval prompt for every comment update, inline `python -c`, or skill-doc-primed env var.

---

[`b0ee90df`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/288/commits/b0ee90df0d45f6dfb0581c5cf1d5cee57463580d) ✨ GH-283 Enable PR/issue comment edit and delete via MCP
[`8e71d48a`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/288/commits/8e71d48a96880949e254bfa42dfedc7d2d6439e1) ♻️ GH-272 Strip forbidden-token priming from skill docs
[`f887263a`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/288/commits/f887263acb7aa1b8ec4214e6c7eafff0bd617b29) ✨ GH-282 Enable diag-friction structured-tool recommendations
Closes #272
Closes #282
Closes #283
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/272

---