### PR TITLE
✨ GH-290 Prevent silent feature activation via reused relations

### DIFF
--- a/references/review-checks-common.md
+++ b/references/review-checks-common.md
@@ -148,6 +148,23 @@ test-only PRs.
 prior review comments. Previous surface-bug fixes do not validate
 structural compliance.
 
+## Cross-Consumer Behavioural Reuse (GH-290)
+
+When a PR reuses an existing data relation (DB row, FK, OneToOne)
+for a new purpose, a sibling repository may already treat row
+presence as an implicit feature flag — populating the relation
+silently activates an unrelated feature. The check fires only
+when the diff dereferences a relation the PR did NOT introduce
+(no sibling `migrations/*.py` in the same PR), then greps
+project-configured sibling repos for boolean/length gating on
+the relation. Severity ladders from INFO (test fixture) →
+WARNING (component visibility) → CRITICAL (route/menu guard).
+
+See [`review-checks/cross-consumer-reuse.md`](review-checks/cross-consumer-reuse.md)
+for trigger details, sibling-repo config schema
+(`.claude/Dev10x/sibling-repos.yaml`), grep patterns, severity
+matrix, reporting format, and silent-skip degradation rules.
+
 ## Parameter Change Analysis
 
 When parameters are added/removed/made optional:

--- a/references/review-checks/cross-consumer-reuse.md
+++ b/references/review-checks/cross-consumer-reuse.md
@@ -1,0 +1,87 @@
+# Cross-Consumer Behavioural Reuse (GH-290)
+
+Catches PRs that reuse an existing data structure (DB relation,
+table, foreign key) for a new purpose when a sibling repository
+(typically a frontend app) treats row presence as an implicit
+feature flag for an unrelated feature. Populating the relation
+to enable feature **B** silently activates feature **A** for
+every affected tenant.
+
+Parameter Change Analysis, Dead Code Detection, and the
+Architecture Checklist (see `review-checks-common.md`) evaluate
+impact from the **current** repository's call graph. None catch
+coupling where row existence elsewhere gates feature visibility.
+
+## When the check fires
+
+Trigger only when the diff touches a model relation the PR did
+**not** introduce — i.e., the diff dereferences an existing
+`related_name`, ForeignKey, or OneToOne accessor on a model
+with no sibling `migrations/*.py` diff in the same PR. Any of
+the following detection signals qualifies:
+
+- PR reads/writes via a `related_name` (or framework-equivalent
+  reverse accessor) on a model with no migration diff in the PR
+- PR adds a resolver, serializer, or handler that dereferences
+  an existing relation
+- PR adds a server-side admin form, inline, or service that
+  populates an existing relation
+- PR's body or linked ticket describes "reusing" or "extending"
+  an existing relation for a new purpose
+
+Skip for docs-only, config-only, pure test-only PRs, and PRs
+that introduce the model/migration themselves (new relation,
+no consumer coupling yet possible).
+
+## How to run the check
+
+1. **Load sibling-repo config** from
+   `.claude/Dev10x/sibling-repos.yaml`. If the file is absent
+   or has no entries, log "no sibling repos configured —
+   skipping cross-consumer check" and return. Graceful no-op.
+
+   Schema:
+   ```yaml
+   # .claude/Dev10x/sibling-repos.yaml
+   repos:
+     - path: /work/example/example-frontend
+       kind: frontend
+     - path: /work/example/example-mobile
+       kind: mobile
+   ```
+
+2. **Extract the reused relation name** from the diff. Look
+   for `<model>.<related_name>`, `<model>.<fk_field>`, or
+   the model field referenced in resolver/admin/service code.
+
+3. **Grep each sibling repo path** for boolean-coercion or
+   length checks on the relation name:
+   - `!!<relation>`, `<relation> &&`, `<relation>?.`
+   - `<relation>.length > 0`, `<relation>.<sub>.length > 0`
+   - Conditional rendering (`{<relation> && <Component/>}`)
+   - Availability gates (`isAvailable = !!<relation>`)
+
+4. **Classify each match by consumer-site kind:**
+
+   | Consumer site | Severity |
+   |---------------|----------|
+   | Side-menu / route guard / page-availability hook | CRITICAL |
+   | Permission check, tenant feature gate | CRITICAL |
+   | Component visibility on a user-facing page | WARNING |
+   | Debug panel, dev-only route, test fixture | INFO |
+   | No matches found | (record as "no coupling detected") |
+
+## Reporting
+
+When the check fires with a match:
+- Cite each consumer `file:line` in the review summary
+- Quote the gating expression verbatim
+- Recommend an explicit feature flag, permission, or admin
+  toggle in the consumer rather than data-presence gating
+
+## Degradation
+
+- No `sibling-repos.yaml` → silent skip (do not error)
+- Sibling repo path missing on disk → log + skip that entry
+- `grep` returns no matches → record "no consumer coupling
+  detected" in the review summary; do not raise a finding

--- a/skills/gh-pr-review/SKILL.md
+++ b/skills/gh-pr-review/SKILL.md
@@ -155,6 +155,24 @@ See [`references/architecture-checklist.md`](references/architecture-checklist.m
 for the rules to load, the per-file signal/violation/severity
 table, and the anchoring-bias anti-pattern.
 
+### Step 4c: Cross-Consumer Behavioural-Reuse Check (GH-290)
+
+Catches PRs that reuse an existing data structure when a sibling
+repository (typically a frontend) gates feature visibility on
+row presence.
+
+**Trigger** — fire ONLY when the diff dereferences an existing
+relation (model `related_name` / FK / OneToOne) with no sibling
+`migrations/*.py` diff in the same PR. Skip otherwise; innocuous
+resolver additions should not trigger cross-repo grep on every
+review.
+
+**How to run** — see
+`references/review-checks/cross-consumer-reuse.md` for the
+sibling-repo config schema (`.claude/Dev10x/sibling-repos.yaml`),
+grep patterns (`!!<relation>`, `<relation>.length > 0`, etc.),
+severity matrix, and silent-skip degradation rule.
+
 ### Step 5: Apply Review Guidelines
 
 **REQUIRED — Read the reference files (GH-181 F1).** Skipping


### PR DESCRIPTION
**When** a backend PR reuses an existing data relation for a new purpose, **I want to** detect sibling-repo consumers that gate UI on row presence, **so I can** prevent silently activating unrelated features for affected tenants.

---

[`3257ccae`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/291/commits/3257ccae16daadd25d57f80a914be2a5697a24e4) ✨ GH-290 Prevent silent feature activation via reused relations

Fixes: https://github.com/Dev10x-Guru/dev10x-claude/issues/290

---