### PR TITLE
♻️ GH-281 Enable flaky-test fixes to ship via work-on pipeline

### DIFF
--- a/skills/py-test-flaky/SKILL.md
+++ b/skills/py-test-flaky/SKILL.md
@@ -1,14 +1,19 @@
 ---
 name: Dev10x:py-test-flaky
 description: >
-  Fix a flaky Python test end-to-end — investigate, reproduce, patch
-  the root cause, and ship the fix with a tracker ticket, branch, and
-  PR. Orchestrates Dev10x ticket, branch, commit, and PR skills so
-  fixes follow project conventions without per-step coaching.
-  TRIGGER when: user reports a flaky pytest test, a test is marked
-  `@pytest.mark.flaky`, or a pytest case fails intermittently in CI.
-  DO NOT TRIGGER when: test failure is deterministic, a non-pytest
-  framework is in use, or the fix is already committed.
+  Investigate a flaky Python test and hand the fix off to
+  Dev10x:work-on as a fully scoped ticket. Reproduces the
+  failure, identifies the root cause, drafts the proposed
+  patch in the ticket description (not in the working tree),
+  files the ticket via Dev10x:ticket-create, then invokes
+  Dev10x:work-on so branching, implementation, py-test gate,
+  self-review, PR creation, monitor, and review-comment
+  triage all run through the standard delivery pipeline.
+  TRIGGER when: user reports a flaky pytest test, a test is
+  marked `@pytest.mark.flaky`, or a pytest case fails
+  intermittently in CI. DO NOT TRIGGER when: test failure is
+  deterministic, a non-pytest framework is in use, or the
+  fix is already committed.
 user-invocable: true
 invocation-name: Dev10x:py-test-flaky
 allowed-tools:
@@ -16,24 +21,25 @@ allowed-tools:
   - Bash(pytest:*)
   - Bash(uv:*)
   - Skill(skill="Dev10x:ticket-create")
-  - Skill(skill="Dev10x:ticket-branch")
-  - Skill(skill="Dev10x:git-commit")
-  - Skill(skill="Dev10x:gh-pr-create")
-  - Skill(skill="Dev10x:gh-pr-monitor")
+  - Skill(skill="Dev10x:work-on")
 ---
 
 # Fix Flaky Python Test
 
-Fix a flaky pytest test through the full shipping pipeline:
-reproduce, root-cause, patch, file a tracker ticket, branch,
-commit, and open a PR. Delegates tracker/git/PR operations to
-sibling Dev10x skills so conventions stay consistent.
+Investigate a flaky pytest test, scope the fix as a ticket,
+and hand delivery off to `Dev10x:work-on`. This skill is a
+narrow *investigator + ticket scoper* — it does NOT mutate
+the working tree, create a branch, commit, or open a PR
+itself. All delivery work runs through `Dev10x:work-on` so
+flaky-test fixes ship with the same coverage gate, self-
+review, PR monitor, and bot-comment triage as any other
+ticket of comparable scope.
 
 ## Instructions
 
-The full workflow — 8 steps covering reproduction, root-cause
-analysis, fix patterns, verification, ticket, branch, commit,
-and PR creation — lives in [`instructions.md`](instructions.md).
+The full workflow — 5 steps covering reproduction, root-cause
+analysis, draft patch, ticket creation, and hand off to
+`Dev10x:work-on` — lives in [`instructions.md`](instructions.md).
 
 When this skill is invoked, Read `instructions.md` now and
 follow it end-to-end. `AskUserQuestion` gates documented there

--- a/skills/py-test-flaky/instructions.md
+++ b/skills/py-test-flaky/instructions.md
@@ -1,6 +1,6 @@
 # Dev10x:py-test-flaky — Instructions
 
-**Announce:** "Using Dev10x:py-test-flaky to fix flaky test [name]."
+**Announce:** "Using Dev10x:py-test-flaky to investigate flaky test [name]."
 
 ## When to Use
 
@@ -10,37 +10,61 @@
 - Test failures appear random or order-dependent
 - Asked to "fix a flaky test"
 
+## Shape
+
+This skill is a **narrow investigator + ticket scoper**. It
+produces a fully-scoped ticket whose description names the
+failure signature, root cause, proposed patch (verbatim), and
+verification plan. Delivery — branch, implementation, py-test
+gate, self-review, PR creation, CI monitor, review-comment
+triage, merge — runs through `Dev10x:work-on` once the ticket
+exists.
+
+**Invariants:**
+
+- **Do NOT apply the fix to the working tree.** The proposed
+  patch lives in the ticket description as a verbatim code
+  block, not in tracked files. `Dev10x:work-on` re-applies
+  it inside its own branched workspace.
+- **Do NOT create a branch, commit, or PR inline.** Every
+  delivery action delegates through `Dev10x:work-on`. The
+  supervisor sees one coherent task list, not two stacked
+  ones.
+- **Order matters.** Ticket is created *before* hand-off,
+  so the verification plan in the description drives the AC
+  `Dev10x:work-on`'s py-test gate later enforces.
+
 ## Orchestration
 
 This skill follows `references/task-orchestration.md` patterns.
 
-**Auto-advance:** Complete each step, immediately start the next — no checkpoints under adaptive friction.
-Never pause between steps except at documented decision gates.
+**Auto-advance:** Complete each step, immediately start the
+next — no checkpoints under adaptive friction. Never pause
+between steps except at documented decision gates.
 
 **REQUIRED: Create tasks before ANY work.** Execute these
 `TaskCreate` calls at startup:
 
 1. `TaskCreate(subject="Reproduce flakiness", activeForm="Reproducing")`
 2. `TaskCreate(subject="Identify root cause", activeForm="Investigating")`
-3. `TaskCreate(subject="Implement fix", activeForm="Implementing fix")`
-4. `TaskCreate(subject="Verify with repeat runs", activeForm="Verifying")`
-5. `TaskCreate(subject="File tech debt ticket", activeForm="Filing ticket")`
-6. `TaskCreate(subject="Create branch", activeForm="Creating branch")`
-7. `TaskCreate(subject="Commit fix", activeForm="Committing")`
-8. `TaskCreate(subject="Create PR", activeForm="Creating PR")`
+3. `TaskCreate(subject="Draft proposed patch", activeForm="Drafting patch")`
+4. `TaskCreate(subject="File ticket via Dev10x:ticket-create", activeForm="Filing ticket")`
+5. `TaskCreate(subject="Hand off to Dev10x:work-on", activeForm="Handing off")`
 
-Mark each task `completed` as its step finishes; auto-advance to the
-next.
+Mark each task `completed` as its step finishes; auto-advance
+to the next.
 
 ## Workflow
 
 ### Step 1: Reproduce the Flakiness
 
-Goal: produce the failure reliably so the fix can be validated.
+Goal: produce the failure reliably so the fix can be validated
+later inside `Dev10x:work-on`.
 
-1. Identify the target test from user input, a CI failure link, or
-   a `@pytest.mark.flaky` marker.
-2. Run the single test in a tight loop (start with 20 iterations):
+1. Identify the target test from user input, a CI failure
+   link, or a `@pytest.mark.flaky` marker.
+2. Run the single test in a tight loop (start with 20
+   iterations):
 
    ```bash
    pytest path/to/test_file.py::TestClass::test_method --count=20
@@ -48,29 +72,35 @@ Goal: produce the failure reliably so the fix can be validated.
    for i in $(seq 1 20); do pytest path/to/test_file.py::TestClass::test_method || break; done
    ```
 
-3. If failures do not reproduce, broaden scope — run the full test
-   class or module to surface order-dependencies, shared state, or
-   randomized Faker values.
+3. If failures do not reproduce, broaden scope — run the full
+   test class or module to surface order-dependencies, shared
+   state, or randomized Faker values.
 4. Record the failure signature (traceback, assertion message,
-   random seed if printed) for the ticket description.
+   random seed if printed). It becomes part of the ticket
+   description in Step 4.
 
 ### Step 2: Identify Root Cause
 
 Read the test and its collaborators. Common flakiness sources:
 
-- **Randomized Faker values** that occasionally violate constraints
+- **Randomized Faker values** that occasionally violate
+  constraints
 - **Shared DB / filesystem state** bleeding across tests
-- **Time-sensitive assertions** (freezegun missing, sleep tolerances)
+- **Time-sensitive assertions** (freezegun missing, sleep
+  tolerances)
 - **Non-deterministic iteration** over sets or unordered dicts
 - **Async / thread race conditions** between fixture and SUT
 - **Conditional branches** in tests that mask failures
 
-Name the root cause in one sentence — it becomes the ticket title
-and commit message.
+Name the root cause in one sentence — it becomes the ticket
+title.
 
-### Step 3: Implement the Fix
+### Step 3: Draft the Proposed Patch
 
-Patch the root cause; do not mask it.
+Compose the fix *without applying it to the working tree*.
+The patch lives in the ticket description as a verbatim code
+block, so `Dev10x:work-on`'s implementation step can apply it
+inside its own branched workspace.
 
 | Cause | Fix pattern |
 |-------|-------------|
@@ -81,97 +111,123 @@ Patch the root cause; do not mask it.
 | Order dependency | Remove global state; isolate DB/files per test |
 | `@pytest.mark.flaky` as a hide | Remove the decorator after fixing the cause |
 
-### Step 4: Verify the Fix
+Capture the proposed patch as a unified diff or a before/after
+code block. Keep it minimal — `Dev10x:work-on`'s self-review
+will refine wording, but the structural change should be
+ready to apply verbatim.
 
-Run the test 20–30 consecutive times; confirm zero failures:
+**Anti-patterns that MUST NOT appear in the proposed patch:**
 
-```bash
-pytest path/to/test_file.py::TestClass::test_method --count=30
-```
+- Adding `@pytest.mark.flaky` as the "fix" — it hides the bug.
+- Replacing randomized data with broad `try/except` swallows.
+- Increasing `sleep()` durations to paper over a race.
 
-Then run the sibling class and module to catch regressions:
+Prefer **deterministic seeds** over retries for randomized data.
 
-```bash
-pytest path/to/test_file.py
-```
+### Step 4: File the Ticket
 
-If any run fails, return to Step 2 — do not proceed until the test
-is stable.
-
-### Step 5: File Tech Debt Ticket
-
-Delegate to `Dev10x:ticket-create` with a structured description.
-The skill routes to the configured tracker (GitHub Issues, Linear,
-or JIRA) and returns the ticket ID.
+Delegate to `Dev10x:ticket-create` with a structured
+description that becomes the spec `Dev10x:work-on` will scope
+against. The skill routes to the configured tracker (GitHub
+Issues, Linear, or JIRA) and returns the ticket ID.
 
 `Skill(skill="Dev10x:ticket-create", args="<title> | <description>")`
 
-Suggested title: `Fix flaky test: <TestClass>::<test_method>`
+**Suggested title:** `Fix flaky test: <TestClass>::<test_method>`
 
-Description should include:
-- Failure signature captured in Step 1
-- Root cause from Step 2
-- Fix summary from Step 3
-- Verification evidence from Step 4 (N consecutive passes)
+**Description structure** (each section is required):
 
-### Step 6: Create Branch
+```
+## Failure signature
 
-Delegate to `Dev10x:ticket-branch` with the ticket ID and title.
+<traceback / assertion message / seed captured in Step 1>
 
-`Skill(skill="Dev10x:ticket-branch", args="<TICKET-ID> <title>")`
+## Root cause
 
-The skill handles worktree detection, latest-develop sync, and
-branch naming per project convention
-(`username/TICKET-ID/fix-flaky-<slug>`).
+<one-sentence root cause from Step 2>
 
-### Step 7: Commit the Fix
+## Proposed solution
 
-Delegate to `Dev10x:git-commit`. The skill enforces gitmoji, ticket
-reference, 72-char limit, and JTBD-style outcome titles.
+<verbatim code block / unified diff from Step 3>
 
-`Skill(skill="Dev10x:git-commit")`
+### Solution guidance (do NOT regress on these)
 
-Commit title example: `🐛 TICKET-123 Stabilize user-login assertion`
+- Never add `@pytest.mark.flaky` as the fix — it hides the bug.
+- Prefer deterministic seeds over retries for randomized data.
+- Re-read the fix diff before committing — flaky fixes can be
+  one-line patches that touch wide fixture surface area.
+- If the root cause is infrastructure (CI runner, external
+  service), still commit the mitigation here, then escalate
+  separately via `Dev10x:park-todo` or a follow-up ticket.
 
-### Step 8: Create Pull Request
+## Verification plan
 
-Delegate to `Dev10x:gh-pr-create`. The skill sources the Job Story
-from the ticket, builds the PR description, and pushes safely.
+- Reproduce the failure with: `pytest <path>::<test> --count=20`
+- Confirm fix with: `pytest <path>::<test> --count=30`
+- Acceptance: 30 consecutive passes on the targeted test, plus
+  zero regressions in the sibling class/module.
 
-`Skill(skill="Dev10x:gh-pr-create")`
+## Acceptance criteria
 
-Optionally follow with `Dev10x:gh-pr-monitor` to watch CI and apply
-fixups if re-runs surface adjacent flakiness.
+- [ ] `pytest <path>::<test> --count=30` passes 30/30
+- [ ] `pytest <path>::<TestClass>` passes (no sibling regressions)
+- [ ] `@pytest.mark.flaky` decorator removed (if it was the hide)
+- [ ] Root cause documented in commit body
+```
+
+The structured `Acceptance criteria` block lets
+`Dev10x:work-on`'s py-test gate parse the `--count=N` target
+and enforce it as the AC line during verification.
+
+### Step 5: Hand Off to Dev10x:work-on
+
+Delegate the entire delivery pipeline to `Dev10x:work-on` so
+branching, implementation, py-test gate, self-review, PR
+creation, CI monitor, review-comment triage, request-review,
+and merge all run through the project-standard flow. The
+ticket created in Step 4 is the sole input.
+
+`Skill(skill="Dev10x:work-on", args="<ticket-url-or-id>")`
+
+This skill returns control once the hand-off is made. The
+supervisor sees `Dev10x:work-on`'s task list from this point
+forward; do not re-create a parallel task scaffold here.
 
 ## Validation Checklist
 
-Before marking the final task complete, verify:
+Before marking the hand-off task complete, verify:
 
-- Test runs 20–30+ times consecutively without failure
-- All tests in the same class pass
-- Tracker ticket created with root cause, fix, and verification
-- Branch follows `username/TICKET-ID/fix-flaky-<slug>` convention
-- Commit message uses gitmoji + ticket ID + outcome-focused title
-- PR created and linked to the ticket
-- `@pytest.mark.flaky` decorator removed (if the fix replaces it)
+- Failure reproduces reliably (Step 1)
+- Root cause is named in one sentence (Step 2)
+- Proposed patch is captured verbatim in the ticket
+  description (Step 3) — NOT applied to the working tree
+- Ticket exists with failure signature, root cause, proposed
+  solution, verification plan, and a structured AC block
+  (Step 4)
+- `Dev10x:work-on` is invoked with the new ticket ID (Step 5)
+- Working tree is clean — no files modified by this skill
 
 ## Integration with Other Skills
 
 ```
-Dev10x:py-test-flaky
-├── delegates to: Dev10x:ticket-create     (Step 5)
-├── delegates to: Dev10x:ticket-branch     (Step 6)
-├── delegates to: Dev10x:git-commit        (Step 7)
-├── delegates to: Dev10x:gh-pr-create      (Step 8)
-└── optionally:   Dev10x:gh-pr-monitor     (Step 8 follow-up)
+Dev10x:py-test-flaky (narrow investigator + scoper)
+├── delegates to: Dev10x:ticket-create   (Step 4)
+└── hands off to: Dev10x:work-on          (Step 5)
+                  └── owns: branch → implement → py-test
+                            → review → pr-create → monitor
+                            → respond → request-review → merge
 ```
 
 ## Important Notes
 
-- Never add `@pytest.mark.flaky` as a fix — it hides the bug.
-- Prefer deterministic seeds over retries for randomized data.
-- Re-read the fix diff before Step 7 — flaky fixes can be one-line
-  patches that touch wide fixture surface area.
-- If the root cause is infrastructure (CI runner, external service),
-  still file the ticket and commit the mitigation — then escalate
-  separately via `Dev10x:park-todo` or a separate issue.
+- This skill does NOT modify tracked files. The proposed patch
+  lives in the ticket description.
+- This skill does NOT create branches, commits, or PRs. All
+  delivery is delegated to `Dev10x:work-on`.
+- Open question (resolved): the proposed patch is staged
+  verbatim in the ticket description — the investigation
+  already did the work; re-deriving it inside `Dev10x:work-on`
+  wastes effort.
+- The `--count=N` verification target is encoded in the
+  structured `Acceptance criteria` block so `Dev10x:work-on`'s
+  py-test gate can parse and enforce it.


### PR DESCRIPTION
**When** a flaky pytest test surfaces and I invoke `Dev10x:py-test-flaky`, **I want to** investigate the failure and scope the fix as a ticket without taking on delivery responsibility, **so I can** hand off branching, implementation, py-test gate, self-review, PR creation, CI monitor, and bot-comment triage to `Dev10x:work-on` and ship flaky-test fixes with the same acceptance criteria as any other ticket of comparable scope.

---

[`7995c1dd`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/293/commits/7995c1ddcd86baedd25582aad8c31bdde4929f75) ♻️ GH-281 Enable flaky-test fixes to ship via work-on pipeline
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/281

---