### PR TITLE
✨ GH-262 Enable trimmer pipelines without broadening allow-rules

### DIFF
--- a/.claude/rules/hook-patterns.md
+++ b/.claude/rules/hook-patterns.md
@@ -167,6 +167,7 @@ higher tiers — `minimal` rules are always active.
 | DX008 | commit-jtbd | strict |
 | DX009 | redundant-fetch | standard (experimental) |
 | DX010 | bash-aggregation | standard |
+| DX011 | pipeline-allow | standard |
 
 ### Configuration
 

--- a/src/dev10x/validators/__init__.py
+++ b/src/dev10x/validators/__init__.py
@@ -71,6 +71,12 @@ _SPECS: list[ValidatorSpec] = [
         profile=ProfileTier.MINIMAL,
     ),
     ValidatorSpec(
+        module_path="dev10x.validators.pipeline_allow",
+        class_name="PipelineAllowValidator",
+        rule_id="DX011",
+        profile=ProfileTier.STANDARD,
+    ),
+    ValidatorSpec(
         module_path="dev10x.validators.skill_redirect",
         class_name="SkillRedirectValidator",
         rule_id="DX006",

--- a/src/dev10x/validators/pipeline_allow.py
+++ b/src/dev10x/validators/pipeline_allow.py
@@ -1,0 +1,113 @@
+"""Validator: auto-approve pipelines when every segment matches an allow-rule.
+
+Claude Code's allow-rule matcher operates on the whole command string, not
+on individual pipeline segments. So `cmd | tail -20` is not covered by
+``Bash(cmd:*)`` + ``Bash(tail:*)`` independently — neither rule matches
+the full pipeline string, and the agent's only escape is to broaden one
+of the rules.
+
+This validator restores narrow-rule coverage for the trimmer pattern
+(``cmd | tail``, ``cmd | head``, ``cmd | wc -l``) by approving when
+every segment is independently allowed. A pipeline is no more dangerous
+than the union of its segments — if each segment is independently
+pre-approved, the composition is too.
+
+Out of scope (do NOT auto-approve):
+  - Process substitution ``<(...)`` / ``>(...)`` — effectively subshells
+  - Backgrounding ``&`` — different execution semantics
+  - Logical operators ``&&`` / ``||`` — handled by the chaining hook
+  - ``;`` chains — handled by the chaining hook
+  - ``$(...)`` command substitution inside the pipeline
+  - Segments leading with ``xargs`` / ``tee`` — these execute their
+    argument, which needs the argument's allow-rule, not the wrapper's
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import ClassVar
+
+from dev10x.domain import HookAllow, HookInput
+from dev10x.domain.profile_tier import ProfileTier
+from dev10x.validators.base import ValidatorBase
+from dev10x.validators.prefix_friction import (
+    _load_all_allow_patterns,
+    _matches_allow_rule,
+)
+
+_TRAILING_REDIRECT_RE = re.compile(r"\s+\d?>{1,2}(?:&\d+|\s*\S+)(?=\s|$)")
+
+_PROCESS_SUBSTITUTION_RE = re.compile(r"[<>]\(")
+
+_TRAILING_BACKGROUND_RE = re.compile(r"(?<!&)&\s*$")
+
+_ARG_EXECUTORS = frozenset({"xargs", "tee"})
+
+_AUTO_APPROVE_MSG = (
+    "✓ Pipeline auto-approved — every segment matches an existing Bash allow-rule (Dev10x DX011)."
+)
+
+
+def _strip_trailing_redirects(segment: str) -> str:
+    """Strip trailing stderr/stdout redirects so the underlying command matches."""
+    prev = ""
+    out = segment
+    while prev != out:
+        prev = out
+        out = _TRAILING_REDIRECT_RE.sub("", out).rstrip()
+    return out
+
+
+def _split_pipeline(command: str) -> list[str]:
+    """Split on ``|`` (single pipe) into trimmed, non-empty segments."""
+    return [s.strip() for s in command.split("|") if s.strip()]
+
+
+def _first_token(segment: str) -> str:
+    tokens = segment.split()
+    return tokens[0] if tokens else ""
+
+
+@dataclass
+class PipelineAllowValidator(ValidatorBase):
+    """Auto-approve pipelines whose segments are all allow-rule matched."""
+
+    name: ClassVar[str] = "pipeline-allow"
+    rule_id: ClassVar[str] = "DX011"
+    profile: ClassVar[ProfileTier] = ProfileTier.STANDARD
+    capabilities: ClassVar[frozenset[str]] = frozenset({"validate"})
+    _allow_patterns: list[str] | None = field(default=None, repr=False)
+
+    def should_run(self, inp: HookInput) -> bool:
+        cmd = inp.command
+        if "|" not in cmd or "||" in cmd:
+            return False
+        if "&&" in cmd or ";" in cmd:
+            return False
+        if "$(" in cmd or "`" in cmd:
+            return False
+        if _PROCESS_SUBSTITUTION_RE.search(cmd):
+            return False
+        if _TRAILING_BACKGROUND_RE.search(cmd):
+            return False
+        return True
+
+    def validate(self, inp: HookInput) -> HookAllow | None:
+        segments = _split_pipeline(command=inp.command)
+        if len(segments) < 2:
+            return None
+
+        if self._allow_patterns is None:
+            self._allow_patterns = _load_all_allow_patterns()
+        if not self._allow_patterns:
+            return None
+
+        for segment in segments:
+            stripped = _strip_trailing_redirects(segment=segment)
+            if _first_token(stripped) in _ARG_EXECUTORS:
+                return None
+            if _matches_allow_rule(stripped, self._allow_patterns) is None:
+                return None
+
+        return HookAllow(message=_AUTO_APPROVE_MSG)

--- a/tests/validators/test_pipeline_allow.py
+++ b/tests/validators/test_pipeline_allow.py
@@ -1,0 +1,179 @@
+"""Tests for PipelineAllowValidator (DX011)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from dev10x.domain import HookAllow
+from dev10x.validators.pipeline_allow import PipelineAllowValidator
+from tests.fakers import BashHookInputFaker
+
+
+def _input(*, command: str) -> BashHookInputFaker:
+    return BashHookInputFaker.build(command=command)
+
+
+@pytest.fixture()
+def validator() -> PipelineAllowValidator:
+    return PipelineAllowValidator()
+
+
+@pytest.fixture()
+def fake_allow_patterns() -> Iterator[None]:
+    patterns = [
+        "uv run",
+        "tail",
+        "head",
+        "wc",
+        "git",
+        "grep",
+        "cat",
+        "rg",
+    ]
+    with patch(
+        "dev10x.validators.pipeline_allow._load_all_allow_patterns",
+        return_value=patterns,
+    ):
+        yield
+
+
+class TestShouldRun:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "uv run dev10x permission doctor | tail -20",
+            "git log --oneline | head",
+            "cat file.txt | grep error | wc -l",
+        ],
+    )
+    def test_true_for_pipelines(self, validator: PipelineAllowValidator, command: str) -> None:
+        assert validator.should_run(inp=_input(command=command)) is True
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git status",
+            "ls -la",
+            "echo hello",
+        ],
+    )
+    def test_false_without_pipe(self, validator: PipelineAllowValidator, command: str) -> None:
+        assert validator.should_run(inp=_input(command=command)) is False
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git status && git log | tail",
+            "git status ; git log | tail",
+            "git log | grep foo || echo none",
+            "git log | tail && echo done",
+        ],
+    )
+    def test_false_with_chaining_operators(
+        self, validator: PipelineAllowValidator, command: str
+    ) -> None:
+        assert validator.should_run(inp=_input(command=command)) is False
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "diff <(sort a) <(sort b) | head",
+            "cat >(grep foo) | tail",
+        ],
+    )
+    def test_false_with_process_substitution(
+        self, validator: PipelineAllowValidator, command: str
+    ) -> None:
+        assert validator.should_run(inp=_input(command=command)) is False
+
+    def test_false_with_command_substitution(self, validator: PipelineAllowValidator) -> None:
+        cmd = "echo $(git rev-parse HEAD) | tail"
+        assert validator.should_run(inp=_input(command=cmd)) is False
+
+    def test_false_with_backquote_substitution(self, validator: PipelineAllowValidator) -> None:
+        cmd = "echo `git rev-parse HEAD` | tail"
+        assert validator.should_run(inp=_input(command=cmd)) is False
+
+    def test_false_with_trailing_background(self, validator: PipelineAllowValidator) -> None:
+        cmd = "git log | tail -20 &"
+        assert validator.should_run(inp=_input(command=cmd)) is False
+
+
+@pytest.mark.usefixtures("fake_allow_patterns")
+class TestValidateAutoApproval:
+    def test_approves_simple_pipeline(self, validator: PipelineAllowValidator) -> None:
+        cmd = "git log --oneline | tail -20"
+        result = validator.validate(inp=_input(command=cmd))
+        assert isinstance(result, HookAllow)
+
+    def test_approves_pipeline_with_stderr_redirect(
+        self, validator: PipelineAllowValidator
+    ) -> None:
+        cmd = "uv run dev10x permission doctor canonicalize --dry-run 2>&1 | tail -20"
+        result = validator.validate(inp=_input(command=cmd))
+        assert isinstance(result, HookAllow)
+
+    def test_approves_pipeline_with_devnull_redirect(
+        self, validator: PipelineAllowValidator
+    ) -> None:
+        cmd = "uv run flake8 tests/pages/crm.py 2>/dev/null | tail -20"
+        result = validator.validate(inp=_input(command=cmd))
+        assert isinstance(result, HookAllow)
+
+    def test_approves_three_segment_pipeline(self, validator: PipelineAllowValidator) -> None:
+        cmd = "cat file.txt | grep error | wc -l"
+        result = validator.validate(inp=_input(command=cmd))
+        assert isinstance(result, HookAllow)
+
+    def test_includes_advisory_message(self, validator: PipelineAllowValidator) -> None:
+        cmd = "git log | tail"
+        result = validator.validate(inp=_input(command=cmd))
+        assert isinstance(result, HookAllow)
+        assert "DX011" in result.message
+
+
+@pytest.mark.usefixtures("fake_allow_patterns")
+class TestValidateNoOpinion:
+    def test_no_opinion_when_segment_unmatched(self, validator: PipelineAllowValidator) -> None:
+        cmd = "kubectl get pods | tail -5"
+        assert validator.validate(inp=_input(command=cmd)) is None
+
+    def test_no_opinion_when_last_segment_unmatched(
+        self, validator: PipelineAllowValidator
+    ) -> None:
+        cmd = "git log | jq ."
+        assert validator.validate(inp=_input(command=cmd)) is None
+
+    def test_no_opinion_when_xargs_in_segment(self, validator: PipelineAllowValidator) -> None:
+        cmd = "git log --format=%H | xargs git show"
+        assert validator.validate(inp=_input(command=cmd)) is None
+
+    def test_no_opinion_when_tee_in_segment(self, validator: PipelineAllowValidator) -> None:
+        cmd = "git log | tee /tmp/log.txt"
+        assert validator.validate(inp=_input(command=cmd)) is None
+
+    def test_no_opinion_for_single_segment(self, validator: PipelineAllowValidator) -> None:
+        cmd = "git log"
+        assert validator.validate(inp=_input(command=cmd)) is None
+
+    def test_no_opinion_when_segment_strips_to_empty(
+        self, validator: PipelineAllowValidator
+    ) -> None:
+        cmd = ">/tmp/out | tail"
+        assert validator.validate(inp=_input(command=cmd)) is None
+
+
+class TestNoAllowRules:
+    def test_no_opinion_when_settings_empty(
+        self, validator: PipelineAllowValidator, tmp_path: Path
+    ) -> None:
+        with patch(
+            "dev10x.validators.pipeline_allow._load_all_allow_patterns",
+            return_value=[],
+        ):
+            cmd = "git log | tail"
+            assert validator.validate(inp=_input(command=cmd)) is None


### PR DESCRIPTION
**When** an agent runs a path-based command with a trimmer like `cmd | tail -20` or `cmd | head -5` to keep tool output manageable, **I want to** have the pipeline auto-approved when every segment is already covered by a narrow `Bash(...)` allow-rule, **so I can** keep narrow allow-rules instead of broadening them (e.g., to `Bash(uv run *)`) or pausing for one-off approval every time output processing is added.

---

[`e794192b`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/294/commits/e794192be52a25c6b41cd7d1fc5ac1d2e23a4d06) ✨ GH-262 Enable trimmer pipelines without broadening allow-rules

Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/262
