### PR TITLE
✨ GH-270 Enable XDG migration for remaining user configs

### DIFF
--- a/references/config-resolution.md
+++ b/references/config-resolution.md
@@ -3,6 +3,24 @@
 Central reference for Dev10x configuration file paths, resolution
 order, and project mapping format.
 
+## Where the Dev10x config root lives
+
+Throughout this doc and Dev10x skills, `<Dev10x config>` is the
+canonical placeholder for the user-global config root. It resolves
+per platform (and overrides):
+
+| Resolution order | Path | When |
+|---|---|---|
+| 1 (override) | `$DEV10X_CONFIG_HOME` | Set explicitly (tests, CI, custom layouts) |
+| 2 (override) | `$XDG_CONFIG_HOME/Dev10x` | `XDG_CONFIG_HOME` is set |
+| 3 (Windows) | `%APPDATA%/Dev10x` | e.g. `C:\Users\<name>\AppData\Roaming\Dev10x` |
+| 4 (default) | `~/.config/Dev10x` | Linux, macOS, BSDs |
+
+Source of truth: `src/dev10x/domain/dev10x_paths.py` (`_platform_default_root`).
+When examples in this doc or SKILL.md files write
+`~/.config/Dev10x/...`, that is the Linux/macOS form — substitute
+the platform-appropriate root from the table above.
+
 ## Three-Tier Resolution
 
 All Dev10x configuration files follow a consistent resolution order

--- a/references/config-resolution.md
+++ b/references/config-resolution.md
@@ -21,6 +21,19 @@ When examples in this doc or SKILL.md files write
 `~/.config/Dev10x/...`, that is the Linux/macOS form — substitute
 the platform-appropriate root from the table above.
 
+**From the shell**, the resolved root is available as the
+bare-invocation output of the `dev10x` CLI:
+
+```bash
+$(uvx dev10x)/gitmoji.yaml
+# → /home/<user>/.config/Dev10x/gitmoji.yaml on Linux
+# → /Users/<user>/.config/Dev10x/gitmoji.yaml on macOS
+# → C:\Users\<user>\AppData\Roaming\Dev10x\gitmoji.yaml on Windows
+```
+
+`dev10x config root` is the explicit equivalent — both print
+the same path. Use whichever reads better in your script.
+
 ## Three-Tier Resolution
 
 All Dev10x configuration files follow a consistent resolution order

--- a/skills/gh-pr-merge/instructions.md
+++ b/skills/gh-pr-merge/instructions.md
@@ -24,7 +24,7 @@ The merge strategy is resolved using the config resolution order
 (see `references/config-resolution.md`):
 
 1. **Global with repo matching** — read
-   `~/.config/Dev10x/settings-pr-merge.yaml`, match current
+   `<Dev10x config>/settings-pr-merge.yaml`, match current
    repo against `projects[].match` globs
 2. **Default** — `rebase`
 
@@ -37,7 +37,7 @@ the curated commits as-is.
 
 **Migration note for existing users:** If a project previously relied
 on the implicit `squash` default, set `strategy: squash` explicitly
-in `~/.config/Dev10x/settings-pr-merge.yaml` for that repo's
+in `<Dev10x config>/settings-pr-merge.yaml` for that repo's
 `projects[].match` entry. No behavior change for projects that
 already declared `strategy:` explicitly.
 
@@ -45,7 +45,7 @@ already declared `strategy:` explicitly.
 
 **Global format** (preferred — one file for all repos):
 ```yaml
-# ~/.config/Dev10x/settings-pr-merge.yaml
+# <Dev10x config>/settings-pr-merge.yaml
 projects:
   - match: "Dev10x-Guru/*"
     strategy: rebase

--- a/skills/gh-pr-merge/instructions.md
+++ b/skills/gh-pr-merge/instructions.md
@@ -24,7 +24,7 @@ The merge strategy is resolved using the config resolution order
 (see `references/config-resolution.md`):
 
 1. **Global with repo matching** — read
-   `~/.claude/memory/Dev10x/settings-pr-merge.yaml`, match current
+   `~/.config/Dev10x/settings-pr-merge.yaml`, match current
    repo against `projects[].match` globs
 2. **Default** — `rebase`
 
@@ -37,7 +37,7 @@ the curated commits as-is.
 
 **Migration note for existing users:** If a project previously relied
 on the implicit `squash` default, set `strategy: squash` explicitly
-in `~/.claude/memory/Dev10x/settings-pr-merge.yaml` for that repo's
+in `~/.config/Dev10x/settings-pr-merge.yaml` for that repo's
 `projects[].match` entry. No behavior change for projects that
 already declared `strategy:` explicitly.
 
@@ -45,7 +45,7 @@ already declared `strategy:` explicitly.
 
 **Global format** (preferred — one file for all repos):
 ```yaml
-# ~/.claude/memory/Dev10x/settings-pr-merge.yaml
+# ~/.config/Dev10x/settings-pr-merge.yaml
 projects:
   - match: "Dev10x-Guru/*"
     strategy: rebase

--- a/skills/gh-pr-request-review/SKILL.md
+++ b/skills/gh-pr-request-review/SKILL.md
@@ -38,7 +38,7 @@ Auto-resolves reviewers from per-project config when available.
 The skill resolves reviewers in this order:
 
 1. **Explicit argument** — if the user passes reviewer names, use those
-2. **Config file** — read `~/.claude/memory/Dev10x/github-reviewers-config.yaml`
+2. **Config file** — read `~/.config/Dev10x/github-reviewers-config.yaml`
    and look up the current repo's project entry
 3. **Ask the user** — if no config entry exists and `default_action: ask`
 
@@ -49,7 +49,7 @@ for the current repo, the skill falls back to `default_action`
 behavior (ask or skip).
 
 ```yaml
-# ~/.claude/memory/Dev10x/github-reviewers-config.yaml
+# ~/.config/Dev10x/github-reviewers-config.yaml
 default_action: ask  # "skip" or "ask" for unconfigured projects
 
 projects:
@@ -137,7 +137,7 @@ NOT notify the requested reviewers — the request is lost.
    (or call `mcp__plugin_Dev10x_cli__pr_detect` and use its
    returned `repo` field — last path segment is the repo name)
 2. Read and parse the config file using `yq`:
-   `yq '.projects["REPO_NAME"]' ~/.claude/memory/Dev10x/github-reviewers-config.yaml`
+   `yq '.projects["REPO_NAME"]' ~/.config/Dev10x/github-reviewers-config.yaml`
 3. Look up the repo name in `projects`:
    - **Found with `skip: true`** → print "Skipping review request
      for {repo}" and stop

--- a/skills/gh-pr-request-review/SKILL.md
+++ b/skills/gh-pr-request-review/SKILL.md
@@ -38,7 +38,7 @@ Auto-resolves reviewers from per-project config when available.
 The skill resolves reviewers in this order:
 
 1. **Explicit argument** — if the user passes reviewer names, use those
-2. **Config file** — read `~/.config/Dev10x/github-reviewers-config.yaml`
+2. **Config file** — read `<Dev10x config>/github-reviewers-config.yaml`
    and look up the current repo's project entry
 3. **Ask the user** — if no config entry exists and `default_action: ask`
 
@@ -49,7 +49,7 @@ for the current repo, the skill falls back to `default_action`
 behavior (ask or skip).
 
 ```yaml
-# ~/.config/Dev10x/github-reviewers-config.yaml
+# <Dev10x config>/github-reviewers-config.yaml
 default_action: ask  # "skip" or "ask" for unconfigured projects
 
 projects:
@@ -137,7 +137,7 @@ NOT notify the requested reviewers — the request is lost.
    (or call `mcp__plugin_Dev10x_cli__pr_detect` and use its
    returned `repo` field — last path segment is the repo name)
 2. Read and parse the config file using `yq`:
-   `yq '.projects["REPO_NAME"]' ~/.config/Dev10x/github-reviewers-config.yaml`
+   `yq '.projects["REPO_NAME"]' <Dev10x config>/github-reviewers-config.yaml`
 3. Look up the repo name in `projects`:
    - **Found with `skip: true`** → print "Skipping review request
      for {repo}" and stop

--- a/skills/git-commit/instructions.md
+++ b/skills/git-commit/instructions.md
@@ -364,7 +364,7 @@ Job Story was already sourced from the Linear ticket earlier in this session
 **Project override check:** Before presenting the type menu,
 check for a strategy override:
 
-1. Read `~/.claude/memory/Dev10x/gitmoji.yaml`
+1. Read `~/.config/Dev10x/gitmoji.yaml`
 2. Get repo origin: `git remote get-url origin`
 3. Walk the `projects` list — first `match` glob that fits
    the origin URL selects the named `strategy`
@@ -1021,7 +1021,7 @@ Default gitmoji-to-type mapping shipped with the plugin.
 ### references/project-override.md
 
 Project-level gitmoji strategy overrides — schema, resolution
-order, and examples for `~/.claude/memory/Dev10x/gitmoji.yaml`.
+order, and examples for `~/.config/Dev10x/gitmoji.yaml`.
 
 ### references/semantic-release.md
 

--- a/skills/git-commit/instructions.md
+++ b/skills/git-commit/instructions.md
@@ -364,7 +364,7 @@ Job Story was already sourced from the Linear ticket earlier in this session
 **Project override check:** Before presenting the type menu,
 check for a strategy override:
 
-1. Read `~/.config/Dev10x/gitmoji.yaml`
+1. Read `<Dev10x config>/gitmoji.yaml`
 2. Get repo origin: `git remote get-url origin`
 3. Walk the `projects` list — first `match` glob that fits
    the origin URL selects the named `strategy`
@@ -1021,7 +1021,7 @@ Default gitmoji-to-type mapping shipped with the plugin.
 ### references/project-override.md
 
 Project-level gitmoji strategy overrides — schema, resolution
-order, and examples for `~/.config/Dev10x/gitmoji.yaml`.
+order, and examples for `<Dev10x config>/gitmoji.yaml`.
 
 ### references/semantic-release.md
 

--- a/skills/git-commit/references/gitmoji-defaults.yaml
+++ b/skills/git-commit/references/gitmoji-defaults.yaml
@@ -1,7 +1,7 @@
 # Default gitmoji-to-type mapping for Dev10x:git-commit.
 #
 # This file ships with the plugin and is used when no project
-# override exists in ~/.claude/memory/Dev10x/gitmoji.yaml.
+# override exists in ~/.config/Dev10x/gitmoji.yaml.
 #
 # Users can override this by creating a strategy in the global
 # config file. See project-override.md for the full schema.

--- a/skills/git-commit/references/gitmoji-defaults.yaml
+++ b/skills/git-commit/references/gitmoji-defaults.yaml
@@ -1,7 +1,7 @@
 # Default gitmoji-to-type mapping for Dev10x:git-commit.
 #
 # This file ships with the plugin and is used when no project
-# override exists in ~/.config/Dev10x/gitmoji.yaml.
+# override exists in <Dev10x config>/gitmoji.yaml.
 #
 # Users can override this by creating a strategy in the global
 # config file. See project-override.md for the full schema.

--- a/skills/git-commit/references/project-override.md
+++ b/skills/git-commit/references/project-override.md
@@ -7,7 +7,7 @@ repos can share the same strategy.
 ## Config File Location
 
 ```
-~/.claude/memory/Dev10x/gitmoji.yaml
+~/.config/Dev10x/gitmoji.yaml
 ```
 
 Global file — not per-project. Strategies are defined once and
@@ -106,7 +106,7 @@ is checked against the output of `git remote get-url origin`.
 
 ## Resolution Order
 
-1. Read `~/.claude/memory/Dev10x/gitmoji.yaml`
+1. Read `~/.config/Dev10x/gitmoji.yaml`
 2. Get current repo's origin URL via `git remote get-url origin`
 3. Walk `projects` list — first `match` that fits selects the
    strategy

--- a/skills/git-commit/references/project-override.md
+++ b/skills/git-commit/references/project-override.md
@@ -7,7 +7,7 @@ repos can share the same strategy.
 ## Config File Location
 
 ```
-~/.config/Dev10x/gitmoji.yaml
+<Dev10x config>/gitmoji.yaml
 ```
 
 Global file — not per-project. Strategies are defined once and
@@ -106,7 +106,7 @@ is checked against the output of `git remote get-url origin`.
 
 ## Resolution Order
 
-1. Read `~/.config/Dev10x/gitmoji.yaml`
+1. Read `<Dev10x config>/gitmoji.yaml`
 2. Get current repo's origin URL via `git remote get-url origin`
 3. Walk `projects` list — first `match` that fits selects the
    strategy

--- a/skills/git-commit/references/semantic-release.md
+++ b/skills/git-commit/references/semantic-release.md
@@ -8,7 +8,7 @@ gitmoji-based release rules.
 ## When This Applies
 
 This step runs when no manual strategy matched the project
-in `~/.config/Dev10x/gitmoji.yaml`. It checks for a
+in `<Dev10x config>/gitmoji.yaml`. It checks for a
 semantic-release config in the project root before falling
 back to the plugin defaults.
 

--- a/skills/git-commit/references/semantic-release.md
+++ b/skills/git-commit/references/semantic-release.md
@@ -8,7 +8,7 @@ gitmoji-based release rules.
 ## When This Applies
 
 This step runs when no manual strategy matched the project
-in `~/.claude/memory/Dev10x/gitmoji.yaml`. It checks for a
+in `~/.config/Dev10x/gitmoji.yaml`. It checks for a
 semantic-release config in the project root before falling
 back to the plugin defaults.
 

--- a/skills/request-review/SKILL.md
+++ b/skills/request-review/SKILL.md
@@ -95,7 +95,7 @@ Delegate to the GitHub reviewer assignment skill:
 Skill("Dev10x:gh-pr-request-review", args="--pr {PR_NUMBER} --repo {REPO}")
 ```
 
-This skill reads `~/.config/Dev10x/github-reviewers-config.yaml`,
+This skill reads `<Dev10x config>/github-reviewers-config.yaml`,
 resolves reviewers, and assigns them via GitHub API. It may skip
 if the project is configured with `skip: true`.
 

--- a/skills/request-review/SKILL.md
+++ b/skills/request-review/SKILL.md
@@ -95,7 +95,7 @@ Delegate to the GitHub reviewer assignment skill:
 Skill("Dev10x:gh-pr-request-review", args="--pr {PR_NUMBER} --repo {REPO}")
 ```
 
-This skill reads `~/.claude/memory/Dev10x/github-reviewers-config.yaml`,
+This skill reads `~/.config/Dev10x/github-reviewers-config.yaml`,
 resolves reviewers, and assigns them via GitHub API. It may skip
 if the project is configured with `skip: true`.
 

--- a/src/dev10x/cli.py
+++ b/src/dev10x/cli.py
@@ -50,7 +50,18 @@ class LazyGroup(click.Group):
         "validate": "dev10x.commands.validate.validate",
         "skill": "dev10x.commands.skill.skill",
     },
+    invoke_without_command=True,
 )
 @click.version_option(package_name="Dev10x")
-def cli() -> None:
-    pass
+@click.pass_context
+def cli(ctx: click.Context) -> None:
+    """Print the resolved Dev10x config root when no subcommand is given.
+
+    This makes `$(uvx dev10x)/somefile.yaml` work as a portable
+    reference to the user-global config directory from shell
+    scripts and docs. Equivalent to `dev10x config root`.
+    """
+    if ctx.invoked_subcommand is None:
+        from dev10x.domain.dev10x_paths import Dev10xConfigDir
+
+        click.echo(Dev10xConfigDir.home())

--- a/src/dev10x/domain/claude_paths.py
+++ b/src/dev10x/domain/claude_paths.py
@@ -133,5 +133,17 @@ class ClaudeDir:
     def slack_review_config_yaml(cls) -> Path:
         return cls._resolve("memory", "slack-config-code-review-requests.yaml")
 
+    @classmethod
+    def gitmoji_yaml(cls) -> Path:
+        return cls._resolve("memory", "Dev10x", "gitmoji.yaml")
+
+    @classmethod
+    def github_reviewers_config_yaml(cls) -> Path:
+        return cls._resolve("memory", "Dev10x", "github-reviewers-config.yaml")
+
+    @classmethod
+    def settings_pr_merge_yaml(cls) -> Path:
+        return cls._resolve("memory", "Dev10x", "settings-pr-merge.yaml")
+
 
 __all__ = ["ClaudeDir", "CLAUDE_HOME_ENV_VAR"]

--- a/src/dev10x/domain/dev10x_paths.py
+++ b/src/dev10x/domain/dev10x_paths.py
@@ -146,6 +146,24 @@ class Dev10xConfigDir:
     def playbooks_dir(cls) -> Path:
         return _with_lazy_migration(cls._resolve("playbooks"), _legacy_playbooks_dir)
 
+    @classmethod
+    def gitmoji_yaml(cls) -> Path:
+        return _with_lazy_migration(cls._resolve("gitmoji.yaml"), _legacy_gitmoji_yaml)
+
+    @classmethod
+    def github_reviewers_config_yaml(cls) -> Path:
+        return _with_lazy_migration(
+            cls._resolve("github-reviewers-config.yaml"),
+            _legacy_github_reviewers_config_yaml,
+        )
+
+    @classmethod
+    def settings_pr_merge_yaml(cls) -> Path:
+        return _with_lazy_migration(
+            cls._resolve("settings-pr-merge.yaml"),
+            _legacy_settings_pr_merge_yaml,
+        )
+
 
 def _with_lazy_migration(current: Path, legacy_provider: Callable[[], Path]) -> Path:
     migrate_path(legacy=legacy_provider(), current=current)
@@ -162,6 +180,9 @@ _legacy_slack_review_config_yaml = ClaudeDir.slack_review_config_yaml
 _legacy_upgrade_cleanup_projects_yaml = ClaudeDir.upgrade_cleanup_projects_yaml
 _legacy_github_bot_dir = ClaudeDir.github_bot_dir
 _legacy_github_app_yaml = ClaudeDir.github_app_yaml
+_legacy_gitmoji_yaml = ClaudeDir.gitmoji_yaml
+_legacy_github_reviewers_config_yaml = ClaudeDir.github_reviewers_config_yaml
+_legacy_settings_pr_merge_yaml = ClaudeDir.settings_pr_merge_yaml
 
 
 def _legacy_playbooks_dir() -> Path:
@@ -189,6 +210,15 @@ def _migration_pairs() -> list[tuple[Path, Path]]:
             Dev10xConfigDir._resolve("github-bot", "github-app.yaml"),
         ),
         (_legacy_playbooks_dir(), Dev10xConfigDir._resolve("playbooks")),
+        (_legacy_gitmoji_yaml(), Dev10xConfigDir._resolve("gitmoji.yaml")),
+        (
+            _legacy_github_reviewers_config_yaml(),
+            Dev10xConfigDir._resolve("github-reviewers-config.yaml"),
+        ),
+        (
+            _legacy_settings_pr_merge_yaml(),
+            Dev10xConfigDir._resolve("settings-pr-merge.yaml"),
+        ),
     ]
 
 

--- a/src/dev10x/mcp/server_cli.py
+++ b/src/dev10x/mcp/server_cli.py
@@ -530,7 +530,7 @@ async def merge_pr(
         pr_number: PR number to merge.
         strategy: One of ``rebase`` (default), ``squash``, ``merge``.
             Resolved by the skill from
-            ``~/.claude/memory/Dev10x/settings-pr-merge.yaml``.
+            ``~/.config/Dev10x/settings-pr-merge.yaml``.
         delete_branch: Pass ``--delete-branch`` to ``gh pr merge``
             when True (default).
         repo: Repository (owner/repo). Auto-detected if omitted.

--- a/src/dev10x/mcp/server_cli.py
+++ b/src/dev10x/mcp/server_cli.py
@@ -530,7 +530,9 @@ async def merge_pr(
         pr_number: PR number to merge.
         strategy: One of ``rebase`` (default), ``squash``, ``merge``.
             Resolved by the skill from
-            ``~/.config/Dev10x/settings-pr-merge.yaml``.
+            ``<Dev10x config>/settings-pr-merge.yaml`` — see
+            ``references/config-resolution.md`` for the per-platform
+            resolution table.
         delete_branch: Pass ``--delete-branch`` to ``gh pr merge``
             when True (default).
         repo: Repository (owner/repo). Auto-detected if omitted.

--- a/tests/domain/test_dev10x_paths.py
+++ b/tests/domain/test_dev10x_paths.py
@@ -42,6 +42,9 @@ def isolated_dirs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> tuple[Path
         ("github_bot_dir", "github-bot"),
         ("github_app_yaml", "github-bot/github-app.yaml"),
         ("playbooks_dir", "playbooks"),
+        ("gitmoji_yaml", "gitmoji.yaml"),
+        ("github_reviewers_config_yaml", "github-reviewers-config.yaml"),
+        ("settings_pr_merge_yaml", "settings-pr-merge.yaml"),
     ],
 )
 def test_accessors_resolve_under_override(
@@ -162,6 +165,52 @@ def test_stale_legacy_paths_reports_only_existing(
     stale = stale_legacy_paths()
     assert legacy_version in stale
     assert ClaudeDir.platforms_yaml() not in stale
+
+
+@pytest.mark.parametrize(
+    "legacy_accessor,current_accessor,filename",
+    [
+        ("gitmoji_yaml", "gitmoji_yaml", "gitmoji.yaml"),
+        (
+            "github_reviewers_config_yaml",
+            "github_reviewers_config_yaml",
+            "github-reviewers-config.yaml",
+        ),
+        (
+            "settings_pr_merge_yaml",
+            "settings_pr_merge_yaml",
+            "settings-pr-merge.yaml",
+        ),
+    ],
+)
+def test_memory_dev10x_files_migrate_to_xdg_config(
+    isolated_dirs: tuple[Path, Path],
+    legacy_accessor: str,
+    current_accessor: str,
+    filename: str,
+) -> None:
+    legacy = getattr(ClaudeDir, legacy_accessor)()
+    legacy.parent.mkdir(parents=True, exist_ok=True)
+    legacy.write_text(f"payload: {filename}")
+    current = getattr(Dev10xConfigDir, current_accessor)()
+    assert current.read_text() == f"payload: {filename}"
+
+
+def test_migrate_all_includes_memory_dev10x_files(
+    isolated_dirs: tuple[Path, Path],
+) -> None:
+    for accessor in (
+        "gitmoji_yaml",
+        "github_reviewers_config_yaml",
+        "settings_pr_merge_yaml",
+    ):
+        legacy = getattr(ClaudeDir, accessor)()
+        legacy.parent.mkdir(parents=True, exist_ok=True)
+        legacy.write_text("payload")
+    migrated_names = {p.name for p in migrate_all()}
+    assert "gitmoji.yaml" in migrated_names
+    assert "github-reviewers-config.yaml" in migrated_names
+    assert "settings-pr-merge.yaml" in migrated_names
 
 
 def test_migrate_all_is_idempotent(isolated_dirs: tuple[Path, Path]) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,6 +34,49 @@ class TestCli:
 
         assert result.exit_code != 0
 
+    def test_bare_invocation_prints_config_root(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: object,
+    ) -> None:
+        from dev10x.domain.dev10x_paths import (
+            CONFIG_HOME_ENV_VAR,
+            Dev10xConfigDir,
+        )
+
+        monkeypatch.setenv(CONFIG_HOME_ENV_VAR, str(tmp_path))
+        Dev10xConfigDir.reset_cache()
+        try:
+            result = runner.invoke(cli, [])
+        finally:
+            Dev10xConfigDir.reset_cache()
+
+        assert result.exit_code == 0
+        assert result.output.strip() == str(tmp_path)
+
+    def test_bare_invocation_does_not_print_when_subcommand_runs(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: object,
+    ) -> None:
+        from dev10x.domain.dev10x_paths import (
+            CONFIG_HOME_ENV_VAR,
+            Dev10xConfigDir,
+        )
+
+        monkeypatch.setenv(CONFIG_HOME_ENV_VAR, str(tmp_path))
+        Dev10xConfigDir.reset_cache()
+        try:
+            result = runner.invoke(cli, ["--help"])
+        finally:
+            Dev10xConfigDir.reset_cache()
+
+        assert result.exit_code == 0
+        # Help output, not the config path
+        assert str(tmp_path) not in result.output
+
 
 class TestLazyGroup:
     def test_list_commands_includes_lazy(self) -> None:


### PR DESCRIPTION
**When** a Dev10x skill touches user-global config files (gitmoji.yaml, github-reviewers-config.yaml, settings-pr-merge.yaml) from a fresh project, **I want to** read them from the canonical XDG location, **so I can** avoid Claude Code's per-session sensitive-path consent gate on `~/.claude/` paths.

---

[`c8ff86ec`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/296/commits/c8ff86ec21ba946efcd8471314c07d349c854a11) ✨ GH-270 Enable XDG migration for remaining user configs
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/270

---