### PR TITLE
✨ GH-297 Enable scope-aware triage and priority-split responses

### DIFF
--- a/skills/gh-pr-respond/SKILL.md
+++ b/skills/gh-pr-respond/SKILL.md
@@ -25,6 +25,7 @@ allowed-tools:
   - Skill(Dev10x:gh-pr-monitor)
   - Skill(Dev10x:git)
   - Skill(Dev10x:gh-pr-merge)
+  - Skill(Dev10x:ticket-create)
 ---
 
 # Respond to PR Review Comments

--- a/skills/gh-pr-respond/instructions.md
+++ b/skills/gh-pr-respond/instructions.md
@@ -60,7 +60,7 @@ Customize with `/Dev10x:playbook edit gh-pr-respond <play>`.
 
 ## Decision Gates
 
-This skill has 6 **blocking decision gates** where execution
+This skill has 7 **blocking decision gates** where execution
 MUST pause for user input via the `AskUserQuestion` tool.
 
 **Plain text questions are NOT acceptable** — they don't block
@@ -77,6 +77,7 @@ Gates numbered by insertion order; execution order differs by mode.
 | 4 | Mode B, Step 5 | Resolve threads confirmation |
 | 5 | Post-Response Continuation | Groom + push + monitor / Push only / Stop |
 | 6 | Mode B, Step 5b / Mode A, Step 1c | Hide obsolete comments |
+| 7 | Mode A, Step 1d / Mode B, Step 4 (per bundle) | YAGNI routing — remove / defer / keep-and-harden |
 
 Each gate is marked with **REQUIRED: `AskUserQuestion`** in the
 step description. If you see that marker, you MUST call the
@@ -93,6 +94,10 @@ step description. If you see that marker, you MUST call the
    (fires at every friction level, including `adaptive`; adaptive
    auto-selects "Hide all resolved" but the gate still fires and
    `minimize_comments` is invoked — GH-208)
+6a. Gate 7 (YAGNI routing): `AskUserQuestion` — MANDATORY per
+    YAGNI bundle (GH-297). Adaptive auto-selects "Remove
+    out-of-scope code" but the gate still fires so the user sees
+    the bundled comment IDs before the removal commit is created.
 7. VALID comments: `Skill(Dev10x:gh-pr-fixup)` — NEVER inline,
    invoke immediately after triage verdict (no pause, no report)
 8. Triage: `Skill(Dev10x:gh-pr-triage)` — NEVER inline, even
@@ -474,13 +479,27 @@ delegate to triage as normal.
   implement fixes manually or post replies via raw `gh api`.
   The fixup skill handles the entire lifecycle: fix, commit, push,
   and reply.
-- If **not VALID** → `Dev10x:gh-pr-triage` has posted a reply but has NOT resolved the
-  thread. Ask the user whether to resolve it (see Step 1b).
+- If **YAGNI** → triage has posted a reply naming the scope mismatch.
+  Do NOT call `Dev10x:gh-pr-fixup` to harden the code. Surface the
+  scope mismatch to the user (one `AskUserQuestion` gate listing
+  the YAGNI bundle's comment IDs and the proposed removal) and
+  route per their choice: remove the code in a single commit
+  spanning all bundled threads, or defer the speculative feature
+  to a follow-up ticket and close the threads. See § YAGNI
+  routing below for the gate details.
+- If **not VALID** (INVALID / QUESTION / OUT_OF_SCOPE) → triage
+  has posted a reply but has NOT resolved the thread. Ask the
+  user whether to resolve it (see Step 1b).
 
-### Step 1b: Confirm thread resolution (non-VALID only)
+### Step 1b: Confirm thread resolution (INVALID / QUESTION / OUT_OF_SCOPE)
 
-When `Dev10x:gh-pr-triage` returns INVALID, QUESTION, or OUT_OF_SCOPE, present the
-verdict and reason to the user and ask for confirmation before resolving:
+Fires only when `Dev10x:gh-pr-triage` returns INVALID, QUESTION, or
+OUT_OF_SCOPE. VALID is handled by `Dev10x:gh-pr-fixup`; YAGNI is
+handled by Step 1d (which owns its own thread-resolution path
+per user choice).
+
+Present the verdict and reason to the user and ask for confirmation
+before resolving:
 
 ```
 Comment r{comment_id} on {path}:{line}:
@@ -520,6 +539,44 @@ gh api graphql -F query=@/tmp/Dev10x/gh/minimize.graphql \
 ```
 
 See `references/github_api.md` § Hiding (Minimizing) Comments.
+
+### Step 1d: YAGNI routing (YAGNI verdict only)
+
+Fires only when `Dev10x:gh-pr-triage` returns `YAGNI`. Triage has
+already posted a reply naming the scope mismatch; this gate decides
+how to close the bundled threads.
+
+**REQUIRED: Call `AskUserQuestion`** (do NOT use plain text).
+
+Present:
+```
+YAGNI bundle on PR #{pr_number}:
+  JTBD: "{PR JTBD outcome phrase}"
+  Out-of-scope code: {feature/module name}
+  Bundled threads: r{id1}, r{id2}, r{id3} (N comments)
+```
+
+Options:
+- **"Remove out-of-scope code" (Recommended)** — Create one removal
+  commit closing all bundled threads. Delegate to
+  `Skill(Dev10x:gh-pr-fixup)` with the bundled comment IDs and an
+  instruction to revert/remove the speculative feature rather than
+  harden it. Reply on each thread with the removal-commit reference
+  using the bundled-reply template.
+- **"Defer to follow-up ticket"** — Leave the code in place, create
+  a tracking ticket via `Dev10x:ticket-create` capturing the
+  speculative feature + the listed concerns, and reply on each
+  thread linking the ticket. No fixup commit is created.
+- **"Keep and harden each thread"** — Override the YAGNI verdict.
+  Treat each comment as `VALID` and delegate to
+  `Dev10x:gh-pr-fixup` per comment. Use only when the user
+  intentionally wants the speculative feature shipped in this PR.
+
+**Bundling guarantee:** When "Remove out-of-scope code" is selected,
+all bundled comment IDs from the YAGNI verdict MUST be passed to
+`Dev10x:gh-pr-fixup` in a single call with `bundled: true` metadata
+(see § Bundled Fixup Mode). Splitting a YAGNI bundle into separate
+removal commits defeats the audit signal that motivated the verdict.
 
 ### Step 2: Check for remaining comments
 
@@ -660,16 +717,47 @@ Present the full plan to the user as a table:
 
 ```
 Found {N} unaddressed comments on PR #{pr_number}:
+  JTBD: "{PR JTBD outcome phrase}"
 
-| # | Author | File:Line | Summary | Verdict | Proposed Response |
-|---|--------|-----------|---------|---------|-------------------|
-| 1 | mike   | sender.py:19 | Use SubFactory | VALID | Change LazyFunction → SubFactory |
-| 2 | mike   | fakers.py:21 | Randomize values | VALID | Use Faker() for all fields |
-| 3 | claude[bot] | dto.py:5 | TYPE_CHECKING | INVALID | 38+ files use this pattern |
-| 4 | claude[bot] | tasks.py:12 | Missing type ann | INVALID | mypy infers from assignment |
+| # | Author | File:Line | Summary | Verdict | Priority | Proposed Response |
+|---|--------|-----------|---------|---------|----------|-------------------|
+| 1 | mike   | sender.py:19 | Use SubFactory | VALID | now | Change LazyFunction → SubFactory |
+| 2 | mike   | fakers.py:21 | Randomize values | VALID | fast-follow | Tracked as test-quality enhancement |
+| 3 | claude[bot] | dto.py:5 | TYPE_CHECKING | INVALID | n/a | 38+ files use this pattern |
+| 4 | claude[bot] | tasks.py:12 | Missing type ann | INVALID | n/a | mypy infers from assignment |
+| 5 | mike   | feature.py:8  | Denorm drift | YAGNI | n/a | Bundle r{ids} → propose removal |
+
+Bundles:
+- YAGNI bundle "speculative-feature-X" (rows 5,7,8,9) → single
+  removal commit proposed
 
 Approve all, or specify which to modify/skip?
 ```
+
+**Priority column (Finding 2, GH-297).** Every row carries a
+`Priority` value so the batch plan no longer leaves defer-vs-handle
+as a manual reviewer decision per comment.
+
+| Priority | Applies to | Action at Step 4 |
+|----------|-----------|------------------|
+| `now`    | `VALID` comments that block correctness, security, or contract guarantees | Delegate to `Dev10x:gh-pr-fixup` in this batch |
+| `fast-follow` | `VALID` comments that are non-blocking enhancements (test-coverage gaps, type narrowing, dedup, edge-case hardening, doc improvements, nice-to-have refactors) | Acknowledge on the thread, create or append to a fast-follow ticket via `Dev10x:ticket-create`, skip fixup in this batch |
+| `n/a`    | `INVALID`, `QUESTION`, `OUT_OF_SCOPE`, `YAGNI` | Verdict already determines the action; priority does not apply |
+
+**Heuristics for assigning `now` vs `fast-follow`:**
+
+- Default to `now` when the comment names a correctness bug, a
+  regression risk, a security hole, a missing migration safeguard,
+  or a contract violation
+- Default to `fast-follow` when the comment names a test gap, a
+  type narrowing, a dedup, an admin edge case the PR did not
+  introduce, a doc improvement, or a refactor opportunity
+- When ambiguous, choose `now` and let the user downgrade to
+  `fast-follow` during the Step 3 approval gate
+
+The fast-follow rows roll up into a single batched ticket so the
+reviewer does not have to thread each deferral by hand. Present the
+proposed ticket title and body inline with the table for confirmation.
 
 ### Step 3: Get user approval
 
@@ -687,20 +775,43 @@ reviewer").
 
 Mark phase transition: `TaskUpdate(taskId=execute_task, status="in_progress")`
 
-For each approved comment:
+For each approved comment, route by **verdict + priority**:
 
-- **VALID** → **REQUIRED: Call `Skill(Dev10x:gh-pr-fixup)`
-  immediately after verdict** — do NOT report the verdict and
-  wait for user input between comments. The triage-to-fixup
-  transition is atomic: verdict received → `Skill()` invoked,
-  no pause. Never manually implement fixes or post replies via
-  raw commands. The fixup skill handles the entire lifecycle.
+- **VALID + priority=`now`** → **REQUIRED: Call
+  `Skill(Dev10x:gh-pr-fixup)` immediately after verdict** — do
+  NOT report the verdict and wait for user input between
+  comments. The triage-to-fixup transition is atomic: verdict
+  received → `Skill()` invoked, no pause. Never manually
+  implement fixes or post replies via raw commands. The fixup
+  skill handles the entire lifecycle.
 
   **Default cardinality is one fixup commit per comment.** When
   several VALID comments share a coherent fix, see the **Bundled
   Fixup Mode** section above — bundling is opt-in and requires
   every affected reply to use the hyperlinked bundled-reply
   template plus the post-groom SHA refresh sub-phase.
+- **VALID + priority=`fast-follow`** → do NOT call
+  `Dev10x:gh-pr-fixup` in this batch. Collect all fast-follow
+  rows, draft a single follow-up ticket via
+  `Dev10x:ticket-create` (one ticket per PR, listing each
+  fast-follow comment link as an acceptance criterion), then
+  reply on each thread acknowledging the deferral with a link
+  to the new ticket:
+
+  ```markdown
+  Acknowledged — deferring to fast-follow [{ticket-id}]({url}).
+  This PR's JTBD ({JTBD outcome}) ships without this change;
+  the follow-up ticket tracks it.
+  ```
+
+  Do NOT resolve the thread automatically.
+- **YAGNI** → respect the bundle. For each YAGNI bundle named in
+  the batch plan, fire one **Step 1d-style YAGNI routing gate**
+  (see Mode A § Step 1d) covering the whole bundle. The selected
+  option (remove / defer / keep-and-harden) determines whether
+  `Dev10x:gh-pr-fixup` is invoked once with all bundled comment
+  IDs (`bundled: true`), whether a deferral ticket is created, or
+  whether the comments fall back to individual VALID handling.
 - **INVALID / QUESTION / OUT_OF_SCOPE** → post reply using MCP tool:
   ```
   mcp__plugin_Dev10x_cli__pr_comment_reply(
@@ -846,7 +957,9 @@ After all comments are processed, report:
 
 ```
 Batch complete: {N} comments processed
-- {x} VALID (fixup commits created)
+- {x} VALID-now (fixup commits created)
+- {f} VALID-fast-follow (deferred to ticket {ticket-id})
+- {g} YAGNI (bundled into {b} removal commit(s) | deferred to ticket {id})
 - {y} INVALID (replied)
 - {z} QUESTION (answered)
 - {w} OUT_OF_SCOPE (acknowledged)

--- a/skills/gh-pr-respond/references/playbook.yaml
+++ b/skills/gh-pr-respond/references/playbook.yaml
@@ -77,22 +77,34 @@ defaults:
         type: detailed
         prompt: >
           Dispatch parallel triage subagents — up to 4 concurrent.
-          Each returns verdict + draft reply. Present results as
-          a table with author, file:line, summary, verdict, and
-          proposed response.
+          Each returns verdict (VALID | YAGNI | INVALID | QUESTION
+          | OUT_OF_SCOPE) and draft reply. For VALID, also assign a
+          priority (now | fast-follow) per the heuristics in
+          instructions.md § Mode B Step 2. Cluster YAGNI verdicts
+          on the same out-of-scope feature into named bundles.
+          Present results as a table with author, file:line,
+          summary, verdict, priority, and proposed response. List
+          YAGNI bundles below the table.
       - subject: Get user approval
         type: detailed
         prompt: >
           REQUIRED: Call AskUserQuestion (Gate 3). Options:
           "Approve all" / "Review one-by-one" / "Skip".
-          User may provide corrections in free text.
+          User may provide corrections in free text (verdict
+          override, priority flip, YAGNI bundle membership).
       - subject: Execute approved responses
         type: detailed
         prompt: >
-          For VALID comments → delegate to Dev10x:gh-pr-fixup
-          (one fixup commit per comment). For non-VALID comments
-          → post reply via gh api. Do NOT resolve threads yet.
-        skills: [Dev10x:gh-pr-fixup]
+          Route by verdict + priority. VALID+now → delegate to
+          Dev10x:gh-pr-fixup (one fixup commit per comment, or
+          bundled per § Bundled Fixup Mode). VALID+fast-follow →
+          batch into a single follow-up ticket via
+          Dev10x:ticket-create, reply on each thread linking the
+          ticket, skip fixup in this batch. YAGNI bundles → fire
+          Gate 7 (Step 1d-style) per bundle and route per user
+          choice. INVALID/QUESTION/OUT_OF_SCOPE → post reply via
+          MCP tool. Do NOT resolve threads yet.
+        skills: [Dev10x:gh-pr-fixup, Dev10x:ticket-create]
       - subject: Resolve threads
         type: detailed
         prompt: >

--- a/skills/gh-pr-triage/SKILL.md
+++ b/skills/gh-pr-triage/SKILL.md
@@ -3,8 +3,9 @@ name: Dev10x:gh-pr-triage
 description: >
   Validate a PR review comment against the codebase. If invalid, reply
   with evidence. Never auto-resolves threads — resolution requires
-  explicit user confirmation. Returns a verdict (VALID, INVALID, QUESTION,
-  OUT_OF_SCOPE) so the caller knows whether a code fix is needed.
+  explicit user confirmation. Returns a verdict (VALID, YAGNI, INVALID,
+  QUESTION, OUT_OF_SCOPE) so the caller knows whether to fix, remove
+  out-of-scope code, reply, or defer.
   TRIGGER when: PR review comment needs validation before implementing fix.
   DO NOT TRIGGER when: comment is clearly valid and needs immediate fix
   (use Dev10x:gh-pr-fixup directly).
@@ -29,10 +30,23 @@ never auto-resolves threads. Returns a verdict to the caller.
 
 | Verdict | Meaning | Action taken |
 |---------|---------|-------------|
-| `VALID` | Comment identifies a real issue needing a fix | None — caller handles |
+| `VALID` | Comment identifies a real issue in code that belongs in this PR | None — caller fixes |
+| `YAGNI` | Real issue, but the commented code is out-of-scope for the PR's JTBD — fix is to remove or defer the code, not harden it | Reply naming the scope mismatch; caller routes to removal |
 | `INVALID` | Comment is factually wrong (code already correct) | Reply with evidence |
 | `QUESTION` | Reviewer asking a question, no code change needed | Reply with answer |
-| `OUT_OF_SCOPE` | Valid concern but beyond this PR's scope | Acknowledge |
+| `OUT_OF_SCOPE` | Valid concern, but the *fix* would expand the PR's scope (code itself is in scope) | Acknowledge, defer concern to follow-up |
+
+**`YAGNI` vs `OUT_OF_SCOPE` — when to use each:**
+
+- `OUT_OF_SCOPE` — The commented code is legitimately part of this PR.
+  The reviewer asks for an enhancement, refactor, or stricter handling
+  that would expand the change beyond its stated JTBD. Defer the concern
+  to a follow-up ticket; the code stays.
+- `YAGNI` — The commented code itself does NOT belong in this PR. The
+  reviewer's bug report is correct, but the right fix is to remove or
+  revert the code rather than harden it. Multiple `YAGNI` verdicts that
+  share one root feature should bundle into a single removal commit
+  (see § Step 4.5).
 
 **Thread resolution policy:** Never auto-resolve threads. Thread
 resolution requires explicit user confirmation. The user supervising
@@ -46,9 +60,9 @@ verify the triage decisions without searching through hidden threads.
 ## NEVER inline triage (GH-463, GH-97)
 
 This is a `Skill()`-only entry point. The verdicts above
-(`VALID`/`INVALID`/`QUESTION`/`OUT_OF_SCOPE`) are this skill's
-output contract — they MUST NOT appear in narrative text as a
-substitute for invoking the skill.
+(`VALID`/`YAGNI`/`INVALID`/`QUESTION`/`OUT_OF_SCOPE`) are this
+skill's output contract — they MUST NOT appear in narrative text
+as a substitute for invoking the skill.
 
 If you find yourself writing:
 
@@ -188,6 +202,52 @@ investigations:
 3. If addressed → INVALID with thread URL reference
 ```
 
+### Step 4.5: JTBD Scope Check (GH-297)
+
+Before rendering a final `VALID` verdict, check whether the commented
+code is in-scope for the PR's stated Job Story. A correct bug report
+against code that doesn't belong in the PR should route to **YAGNI**
+(remove or defer the code), not `VALID` (harden it).
+
+**Trigger this check** only when the investigation in Step 4 concludes
+the comment is factually correct (about to verdict `VALID`). Skip for
+`INVALID`, `QUESTION`, or pre-existing `OUT_OF_SCOPE` paths.
+
+**Procedure:**
+
+1. **Extract the PR's stated JTBD** — read the PR body's Job Story
+   block. If absent, fall back to the PR title's outcome phrase
+   ("Enable …", "Fix …", "Refactor …").
+2. **Locate the commented code's origin in this PR** — was the
+   commented line *added* or *modified* by this PR, or is it
+   pre-existing untouched code? (Check `git blame` against the PR's
+   merge-base or use the comment's `diff_hunk` context.)
+3. **Compare the commented code's purpose against the JTBD:**
+   - Does the commented code implement the JTBD outcome?
+   - Or is it incidental scope-creep (a speculative feature, an
+     opportunistic refactor, a "while I'm here" addition) riding on
+     a PR scoped to something else?
+4. **Cross-thread bundling signal** — scan other PR threads (from
+   Step 2) for comments targeting the same speculative code path.
+   When two or more correct bug reports cluster on one out-of-scope
+   feature, all of them route to **YAGNI** with a shared removal
+   recommendation. Record the bundle in the verdict output so
+   `Dev10x:gh-pr-respond` can collapse them into one removal commit.
+
+**Decision matrix:**
+
+| Code is in-scope for JTBD? | Comment correct? | Verdict |
+|----------------------------|------------------|---------|
+| Yes                        | Yes              | `VALID` |
+| No (speculative / drift)   | Yes              | `YAGNI` |
+| Yes                        | Reviewer asks more | `OUT_OF_SCOPE` (defer concern) |
+
+**When in doubt, default to `VALID`.** YAGNI is the explicit carve-out
+for cases where the scope mismatch is clearly evident from the JTBD
+and the diff context. If the JTBD is vague or the code's relationship
+to it is ambiguous, choose `VALID` and let the author/reviewer decide
+removal vs hardening during fixup.
+
 ### Step 5: Render Verdict
 
 Based on investigation, choose one of:
@@ -201,6 +261,33 @@ delegate to `Dev10x:gh-pr-fixup`.
 ```
 Verdict: VALID
 Reason: {brief explanation of why the comment is correct}
+```
+
+#### YAGNI — Real issue, but code is out-of-scope for the PR's JTBD
+
+Post a brief reply naming the scope mismatch and proposing removal.
+Do **NOT** resolve the thread — the caller (`Dev10x:gh-pr-respond`)
+collapses related YAGNI verdicts into a single removal commit and
+closes the threads together.
+
+**Reply format:**
+
+```markdown
+Correct catch — {one-sentence acknowledgment of the bug}.
+
+This code is out of scope for the PR's JTBD ({JTBD outcome phrase}).
+The right fix is to remove {speculative feature / drifted code} from
+this PR rather than harden it. Will bundle with related thread(s) into
+a single removal commit, or defer to a follow-up ticket if the feature
+is desired.
+```
+
+**Output:**
+```
+Verdict: YAGNI
+Reason: {scope-mismatch explanation, naming the JTBD and the out-of-scope code}
+Bundle: {comma-separated comment IDs of related YAGNI threads, or "single"}
+Action: Replied acknowledging removal route (thread left open for user to resolve)
 ```
 
 #### INVALID — Comment is factually wrong
@@ -316,6 +403,9 @@ Verify the comment ID and repository.
 If investigation is inconclusive:
 - Default to `VALID` (let the fix author decide)
 - Log uncertainty: "Leaning VALID — investigation inconclusive"
+- Never default to `YAGNI` — it requires an explicit JTBD-scope
+  mismatch (Step 4.5). Ambiguous scope means `VALID` and let the
+  author choose removal vs hardening at fixup time.
 
 ### Thread Already Resolved
 If the thread is already resolved, skip it:

--- a/skills/gh-pr-triage/references/validation-patterns.md
+++ b/skills/gh-pr-triage/references/validation-patterns.md
@@ -125,6 +125,55 @@ Out of scope for this PR. {optional: "Tracked in TICKET-ID" or
 "Good idea for a follow-up."}
 ```
 
+## Pattern: YAGNI / Scope-Drift Code (GH-297)
+
+**Detection:** Comment correctly identifies a bug, gap, or hardening
+need — but the commented code itself is speculative and does not
+serve the PR's stated Job Story. Multiple such comments often cluster
+on a single speculative feature riding on an unrelated PR (refactor,
+bugfix, or unrelated feature).
+
+**Signals:**
+- PR title/JTBD describes outcome A (e.g., "Refactor storage shape"),
+  but the commented code implements outcome B (e.g., a new
+  denormalization feature)
+- Several VALID-looking comments on this PR all target the same
+  feature/module that the JTBD does not mention
+- `git blame` shows the commented lines were added in this PR's diff
+  rather than being pre-existing
+- Reviewer language hints at scope ("why is this here?", "didn't
+  expect this in a refactor", "is this part of the refactor?")
+
+**Investigation:**
+1. Read the PR's Job Story / title outcome (e.g., "Refactor X",
+   "Fix Y") — store as the JTBD anchor
+2. For the commented line, check whether it was added by this PR
+   and whether it implements the JTBD outcome
+3. Scan all PR threads (Pattern: Previously Addressed scan) for
+   other comments on the same speculative code path
+4. If the code is added-by-this-PR AND off-JTBD → **YAGNI**
+5. Record the bundle of related YAGNI comment IDs so the caller
+   can collapse them into one removal commit
+
+**Reply template:**
+```
+Correct catch — {one-sentence acknowledgment of the bug}.
+
+This code is out of scope for the PR's JTBD ({JTBD outcome phrase}).
+The right fix is to remove {feature/module name} from this PR rather
+than harden it. Will bundle with related thread(s) into a single
+removal commit, or defer to a follow-up ticket if the feature is
+desired.
+```
+
+**Anti-pattern to avoid:** Routing the comment as `VALID` and starting
+to harden the out-of-scope code. The audit (GH-297) caught a session
+where four YAGNI-class comments on one speculative feature were each
+hardened individually before the reviewer manually intervened with
+"remove this feature — out of scope." The investigation steps above
+must run *before* the verdict is rendered, not after the fix is
+drafted.
+
 ## Pattern: Intentional Design
 
 **Detection:** Reviewer questions a design choice that was deliberate —


### PR DESCRIPTION
**When** the `Dev10x:gh-pr-triage` and `Dev10x:gh-pr-respond` skills process a batch of PR review comments, **I want to** name out-of-scope code as YAGNI and split VALID findings into now-vs-fast-follow priority, **so I can** stop manually steering removal-vs-hardening decisions and per-finding deferrals across the whole batch.

---

[`d441dfbd`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/300/commits/d441dfbdd9dcd8e3feccb0ea76393b73e414eda3) ✨ GH-297 Enable scope-aware triage and priority-split responses
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/297

---