### PR TITLE
✨ GH-261 Prevent context-anxiety pauses in adaptive solo sessions

### DIFF
--- a/hooks/scripts/session-start.py
+++ b/hooks/scripts/session-start.py
@@ -92,7 +92,9 @@ def main() -> None:
     # Features that produce additionalContext (order matters for readability).
     context_parts: list[str] = []
 
-    out = _run_feature(name="session-git-aliases", fn=s.session_git_aliases, audit_hook=audit_hook)
+    out = _run_feature(
+        name="session-git-aliases", fn=s.session_git_aliases, audit_hook=audit_hook
+    )
     if out.strip():
         context_parts.append(out.strip())
 
@@ -105,6 +107,10 @@ def main() -> None:
     guidance = s.build_guidance_context()
     if guidance:
         context_parts.append(guidance)
+
+    reassurance = s.build_autonomy_reassurance_context()
+    if reassurance:
+        context_parts.append(reassurance)
 
     install_check = s.build_install_check_context()
     if install_check:

--- a/src/dev10x/hooks/session.py
+++ b/src/dev10x/hooks/session.py
@@ -24,6 +24,7 @@ from dev10x.domain.session_document import (
     read_json as _read_json,
 )
 from dev10x.hooks.session_dispatch import (
+    build_autonomy_reassurance_context,  # noqa: F401 — re-exported via __all__
     build_guidance_context,  # noqa: F401 — re-exported via __all__
     build_install_check_context,  # noqa: F401 — re-exported via __all__
     build_reload_context,  # noqa: F401 — re-exported via __all__
@@ -70,6 +71,7 @@ def _format_decision_guidance(*, plan, friction_level):
 
 
 __all__ = [
+    "build_autonomy_reassurance_context",
     "build_guidance_context",
     "build_install_check_context",
     "build_reload_context",

--- a/src/dev10x/hooks/session_dispatch.py
+++ b/src/dev10x/hooks/session_dispatch.py
@@ -99,6 +99,20 @@ def build_guidance_context() -> str:
     return guidance_file.read_text() if guidance_file.exists() else ""
 
 
+def build_autonomy_reassurance_context() -> str:
+    """Reassurance block for adaptive + solo-maintainer sessions (GH-261).
+
+    Returns an empty string outside the autonomous-shipping profile; the
+    orchestrator drops empty segments so non-solo sessions see no change.
+    """
+    from dev10x.hooks.session_policy import BuildAutonomyReassuranceRule
+
+    toplevel = _get_toplevel()
+    if not toplevel:
+        return ""
+    return BuildAutonomyReassuranceRule(toplevel=toplevel).apply()
+
+
 def build_install_check_context() -> str:
     """Warn the user when the Dev10x install needs bootstrap or upgrade.
 
@@ -155,7 +169,9 @@ def session_migrate_permissions() -> None:
     Delegates to :class:`MigratePluginPermissionsRule`. Only runs when
     installed via the plugin cache (not ``--plugin-dir``).
     """
-    rule = MigratePluginPermissionsRule(plugin_root=_plugin_root(), home_path=Path.home())
+    rule = MigratePluginPermissionsRule(
+        plugin_root=_plugin_root(), home_path=Path.home()
+    )
     if not rule.applicable():
         sys.exit(0)
     total_migrated, files_changed = rule.apply()
@@ -210,7 +226,9 @@ def session_goodbye(data: dict | None = None) -> None:
     session_id = data.get("session_id") or ""
     url = "https://www.skool.com/Dev10x-1892"
     print()
-    print("Thank you for using Dev10x. Join the community to get the most out of the plugin:")
+    print(
+        "Thank you for using Dev10x. Join the community to get the most out of the plugin:"
+    )
     print(f"\033]8;;{url}\033\\{url}\033]8;;\033\\")
     if session_id:
         print()
@@ -221,6 +239,7 @@ def session_goodbye(data: dict | None = None) -> None:
 __all__ = [
     "build_install_check_context",
     "build_reload_context",
+    "build_autonomy_reassurance_context",
     "build_guidance_context",
     "session_reload",
     "context_compact",

--- a/src/dev10x/hooks/session_policy.py
+++ b/src/dev10x/hooks/session_policy.py
@@ -102,6 +102,55 @@ class ReadFrictionLevelRule:
 
 
 @dataclass(frozen=True)
+class BuildAutonomyReassuranceRule:
+    """Build a reassurance block for autonomous sessions (GH-261).
+
+    Fires only when ``friction_level: adaptive`` AND ``solo-maintainer`` is in
+    ``active_modes``. Reassures the agent that long task lists are by design
+    and that re-asking settled scope decisions is the drift mode the
+    supervisor explicitly opted out of.
+
+    Returns an empty string outside the autonomous-shipping profile so the
+    SessionStart orchestrator can drop the segment silently.
+    """
+
+    toplevel: str
+
+    REASSURANCE_TEXT = (
+        "**Supervisor monitors context.** Long task lists are by design — "
+        "the work-on skill creates one task per play step so the supervisor "
+        'sees scope upfront. Do NOT pause to ask "should I proceed?" when:\n'
+        "\n"
+        "- The user already answered a scope AskUserQuestion\n"
+        "- friction_level: adaptive is set (auto-advance is the contract)\n"
+        "- The skill instructions explicitly cover the next step\n"
+        "\n"
+        "If context truly becomes a problem, the supervisor will interrupt. "
+        "Context anxiety is the agent's drift mode — trust the plan."
+    )
+
+    def apply(self) -> str:
+        session_yaml = Path(self.toplevel) / ".claude" / "Dev10x" / "session.yaml"
+        if not session_yaml.exists():
+            return ""
+        try:
+            import yaml
+
+            with open(session_yaml) as f:
+                data = yaml.safe_load(f) or {}
+        except Exception:
+            return ""
+
+        level = FrictionLevel.from_yaml(data.get("friction_level"))
+        modes = data.get("active_modes") or []
+        if level is not FrictionLevel.ADAPTIVE:
+            return ""
+        if "solo-maintainer" not in modes:
+            return ""
+        return self.REASSURANCE_TEXT
+
+
+@dataclass(frozen=True)
 class DecisionGuidanceRule:
     """Format resume guidance for the agent based on plan + friction level.
 
@@ -116,7 +165,9 @@ class DecisionGuidanceRule:
 
     def apply(self) -> str:
         if not isinstance(self.friction_level, FrictionLevel):
-            raise UnknownFrictionLevelError(f"Unknown friction level: {self.friction_level!r}")
+            raise UnknownFrictionLevelError(
+                f"Unknown friction level: {self.friction_level!r}"
+            )
 
         summary = PlanSummary.from_dict(data=self.plan)
         decisions = summary.pending_decisions
@@ -138,7 +189,9 @@ class DecisionGuidanceRule:
                 "Re-ask each pending decision using AskUserQuestion — "
                 "invoke Dev10x:ask before advancing."
             )
-        raise UnknownFrictionLevelError(f"Unhandled friction level: {self.friction_level!r}")
+        raise UnknownFrictionLevelError(
+            f"Unhandled friction level: {self.friction_level!r}"
+        )
 
 
 @dataclass(frozen=True)
@@ -187,7 +240,9 @@ class MigratePluginPermissionsRule:
                         raw = permissions.get(key, [])
                         if not raw:
                             continue
-                        new_rules, count = _migrate_rules(rules=raw, replacements=replacements)
+                        new_rules, count = _migrate_rules(
+                            rules=raw, replacements=replacements
+                        )
                         new_rules = _deduplicate_rules(rules=new_rules)
                         total_migrated += count
                         if count:
@@ -195,7 +250,9 @@ class MigratePluginPermissionsRule:
                             changed = True
                     if not changed:
                         continue
-                    atomic_write_text(settings_file, json.dumps(settings, indent=2) + "\n")
+                    atomic_write_text(
+                        settings_file, json.dumps(settings, indent=2) + "\n"
+                    )
                 files_changed.append(settings_file.name)
             except (json.JSONDecodeError, OSError):
                 continue
@@ -206,6 +263,7 @@ class MigratePluginPermissionsRule:
 __all__ = [
     "UnknownFrictionLevelError",
     "ReadFrictionLevelRule",
+    "BuildAutonomyReassuranceRule",
     "DecisionGuidanceRule",
     "MigratePluginPermissionsRule",
     "_build_migration_replacements",

--- a/tests/hooks/test_orchestrators.py
+++ b/tests/hooks/test_orchestrators.py
@@ -71,6 +71,95 @@ class TestOrchestratorConsolidation:
         assert result.returncode == 0
 
 
+class TestAutonomyReassurance:
+    """GH-261: SessionStart MOTD injects a reassurance block when the
+    supervisor opted into adaptive + solo-maintainer autonomy.
+
+    The block fires ONLY when both conditions hold — any other profile
+    must leave session output unchanged so attended/team sessions are
+    not nudged toward auto-advance behavior.
+    """
+
+    def _write_session_yaml(self, *, tmp_path: Path, content: str) -> Path:
+        toplevel = tmp_path / "repo"
+        (toplevel / ".claude" / "Dev10x").mkdir(parents=True)
+        (toplevel / ".claude" / "Dev10x" / "session.yaml").write_text(content)
+        return toplevel
+
+    def test_fires_on_adaptive_solo_maintainer(self, tmp_path: Path) -> None:
+        from dev10x.hooks.session_policy import BuildAutonomyReassuranceRule
+
+        toplevel = self._write_session_yaml(
+            tmp_path=tmp_path,
+            content="friction_level: adaptive\nactive_modes: [solo-maintainer]\n",
+        )
+        result = BuildAutonomyReassuranceRule(toplevel=str(toplevel)).apply()
+        assert "Supervisor monitors context" in result
+        assert "trust the plan" in result
+
+    def test_silent_when_friction_guided(self, tmp_path: Path) -> None:
+        from dev10x.hooks.session_policy import BuildAutonomyReassuranceRule
+
+        toplevel = self._write_session_yaml(
+            tmp_path=tmp_path,
+            content="friction_level: guided\nactive_modes: [solo-maintainer]\n",
+        )
+        assert BuildAutonomyReassuranceRule(toplevel=str(toplevel)).apply() == ""
+
+    def test_silent_when_solo_maintainer_missing(self, tmp_path: Path) -> None:
+        from dev10x.hooks.session_policy import BuildAutonomyReassuranceRule
+
+        toplevel = self._write_session_yaml(
+            tmp_path=tmp_path,
+            content="friction_level: adaptive\nactive_modes: []\n",
+        )
+        assert BuildAutonomyReassuranceRule(toplevel=str(toplevel)).apply() == ""
+
+    def test_silent_when_session_yaml_missing(self, tmp_path: Path) -> None:
+        from dev10x.hooks.session_policy import BuildAutonomyReassuranceRule
+
+        toplevel = tmp_path / "repo"
+        toplevel.mkdir()
+        assert BuildAutonomyReassuranceRule(toplevel=str(toplevel)).apply() == ""
+
+    def test_silent_when_session_yaml_malformed(self, tmp_path: Path) -> None:
+        from dev10x.hooks.session_policy import BuildAutonomyReassuranceRule
+
+        toplevel = self._write_session_yaml(
+            tmp_path=tmp_path,
+            content="friction_level: adaptive\nactive_modes: [solo-maintainer\n",
+        )
+        assert BuildAutonomyReassuranceRule(toplevel=str(toplevel)).apply() == ""
+
+    def test_dispatch_returns_empty_without_toplevel(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from dev10x.hooks import session_dispatch
+
+        monkeypatch.setattr(session_dispatch, "_get_toplevel", lambda: None)
+        assert session_dispatch.build_autonomy_reassurance_context() == ""
+
+    def test_dispatch_resolves_through_rule_with_toplevel(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from dev10x.hooks import session_dispatch
+
+        toplevel = self._write_session_yaml(
+            tmp_path=tmp_path,
+            content="friction_level: adaptive\nactive_modes: [solo-maintainer]\n",
+        )
+        monkeypatch.setattr(session_dispatch, "_get_toplevel", lambda: str(toplevel))
+        assert (
+            "Supervisor monitors context"
+            in session_dispatch.build_autonomy_reassurance_context()
+        )
+
+    def test_facade_reexports_dispatch(self) -> None:
+        from dev10x.hooks import session
+
+        assert hasattr(session, "build_autonomy_reassurance_context")
+
+
 class TestRunFeatureBufferDiscard:
     """E9: _run_feature must discard partial stdout when a feature raises.
 
@@ -81,7 +170,9 @@ class TestRunFeatureBufferDiscard:
     def _import_session_start(self):
         import importlib.util
 
-        spec = importlib.util.spec_from_file_location("_session_start_under_test", SESSION_START)
+        spec = importlib.util.spec_from_file_location(
+            "_session_start_under_test", SESSION_START
+        )
         assert spec is not None and spec.loader is not None
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)


### PR DESCRIPTION
**When** the supervisor has set `friction_level: adaptive` with `solo-maintainer` active and `Dev10x:work-on` runs a long task list, **I want to** see a SessionStart reassurance block that names the autonomy contract, **so I can** stop pausing to re-ask scope decisions the supervisor already settled and finish the bundle without context-anxiety drift.

---

[`1b7831a0`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/301/commits/1b7831a01f6117c29369f51cf9d7aba479cb062f) ✨ GH-261 Prevent context-anxiety pauses in adaptive solo sessions
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/261

---