### PR TITLE
✨ GH-233 Enable friction-free JIRA tenant wrappers

### DIFF
--- a/skills/jira/SKILL.md
+++ b/skills/jira/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: Dev10x:jira
+description: Use when querying, linking, or fetching JIRA issues — so credentials, hook-safe curl patterns, and hierarchy gotchas are always at hand
+user-invocable: false
+allowed-tools:
+  - Bash(${CLAUDE_PLUGIN_ROOT}/skills/jira/scripts/:*)
+---
+
+**Announce:** "Using Dev10x:jira to [purpose]."
+
+## Prerequisites
+
+Set the `JIRA_TENANT` env var to your Atlassian tenant name
+(e.g., `mycompany` for `mycompany.atlassian.net`). All scripts
+require it — there is no default.
+
+Store credentials in the system keyring:
+```bash
+secret-tool store --label "JIRA email" service jira key email
+secret-tool store --label "JIRA API token" service jira key api_token
+```
+
+## Scripts
+
+All scripts live in `${CLAUDE_PLUGIN_ROOT}/skills/jira/scripts/` and are
+pre-approved via `allowed-tools`.
+
+| Script | Purpose | Example |
+|--------|---------|---------|
+| `jira-get.sh` | Fetch issue by key | `jira-get.sh PROJ-100` |
+| `jira-search.sh` | Search by JQL | `jira-search.sh "text ~ 'wheel nut'"` |
+| `jira-link.sh` | Link two issues | `jira-link.sh PROJ-100 "Blocks" PROJ-200` |
+| `jira-link-types.sh` | List available link types | `jira-link-types.sh` |
+| `jira-update.sh` | Update issue from JSON file | `jira-update.sh PROJ-100 /tmp/payload.json` |
+| `jira-comment.sh` | Add a comment from a file | `jira-comment.sh PROJ-100 /tmp/body.md` |
+
+## Tenant Wrapper Pattern
+
+A tenant wrapper skill (e.g. `acme:jira`) binds a fixed
+`JIRA_TENANT` and delegates here. **Do NOT bind the tenant with a
+command-line env prefix:**
+
+```bash
+# ❌ Anti-pattern — env prefix shifts the allow-rule prefix
+JIRA_TENANT=acme ${CLAUDE_PLUGIN_ROOT}/skills/jira/scripts/jira-get.sh PROJ-1
+```
+
+The leading `JIRA_TENANT=acme` shifts the effective Bash command
+prefix, so **no** `Bash(.../scripts/jira-get.sh:*)` allow rule can
+ever match — every call hits the permission gate. This is the same
+prefix-shift class as the global "No env-var prefix on git" rule.
+
+**Instead, ship a wrapper script** that binds the tenant *inside* the
+command, so the wrapper's own path is what the allow rule matches:
+
+```bash
+# ✅ Wrapper script — tenant binding inside, one allow rule, no friction
+~/.claude/skills/acme:jira/scripts/jira-get.sh PROJ-1
+```
+
+A copy-paste starting point lives at
+[`templates/jira-wrap.sh.example`](templates/jira-wrap.sh.example).
+Each thin wrapper `export JIRA_TENANT=<tenant>` then `exec`s the
+matching base script. Pre-approve the wrapper directory with one rule:
+
+```json
+"Bash(~/.claude/skills/acme:jira/scripts/:*)"
+```
+
+This keeps the tenant binding inside the skill (not scattered across
+user settings) and covers every base op — get, search, link, update,
+comment — without a per-script allow rule or an env-var prefix.
+
+The alternative — setting `JIRA_TENANT` in `~/.claude/settings.json`
+under `env:` — also removes the prefix, but binds a single tenant for
+the whole session and so cannot serve multiple tenants. Prefer the
+wrapper-script approach.
+
+## Hook Safety
+
+The PreToolUse hook **blocks `for` loops** in Bash commands. Always call scripts individually — one call per Bash tool use.
+
+```bash
+# ❌ Blocked by hook
+for payload in '...' '...'; do curl ...; done
+
+# ✅ Separate tool calls
+${CLAUDE_PLUGIN_ROOT}/skills/jira/scripts/jira-link.sh PROJ-100 "1-Relates" PROJ-200
+${CLAUDE_PLUGIN_ROOT}/skills/jira/scripts/jira-link.sh PROJ-100 "1-Relates" PROJ-300
+```
+
+## JIRA Hierarchy Gotcha
+
+**Task → Task parent assignment fails** with: `"Given parent work item does not belong to appropriate hierarchy."`
+
+Tasks can only be children of Epics. Use **issue links** instead for same-level relationships:
+
+| Need | Use |
+|------|-----|
+| Group related tasks | `1-Relates` link |
+| Sequence work | `Blocks` link (`inward` blocks `outward`) |
+| True parent/child | Create an Epic and use the `parent` field |
+
+## Common Operations
+
+### Fetch an issue
+```bash
+${CLAUDE_PLUGIN_ROOT}/skills/jira/scripts/jira-get.sh PROJ-100
+```
+
+### Search issues
+```bash
+${CLAUDE_PLUGIN_ROOT}/skills/jira/scripts/jira-search.sh "text ~ 'search term' ORDER BY created DESC"
+```
+
+### Link tickets (inward [type] outward)
+```bash
+${CLAUDE_PLUGIN_ROOT}/skills/jira/scripts/jira-link.sh PROJ-100 "1-Relates" PROJ-200
+${CLAUDE_PLUGIN_ROOT}/skills/jira/scripts/jira-link.sh PROJ-100 "Blocks" PROJ-200
+```
+HTTP 201 = success.
+
+### Update an issue from JSON payload
+```bash
+# Write ADF payload to a file first, then update
+${CLAUDE_PLUGIN_ROOT}/skills/jira/scripts/jira-update.sh PROJ-100 /tmp/claude/jira-payload.json
+```
+HTTP 204 = success.
+
+### Add a comment from a file
+```bash
+${CLAUDE_PLUGIN_ROOT}/skills/jira/scripts/jira-comment.sh PROJ-100 /tmp/claude/comment-body.md
+```
+
+### List link types
+```bash
+${CLAUDE_PLUGIN_ROOT}/skills/jira/scripts/jira-link-types.sh
+```

--- a/skills/jira/scripts/_jira-env.sh
+++ b/skills/jira/scripts/_jira-env.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Shared JIRA environment for all jira-*.sh scripts.
+# Sources credentials from system keyring and builds base URL.
+#
+# Required: JIRA_TENANT env var (e.g., "mycompany" for mycompany.atlassian.net)
+
+if [ -z "${JIRA_TENANT:-}" ]; then
+  echo "Error: JIRA_TENANT env var is required (e.g., 'mycompany' for mycompany.atlassian.net)" >&2
+  exit 1
+fi
+
+# These are consumed by the scripts that source this file.
+# shellcheck disable=SC2034
+JIRA_BASE_URL="https://${JIRA_TENANT}.atlassian.net/rest/api/3"
+# shellcheck disable=SC2034
+JIRA_EMAIL=$(secret-tool lookup service jira key email)
+# shellcheck disable=SC2034
+JIRA_TOKEN=$(secret-tool lookup service jira key api_token)

--- a/skills/jira/scripts/jira-comment.sh
+++ b/skills/jira/scripts/jira-comment.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Add a comment to a JIRA issue.
+#
+# Usage:
+#   jira-comment.sh ISSUE-KEY /path/to/body.md
+#
+# The body file contains the comment body as plain text or JIRA wiki markup.
+# This script uses the v2 REST API endpoint which accepts wiki markup directly
+# (v3 requires ADF JSON, which is impractical for ad-hoc commenting).
+#
+# Output: HTTP status code and the created comment ID
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/_jira-env.sh"
+
+TICKET_KEY="${1:?Usage: jira-comment.sh ISSUE-KEY BODY_FILE}"
+BODY_FILE="${2:?Usage: jira-comment.sh ISSUE-KEY BODY_FILE}"
+
+if [ ! -f "$BODY_FILE" ]; then
+  echo "Error: Body file not found: $BODY_FILE" >&2
+  exit 1
+fi
+
+# v2 endpoint accepts a plain wiki-markup string for `body`. Use jq -Rs to
+# read the body file and JSON-encode it as a string value.
+PAYLOAD=$(jq -Rs '{body: .}' "$BODY_FILE")
+
+# v2 URL (the _jira-env.sh base URL points at v3 — substitute).
+V2_BASE_URL="${JIRA_BASE_URL%/3}/2"
+
+curl -s -w "\nHTTP_STATUS:%{http_code}\n" -X POST \
+  -u "${JIRA_EMAIL}:${JIRA_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "$PAYLOAD" \
+  "${V2_BASE_URL}/issue/${TICKET_KEY}/comment" \
+  | jq '. | {id: .id, self: .self, status: ((.errorMessages // .errors) // "ok")}' 2>/dev/null || cat

--- a/skills/jira/scripts/jira-get.sh
+++ b/skills/jira/scripts/jira-get.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Fetch a JIRA issue by key.
+#
+# Usage:
+#   jira-get.sh ISSUE-KEY
+#   jira-get.sh ISSUE-KEY summary,status,parent,subtasks,issuelinks
+#
+# Output: pretty-printed JSON
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/_jira-env.sh"
+
+KEY="${1:?Usage: jira-get.sh ISSUE-KEY [fields]}"
+FIELDS="${2:-summary,status,issuetype,parent,subtasks,issuelinks}"
+
+curl -s \
+  -u "${JIRA_EMAIL}:${JIRA_TOKEN}" \
+  "${JIRA_BASE_URL}/issue/${KEY}?fields=${FIELDS}" \
+  | jq .

--- a/skills/jira/scripts/jira-link-types.sh
+++ b/skills/jira/scripts/jira-link-types.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# List all available JIRA issue link types.
+#
+# Usage:
+#   jira-link-types.sh
+#
+# Output: one line per type: ID  Name  |  inward / outward
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/_jira-env.sh"
+
+curl -s \
+  -u "${JIRA_EMAIL}:${JIRA_TOKEN}" \
+  "${JIRA_BASE_URL}/issueLinkType" \
+  | jq -r '.issueLinkTypes[] | "\(.id | tostring | (" " * (6 - length)) + .)  \(.name)  | \(.inward // "") / \(.outward // "")"'

--- a/skills/jira/scripts/jira-link.sh
+++ b/skills/jira/scripts/jira-link.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Create a link between two JIRA issues.
+#
+# Usage:
+#   jira-link.sh PROJ-100 "1-Relates" PROJ-200
+#   jira-link.sh PROJ-100 "Blocks" PROJ-200
+#
+# Common link type names:
+#   "1-Relates"   — relates to / relates to
+#   "Blocks"      — is blocked by / blocks
+#   "Duplicate"   — is duplicated by / duplicates
+#   "Cloners"     — is cloned by / clones
+#
+# The INWARD issue is the one described by the inward text (e.g. "is blocked by").
+# The OUTWARD issue is the one described by the outward text (e.g. "blocks").
+# Example: jira-link.sh PROJ-100 "Blocks" PROJ-200
+#   means PROJ-100 blocks PROJ-200 (PROJ-200 is blocked by PROJ-100)
+#
+# Output: HTTP status code (201 = success)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/_jira-env.sh"
+
+INWARD="${1:?Usage: jira-link.sh INWARD_KEY LINK_TYPE OUTWARD_KEY}"
+TYPE="${2:?Usage: jira-link.sh INWARD_KEY LINK_TYPE OUTWARD_KEY}"
+OUTWARD="${3:?Usage: jira-link.sh INWARD_KEY LINK_TYPE OUTWARD_KEY}"
+
+HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X POST \
+  -u "${JIRA_EMAIL}:${JIRA_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "{\"type\":{\"name\":\"${TYPE}\"},\"inwardIssue\":{\"key\":\"${INWARD}\"},\"outwardIssue\":{\"key\":\"${OUTWARD}\"}}" \
+  "${JIRA_BASE_URL}/issueLink")
+
+echo "HTTP ${HTTP_STATUS} — ${INWARD} [${TYPE}] ${OUTWARD}"

--- a/skills/jira/scripts/jira-search.sh
+++ b/skills/jira/scripts/jira-search.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Search JIRA issues with a JQL query.
+#
+# Usage:
+#   jira-search.sh "text ~ 'wheel nut'"
+#   jira-search.sh "assignee = currentUser() AND updated >= 2026-01-01" 20
+#
+# Output: pretty-printed JSON (key, summary, status, parent, issuetype, created)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/_jira-env.sh"
+
+JQL="${1:?Usage: jira-search.sh JQL_QUERY [max_results]}"
+MAX="${2:-10}"
+FIELDS="key,summary,status,issuetype,parent,created"
+
+ENCODED=$(jq -Rr @uri <<< "$JQL")
+
+curl -s \
+  -u "${JIRA_EMAIL}:${JIRA_TOKEN}" \
+  "${JIRA_BASE_URL}/search/jql?jql=${ENCODED}&maxResults=${MAX}&fields=${FIELDS}" \
+  | jq .

--- a/skills/jira/scripts/jira-update.sh
+++ b/skills/jira/scripts/jira-update.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Update a JIRA issue using a JSON payload file.
+#
+# Usage:
+#   jira-update.sh ISSUE-KEY /path/to/payload.json
+#
+# The payload file must contain valid JIRA REST API v3 JSON.
+# Example payload for updating description:
+#   {"fields":{"description":{"version":1,"type":"doc","content":[...]}}}
+#
+# Output: HTTP status code (204 = success)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/_jira-env.sh"
+
+TICKET_KEY="${1:?Usage: jira-update.sh ISSUE-KEY PAYLOAD_FILE}"
+PAYLOAD_FILE="${2:?Usage: jira-update.sh ISSUE-KEY PAYLOAD_FILE}"
+
+if [ ! -f "$PAYLOAD_FILE" ]; then
+  echo "Error: Payload file not found: $PAYLOAD_FILE" >&2
+  exit 1
+fi
+
+curl -s -w "\n%{http_code}" -X PUT \
+  -u "${JIRA_EMAIL}:${JIRA_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d @"$PAYLOAD_FILE" \
+  "${JIRA_BASE_URL}/issue/${TICKET_KEY}"

--- a/skills/jira/templates/jira-wrap.sh.example
+++ b/skills/jira/templates/jira-wrap.sh.example
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Tenant-wrapper template for dev10x:jira scripts.
+#
+# WHY THIS EXISTS
+#   A tenant wrapper skill (e.g. `acme:jira`) must bind a fixed
+#   JIRA_TENANT before delegating to the shared dev10x:jira scripts.
+#   The obvious approach — a command-line env prefix —
+#
+#       JIRA_TENANT=acme ~/.claude/skills/.../jira-get.sh PROJ-1
+#
+#   breaks Claude Code Bash allow-rule matching: the leading
+#   `JIRA_TENANT=acme` shifts the effective command prefix, so no
+#   `Bash(.../scripts/jira-get.sh:*)` allow rule can ever match and
+#   every call hits the permission gate. (Same prefix-shift class as
+#   the "No env-var prefix on git" guideline.)
+#
+#   A wrapper SCRIPT moves the tenant binding inside the command, so
+#   the wrapper's own path is what the allow rule matches. One allow
+#   rule per wrapper — no prefix, no friction.
+#
+# HOW TO USE
+#   1. Copy this file into your tenant skill at:
+#        ~/.claude/skills/<tenant>:jira/scripts/jira-<op>.sh
+#      (one thin wrapper per base op you call: get, search, link,
+#      link-types, update, comment — or a single dispatcher, see below).
+#   2. Set TENANT and BASE_SCRIPTS below.
+#   3. Pre-approve the wrapper path in settings, e.g.
+#        "Bash(~/.claude/skills/<tenant>:jira/scripts/:*)"
+#   4. Call the wrapper directly — never with a JIRA_TENANT= prefix.
+
+set -euo pipefail
+
+# --- Configure these two values for your tenant ---------------------
+TENANT="acme"                                  # -> acme.atlassian.net
+BASE_SCRIPTS="${HOME}/.claude/skills/jira/scripts"  # dev10x:jira scripts dir
+# --------------------------------------------------------------------
+
+# Derive the base op from this wrapper's own filename: a wrapper named
+# `jira-get.sh` execs the base `jira-get.sh`. (Rename the copy to pick
+# the op; no per-op editing needed.)
+OP="$(basename "${BASH_SOURCE[0]}")"
+
+export JIRA_TENANT="${TENANT}"
+exec "${BASE_SCRIPTS}/${OP}" "$@"


### PR DESCRIPTION
**When** I write a tenant wrapper skill around `dev10x:jira` (e.g. `tt:jira`), **I want to** bind `JIRA_TENANT` without a command-line env prefix, **so I can** pre-approve the JIRA scripts with one Bash allow rule and stop hitting the permission gate on every call.

---

[`5ca5dc64`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/305/commits/5ca5dc64219cef01caf0da8f74092cb26479e566) ✨ GH-233 Enable friction-free JIRA tenant wrappers
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/233

---