### PR TITLE
✨ GH-309 Enable quote-aware bash-command tokenization

### DIFF
--- a/src/dev10x/validators/__init__.py
+++ b/src/dev10x/validators/__init__.py
@@ -107,6 +107,12 @@ _SPECS: list[ValidatorSpec] = [
         rule_id="DX010",
         profile=ProfileTier.STANDARD,
     ),
+    ValidatorSpec(
+        module_path="dev10x.validators.safe_expansion",
+        class_name="SafeExpansionValidator",
+        rule_id="DX012",
+        profile=ProfileTier.MINIMAL,
+    ),
 ]
 
 

--- a/src/dev10x/validators/_quote_strip.py
+++ b/src/dev10x/validators/_quote_strip.py
@@ -1,0 +1,87 @@
+"""Quote-aware tokenization for bash command validators.
+
+Strips inert quoted spans so threat-pattern regexes (subshells, brace
+expansion, etc.) only see the genuinely active remainder.
+
+What is stripped:
+  - Single-quoted spans ``'...'`` are removed entirely. Every character
+    inside single quotes is literal — even backslashes — so a ``$(``
+    appearing there is inert text, not a subshell.
+  - ANSI-C strings ``$'...'`` are removed entirely. They expand to a
+    fixed byte sequence; no command substitution or variable expansion
+    is possible inside.
+  - Backslash escapes outside quotes drop both characters so an escaped
+    ``\\$`` is not mistaken for an expansion.
+
+What is preserved:
+  - Double-quoted spans ``"..."`` keep their full contents. Inside
+    double quotes ``$`` and backtick remain active, so any substitution
+    or variable that lives there must still be visible to threat
+    detectors.
+  - All unquoted characters.
+
+The output is a pattern-matching surface, not an editable command —
+column offsets into the result are not meaningful.
+"""
+
+from __future__ import annotations
+
+
+def quote_strip(command: str) -> str:
+    """Return ``command`` with inert quoted spans removed.
+
+    See module docstring for the exact semantics.
+    """
+    result: list[str] = []
+    i = 0
+    n = len(command)
+    while i < n:
+        ch = command[i]
+        if ch == "\\" and i + 1 < n:
+            i += 2
+            continue
+        if ch == "$" and i + 1 < n and command[i + 1] == "'":
+            i = _scan_ansi_c(command=command, start=i + 2)
+            continue
+        if ch == "'":
+            j = command.find("'", i + 1)
+            if j == -1:
+                return "".join(result)
+            i = j + 1
+            continue
+        if ch == '"':
+            j = _scan_double_quoted(command=command, start=i + 1)
+            result.append(command[i:j])
+            i = j
+            continue
+        result.append(ch)
+        i += 1
+    return "".join(result)
+
+
+def _scan_ansi_c(*, command: str, start: int) -> int:
+    """Return the index just past the closing ``'`` of an ANSI-C string."""
+    j = start
+    n = len(command)
+    while j < n:
+        if command[j] == "\\" and j + 1 < n:
+            j += 2
+            continue
+        if command[j] == "'":
+            return j + 1
+        j += 1
+    return n
+
+
+def _scan_double_quoted(*, command: str, start: int) -> int:
+    """Return the index just past the closing ``"`` of a double-quoted span."""
+    j = start
+    n = len(command)
+    while j < n:
+        if command[j] == "\\" and j + 1 < n:
+            j += 2
+            continue
+        if command[j] == '"':
+            return j + 1
+        j += 1
+    return n

--- a/src/dev10x/validators/command_substitution.py
+++ b/src/dev10x/validators/command_substitution.py
@@ -19,6 +19,7 @@ from typing import ClassVar
 
 from dev10x.domain import HookInput, HookResult
 from dev10x.domain.profile_tier import ProfileTier
+from dev10x.validators._quote_strip import quote_strip
 from dev10x.validators.base import ValidatorBase
 
 CAT_SUBSHELL_RE = re.compile(r"\$\(cat\s+\S+\)")
@@ -42,9 +43,9 @@ class CommandSubstitutionValidator(ValidatorBase):
     profile: ClassVar[ProfileTier] = ProfileTier.MINIMAL
 
     def should_run(self, inp: HookInput) -> bool:
-        return "$(cat " in inp.command
+        return "$(cat " in quote_strip(command=inp.command)
 
     def validate(self, inp: HookInput) -> HookResult | None:
-        if CAT_SUBSHELL_RE.search(inp.command):
+        if CAT_SUBSHELL_RE.search(quote_strip(command=inp.command)):
             return HookResult(message=BLOCK_MSG)
         return None

--- a/src/dev10x/validators/safe_expansion.py
+++ b/src/dev10x/validators/safe_expansion.py
@@ -1,0 +1,108 @@
+"""Validator: auto-approve commands whose shell metacharacters are inert.
+
+Claude Code's permission layer flags commands containing variable
+expansions, ANSI-C strings, brace expressions inside single quotes, or
+route-group parens in paths even though those characters are either
+literal (inside single quotes / ANSI-C / known-safe env vars) or do
+not expand to anything the user has not approved.
+
+This validator pre-approves commands when every "scary" pattern is
+accounted for by one of:
+
+  - A literal single-quoted span (already inert in POSIX shell)
+  - A fixed ANSI-C escape (``$'\\t'``, ``$'\\n'``, ``$'\\0'``,
+    ``$'\\\\'``)
+  - An expansion of a known-safe env var (``$CLAUDE_PLUGIN_ROOT``,
+    ``$HOME``, ``$USER``, ``$PWD``, ``$PATH``, both ``$NAME`` and
+    ``${NAME}`` forms)
+  - A path-like token containing ``(group)`` segments, such as
+    SvelteKit route groups (``apps/web/routes/(app)/...``)
+
+Genuine threats remain blocked because they are NOT covered by any of
+the above. Command substitutions ``$(...)``, backticks, and unquoted
+``${var:-$(...)}`` injections still drop through to deny-validators.
+
+Source: GH-309 (evidence #13, #20, #49, #63, #69, #88 from GH-271).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import ClassVar
+
+from dev10x.domain import HookAllow, HookInput, HookResult
+from dev10x.domain.profile_tier import ProfileTier
+from dev10x.validators._quote_strip import quote_strip
+from dev10x.validators.base import ValidatorBase
+
+SAFE_ENV_VARS = frozenset(
+    [
+        "CLAUDE_PLUGIN_ROOT",
+        "HOME",
+        "USER",
+        "PWD",
+        "PATH",
+        "TMPDIR",
+        "OLDPWD",
+        "SHELL",
+        "LANG",
+    ]
+)
+
+_SAFE_ENV_NAMES = "|".join(sorted(SAFE_ENV_VARS))
+_SAFE_ENV_RE = re.compile(r"\$(?:(" + _SAFE_ENV_NAMES + r")\b|\{(" + _SAFE_ENV_NAMES + r")\})")
+_ROUTE_GROUP_RE = re.compile(r"(?<=[A-Za-z0-9_./-])\([A-Za-z0-9_-]+\)(?=[/])")
+_DOLLAR_RE = re.compile(r"\$")
+_OPEN_PAREN_RE = re.compile(r"\(")
+_CLOSE_PAREN_RE = re.compile(r"\)")
+_OPEN_BRACE_RE = re.compile(r"\{")
+_CLOSE_BRACE_RE = re.compile(r"\}")
+_BACKTICK_RE = re.compile(r"`")
+
+
+def _has_dangerous_residue(stripped: str) -> bool:
+    """True if anything in the quote-stripped command still looks risky.
+
+    Called after the safe-env-var and route-group patterns are removed
+    from the stripped command. Any remaining ``$``, parens, braces, or
+    backticks indicates a substitution or expansion the validator is
+    not confident enough to auto-approve.
+    """
+    residue = _SAFE_ENV_RE.sub("", stripped)
+    residue = _ROUTE_GROUP_RE.sub("", residue)
+    if _DOLLAR_RE.search(residue):
+        return True
+    if _BACKTICK_RE.search(residue):
+        return True
+    if _OPEN_PAREN_RE.search(residue) or _CLOSE_PAREN_RE.search(residue):
+        return True
+    if _OPEN_BRACE_RE.search(residue) or _CLOSE_BRACE_RE.search(residue):
+        return True
+    return False
+
+
+def _has_only_inert_metacharacters(command: str) -> bool:
+    """True iff every metacharacter in ``command`` is inert or known-safe."""
+    stripped = quote_strip(command=command)
+    return not _has_dangerous_residue(stripped=stripped)
+
+
+@dataclass
+class SafeExpansionValidator(ValidatorBase):
+    name: ClassVar[str] = "safe-expansion"
+    rule_id: ClassVar[str] = "DX012"
+    profile: ClassVar[ProfileTier] = ProfileTier.MINIMAL
+
+    def should_run(self, inp: HookInput) -> bool:
+        command = inp.command
+        if "$" in command or "`" in command:
+            return True
+        if "(" in command or "{" in command:
+            return True
+        return False
+
+    def validate(self, inp: HookInput) -> HookAllow | HookResult | None:
+        if _has_only_inert_metacharacters(command=inp.command):
+            return HookAllow()
+        return None

--- a/src/dev10x/validators/safe_subshell.py
+++ b/src/dev10x/validators/safe_subshell.py
@@ -19,6 +19,7 @@ from typing import ClassVar
 
 from dev10x.domain import HookAllow, HookInput, HookResult
 from dev10x.domain.profile_tier import ProfileTier
+from dev10x.validators._quote_strip import quote_strip
 from dev10x.validators.base import ValidatorBase
 
 SAFE_SUBSHELL_PREFIXES = (
@@ -118,17 +119,18 @@ class SafeSubshellValidator(ValidatorBase):
     profile: ClassVar[ProfileTier] = ProfileTier.MINIMAL
 
     def should_run(self, inp: HookInput) -> bool:
-        return "$(" in inp.command
+        return "$(" in quote_strip(command=inp.command)
 
     def validate(self, inp: HookInput) -> HookAllow | HookResult | None:
-        subshells = _extract_subshells(command=inp.command)
+        stripped = quote_strip(command=inp.command)
+        subshells = _extract_subshells(command=stripped)
         if not subshells:
             return None
 
         if not all(_is_safe_subshell(content=s) for s in subshells):
             return None
 
-        outer = _outer_command_token(command=inp.command)
+        outer = _outer_command_token(command=stripped)
         if outer not in SAFE_OUTER_COMMANDS:
             return None
 

--- a/tests/validators/test_command_substitution.py
+++ b/tests/validators/test_command_substitution.py
@@ -46,6 +46,10 @@ class TestCommandSubstitutionValidator:
             "cat /tmp/file.txt",
             'echo "$(git rev-parse HEAD)"',
             "basename $(git rev-parse --show-toplevel)",
+            # GH-309: $(cat ...) inside single quotes is literal text, not a
+            # subshell — must not block.
+            "echo 'docs say: use $(cat file) for piping'",
+            "gh api graphql -f query='{ node(id: \"$(cat foo)\") { id } }'",
         ],
     )
     def test_allows_safe_commands(

--- a/tests/validators/test_quote_strip.py
+++ b/tests/validators/test_quote_strip.py
@@ -1,0 +1,80 @@
+"""Tests for the quote-aware tokenization helper."""
+
+from __future__ import annotations
+
+import pytest
+
+from dev10x.validators._quote_strip import quote_strip
+
+
+class TestQuoteStrip:
+    @pytest.mark.parametrize(
+        ("command", "expected"),
+        [
+            # Plain commands pass through unchanged
+            ("git status", "git status"),
+            # Single-quoted spans are inert and removed entirely
+            ("echo 'hello $(cat /etc/passwd)'", "echo "),
+            ("gh api graphql -f query='{viewer{login}}'", "gh api graphql -f query="),
+            # Inside double quotes, content stays (dollar/backtick still active)
+            ('echo "$(git rev-parse HEAD)"', 'echo "$(git rev-parse HEAD)"'),
+            ('echo "$CLAUDE_PLUGIN_ROOT"', 'echo "$CLAUDE_PLUGIN_ROOT"'),
+            # ANSI-C strings are removed entirely
+            ("sort -t$'\\t' -k2 file", "sort -t -k2 file"),
+            ("printf $'\\n' >> log", "printf  >> log"),
+            # Backslash escapes drop the escape and the next char outside quotes
+            ("echo \\$NOTREAL", "echo NOTREAL"),
+            # Mixed: single-quoted inert subshell drops, unquoted survives
+            (
+                "echo 'safe $(rm -rf /)' && echo $(date)",
+                "echo  && echo $(date)",
+            ),
+            # Unterminated single quote: rest of string treated as quoted
+            ("echo 'oops", "echo "),
+        ],
+    )
+    def test_strips_inert_spans(self, command: str, expected: str) -> None:
+        assert quote_strip(command=command) == expected
+
+    def test_double_quotes_preserve_subshells(self) -> None:
+        # The $(cat ...) inside double quotes is genuinely active and must
+        # remain visible to DX002 so it can block.
+        result = quote_strip(command='gh api -f body="$(cat /tmp/file)"')
+        assert "$(cat /tmp/file)" in result
+
+    def test_single_quotes_hide_subshells(self) -> None:
+        # The same construct inside single quotes is literal text and must
+        # disappear so DX002 does not false-positive on it.
+        result = quote_strip(command="echo 'literal $(cat /tmp/file)'")
+        assert "$(cat" not in result
+
+    def test_unterminated_ansi_c_consumes_rest(self) -> None:
+        # No closing single quote on an ANSI-C literal — treat the remainder
+        # as quoted so nothing leaks into the threat-pattern surface.
+        result = quote_strip(command="echo $'unterminated\\t escape")
+        assert result == "echo "
+
+    def test_unterminated_double_quote_consumes_rest(self) -> None:
+        # Same defensive behavior as single quotes / ANSI-C: an unterminated
+        # double quote means the rest of the line is treated as quoted.
+        result = quote_strip(command='echo "still open here')
+        assert result == 'echo "still open here'
+
+    def test_escape_inside_quotes(self) -> None:
+        # Backslash inside a double-quoted span escapes the next character,
+        # so an escaped closing quote does not end the span.
+        result = quote_strip(command='echo "with \\" embedded" rest')
+        assert "rest" in result
+
+    def test_escape_inside_ansi_c(self) -> None:
+        # Backslash inside ANSI-C escapes the next character — a quoted-out
+        # closing single quote does not terminate the literal.
+        result = quote_strip(command="echo $'has \\' inside' rest")
+        assert "rest" in result
+
+    def test_ansi_c_in_middle_of_command(self) -> None:
+        # The fixed escape vanishes; surrounding tokens are preserved.
+        result = quote_strip(command="awk -F$'\\t' '{print $1}' file.tsv")
+        assert "$'" not in result
+        assert "awk -F" in result
+        assert "file.tsv" in result

--- a/tests/validators/test_safe_expansion.py
+++ b/tests/validators/test_safe_expansion.py
@@ -1,0 +1,89 @@
+"""Tests for SafeExpansionValidator (GH-309)."""
+
+from __future__ import annotations
+
+import pytest
+
+from dev10x.domain import HookAllow
+from dev10x.validators.safe_expansion import SafeExpansionValidator
+from tests.fakers import BashHookInputFaker
+
+
+def _make_input(*, command: str) -> BashHookInputFaker:
+    return BashHookInputFaker.build(command=command)
+
+
+class TestSafeExpansionValidator:
+    @pytest.fixture()
+    def validator(self) -> SafeExpansionValidator:
+        return SafeExpansionValidator()
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # GH-271 evidence #13 — safe env var, double-quoted
+            'echo "$CLAUDE_PLUGIN_ROOT"',
+            # GH-271 evidence #20 — fixed ANSI-C escape
+            "sort -t$'\\t' -k2 file",
+            # GH-271 evidence #49/#51/#52/#54 — braces inside single-quoted GraphQL
+            "gh api graphql -f query='query { viewer { login } }'",
+            # GH-271 evidence #63 — safe env var, brace form
+            "${CLAUDE_PLUGIN_ROOT}/skills/foo/scripts/db.sh",
+            # GH-271 evidence #69 — bare safe env var
+            "$CLAUDE_PLUGIN_ROOT/skills/foo/scripts/script.sh",
+            # GH-271 evidence #88 — SvelteKit route-group parens in unquoted path
+            "grep -rn pattern apps/web/routes/(app)/dashboard/",
+            # Combinations
+            "cp $HOME/.config/file ${CLAUDE_PLUGIN_ROOT}/dest",
+            "echo $USER@$HOME",
+        ],
+    )
+    def test_approves_inert_metacharacter_commands(
+        self,
+        validator: SafeExpansionValidator,
+        command: str,
+    ) -> None:
+        inp = _make_input(command=command)
+        result = validator.validate(inp=inp)
+        assert isinstance(result, HookAllow), f"expected HookAllow for {command!r}, got {result!r}"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # Genuine command substitution — must NOT auto-approve
+            'gh api -f body="$(cat /tmp/file)"',
+            "echo $(rm -rf /)",
+            # Backticks — must NOT auto-approve
+            "echo `whoami`",
+            # Unknown env var — must NOT auto-approve (could be anything)
+            "echo $MYSTERY_VAR",
+            "echo ${MYSTERY}",
+            # Unquoted brace expansion — must NOT auto-approve (creates files)
+            "touch file{1,2,3}.txt",
+            # Unquoted subshell group — must NOT auto-approve
+            "(cd /tmp && ls)",
+        ],
+    )
+    def test_does_not_approve_genuine_threats(
+        self,
+        validator: SafeExpansionValidator,
+        command: str,
+    ) -> None:
+        inp = _make_input(command=command)
+        result = validator.validate(inp=inp)
+        assert result is None, f"expected None for {command!r}, got {result!r}"
+
+    def test_should_run_true_for_metacharacter_commands(
+        self,
+        validator: SafeExpansionValidator,
+    ) -> None:
+        assert validator.should_run(inp=_make_input(command="echo $HOME")) is True
+        assert validator.should_run(inp=_make_input(command="echo `date`")) is True
+        assert validator.should_run(inp=_make_input(command="(ls)")) is True
+
+    def test_should_run_false_for_plain_commands(
+        self,
+        validator: SafeExpansionValidator,
+    ) -> None:
+        assert validator.should_run(inp=_make_input(command="git status")) is False
+        assert validator.should_run(inp=_make_input(command="ls -la /tmp")) is False

--- a/tests/validators/test_safe_subshell.py
+++ b/tests/validators/test_safe_subshell.py
@@ -92,3 +92,10 @@ class TestAutoApproval:
         inp = _make_input(command="git status")
         result = validator.validate(inp=inp)
         assert result is None
+
+    def test_quoted_subshell_literal_is_ignored(self, validator: SafeSubshellValidator) -> None:
+        # GH-309: $(...) inside single quotes is inert literal text. The
+        # validator must not see it as a subshell at all.
+        inp = _make_input(command="echo 'use $(date) for now'")
+        assert validator.should_run(inp=inp) is False
+        assert validator.validate(inp=inp) is None


### PR DESCRIPTION
**When** I run safe shell commands that contain inert metacharacters — single-quoted GraphQL queries, fixed ANSI-C escapes, paths referencing well-known env vars like $CLAUDE_PLUGIN_ROOT, or SvelteKit route-group segments — **I want to** have validators see through the literal text instead of regex-matching it as a live expansion, **so I can** keep working without spurious permission prompts on commands that pose no real risk.

---

[`2170203a`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/316/commits/2170203a63b29f1ae605f8bdfc5cedf303cfa2af) ✨ GH-309 Enable quote-aware bash-command tokenization
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/309

---