### PR TITLE
✨ GH-308 Enable friction-free permission-friction bundle (4 tickets)

### DIFF
--- a/.claude/rules/mcp-tools.md
+++ b/.claude/rules/mcp-tools.md
@@ -93,6 +93,7 @@ supporting each tool:
 | `pr_get` | `cli` | GH-267 | v0.74.0+ |
 | `pr_comments` | `cli` | PR #126 | v0.25.0+ |
 | `pr_comment_reply` | `cli` | PR #399 | v0.37.0+ |
+| `pr_review_comment_edit` | `cli` | GH-304 | v0.76.0+ |
 | `pr_issue_comment` | `cli` | GH-205 | v0.72.0+ |
 | `request_review` | `cli` | PR #126 | v0.25.0+ |
 | `detect_base_branch` | `cli` | PR #191 | v0.30.0+ |

--- a/skills/plugin-maintenance/SKILL.md
+++ b/skills/plugin-maintenance/SKILL.md
@@ -35,7 +35,6 @@ allowed-tools:
   - Bash(uvx dev10x permission investigate:*)
   - Bash(uvx dev10x permission record-upgrade:*)
   - Bash(uvx dev10x playbook diff:*)
-  - mcp__plugin_Dev10x_cli__update_paths
   - Agent(Dev10x:permission-auditor)
   - AskUserQuestion
   - TaskCreate
@@ -206,9 +205,16 @@ or it prompts on every Write/Edit/Read until the user runs
 Directories registered come from `workspace_directories:` in
 `${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/projects.yaml`.
 
+1. Dry run (REQUIRED — show the user before applying):
+
 ```bash
-mcp__plugin_Dev10x_cli__update_paths(ensure_workspace=true, dry_run=true)
-mcp__plugin_Dev10x_cli__update_paths(ensure_workspace=true)
+uvx dev10x permission ensure-workspace --dry-run
+```
+
+2. Apply:
+
+```bash
+uvx dev10x permission ensure-workspace
 ```
 
 ### 4. Ensure base permissions **[bootstrap]**
@@ -231,14 +237,14 @@ entries.
 
 1. Dry run:
 
-```
-mcp__plugin_Dev10x_cli__update_paths(ensure_base=true, dry_run=true)
+```bash
+uvx dev10x permission ensure-base --dry-run
 ```
 
 2. Apply:
 
-```
-mcp__plugin_Dev10x_cli__update_paths(ensure_base=true)
+```bash
+uvx dev10x permission ensure-base
 ```
 
 ### 5. Generalize session-specific permissions *(full only)*
@@ -249,14 +255,14 @@ wildcard patterns that work across future sessions.
 
 1. Dry run:
 
-```
-mcp__plugin_Dev10x_cli__update_paths(generalize=true, dry_run=true)
+```bash
+uvx dev10x permission generalize --dry-run
 ```
 
 2. Apply:
 
-```
-mcp__plugin_Dev10x_cli__update_paths(generalize=true)
+```bash
+uvx dev10x permission generalize
 ```
 
 **What gets generalized:**
@@ -297,14 +303,14 @@ versions may add scripts that are not yet enumerated.
 
 1. Dry run:
 
-```
-mcp__plugin_Dev10x_cli__update_paths(ensure_scripts=true, dry_run=true)
+```bash
+uvx dev10x permission ensure-scripts --dry-run
 ```
 
 2. Add missing rules:
 
-```
-mcp__plugin_Dev10x_cli__update_paths(ensure_scripts=true)
+```bash
+uvx dev10x permission ensure-scripts
 ```
 
 **What gets scanned:**
@@ -327,14 +333,14 @@ the prompt-displayed path, so each rule ships in two variants —
 
 1. Dry run:
 
-```
-mcp__plugin_Dev10x_cli__update_paths(ensure_reads=true, dry_run=true)
+```bash
+uvx dev10x permission ensure-reads --dry-run
 ```
 
 2. Apply:
 
-```
-mcp__plugin_Dev10x_cli__update_paths(ensure_reads=true)
+```bash
+uvx dev10x permission ensure-reads
 ```
 
 **What gets emitted (per skill, per top-level dir):**
@@ -518,29 +524,22 @@ users do not need to migrate config files.
 
 ## Options
 
-### update_paths MCP tool
+All maintenance commands are subcommands of `uvx dev10x permission …`.
+Run `uvx dev10x permission <subcommand> --help` for the authoritative
+flag list.
 
-| Parameter | Purpose |
-|-----------|---------|
-| `dry_run` | Preview changes without writing |
-| `version` | Target a specific version instead of latest |
-| `init` | Copy plugin default config to userspace for customization |
-| `ensure_base` | Add missing base permissions from projects.yaml |
-| `generalize` | Replace session-specific args with wildcard patterns |
-| `ensure_scripts` | Verify all plugin scripts have allow rules; add missing |
-| `ensure_reads` | Emit per-skill folder Read rules with `~/` + `/home/<user>/` twins |
-
-### update-paths.py CLI
+### Common flags (most subcommands)
 
 | Flag | Purpose |
 |------|---------|
 | `--dry-run` | Preview what would change without writing |
-| `--summary` | One line per changed file |
+| `--summary` | One line per changed file (where supported) |
 | `--quiet` | Suppress per-file details and headers |
-| `--version VER` | Target a specific version |
+
+### `update-paths` extras
+
+| Flag | Purpose |
+|------|---------|
+| `--init` | Copy plugin default config to userspace for customization |
+| `--version VER` | Target a specific version instead of latest |
 | `--restore` | Restore settings from most recent backups |
-
-### merge-worktree-permissions.py / clean-project-files.py
-
-Both accept `--dry-run` (and `--summary` for clean-project-files).
-See the script `--help` output for the full list.

--- a/skills/slack-review-request/SKILL.md
+++ b/skills/slack-review-request/SKILL.md
@@ -10,7 +10,7 @@ description: >
 user-invocable: true
 invocation-name: Dev10x:slack-review-request
 allowed-tools:
-  - Bash(${CLAUDE_PLUGIN_ROOT}/skills/slack-review-request/scripts/:*)
+  - Bash(uvx dev10x skill notify slack-review-prepare:*)
   - Bash(gh pr view:*)
 ---
 
@@ -105,8 +105,8 @@ and channel lookup in one call. Inlining bypasses these and produces
 malformed mentions.
 
 ```bash
-${CLAUDE_PLUGIN_ROOT}/skills/slack-review-request/scripts/slack-review-request.py \
-  prepare --pr {pr_number} --repo {repo}
+uvx dev10x skill notify slack-review-prepare \
+  --pr {pr_number} --repo {repo}
 ```
 
 Output is JSON with keys:
@@ -151,9 +151,11 @@ a temporary file and pass it:
 
 `Skill(skill="Dev10x:slack", args="--channel {channel} --message-file {temp_file}")`
 
-**NEVER call `slack-review-request.py send` directly** — delegate to
-the slack skill to honor global Slack posting rules. The script is
-an internal fallback only.
+**NEVER call `slack-review-request.py send` or `slack-notify.py`
+directly** — delegate to the slack skill (which now invokes
+`uvx dev10x skill notify slack-send`) so global Slack posting
+rules are honored. The version-pinned scripts are an internal
+fallback only.
 
 Report success: channel ID, thread timestamp (if available).
 

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -11,6 +11,7 @@ description: >
 user-invocable: true
 invocation-name: Dev10x:slack
 allowed-tools:
+  - Bash(uvx dev10x skill notify slack-send:*)
   - Bash(${CLAUDE_PLUGIN_ROOT}/skills/slack/slack-notify.py:*)
 ---
 
@@ -154,10 +155,16 @@ the top-level keys.
 
 ## Usage
 
+**Friction-free CLI:** prefer `uvx dev10x skill notify slack-send`
+for the common send paths. The underlying `slack-notify.py` script
+remains available for advanced flags (file upload, message
+update, reactions, reminder DMs) until they are exposed on the
+CLI surface.
+
 ### Send a message
 
 ```bash
-${CLAUDE_PLUGIN_ROOT}/skills/slack/slack-notify.py \
+uvx dev10x skill notify slack-send \
   --channel CHANNEL_ID \
   --message "Your message here"
 ```
@@ -165,7 +172,7 @@ ${CLAUDE_PLUGIN_ROOT}/skills/slack/slack-notify.py \
 ### Reply in a thread
 
 ```bash
-${CLAUDE_PLUGIN_ROOT}/skills/slack/slack-notify.py \
+uvx dev10x skill notify slack-send \
   --channel CHANNEL_ID \
   --thread-ts 1770113637.855309 \
   --message "Thread reply"

--- a/skills/upgrade-cleanup/projects.yaml
+++ b/skills/upgrade-cleanup/projects.yaml
@@ -293,6 +293,32 @@ base_permissions:
   # already covered above; this rule covers the yq invocation.
   - "Bash(yq:*)"
 
+  # --- Structured-data + safe-lookup tools (GH-308) ---
+  # Read-only data-format tools and binary-existence lookups.
+  # `Dev10x:diag-friction` steers agents toward these as structured
+  # alternatives to `python -c` / `sh -c` — their inclusion here makes
+  # the recommendation actionable (invoking jq/yamllint/etc. never
+  # prompts). `yq` already covered above under "YAML config parsing".
+  #
+  # Caveat: bare `command`/`which`/`type` can execute arbitrary binaries
+  # (`command <bin> <args>`); only the lookup-flag forms are listed.
+  # Do NOT generalize to `Bash(command:*)`.
+  - "Bash(jq:*)"
+  - "Bash(yamllint:*)"
+  - "Bash(actionlint:*)"
+  - "Bash(tomlq:*)"
+  - "Bash(xq:*)"
+  - "Bash(pup:*)"
+  - "Bash(bash -n:*)"
+  - "Bash(shellcheck:*)"
+  - "Bash(shfmt:*)"
+  - "Bash(zsh -n:*)"
+  - "Bash(command -v:*)"
+  - "Bash(command -V:*)"
+  - "Bash(which:*)"
+  - "Bash(type:*)"
+  - "Bash(hash:*)"
+
   # --- SSH probes (GH-20) ---
   # Push/PR setup paths verify GitHub SSH access.
   - "Bash(ssh -T git@github.com)"

--- a/skills/upgrade-cleanup/projects.yaml
+++ b/skills/upgrade-cleanup/projects.yaml
@@ -164,6 +164,7 @@ base_permissions:
   - "mcp__plugin_Dev10x_cli__issue_create"
   - "mcp__plugin_Dev10x_cli__pr_comments"
   - "mcp__plugin_Dev10x_cli__pr_comment_reply"
+  - "mcp__plugin_Dev10x_cli__pr_review_comment_edit"
   - "mcp__plugin_Dev10x_cli__request_review"
   - "mcp__plugin_Dev10x_cli__detect_base_branch"
   - "mcp__plugin_Dev10x_cli__verify_pr_state"

--- a/src/dev10x/commands/skill.py
+++ b/src/dev10x/commands/skill.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 import sys
 from pathlib import Path
 
@@ -9,6 +10,96 @@ import click
 @click.group()
 def skill() -> None:
     """Skill script commands (audit, notify, permission, release-notes)."""
+
+
+@skill.group()
+def notify() -> None:
+    """Post notifications (Slack review requests, generic Slack sends).
+
+    Exposes the slack-review-request prepare/send flow and the generic
+    slack-notify send call as version-stable `dev10x` subcommands so the
+    `Dev10x:slack-review-request` and `Dev10x:slack` skills do not need
+    to embed plugin-cache paths in their documented invocations.
+    """
+
+
+def _plugin_root() -> Path:
+    """Resolve the plugin root containing the skills/ directory.
+
+    `src/dev10x/commands/skill.py` -> parents[3] = plugin root.
+    """
+    return Path(__file__).resolve().parents[3]
+
+
+@notify.command(name="slack-review-prepare")
+@click.option("--pr", type=int, required=True, help="PR number")
+@click.option("--repo", required=True, help="GitHub repo (owner/name)")
+def slack_review_prepare(*, pr: int, repo: str) -> None:
+    """Resolve slack-review-request project config and emit the JSON envelope.
+
+    Wraps `dev10x.skills.notifications.slack_review_request` so callers
+    can invoke `uvx dev10x skill notify slack-review-prepare ...` instead
+    of the version-pinned `skills/slack-review-request/scripts/...`
+    script path. Output is identical to the underlying `prepare` call.
+    """
+    import argparse
+
+    from dev10x.skills.notifications import slack_review_request
+
+    args = argparse.Namespace(pr=pr, repo=repo)
+    slack_review_request.cmd_prepare(args)
+
+
+@notify.command(name="slack-send")
+@click.option("--channel", required=True, help="Slack channel ID (e.g., C042DJ8AJKB)")
+@click.option("--message", default=None, help="Message text (or use --message-file)")
+@click.option(
+    "--message-file",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help="Read message body from this file",
+)
+@click.option("--thread-ts", default=None, help="Reply in this thread")
+@click.option("--workspace", default=None, help="Select non-default Slack workspace")
+def slack_send(
+    *,
+    channel: str,
+    message: str | None,
+    message_file: Path | None,
+    thread_ts: str | None,
+    workspace: str | None,
+) -> None:
+    """Send a Slack message via the plugin's slack-notify.py script.
+
+    Delegates to `skills/slack/slack-notify.py` while exposing a
+    version-stable CLI surface. The underlying script handles token
+    resolution, user-group mention expansion, and bot identity.
+    """
+    if not message and not message_file:
+        raise click.UsageError("Provide --message or --message-file.")
+
+    slack_notify = _plugin_root() / "skills" / "slack" / "slack-notify.py"
+    if not slack_notify.exists():
+        click.echo(f"slack-notify.py not found at {slack_notify}", err=True)
+        sys.exit(1)
+
+    cmd: list[str] = [str(slack_notify), "--channel", channel]
+    if message_file is not None:
+        cmd.extend(["--message-file", str(message_file)])
+    if message is not None:
+        cmd.extend(["--message", message])
+    if thread_ts is not None:
+        cmd.extend(["--thread-ts", thread_ts])
+    if workspace is not None:
+        cmd.extend(["--workspace", workspace])
+
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    if result.stdout:
+        click.echo(result.stdout.rstrip())
+    if result.returncode != 0:
+        if result.stderr:
+            click.echo(result.stderr.rstrip(), err=True)
+        sys.exit(result.returncode)
 
 
 @skill.command(name="count-instructions")

--- a/src/dev10x/github/__init__.py
+++ b/src/dev10x/github/__init__.py
@@ -573,6 +573,45 @@ async def pr_comment_reply(
     return _parse_gh_api_result(result)
 
 
+async def pr_comment_edit(
+    *,
+    comment_id: int,
+    body: str,
+    repo: str | None = None,
+) -> Result[dict[str, Any]]:
+    """Edit a PR inline review-thread comment body (GH-304).
+
+    Uses PATCH against ``/repos/{owner}/{repo}/pulls/comments/{id}``.
+    Distinct from :func:`issue_comment_edit` which targets the
+    ``/issues/comments/`` endpoint (top-level issue + PR comments).
+    Use this for inline review-thread comments (the ones tied to a
+    file path + line number on a PR review).
+
+    Thin public wrapper around :func:`_pr_comment_edit`; promoted to
+    a stable name so the MCP boundary can expose it without leaking
+    the private underscore-prefixed symbol.
+
+    Args:
+        comment_id: Numeric ID of the review-thread comment to edit
+            (from the ``/comments/<id>`` URL fragment).
+        body: New body text (full replacement, not a delta).
+        repo: Repository (owner/repo). Auto-detected if omitted.
+
+    Returns:
+        On success: ``{"id": int, "body": str, "html_url": str}``.
+    """
+    repo_result = await _resolve_repo(repo)
+    if isinstance(repo_result, ErrorResult):
+        return repo_result
+    resolved_repo = repo_result.value
+
+    return await _pr_comment_edit(
+        resolved_repo=str(resolved_repo),
+        comment_id=comment_id,
+        body=body,
+    )
+
+
 async def pr_issue_comment(
     *,
     pr_number: int,

--- a/src/dev10x/mcp/server_cli.py
+++ b/src/dev10x/mcp/server_cli.py
@@ -282,6 +282,45 @@ async def pr_issue_comment(
 
 
 @server.tool()
+async def pr_review_comment_edit(
+    comment_id: int,
+    body: str,
+    repo: str | None = None,
+    cwd: str | None = None,
+) -> dict:
+    """Edit a PR inline review-thread comment body (GH-304).
+
+    Uses PATCH against `/repos/{owner}/{repo}/pulls/comments/{id}`.
+    Distinct from `issue_comment_edit` which targets the
+    `/issues/comments/` endpoint (top-level issue + PR comments).
+    Use this when editing inline review-thread comments — the ones
+    tied to a file path + line number on a PR review (e.g., bot
+    findings from claude-review, hygiene-review).
+
+    Args:
+        comment_id: Numeric ID of the review-thread comment to edit
+            (from the /comments/<id> URL fragment).
+        body: New body text (full replacement, not a delta).
+        repo: Repository (owner/repo). Auto-detected if omitted.
+        cwd: Effective working directory (GH-979).
+
+    Returns:
+        Dictionary with keys: id, body, html_url.
+    """
+    from dev10x import github as gh
+    from dev10x.subprocess_utils import use_cwd
+
+    with use_cwd(cwd):
+        return (
+            await gh.pr_comment_edit(
+                comment_id=comment_id,
+                body=body,
+                repo=repo,
+            )
+        ).to_dict()
+
+
+@server.tool()
 async def minimize_comments(
     node_ids: list[str],
     classifier: str = "OUTDATED",

--- a/tests/commands/test_skill_notify.py
+++ b/tests/commands/test_skill_notify.py
@@ -1,0 +1,240 @@
+"""Tests for `dev10x skill notify` subcommands (GH-313)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from dev10x.cli import cli
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+class TestPluginRoot:
+    def test_plugin_root_resolves_to_repo_root(self) -> None:
+        from dev10x.commands.skill import _plugin_root
+
+        root = _plugin_root()
+
+        assert (root / "skills").is_dir(), f"skills/ not under {root}"
+        assert (root / "src" / "dev10x" / "commands" / "skill.py").is_file()
+
+
+class TestNotifyGroupRegistration:
+    def test_notify_group_exposed(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["skill", "notify", "--help"])
+
+        assert result.exit_code == 0
+        assert "slack-review-prepare" in result.output
+        assert "slack-send" in result.output
+
+    def test_slack_review_prepare_help(self, runner: CliRunner) -> None:
+        result = runner.invoke(
+            cli,
+            ["skill", "notify", "slack-review-prepare", "--help"],
+        )
+
+        assert result.exit_code == 0
+        assert "--pr" in result.output
+        assert "--repo" in result.output
+
+    def test_slack_send_help(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["skill", "notify", "slack-send", "--help"])
+
+        assert result.exit_code == 0
+        assert "--channel" in result.output
+        assert "--message" in result.output
+        assert "--message-file" in result.output
+        assert "--thread-ts" in result.output
+        assert "--workspace" in result.output
+
+
+class TestSlackReviewPrepare:
+    def test_delegates_to_cmd_prepare(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_cmd_prepare(args: object) -> None:
+            captured["pr"] = args.pr  # type: ignore[attr-defined]
+            captured["repo"] = args.repo  # type: ignore[attr-defined]
+
+        from dev10x.skills.notifications import slack_review_request
+
+        monkeypatch.setattr(slack_review_request, "cmd_prepare", fake_cmd_prepare)
+
+        result = runner.invoke(
+            cli,
+            ["skill", "notify", "slack-review-prepare", "--pr", "42", "--repo", "org/r"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert captured == {"pr": 42, "repo": "org/r"}
+
+
+class TestSlackSend:
+    def test_requires_message_or_file(self, runner: CliRunner) -> None:
+        result = runner.invoke(
+            cli,
+            ["skill", "notify", "slack-send", "--channel", "C123"],
+        )
+
+        assert result.exit_code != 0
+        assert "Provide --message or --message-file" in result.output
+
+    def test_invokes_slack_notify_script(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        fake_script = tmp_path / "slack-notify.py"
+        fake_script.write_text("#!/usr/bin/env python\n")
+
+        from dev10x.commands import skill as skill_module
+
+        monkeypatch.setattr(
+            skill_module,
+            "_plugin_root",
+            lambda: tmp_path.parent,
+        )
+        (tmp_path.parent / "skills" / "slack").mkdir(parents=True, exist_ok=True)
+        real_script = tmp_path.parent / "skills" / "slack" / "slack-notify.py"
+        real_script.write_text("#!/usr/bin/env python\n")
+
+        captured_cmd: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+            captured_cmd.append(cmd)
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout="✅ Slack message sent",
+                stderr="",
+            )
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        result = runner.invoke(
+            cli,
+            [
+                "skill",
+                "notify",
+                "slack-send",
+                "--channel",
+                "C123",
+                "--message",
+                "hello",
+                "--thread-ts",
+                "1.2",
+                "--workspace",
+                "aperture",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Slack message sent" in result.output
+        assert captured_cmd, "subprocess.run was not invoked"
+        cmd = captured_cmd[0]
+        assert cmd[0] == str(real_script)
+        assert "--channel" in cmd and "C123" in cmd
+        assert "--message" in cmd and "hello" in cmd
+        assert "--thread-ts" in cmd and "1.2" in cmd
+        assert "--workspace" in cmd and "aperture" in cmd
+
+    def test_passes_message_file_through(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        from dev10x.commands import skill as skill_module
+
+        monkeypatch.setattr(skill_module, "_plugin_root", lambda: tmp_path)
+        slack_dir = tmp_path / "skills" / "slack"
+        slack_dir.mkdir(parents=True, exist_ok=True)
+        (slack_dir / "slack-notify.py").write_text("#!/usr/bin/env python\n")
+
+        msg_file = tmp_path / "msg.txt"
+        msg_file.write_text("hello from file")
+
+        captured_cmd: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+            captured_cmd.append(cmd)
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        result = runner.invoke(
+            cli,
+            [
+                "skill",
+                "notify",
+                "slack-send",
+                "--channel",
+                "C123",
+                "--message-file",
+                str(msg_file),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "--message-file" in captured_cmd[0]
+        assert str(msg_file) in captured_cmd[0]
+
+    def test_propagates_nonzero_exit_code(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        from dev10x.commands import skill as skill_module
+
+        monkeypatch.setattr(skill_module, "_plugin_root", lambda: tmp_path.parent)
+        slack_dir = tmp_path.parent / "skills" / "slack"
+        slack_dir.mkdir(parents=True, exist_ok=True)
+        (slack_dir / "slack-notify.py").write_text("#!/usr/bin/env python\n")
+
+        def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=2,
+                stdout="",
+                stderr="missing_scope",
+            )
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        result = runner.invoke(
+            cli,
+            ["skill", "notify", "slack-send", "--channel", "C123", "--message", "x"],
+        )
+
+        assert result.exit_code == 2
+
+    def test_missing_slack_notify_script(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        from dev10x.commands import skill as skill_module
+
+        monkeypatch.setattr(skill_module, "_plugin_root", lambda: tmp_path / "missing")
+
+        result = runner.invoke(
+            cli,
+            ["skill", "notify", "slack-send", "--channel", "C123", "--message", "x"],
+        )
+
+        assert result.exit_code == 1
+        assert "slack-notify.py not found" in result.output


### PR DESCRIPTION
**When** I run Dev10x skills that drive notifications, plugin maintenance, or PR review-thread workflows, **I want to** invoke them through stable, pre-approvable command prefixes, **so I can** avoid per-invocation permission prompts and version-pinned allow-rule rot across `claude plugin update` cycles.

---

[`8d5a8218`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/317/commits/8d5a821813707f15330b9de9fac7ef25f275a4a4) ✨ GH-308 Enable structured-data tools without prompts
[`c3eed6f9`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/317/commits/c3eed6f9ec0fd501353274a89134f7897790ff88) ✨ GH-304 Enable PR review-thread comment editing via MCP
[`5ac869b4`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/317/commits/5ac869b437f161d9f07e97d447d1f1113f386043) ♻️ GH-306 Enable friction-free plugin-maintenance via dev10x CLI
[`bbe4f268`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/317/commits/bbe4f2681b5240752f85c405bdf85a85b1786914) ✨ GH-313 Enable Slack review-request via dev10x CLI

Closes #304
Closes #306
Closes #308
Closes #313

Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/308