### PR TITLE
✨ GH-85 Align park-discover with session.yaml deferral substrate

### DIFF
--- a/skills/gh-pr-bookmark/SKILL.md
+++ b/skills/gh-pr-bookmark/SKILL.md
@@ -11,7 +11,7 @@ description: >
 user-invocable: true
 invocation-name: Dev10x:gh-pr-bookmark
 allowed-tools:
-  - Bash(gh:*)
+  - mcp__plugin_Dev10x_cli__pr_detect
   - Skill(Dev10x:park)
 ---
 
@@ -34,16 +34,20 @@ Mark completed when done: `TaskUpdate(taskId, status="completed")`
 
 Thin wrapper around `Dev10x:park` that pre-selects the **PR session
 bookmark** target. Use at end-of-session or when pausing work on a PR.
+`Dev10x:park` posts the comment AND appends a `source: pr-bookmark`
+entry to `.claude/Dev10x/session.yaml` so the bookmark is discoverable
+locally by `Dev10x:park-discover` (GH-85).
 
 ## Workflow
 
 ### 1. Detect PR
 
-```bash
-gh pr list --head "$(git branch --show-current)" --state open --json number,url --limit 1
+```
+mcp__plugin_Dev10x_cli__pr_detect(arg="")
 ```
 
-If no open PR found, tell the user and stop.
+The MCP wrapper resolves the current branch's PR. Treat an
+`{"error": ...}` response as "no open PR" — tell the user and stop.
 
 ### 2. Delegate to Dev10x:park
 

--- a/skills/park-discover/SKILL.md
+++ b/skills/park-discover/SKILL.md
@@ -10,9 +10,12 @@ description: >
 user-invocable: true
 invocation-name: Dev10x:park-discover
 allowed-tools:
-  - Bash(gh pr view:*)
-  - Bash(gh pr list:*)
-  - Bash(jq:*)
+  - Read
+  - Grep
+  - Bash(git branch:*)
+  - Bash(git log:*)
+  - mcp__plugin_Dev10x_cli__pr_detect
+  - mcp__plugin_Dev10x_cli__pr_comments
   - mcp__claude_ai_Slack__slack_search_public_and_private
 ---
 
@@ -42,136 +45,216 @@ Invoke this skill when the user asks about existing deferred items:
 Do NOT use for writing new deferrals — use `Dev10x:park-todo` or
 `Dev10x:park` instead.
 
+## Substrate
+
+The canonical store for deferred work is
+`.claude/Dev10x/session.yaml` (GH-85). Every writer in the
+park/session family appends a structured entry into its
+`tasks:` list with a `source:` field that names the writer:
+
+| `source:` value     | Written by                          |
+|---------------------|-------------------------------------|
+| `manual`            | `Dev10x:park` (target: TODO)        |
+| `code-todo`         | `Dev10x:park-todo` (inline mode)    |
+| `slack-reminder`    | `Dev10x:park-remind`                |
+| `pr-bookmark`       | `Dev10x:park` (target: PR bookmark) |
+| `session-wrap-up`   | `Dev10x:session-wrap-up` Phase 3b   |
+
+External sources (Slack DMs, PR comments) remain as the
+authoritative content; session.yaml carries a pointer
+(`metadata.slack_ts`, `metadata.pr_url`) so the discovery
+report can link out.
+
 ## Workflow
 
-### 1. Detect context
+### 1. Read session.yaml (primary source)
+
+Read `.claude/Dev10x/session.yaml` directly with the Read
+tool. If the file does not exist, note "No session.yaml — no
+local deferrals indexed" and skip to the external-sources
+step.
+
+```
+Read(file_path="<repo-root>/.claude/Dev10x/session.yaml")
+```
+
+Parse the YAML and extract three sections:
+
+- `continuation_prompt:` — a paragraph carrying diagnosed
+  context from the prior session. Surface this **verbatim** in
+  the report; do not summarize.
+- `tasks:` — a list of structured entries. Each entry has
+  `subject`, `status`, and (when present) `metadata` and
+  `source`. Group by `source:` for the report.
+- `insights:` — a list of lessons / decisions the prior
+  session carried forward. Surface each item verbatim.
+
+### 2. Read legacy `.claude/TODO.md` (back-compat)
+
+For repos that still carry items in the pre-GH-85 TODO file:
+
+```
+Read(file_path="<repo-root>/.claude/TODO.md")
+```
+
+If the file does not exist, note "No legacy TODO file" and
+move on. Extract pending items (`- [ ]` lines) and present
+them under a separate **Legacy TODO file** heading so the user
+can migrate them into session.yaml.
+
+### 3. Scan code TODOs / FIXMEs (Grep tool)
+
+```
+Grep(pattern="TODO|FIXME", path="src", output_mode="content", -n=true)
+```
+
+Distinguish in-flight items added in the current branch from
+long-standing tech debt by checking the branch's commits:
 
 ```bash
-date +%Y-%m-%d
-git branch --show-current
-basename "$(git rev-parse --show-toplevel)"
+git log --oneline origin/develop..HEAD
 ```
 
-Determine the lookback date: default is yesterday. If the user
-specifies a date or range, use that instead.
+Only flag TODOs introduced on the current branch as actionable;
+the rest are tech-debt notes for `Dev10x:project-audit`.
 
-### 2. Check all deferral sources
+### 4. Open PR bookmark comments
 
-Run all checks in parallel where possible. Report findings grouped
-by source.
-
-#### 2a. Project TODO file
-
-Read `.claude/TODO.md` in the repo root. Extract pending items
-(`- [ ]` lines). If the file doesn't exist, note "No project TODO
-file."
-
-#### 2b. Recent code TODOs
-
-Grep for TODO/FIXME comments in `src/`:
-
-```bash
-grep -rn "TODO\|FIXME" src/ --include="*.py" | head -30
-```
-
-Distinguish long-standing tech debt from recently added items by
-checking `git log` for the lookback period.
-
-#### 2c. Slack DM reminders
-
-Search for bot-sent reminders using MCP Slack tools (read mode):
+Detect the PR for the current branch via the MCP wrapper:
 
 ```
-mcp__claude_ai_Slack__slack_search_public_and_private
-  query: "from:<@U0AD92X4X1S> 🔖 after:LOOKBACK_DATE"
-  include_bots: true
-  sort: timestamp
-  sort_dir: desc
-  limit: 20
+mcp__plugin_Dev10x_cli__pr_detect(arg="")
 ```
 
-The `🔖` emoji is the standard prefix from `Dev10x:park-remind`.
+If a PR is found, fetch its comments via the MCP wrapper:
 
-If no results with `🔖`, broaden to:
 ```
-from:<@U0AD92X4X1S> after:LOOKBACK_DATE defer OR TODO OR reminder
-```
-
-#### 2d. Memory files
-
-Grep the global memory directory for in-progress or deferred items:
-
-```bash
-grep -rn "defer\|TODO\|in-progress\|pick up" \
-  ~/.claude/memory/ \
-  --include="*.md" || true
+mcp__plugin_Dev10x_cli__pr_comments(action="list", pr_number=<number>)
 ```
 
-#### 2e. Git log (recent commits)
+Filter for comments whose body starts with
+`🔖 **Session bookmark**` (the standard marker set by
+`Dev10x:session-wrap-up`). Include the matched comments under
+**PR Session Bookmarks**.
 
-Check for recent commits by the user in the lookback period:
+Skip silently when `pr_detect` returns `{"error": ...}` — that
+means no PR for the current branch, not a failure.
 
-```bash
-git log --all --since="LOOKBACK_DATE" --oneline --author="<username>" \
-  | head -20
+### 5. Slack DM reminders
+
+Search Slack for self-reminders from the park-remind bot. The
+`🔖` emoji is the standard prefix from `Dev10x:park-remind`:
+
+```
+mcp__claude_ai_Slack__slack_search_public_and_private(
+  query="from:<@U0AD92X4X1S> 🔖",
+  include_bots=true,
+  sort="timestamp",
+  sort_dir="desc",
+  limit=20)
 ```
 
-This provides context on what was being worked on.
+If no results, broaden to `from:<@U0AD92X4X1S> defer OR TODO OR
+reminder`. Skip silently when Slack search returns no matches.
 
-#### 2f. PR wrap-up reminders
+### 6. Memory notes (`~/.claude/memory/`)
 
-Check open PRs for automated session bookmark comments posted by
-`Dev10x:session-wrap-up`. These are self-reminders left on PRs during
-previous sessions:
+Search the global memory directory for in-progress items:
 
-```bash
-gh pr list --author="@me" --state open \
-  --json number,title,url --limit 10
+```
+Grep(pattern="defer|TODO|in-progress|pick up",
+     path="/home/<user>/.claude/memory",
+     glob="*.md",
+     output_mode="content", -n=true)
 ```
 
-For each PR, search for reminder comments with the standard prefix:
+These are user-global notes, not project-local — surface them
+in a dedicated section.
 
-```bash
-gh pr view {N} --json comments --jq '.comments[]
-  | select(.body | test("🔖 \\*\\*Session bookmark\\*\\*"))
-  | {body: .body[0:300], createdAt: .createdAt}'
-```
+## Presentation
 
-The `🔖 **Session bookmark**` prefix is the standard marker set by
-`Dev10x:session-wrap-up`. Include matching comments in the findings under
-"### PR Session Bookmarks".
-
-### 3. Present findings
-
-Group results by source in a scannable format:
+Group findings in a scannable format. Always lead with
+`continuation_prompt` verbatim — it is qualitatively richer
+than any single TODO line.
 
 ```markdown
-## Deferred Items — [project name]
+## Deferred Items — <project name>
 
-### .claude/TODO.md
-(items or "No project TODO file")
+### Continuation prompt (session.yaml)
 
-### Slack DM Reminders
-(items or "None found")
+<continuation_prompt verbatim, or "(none)">
 
-### Recent Code TODOs
-(items or "Only long-standing tech debt")
+### Open tasks (session.yaml)
 
-### Memory Notes
-(items or "None")
+#### From session-wrap-up
+- [<status>] <subject> — <metadata summary>
 
-### Recent Activity (context)
-(recent commits or "No commits in lookback period")
+#### From park (manual / PR bookmark)
+- [<status>] <subject> — <metadata summary>
+
+#### From park-todo (code-todo)
+- [<status>] <subject> — `<metadata.location>`
+
+#### From park-remind (slack-reminder)
+- [<status>] <subject> — Slack ts `<metadata.slack_ts>`
+
+### Carried insights (session.yaml)
+
+- <insight 1 verbatim>
+- <insight 2 verbatim>
 
 ### PR Session Bookmarks
-(matching PR comments or "None found")
+
+- PR #<n>: <comment excerpt> (<comment url>)
+
+### Slack reminders
+
+- <message excerpt> (<permalink>)
+
+### Legacy TODO file (`.claude/TODO.md`)
+
+- [ ] <legacy item> (consider migrating to session.yaml via park)
+
+### Recent code TODOs (current branch)
+
+- `<file>:<line>` <comment>
+
+### Memory notes (`~/.claude/memory/`)
+
+- <file>: <excerpt>
 ```
 
-### 4. Offer next steps
+If a section has no matches, render it as `(none)` rather than
+omitting — the absence is itself information.
 
-If deferred items were found, ask:
-- "Want to start working on any of these?"
-- "Want me to check other repos too?" (if multi-repo context)
+## Next steps
+
+After presenting findings, ask whether to resume any item.
+**REQUIRED: Call `AskUserQuestion`** (do NOT use plain text)
+when at least one source returned items.
+
+Options:
+- Resume the continuation prompt (Recommended when present)
+- Pick a specific task to work on
+- Migrate legacy TODO.md items into session.yaml
+- Just informational — close
+
+## Commands and permissions
+
+This skill MUST NOT use any of the following anti-patterns —
+they all trigger permission friction and were the second
+documented friction class in GH-85:
+
+| ❌ Anti-pattern                              | ✅ Use instead                              |
+|---------------------------------------------|---------------------------------------------|
+| `cat .claude/TODO.md`                       | `Read(file_path=...)`                       |
+| `grep -rn 'TODO' src/`                      | `Grep(pattern='TODO', path='src')`          |
+| `date +%Y-%m-%d; git branch ...; basename` | Single Bash call per command                |
+| `$(git rev-parse --show-toplevel)`          | Pass an absolute path to Read directly      |
+| `gh pr view N --json comments --jq ...`     | `mcp__plugin_Dev10x_cli__pr_comments(...)` |
+
+Every Bash invocation in this skill is a single command — no
+`;` chaining, no `&&`, no subshells, no inline scripts.
 
 ## Used By
 

--- a/skills/park-remind/SKILL.md
+++ b/skills/park-remind/SKILL.md
@@ -11,8 +11,14 @@ description: >
 user-invocable: true
 invocation-name: Dev10x:park-remind
 allowed-tools:
+  - Read
+  - Write
+  - Edit
   - Bash(${CLAUDE_PLUGIN_ROOT}/skills/slack/slack-notify.py:*)
   - Bash(/tmp/Dev10x/bin/mktmp.sh:*)
+  - Bash(git branch:*)
+  - Bash(git rev-parse:*)
+  - mcp__plugin_Dev10x_cli__mktmp
   - Write(/tmp/Dev10x/slack/**)
 ---
 
@@ -34,7 +40,10 @@ Mark completed when done: `TaskUpdate(taskId, status="completed")`
 ## Overview
 
 Send a self-DM via Slack with a deferred item, formatted with session
-context so you know where to pick it up.
+context so you know where to pick it up. After the DM is sent, append
+a pointer entry to `.claude/Dev10x/session.yaml` so
+`Dev10x:park-discover` can surface it locally without a Slack search
+(GH-85).
 
 ## Prerequisites
 
@@ -47,13 +56,16 @@ context so you know where to pick it up.
 
 ```bash
 git branch --show-current
-basename "$(git rev-parse --show-toplevel)"
-date +%Y-%m-%d
 ```
 
-Extract from branch name:
+```bash
+git rev-parse --show-toplevel
+```
+
+Each in a single Bash call — no `;` chaining, no subshells.
+Extract from the branch name:
 - Ticket ID (pattern: `username/TICKET-ID/[worktree/]description`)
-- Project name (from repo root basename)
+- Project name (from the toplevel basename)
 
 ### 2. Format message
 
@@ -74,9 +86,10 @@ separate line after the item text.
 For multi-line messages, write the formatted text to a unique temp file
 using the Write tool first, then pass it via command substitution:
 
-```bash
-/tmp/Dev10x/bin/mktmp.sh slack remind-msg .txt
 ```
+mcp__plugin_Dev10x_cli__mktmp(namespace="slack", prefix="remind-msg", ext=".txt")
+```
+
 Write content to the returned path using Write tool, then:
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/skills/slack/slack-notify.py \
@@ -87,9 +100,36 @@ Do NOT use heredoc (`cat <<'EOF'`) to build the message inline —
 the bash security hook blocks it. Always use Write tool → temp file
 → `$(cat ...)` for multi-line content.
 
-### 4. Confirm
+### 4. Append to session.yaml
 
-Report to user: "Sent reminder to your Slack DMs."
+After Slack confirms delivery, append a pointer entry to the
+session.yaml `tasks:` list using the schema documented in
+`Dev10x:park-todo` § Session.yaml Append:
+
+```yaml
+- subject: <item text, single line>
+  status: pending
+  source: slack-reminder
+  created_at: <YYYY-MM-DD>
+  metadata:
+    branch: <current-branch>
+    slack_ts: <timestamp returned by slack-notify>
+    slack_permalink: <permalink returned by slack-notify>
+```
+
+The Slack DM remains the authoritative content; the session.yaml
+entry is the local index that `Dev10x:park-discover` reads
+without a network round-trip.
+
+If session.yaml does not exist, create it with the new entry
+under `tasks:` while preserving any sibling fields. Never
+overwrite `friction_level`, `active_modes`,
+`continuation_prompt`, or `insights`.
+
+### 5. Confirm
+
+Report to user: "Sent reminder to your Slack DMs and indexed in
+session.yaml."
 
 ## Standalone Usage
 

--- a/skills/park-todo/SKILL.md
+++ b/skills/park-todo/SKILL.md
@@ -1,21 +1,26 @@
 ---
 name: Dev10x:park-todo
 description: >
-  Defer work to code or project-level storage — so items resurface
+  Defer work to code or session-level storage — so items resurface
   when editing nearby code or starting a new session in the same
   project, instead of being forgotten.
-  TRIGGER when: deferring work to code comments, TODO.md, or project
-  memory files.
+  TRIGGER when: deferring work to code comments or the session.yaml
+  task index.
   DO NOT TRIGGER when: deferring to Slack (use Dev10x:park-remind),
   or routing to the best destination automatically (use Dev10x:park).
 user-invocable: true
 invocation-name: Dev10x:park-todo
+allowed-tools:
+  - Read
+  - Edit
+  - Write
+  - Bash(git branch:*)
+  - Bash(git rev-parse:*)
 ---
 
-# Dev10x:park-todo — Persistent Code/Project Deferrals
+# Dev10x:park-todo — Persistent Code/Session Deferrals
 
-**Announce:** "Using Dev10x:park-todo to [add TODO/FIXME to code | update
-project TODO list]."
+**Announce:** "Using Dev10x:park-todo to [add TODO/FIXME to code | append item to session.yaml]."
 
 ## Orchestration
 
@@ -33,12 +38,17 @@ Mark completed when done: `TaskUpdate(taskId, status="completed")`
 Write deferred items to persistent storage where they will be
 rediscovered by humans or Claude in the right context.
 
+The canonical task index is `.claude/Dev10x/session.yaml` (GH-85).
+Every project deferral appends an entry to its `tasks:` list so
+`Dev10x:park-discover` surfaces it on the next session start.
+
 ## Modes
 
 ### 1. Inline Code (TODO / FIXME)
 
 When a specific file and location are relevant, insert a comment
-directly in the code:
+directly in the code AND index it in session.yaml so the
+discovery skill can find it without grepping `src/`.
 
 - `# TODO: message` — actionable, expected soon (this PR, next session)
 - `# FIXME: message` — known issue, no timeline, boy scout rule applies
@@ -47,7 +57,9 @@ directly in the code:
 
 1. Read the target file
 2. Use Edit to insert the comment at the appropriate line
-3. Report what was added and where
+3. Append an index entry to session.yaml (see § Session.yaml Append)
+   with `source: code-todo` and `metadata.location: "<path>:<line>"`
+4. Report what was added and where
 
 **Example:**
 
@@ -56,46 +68,55 @@ directly in the code:
 WEBHOOK_SECRET = os.environ.get("STRIPE_WEBHOOK_SECRET", "")
 ```
 
-### 2. Project TODO File
+### 2. Project Task Index (session.yaml)
 
-When no specific file is relevant, append to `.claude/TODO.md` in the
-current repository root.
+When no specific file is relevant, append to the session.yaml
+`tasks:` list with `source: park` so `Dev10x:park-discover`
+finds it.
 
-**Format:**
+This replaces the pre-GH-85 `.claude/TODO.md` file. The TODO
+file is still read by `Dev10x:park-discover` for back-compat,
+but new items are written to session.yaml.
 
-```markdown
-## YYYY-MM-DD — branch: username/TICKET-ID/short-desc
+## Session.yaml Append
 
-- [ ] Item description
-- [ ] Another item with context or link
+Use the Read tool to load the current
+`.claude/Dev10x/session.yaml` (create if missing), then use
+Write or Edit to add the new task entry. The schema for a
+task entry is:
+
+```yaml
+tasks:
+  - subject: <one-line description>
+    status: pending
+    source: <code-todo | park>
+    created_at: <YYYY-MM-DD>
+    metadata:
+      branch: <current-branch>
+      location: <file:line>   # only for source: code-todo
 ```
 
-**How to append:**
+**Append rules:**
 
-1. Read `.claude/TODO.md` if it exists
-2. Check if a section for today's date + current branch already exists
-3. If yes, append the new item to that section
-4. If no, create a new section header and add the item
-5. Write the updated file
+1. Read existing session.yaml. If absent, write a minimal
+   shell preserving any sibling fields the writer should leave
+   alone (`friction_level`, `active_modes`, `continuation_prompt`,
+   `insights`).
+2. Add the new entry to the END of the `tasks:` list — never
+   replace or reorder existing entries.
+3. Preserve YAML key order: top-level keys stay in their
+   existing positions; only the new task is appended.
 
-**If `.claude/TODO.md` does not exist, create it with a header:**
-
-```markdown
-# Project TODO — Deferred Items
-
-Items deferred from Claude sessions. Review at session start.
-
-## YYYY-MM-DD — branch: username/TICKET-ID/short-desc
-
-- [ ] First deferred item
-```
+**Never overwrite** `friction_level`, `active_modes`,
+`continuation_prompt`, or `insights` while appending tasks.
 
 ## Context Gathering
 
 When invoked, auto-detect:
-- Current date: `date +%Y-%m-%d`
-- Current branch: `git branch --show-current`
-- Repository root: `git rev-parse --show-toplevel`
+- Current branch: `git branch --show-current` (single Bash call)
+- Repository root: `git rev-parse --show-toplevel` (single Bash call)
+- Current date: derive from the session — the writer is invoked
+  in-session, so the date is "today" without a `date` shell-out
 
 ## Review Mode Redirect
 
@@ -106,5 +127,7 @@ deferrals; `Dev10x:park-discover` is for *reading them back*.
 
 ## Used By
 
-- `Dev10x:park` — when user picks "project TODO" or "inline code"
-- `Dev10x:session-wrap-up` — Phase 1 scans `.claude/TODO.md` for existing items
+- `Dev10x:park` — when user picks "project task index" or "inline code"
+- `Dev10x:session-wrap-up` — Phase 1 reads session.yaml `tasks:`
+  for existing items (and the legacy `.claude/TODO.md` for
+  back-compat)

--- a/skills/park/SKILL.md
+++ b/skills/park/SKILL.md
@@ -2,8 +2,8 @@
 name: Dev10x:park
 description: >
   Smart deferral router — saves tasks for later to the right place
-  (PR, ticket, code, Slack, or project TODO) so they are actually
-  rediscovered instead of being forgotten.
+  (PR, ticket, code, Slack, or session.yaml task index) so they
+  are actually rediscovered instead of being forgotten.
   TRIGGER when: a task should be saved for later instead of done now.
   DO NOT TRIGGER when: task should be done now, or specifically
   deferring to code (use Dev10x:park-todo) or Slack (use
@@ -11,11 +11,17 @@ description: >
 user-invocable: true
 invocation-name: Dev10x:park
 allowed-tools:
-  - Bash(gh pr view:*)
-  - Bash(gh pr list:*)
-  - Bash(gh pr comment:*)
-  - Bash(gh api:*)
+  - Read
+  - Write
+  - Edit
+  - Bash(git branch:*)
+  - Bash(git rev-parse:*)
+  - Bash(git log:*)
   - mcp__plugin_Dev10x_cli__pr_comments
+  - mcp__plugin_Dev10x_cli__pr_detect
+  - mcp__plugin_Dev10x_cli__pr_issue_comment
+  - mcp__plugin_Dev10x_cli__issue_comment_edit
+  - mcp__plugin_Dev10x_cli__mktmp
   - AskUserQuestion
 ---
 
@@ -37,7 +43,14 @@ Mark completed when done: `TaskUpdate(taskId, status="completed")`
 ## Overview
 
 Route a single deferred item to the right discovery context. Can be
-invoked standalone or called by `Dev10x:session-wrap-up` for each open loop.
+invoked standalone or called by `Dev10x:session-wrap-up` for each open
+loop.
+
+Every routed deferral that has a local representation also lands as
+an entry in `.claude/Dev10x/session.yaml` `tasks:` with a `source:`
+field that names the target (GH-85). This guarantees
+`Dev10x:park-discover` can surface the item without scanning every
+write path.
 
 ## Workflow
 
@@ -49,24 +62,29 @@ Accept the item to defer. This is either:
 
 ### 2. Detect context
 
-Run these checks to determine available targets:
+Run these checks to determine available targets. Each is a single
+Bash call — no `;` chaining, no subshells inside command strings.
 
-**Branch + ticket:**
+**Branch:**
 ```bash
 git branch --show-current
 ```
-Extract ticket ID from branch name (pattern: `username/TICKET-ID/[worktree/]desc`).
+
+Extract ticket ID from the branch name (pattern:
+`username/TICKET-ID/[worktree/]desc`).
+
+**Repository toplevel:**
+```bash
+git rev-parse --show-toplevel
+```
 
 **Open PR:**
-```bash
-gh pr list --head "$(git branch --show-current)" --state open \
-  --json number,url --limit 1
+```
+mcp__plugin_Dev10x_cli__pr_detect(arg="")
 ```
 
-**Repository root:**
-```bash
-basename "$(git rev-parse --show-toplevel)"
-```
+The MCP wrapper auto-detects the PR for the current branch. Treat
+an `{"error": ...}` response as "no open PR" rather than a failure.
 
 ### 3. Present targets
 
@@ -74,7 +92,7 @@ Build target list based on detected context. Always available:
 
 | # | Target | When it surfaces |
 |---|--------|-----------------|
-| 1 | `.claude/TODO.md` | Next Claude session in this project |
+| 1 | session.yaml task index | Next `Dev10x:park-discover` run |
 | 2 | Slack DM to self | When clearing Slack messages |
 | 3 | Create issue | When triaging backlog or planning sprint |
 
@@ -98,23 +116,46 @@ For each selected target:
 
 | Target | Action |
 |--------|--------|
-| `.claude/TODO.md` | Invoke `Dev10x:park-todo` (project file mode) |
-| Slack DM | Invoke `Dev10x:park-remind` |
-| Create issue | Ask user which tracker (Linear, GitHub Issues, Jira, etc.) then create the issue with the deferred item as description |
-| Issue tracker comment | Post comment via the appropriate tracker MCP or CLI tool |
-| PR comment | Post as PR comment (simple format) |
-| PR session bookmark | Post as PR comment with rich metadata (see PR Bookmark Format below) |
+| session.yaml task index | Append entry with `source: park` (see § Session.yaml Append) |
+| Slack DM | Invoke `Dev10x:park-remind` (which also appends `source: slack-reminder`) |
+| Create issue | Ask user which tracker (Linear, GitHub Issues, Jira, etc.) then create the issue with the deferred item as description; also append a `source: park` entry pointing at the new issue URL |
+| Issue tracker comment | Post comment via the appropriate tracker MCP or CLI tool; also append a `source: park` entry pointing at the comment URL |
+| PR comment | Post as PR comment (simple format); also append a `source: park` entry with the PR URL |
+| PR session bookmark | Post as PR comment with rich metadata (see PR Bookmark Format below); also append a `source: pr-bookmark` entry with the PR URL + comment ID |
 | Inline TODO/FIXME | Invoke `Dev10x:park-todo` (inline mode) — ask user for file path if not provided |
 | Keep in session | Invoke `Dev10x:session-tasks` to create a TaskCreate entry |
 
-### 5. Confirm
+### 5. Session.yaml Append
 
-Report which targets received the item:
+The schema for a `park`-sourced task entry mirrors the one in
+`Dev10x:park-todo` § Session.yaml Append:
+
+```yaml
+- subject: <one-line description>
+  status: pending
+  source: <park | pr-bookmark>
+  created_at: <YYYY-MM-DD>
+  metadata:
+    branch: <current-branch>
+    pr_url: <url>         # when target is PR comment / bookmark
+    comment_id: <id>      # when target is PR comment / bookmark
+    issue_url: <url>      # when target creates an issue
+```
+
+Read the existing session.yaml, append the entry to the end of
+the `tasks:` list, then write back. Never overwrite
+`friction_level`, `active_modes`, `continuation_prompt`, or
+`insights`.
+
+### 6. Confirm
+
+Report which targets received the item AND confirm the
+session.yaml index entry:
 
 ```
 Deferred "Add order confirmation email":
-  ✓ .claude/TODO.md (project)
-  ✓ Slack DM sent
+  ✓ session.yaml task index (source: park)
+  ✓ Slack DM sent (source: slack-reminder)
 ```
 
 ## Formatting for External Targets
@@ -145,11 +186,8 @@ session left off.
 
 Gather this data before composing:
 
-1. **Session ID** — extract from the current JSONL filename:
-   ```bash
-   basename "$(ls -t ~/.claude/projects/<encoded-cwd>/*.jsonl | head -1)" .jsonl
-   ```
-2. **Review threads** — list root comments and their status:
+1. **Session ID** — extract from the current JSONL filename
+2. **Review threads** — list root comments and their status via:
    ```
    mcp__plugin_Dev10x_cli__pr_comments(action="list", pr_number={number})
    ```
@@ -190,19 +228,23 @@ Compose the comment:
 2. {next step}
 ```
 
-Write the comment to a unique temp file and post via `--body-file`:
-```bash
-/tmp/Dev10x/bin/mktmp.sh git pr-comment .txt
+Compose the comment body in memory (or via the mktmp wrapper if
+the body needs an intermediate file), then post it via the MCP
+wrapper:
+
 ```
-Write content to the returned path using Write tool, then:
-```bash
-gh pr comment {number} --body-file <unique-path>
+mcp__plugin_Dev10x_cli__pr_issue_comment(pr_number=<number>, body=<composed-body>)
 ```
 
-To **update** an existing bookmark comment instead of creating a new one:
-```bash
-gh api repos/{owner}/{repo}/issues/comments/{comment_id} \
-  -X PATCH -F body=@<unique-path>
+The wrapper returns the new comment's `id` and `html_url`. Store
+the `id` in the session.yaml entry's `metadata.comment_id` so the
+bookmark can be edited later without re-detecting the comment.
+
+To **update** an existing bookmark comment instead of creating a
+new one, edit by `comment_id`:
+
+```
+mcp__plugin_Dev10x_cli__issue_comment_edit(comment_id=<id>, body=<new-body>)
 ```
 
 ## Used By


### PR DESCRIPTION
**When** I resume work after a session-wrap-up and ask park-discover what is deferred, **I want** every park/session writer to index its output in `.claude/Dev10x/session.yaml`, **so I can** see the prior session's continuation prompt, tasks, and insights without grepping five different stores or losing the highest-signal handoff artifact.

---

[`ecfd460b`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/318/commits/ecfd460b498e389c5eaa543fc4b0f71c64b49305) ✨ GH-85 Align park-discover with session.yaml deferral substrate
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/85

---
