### PR TITLE
✨ GH-310 Prevent permission prompts from stalling unattended runs

### DIFF
--- a/references/permission-architecture.md
+++ b/references/permission-architecture.md
@@ -67,6 +67,64 @@ When adding a new SkillRedirectValidator entry:
 | `clean-project-files.py` | Must detect and skip hook-enabled rules during cleanup |
 | `plugin-maintenance` skill (invoked directly or via `upgrade-cleanup`) | Must not strip hook-enabled rules from project settings |
 
+## Proactive Safe-Command Allowlist (GH-310)
+
+An unsupervised (adaptive / AFK) session treats every permission
+prompt as a **hard stop** — there is no human to answer it, so the
+session cannot complete. The same prompt is also the trigger for
+Claude Code's option-2 "Yes, and don't ask again for…" feature,
+which strips a command down to its broadest prefix and writes a
+catch-all `Bash(<verb> *)` rule into the user's allow list.
+
+### Why deny rules cannot fix the footgun
+
+A natural instinct is to ship `deny` rules for the catch-all shapes
+(`Bash(git *)`, `Bash(gh *)`, …). This **backfires**. Claude Code
+evaluates rules in the order `deny → ask → allow`, and the first
+match wins, so a deny always beats a more-specific allow. The space
+in `Bash(git *)` is a trailing wildcard equivalent to `:*`, so the
+pattern matches **every** `git <args>` command. A `deny: Bash(git *)`
+would therefore also block `git status`, `git log`, and every other
+git subcommand — for every plugin user — even with
+`allow: Bash(git status:*)` present.
+
+Source: [Claude Code permissions docs](https://code.claude.com/docs/en/permissions.md)
+— "Rules are evaluated `deny → ask → allow`; the first matching rule
+wins" and "`Bash(git *)` matches `git log --oneline --all`".
+
+### The fix: pre-approve the safe surface
+
+The only safe defense is to **enumerate the safe commands as `allow`
+rules** so the prompt never fires and option-2 never gets the chance
+to write a catch-all. The catalog lives in
+`skills/upgrade-cleanup/projects.yaml` under `base_permissions:` and
+is propagated into each project's `settings.local.json` by
+`uvx dev10x permission ensure-base`.
+
+What belongs in the catalog (safe to auto-approve):
+
+- Read-only filesystem / text inspection (`ls`, `cat`, `grep`, `rg`,
+  `stat`, `wc`, `diff`, …) — never mutate state.
+- `--version` / `--help` info flags for execution-capable verbs.
+- Read-only subcommands of rich verbs (`git show`, `git rev-parse`,
+  `gh release view`, `gh workflow list`, `uv pip list`, …).
+
+What is deliberately excluded (keeps prompting, routes to a skill,
+or is forbidden by a hook):
+
+- Arbitrary code execution — `python -c`, `sh -c`, `bash -c`,
+  `eval`, and package runners (`npx <pkg>`, `pnpm dlx <pkg>`,
+  `pipx run <pkg>`, `bunx <pkg>`).
+- Network fetch-and-exec or exfiltration — `curl <url>`,
+  `wget <url>` (only `--version` is allowed).
+- Destructive filesystem operations.
+- Env-prefixed commands (`env VAR=x cmd`) — tracked under GH-311.
+- The bare-verb catch-alls themselves (`Bash(git *)`, etc.).
+
+The upstream UI defect that generates the catch-all is tracked
+separately (GH-312); this allowlist is the defense-in-depth that
+keeps unattended sessions moving without it.
+
 ## References
 
 - [ADR-0003](../docs/adr/0003-allow-rules-as-hook-enablers.md) — decision record

--- a/skills/upgrade-cleanup/projects.yaml
+++ b/skills/upgrade-cleanup/projects.yaml
@@ -349,6 +349,116 @@ base_permissions:
   - "Bash(git master-rebase:*)"
   - "Bash(git autosquash-master:*)"
 
+  # --- Safe-by-default command catalog (GH-310) ---
+  # Goal: an unsupervised (adaptive / AFK) session must never stall on a
+  # permission prompt for a command that is safe to run. Every prompt is
+  # BOTH a hard stop for an unattended session AND the trigger for Claude
+  # Code's option-2 "Yes, and don't ask again" footgun, which writes a
+  # dangerous catch-all `Bash(<verb> *)` into the user's allow list.
+  #
+  # Why allow, not deny (GH-310): a `deny: Bash(git *)` does NOT neutralize
+  # the footgun — Claude Code evaluates deny -> ask -> allow and the first
+  # match wins, and `Bash(git *)` matches ALL `git <args>` (the space-star
+  # is a trailing wildcard). So a catch-all deny would also block
+  # `git status`, `git log`, etc. for every user. The only safe defense is
+  # to pre-approve the safe surface proactively, so the prompt never fires
+  # and option-2 never gets the chance.
+  #
+  # Boundary — deliberately NOT listed here (these keep prompting, route to
+  # a skill, or are forbidden by a hook): arbitrary code execution
+  # (`python -c`, `sh -c`, `bash -c`, `eval`, package runners like
+  # `npx <pkg>` / `pnpm dlx <pkg>` / `pipx run <pkg>` / `bunx <pkg>`),
+  # network fetch-and-exec or exfil (`curl <url>`, `wget <url>` beyond
+  # `--version`), destructive filesystem ops, env-prefixed commands
+  # (`env VAR=x cmd` — GH-311), and the bare-verb catch-alls themselves.
+
+  # Read-only filesystem & text inspection — never mutate state
+  - "Bash(ls:*)"
+  - "Bash(cat:*)"
+  - "Bash(head:*)"
+  - "Bash(tail:*)"
+  - "Bash(wc:*)"
+  - "Bash(tree:*)"
+  - "Bash(file:*)"
+  - "Bash(stat:*)"
+  - "Bash(du:*)"
+  - "Bash(df:*)"
+  - "Bash(pwd)"
+  - "Bash(realpath:*)"
+  - "Bash(readlink:*)"
+  - "Bash(basename:*)"
+  - "Bash(dirname:*)"
+  - "Bash(nl:*)"
+  - "Bash(grep:*)"
+  - "Bash(egrep:*)"
+  - "Bash(fgrep:*)"
+  - "Bash(rg:*)"
+  - "Bash(sort:*)"
+  - "Bash(uniq:*)"
+  - "Bash(cut:*)"
+  - "Bash(column:*)"
+  - "Bash(comm:*)"
+  - "Bash(diff:*)"
+  - "Bash(echo:*)"
+  - "Bash(printf:*)"
+  - "Bash(date:*)"
+
+  # Version / help info flags for the option-2 footgun verbs — always safe
+  - "Bash(git --version)"
+  - "Bash(gh --version)"
+  - "Bash(gh --help)"
+  - "Bash(bash --version)"
+  - "Bash(sh --version)"
+  - "Bash(uv --version)"
+  - "Bash(uvx --version)"
+  - "Bash(npx --version)"
+  - "Bash(npm --version)"
+  - "Bash(pnpm --version)"
+  - "Bash(pipx --version)"
+  - "Bash(bun --version)"
+  - "Bash(yarn --version)"
+  - "Bash(node --version)"
+  - "Bash(python --version)"
+  - "Bash(python3 --version)"
+  - "Bash(curl --version)"
+  - "Bash(wget --version)"
+  - "Bash(env --version)"
+  - "Bash(xargs --version)"
+  - "Bash(make --version)"
+
+  # git — read-only inspection (mutating git already covered above and
+  # routed to skills via the SkillRedirectValidator allow rules)
+  - "Bash(git show:*)"
+  - "Bash(git rev-parse:*)"
+  - "Bash(git describe:*)"
+  - "Bash(git ls-files:*)"
+  - "Bash(git ls-tree:*)"
+  - "Bash(git blame:*)"
+  - "Bash(git shortlog:*)"
+  - "Bash(git merge-base:*)"
+  - "Bash(git worktree list:*)"
+  - "Bash(git config --get:*)"
+  - "Bash(git config --list:*)"
+  - "Bash(git tag --list:*)"
+  - "Bash(git reflog:*)"
+  - "Bash(git cat-file:*)"
+  - "Bash(git rev-list:*)"
+  - "Bash(git for-each-ref:*)"
+
+  # gh — read-only inspection (mutating gh already covered above)
+  - "Bash(gh release view:*)"
+  - "Bash(gh release list:*)"
+  - "Bash(gh search:*)"
+  - "Bash(gh label list:*)"
+  - "Bash(gh workflow view:*)"
+  - "Bash(gh workflow list:*)"
+  - "Bash(gh cache list:*)"
+  - "Bash(gh pr status:*)"
+
+  # uv — read-only environment inspection (test/lint/run already covered)
+  - "Bash(uv pip list:*)"
+  - "Bash(uv tree:*)"
+
   # --- Dev10x skills ---
   - "Skill(Dev10x:*)"
 


### PR DESCRIPTION
**When** I run an unattended (adaptive / AFK) session, **I want to** have every safely-executable command pre-approved as a narrow allow rule, **so I can** let the session complete without stalling on a permission prompt — the same prompt that triggers Claude Code's option-2 catch-all footgun.

---

[`35f9c82c`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/324/commits/35f9c82cdf3ae96c5a03292e446f1a1de58822a0) ✨ GH-310 Prevent permission prompts from stalling unattended runs
Closes #310
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/310

---