### PR TITLE
✅ GH-247 Cover untested MCP tools and CLI shipping paths

### DIFF
--- a/tests/commands/test_playbook.py
+++ b/tests/commands/test_playbook.py
@@ -1,0 +1,170 @@
+"""CLI tests for ``dev10x playbook diff`` (GH-247 finding G8)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from dev10x.commands.playbook import playbook
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def plugin_root(tmp_path: Path) -> Path:
+    """Create a minimal plugin root with a ``work-on`` default playbook."""
+    skill_dir = tmp_path / "plugin" / "skills" / "work-on" / "references"
+    skill_dir.mkdir(parents=True)
+    default = {
+        "version": "1.0.0",
+        "defaults": {
+            "feature": {
+                "steps": [
+                    {"subject": "New upstream step", "type": "detailed"},
+                    {"subject": "Shared step", "type": "detailed", "prompt": "do it"},
+                    {
+                        "subject": "Changed step",
+                        "type": "detailed",
+                        "prompt": "updated prompt",
+                    },
+                ],
+            },
+        },
+    }
+    (skill_dir / "playbook.yaml").write_text(yaml.dump(default))
+    return tmp_path / "plugin"
+
+
+@pytest.fixture
+def project_root(tmp_path: Path) -> Path:
+    """Create a project directory with a ``work-on`` user override."""
+    override_dir = tmp_path / "project" / ".claude" / "Dev10x" / "playbooks"
+    override_dir.mkdir(parents=True)
+    user = {
+        "overrides": [
+            {
+                "play": "feature",
+                "steps": [
+                    # "New upstream step" is absent → will appear as (new)
+                    {"subject": "Shared step", "type": "detailed", "prompt": "do it"},
+                    {
+                        "subject": "Changed step",
+                        "type": "detailed",
+                        # user has customized prompt → customized (preserved)
+                        "prompt": "my custom prompt",
+                    },
+                    {"subject": "Removed user step", "type": "detailed"},
+                ],
+            }
+        ]
+    }
+    (override_dir / "work-on.yaml").write_text(yaml.dump(user))
+    return tmp_path / "project"
+
+
+@pytest.fixture
+def result(
+    plugin_root: Path,
+    project_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> object:
+    """Invoke ``playbook diff`` via CliRunner with isolated fixtures."""
+    monkeypatch.chdir(project_root)
+    runner = CliRunner()
+    return runner.invoke(
+        playbook,
+        ["diff", "--plugin-root", str(plugin_root)],
+        catch_exceptions=False,
+    )
+
+
+# ── TestPlaybookDiffCli ───────────────────────────────────────────────────────
+
+
+class TestPlaybookDiffCli:
+    """``dev10x playbook diff`` surfaces New/Removed/Changed/Customized in output."""
+
+    def test_exits_successfully(self, result: object) -> None:
+        assert result.exit_code == 0
+
+    def test_new_step_appears_in_output(self, result: object) -> None:
+        assert "(new)" in result.output
+
+    def test_removed_step_appears_in_output(self, result: object) -> None:
+        assert "(removed)" in result.output
+
+    def test_changed_step_appears_in_output(self, result: object) -> None:
+        assert "(changed)" in result.output
+
+    def test_customized_field_appears_in_output(self, result: object) -> None:
+        assert "customized" in result.output
+
+    def test_skill_key_appears_in_output(self, result: object) -> None:
+        assert "work-on" in result.output
+
+    def test_findings_summary_line_appears(self, result: object) -> None:
+        assert "override(s) have upstream changes worth reviewing" in result.output
+
+
+class TestPlaybookDiffCliNoOverrides:
+    """``dev10x playbook diff`` handles the case where no overrides are found."""
+
+    def test_prints_no_overrides_message(
+        self,
+        plugin_root: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        empty_project = tmp_path / "empty"
+        empty_project.mkdir()
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.chdir(empty_project)
+        monkeypatch.setenv("HOME", str(fake_home))
+        runner = CliRunner()
+        result = runner.invoke(
+            playbook,
+            ["diff", "--plugin-root", str(plugin_root)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert "No user playbook overrides found" in result.output
+
+
+class TestPlaybookDiffCliSkillFilter:
+    """``--skill`` flag limits the diff to the specified skill key."""
+
+    def test_skill_filter_matches_override(
+        self,
+        plugin_root: Path,
+        project_root: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.chdir(project_root)
+        runner = CliRunner()
+        result = runner.invoke(
+            playbook,
+            ["diff", "--plugin-root", str(plugin_root), "--skill", "work-on"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert "work-on" in result.output
+
+    def test_skill_filter_misses_when_no_match(
+        self,
+        plugin_root: Path,
+        project_root: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.chdir(project_root)
+        runner = CliRunner()
+        result = runner.invoke(
+            playbook,
+            ["diff", "--plugin-root", str(plugin_root), "--skill", "nonexistent-skill"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert "No user override found for skill" in result.output

--- a/tests/github/test_queries.py
+++ b/tests/github/test_queries.py
@@ -97,6 +97,39 @@ class TestPRStatusFromNode:
         assert status.merged_at is None
 
 
+class TestParseSingle:
+    def test_returns_status_when_node_present(self) -> None:
+        data = {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "number": 42,
+                        "title": "Fix bug",
+                        "state": "OPEN",
+                        "isDraft": False,
+                        "mergedAt": None,
+                        "headRefName": "feature/x",
+                        "baseRefName": "develop",
+                        "mergeable": "MERGEABLE",
+                        "reviewDecision": None,
+                        "url": "https://github.com/org/repo/pull/42",
+                    }
+                }
+            }
+        }
+        status = PRStatusQuery.parse_single(data=data)
+        assert status is not None
+        assert status.number == 42
+        assert status.title == "Fix bug"
+
+    def test_returns_none_when_pull_request_node_absent(self) -> None:
+        data: dict = {"data": {"repository": {}}}
+        assert PRStatusQuery.parse_single(data=data) is None
+
+    def test_returns_none_when_data_empty(self) -> None:
+        assert PRStatusQuery.parse_single(data={}) is None
+
+
 class TestParseBatch:
     def test_extracts_each_requested_pr(self) -> None:
         data = {

--- a/tests/hooks/test_session_start_hooks.py
+++ b/tests/hooks/test_session_start_hooks.py
@@ -206,6 +206,54 @@ class TestSessionInstallCheck:
         assert exc_info.value.code == 0
         assert capsys.readouterr().out == ""
 
+    def test_guides_upgrade_on_fresh_bootstrap_no_version_recorded(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Config dir present but version.yml absent — needs_upgrade fires with 'never applied'."""
+        from dev10x.domain.claude_paths import CLAUDE_HOME_ENV_VAR
+        from dev10x.domain.dev10x_paths import CONFIG_HOME_ENV_VAR, Dev10xConfigDir
+        from dev10x.hooks.session_dispatch import build_install_check_context
+
+        monkeypatch.setenv(CLAUDE_HOME_ENV_VAR, str(tmp_path))
+        monkeypatch.setenv(CONFIG_HOME_ENV_VAR, str(tmp_path / "config_dev10x"))
+        Dev10xConfigDir.reset_cache()
+        Dev10xConfigDir.home().mkdir(parents=True)
+
+        plugin_root = tmp_path / "plugin"
+        (plugin_root / ".claude-plugin").mkdir(parents=True)
+        (plugin_root / ".claude-plugin" / "plugin.json").write_text(
+            json.dumps({"version": "0.72.0"})
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+
+        ctx = build_install_check_context()
+
+        assert "0.72.0" in ctx
+        assert "never applied" in ctx
+        assert "/Dev10x:upgrade-cleanup" in ctx
+
+    def test_silent_when_plugin_version_unreadable(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Plugin manifest missing/unreadable — needs_upgrade short-circuits to False."""
+        from dev10x.domain.claude_paths import CLAUDE_HOME_ENV_VAR
+        from dev10x.domain.dev10x_paths import CONFIG_HOME_ENV_VAR, Dev10xConfigDir
+        from dev10x.domain.install_version import write_applied_version
+        from dev10x.hooks.session_dispatch import build_install_check_context
+
+        monkeypatch.setenv(CLAUDE_HOME_ENV_VAR, str(tmp_path))
+        monkeypatch.setenv(CONFIG_HOME_ENV_VAR, str(tmp_path / "config_dev10x"))
+        Dev10xConfigDir.reset_cache()
+        Dev10xConfigDir.home().mkdir(parents=True)
+        write_applied_version(plugin_version="0.71.0")
+
+        monkeypatch.setattr(
+            "dev10x.domain.install_version.read_plugin_version",
+            lambda **kwargs: None,
+        )
+
+        assert build_install_check_context() == ""
+
 
 class TestSessionGitAliases:
     def test_outputs_alias_status(self, runner: CliRunner) -> None:

--- a/tests/mcp/test_cli_server.py
+++ b/tests/mcp/test_cli_server.py
@@ -1414,3 +1414,238 @@ class TestCwdParameterActivation:
                 pass
 
         mock_use_cwd.assert_called_once_with(str(tmp_path))
+
+
+# ── GH-247 G1: four untested delegation handlers ─────────────────
+
+
+class TestPrIssueComment:
+    @pytest.mark.asyncio
+    @patch("dev10x.github.pr_issue_comment", new_callable=AsyncMock)
+    async def test_delegates_to_github_module(
+        self,
+        mock_fn: AsyncMock,
+    ) -> None:
+        mock_fn.return_value = ok({"id": 1, "body": "hello", "created_at": "2026-01-01"})
+
+        result = await cli_server.pr_issue_comment(
+            pr_number=42,
+            body="hello",
+            repo="o/r",
+        )
+
+        assert result == {"id": 1, "body": "hello", "created_at": "2026-01-01"}
+        assert mock_fn.call_args.kwargs == {
+            "pr_number": 42,
+            "body": "hello",
+            "repo": "o/r",
+        }
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.pr_issue_comment", new_callable=AsyncMock)
+    async def test_returns_error_on_failure(
+        self,
+        mock_fn: AsyncMock,
+    ) -> None:
+        mock_fn.return_value = err("Not Found")
+
+        result = await cli_server.pr_issue_comment(pr_number=99, body="x")
+
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.pr_issue_comment", new_callable=AsyncMock)
+    async def test_forwards_repo_none_when_omitted(
+        self,
+        mock_fn: AsyncMock,
+    ) -> None:
+        mock_fn.return_value = ok({"id": 2, "body": "y", "created_at": "2026-01-01"})
+
+        await cli_server.pr_issue_comment(pr_number=1, body="y")
+
+        assert mock_fn.call_args.kwargs["repo"] is None
+
+
+class TestMinimizeComments:
+    @pytest.mark.asyncio
+    @patch("dev10x.github.minimize_comments", new_callable=AsyncMock)
+    async def test_delegates_to_github_module(
+        self,
+        mock_fn: AsyncMock,
+    ) -> None:
+        mock_fn.return_value = ok({"m0": {"isMinimized": True}})
+
+        result = await cli_server.minimize_comments(
+            node_ids=["PRRC_abc"],
+            classifier="RESOLVED",
+            repo="o/r",
+        )
+
+        assert result == {"m0": {"isMinimized": True}}
+        assert mock_fn.call_args.kwargs == {
+            "node_ids": ["PRRC_abc"],
+            "classifier": "RESOLVED",
+            "repo": "o/r",
+        }
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.minimize_comments", new_callable=AsyncMock)
+    async def test_returns_error_on_failure(
+        self,
+        mock_fn: AsyncMock,
+    ) -> None:
+        mock_fn.return_value = err("GraphQL error")
+
+        result = await cli_server.minimize_comments(node_ids=["PRRC_bad"])
+
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.minimize_comments", new_callable=AsyncMock)
+    async def test_forwards_default_classifier_outdated(
+        self,
+        mock_fn: AsyncMock,
+    ) -> None:
+        mock_fn.return_value = ok({"m0": {"isMinimized": True}})
+
+        await cli_server.minimize_comments(node_ids=["PRRC_x"])
+
+        assert mock_fn.call_args.kwargs["classifier"] == "OUTDATED"
+
+
+class TestRequestReview:
+    @pytest.mark.asyncio
+    @patch("dev10x.github.request_review", new_callable=AsyncMock)
+    async def test_delegates_to_github_module(
+        self,
+        mock_fn: AsyncMock,
+    ) -> None:
+        mock_fn.return_value = ok({"requested_reviewers": ["alice"]})
+
+        result = await cli_server.request_review(
+            pr_number=42,
+            reviewers=["alice"],
+            team=False,
+            repo="o/r",
+        )
+
+        assert result == {"requested_reviewers": ["alice"]}
+        assert mock_fn.call_args.kwargs == {
+            "pr_number": 42,
+            "reviewers": ["alice"],
+            "team": False,
+            "repo": "o/r",
+        }
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.request_review", new_callable=AsyncMock)
+    async def test_returns_error_on_failure(
+        self,
+        mock_fn: AsyncMock,
+    ) -> None:
+        mock_fn.return_value = err("Not Found")
+
+        result = await cli_server.request_review(pr_number=99, reviewers=["x"])
+
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.request_review", new_callable=AsyncMock)
+    async def test_forwards_team_none_when_omitted(
+        self,
+        mock_fn: AsyncMock,
+    ) -> None:
+        mock_fn.return_value = ok({"requested_reviewers": ["bob"]})
+
+        await cli_server.request_review(pr_number=1, reviewers=["bob"])
+
+        assert mock_fn.call_args.kwargs["team"] is None
+
+
+class TestResolveReviewThread:
+    @pytest.mark.asyncio
+    @patch("dev10x.github.resolve_review_thread", new_callable=AsyncMock)
+    async def test_delegates_to_github_module(
+        self,
+        mock_fn: AsyncMock,
+    ) -> None:
+        mock_fn.return_value = ok({"t0": {"isResolved": True}})
+
+        result = await cli_server.resolve_review_thread(
+            thread_ids=["PRRT_abc"],
+            comment_ids=None,
+            repo="o/r",
+        )
+
+        assert result == {"t0": {"isResolved": True}}
+        assert mock_fn.call_args.kwargs == {
+            "thread_ids": ["PRRT_abc"],
+            "comment_ids": None,
+            "repo": "o/r",
+        }
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.resolve_review_thread", new_callable=AsyncMock)
+    async def test_returns_error_on_failure(
+        self,
+        mock_fn: AsyncMock,
+    ) -> None:
+        mock_fn.return_value = err("GraphQL error")
+
+        result = await cli_server.resolve_review_thread(thread_ids=["PRRT_bad"])
+
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.resolve_review_thread", new_callable=AsyncMock)
+    async def test_accepts_comment_ids_instead_of_thread_ids(
+        self,
+        mock_fn: AsyncMock,
+    ) -> None:
+        mock_fn.return_value = ok({"t0": {"isResolved": True}})
+
+        await cli_server.resolve_review_thread(
+            comment_ids=["PRRC_xyz"],
+            repo="o/r",
+        )
+
+        assert mock_fn.call_args.kwargs["comment_ids"] == ["PRRC_xyz"]
+        assert mock_fn.call_args.kwargs["thread_ids"] is None
+
+
+# ── GH-247 G9: issue_create label forwarding ─────────────────────
+
+
+class TestIssueCreateLabelForwarding:
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run_script", new_callable=AsyncMock)
+    async def test_forwards_each_label_with_repeated_flag(
+        self,
+        mock_run: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(
+            stdout='{"number":1,"title":"t","url":"https://github.com/o/r/issues/1"}',
+        )
+
+        await cli_server.issue_create(title="t", labels=["bug", "urgent"])
+
+        call_args = list(mock_run.call_args[0])
+        label_indices = [i for i, v in enumerate(call_args) if v == "--label"]
+        assert len(label_indices) == 2
+        assert call_args[label_indices[0] + 1] == "bug"
+        assert call_args[label_indices[1] + 1] == "urgent"
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run_script", new_callable=AsyncMock)
+    async def test_no_label_flag_when_labels_omitted(
+        self,
+        mock_run: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(
+            stdout='{"number":2,"title":"t","url":"https://github.com/o/r/issues/2"}',
+        )
+
+        await cli_server.issue_create(title="t")
+
+        call_args = list(mock_run.call_args[0])
+        assert "--label" not in call_args

--- a/tests/skills/diag-friction/test_smoke.py
+++ b/tests/skills/diag-friction/test_smoke.py
@@ -1,0 +1,313 @@
+"""End-to-end smoke tests integrating SKILL.md orchestration with the
+diag-friction analyzers (GH-247 finding G7).
+
+Coverage goal: verify that the two runtime data sources the skill reads
+during Step 2 and Step 3c-pre are internally consistent and route
+representative friction-causing commands to the documented skills/tools
+exactly as the SKILL.md orchestration prescribes.
+
+What is NOT covered here (already covered in other suites):
+- cli_friction.scan_file / scan_paths / find_target_files   → test_cli_friction.py
+- structured-alternatives KB schema validation              → test_structured_alternatives.py
+
+What IS added here:
+- Command-skill-map.yaml: prefix-match routing (Step 2) for canonical
+  friction commands → expected skill / tool
+- Inline-code path (Step 3c-pre): end-to-end prefix detection +
+  keyword-match → structured-tool recommendation
+- META_DOC_SKILLS exemption: diag-friction's own SKILL.md is exempt from
+  the cli-friction scanner (it quotes bad commands deliberately)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml", reason="pyyaml not installed")
+
+from dev10x.skills.audit import cli_friction as cli_friction_mod  # noqa: E402
+
+# ── Paths to canonical data files ────────────────────────────────────────────
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MAP_PATH = _REPO_ROOT / "src" / "dev10x" / "validators" / "command-skill-map.yaml"
+_SA_PATH = _REPO_ROOT / "skills" / "diag-friction" / "references" / "structured-alternatives.yaml"
+_SKILL_MD_PATH = _REPO_ROOT / "skills" / "diag-friction" / "SKILL.md"
+
+
+# ── Shared fixtures ───────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def command_map() -> dict:
+    return yaml.safe_load(_MAP_PATH.read_text())
+
+
+@pytest.fixture(scope="module")
+def sa_kb() -> dict:
+    return yaml.safe_load(_SA_PATH.read_text())
+
+
+# ── Helpers that replicate the SKILL.md matching algorithms ──────────────────
+
+
+def _match_command_to_rule(command: str, rules: list[dict]) -> dict | None:
+    """Replicate the Step 2 prefix-match algorithm documented in SKILL.md.
+
+    "Match the identified command against the patterns list in each mapping
+    entry.  Use prefix matching — if the command starts with any pattern in
+    the list, it matches that entry."
+
+    Returns the first matching rule dict, or None when no rule matches.
+    """
+    for rule in rules:
+        if rule.get("matcher") != "Bash":
+            continue
+        for pattern in rule.get("patterns", []):
+            if command.startswith(pattern):
+                return rule
+    return None
+
+
+def _match_inline_code_keyword(body: str, alternatives: list[dict]) -> str | None:
+    """Replicate the Step 3c-pre keyword-match algorithm.
+
+    "Match the body against each entry's detection_keywords (substring match;
+    first hit wins)."
+
+    Returns the matched tool string, or the fallback tool when no keyword
+    matches.
+    """
+    for entry in alternatives:
+        for keyword in entry["detection_keywords"]:
+            if keyword in body:
+                return entry["tool"]
+    # Fallback: empty detection_keywords entry
+    for entry in alternatives:
+        if entry["detection_keywords"] == []:
+            return entry["tool"]
+    return None
+
+
+# ── Step 2: command-skill-map routing (representative friction commands) ──────
+
+
+class TestCommandSkillMapRouting:
+    """Step 2 prefix-match routes friction commands to the documented skill/tool.
+
+    Each scenario drives the same algorithm the skill uses at runtime so a
+    map regression (entry deleted, pattern renamed) surfaces here immediately.
+    """
+
+    @pytest.mark.parametrize(
+        ("command", "expected_compensation_type", "expected_target"),
+        [
+            # Bash hard-block rules → use-skill
+            ("git commit -m 'Enable X'", "use-skill", "Dev10x:git-commit"),
+            ("gh pr create --title 'Enable X'", "use-skill", "Dev10x:gh-pr-create"),
+            ("gh pr merge --squash", "use-skill", "Dev10x:gh-pr-merge"),
+            ("git push origin feature-branch", "use-skill", "Dev10x:git"),
+            ("git rebase -i develop", "use-skill", "Dev10x:git-groom"),
+            ("gh pr checks --watch", "use-skill", "Dev10x:gh-pr-monitor"),
+            # Bash hard-block rules → use-tool
+            ("gh pr view 42", "use-tool", "mcp__plugin_Dev10x_cli__pr_get"),
+            ("gh issue close 123", "use-tool", "mcp__plugin_Dev10x_cli__issue_close"),
+            ("gh issue reopen 99", "use-tool", "mcp__plugin_Dev10x_cli__issue_reopen"),
+            ("gh issue view 7", "use-tool", "mcp__plugin_Dev10x_cli__issue_get"),
+            (
+                "gh issue create --title x",
+                "use-tool",
+                "mcp__plugin_Dev10x_cli__issue_create",
+            ),
+            ("gh pr edit --title y", "use-tool", "mcp__plugin_Dev10x_cli__update_pr"),
+            (
+                "gh issue edit 5 --title z",
+                "use-tool",
+                "mcp__plugin_Dev10x_cli__issue_edit",
+            ),
+            (
+                "gh issue comment 3 --body hi",
+                "use-tool",
+                "mcp__plugin_Dev10x_cli__issue_comment",
+            ),
+        ],
+    )
+    def test_command_routes_to_expected_target(
+        self,
+        command: str,
+        expected_compensation_type: str,
+        expected_target: str,
+        command_map: dict,
+    ) -> None:
+        rules = command_map["rules"]
+        matched_rule = _match_command_to_rule(command=command, rules=rules)
+
+        assert matched_rule is not None, (
+            f"Command {command!r} matched no rule — map entry may be missing or renamed"
+        )
+
+        compensations = matched_rule.get("compensations", [])
+        assert compensations, f"Rule {matched_rule['name']!r} has no compensations"
+
+        # First compensation is documented as the recommended path
+        first = compensations[0]
+        assert first["type"] == expected_compensation_type, (
+            f"Rule {matched_rule['name']!r}: expected type {expected_compensation_type!r}, "
+            f"got {first['type']!r}"
+        )
+
+        target_key = "skill" if expected_compensation_type == "use-skill" else "tool"
+        assert first[target_key] == expected_target, (
+            f"Rule {matched_rule['name']!r}: expected {target_key}={expected_target!r}, "
+            f"got {first.get(target_key)!r}"
+        )
+
+    def test_unrecognised_command_returns_no_match(self, command_map: dict) -> None:
+        """Step 2 falls through to Step 3 when no rule matches."""
+        rules = command_map["rules"]
+        result = _match_command_to_rule(
+            command="some-totally-unknown-cli-tool --flag",
+            rules=rules,
+        )
+        assert result is None
+
+    def test_map_has_config_and_rules_sections(self, command_map: dict) -> None:
+        assert "config" in command_map, "command-skill-map.yaml missing 'config' section"
+        assert "rules" in command_map, "command-skill-map.yaml missing 'rules' section"
+        assert isinstance(command_map["rules"], list)
+        assert len(command_map["rules"]) > 0
+
+    def test_every_bash_rule_has_name_patterns_compensations(self, command_map: dict) -> None:
+        for rule in command_map["rules"]:
+            if rule.get("matcher") != "Bash":
+                continue
+            assert "name" in rule, f"Bash rule missing 'name': {rule}"
+            assert "patterns" in rule, f"Rule {rule['name']!r} missing 'patterns'"
+            assert isinstance(rule["patterns"], list) and rule["patterns"]
+            assert "compensations" in rule, f"Rule {rule['name']!r} missing 'compensations'"
+            assert rule["compensations"], f"Rule {rule['name']!r} has empty compensations"
+
+
+# ── Step 3c-pre: inline-code → structured-alternative routing ────────────────
+
+
+class TestInlineCodeStructuredAlternativeRouting:
+    """Step 3c-pre: prefix detection + keyword-match → structured tool.
+
+    End-to-end path: command starts with an inline-code prefix (Step 3c-pre
+    guard), then the body is keyword-matched to the canonical tool.
+    """
+
+    @pytest.mark.parametrize(
+        ("command", "expected_tool"),
+        [
+            # Each command must (a) begin with an inline-code prefix,
+            # (b) have a body whose keywords match a KB entry.
+            (
+                "python3 -c \"import json; json.loads(open('x.json').read())\"",
+                "jq",
+            ),
+            (
+                "python -c \"import yaml; yaml.safe_load(open('x.yml'))\"",
+                "yq",
+            ),
+            (
+                "sh -c \"import requests; requests.get('https://api.example.com/data')\"",
+                "curl",
+            ),
+            (
+                "node -e \"const d = JSON.parse(fs.readFileSync('x.json'))\"",
+                "jq",
+            ),
+            (
+                "bash -c \"import tomllib; tomllib.loads(open('p.toml').read())\"",
+                "tomlq",
+            ),
+        ],
+    )
+    def test_inline_command_surfaces_structured_alternative(
+        self,
+        command: str,
+        expected_tool: str,
+        sa_kb: dict,
+    ) -> None:
+        prefixes: list[str] = sa_kb["inline_code_prefixes"]
+        alternatives: list[dict] = sa_kb["alternatives"]
+
+        # Guard: command starts with a recognised inline-code prefix
+        matched_prefix = next(
+            (p for p in prefixes if command.startswith(p)),
+            None,
+        )
+        assert matched_prefix is not None, (
+            f"Command {command!r} did not start with any inline_code_prefix — "
+            f"test setup error or KB prefix missing"
+        )
+
+        # Extract body (everything after the prefix)
+        body = command[len(matched_prefix) :].strip().strip("\"'")
+
+        matched_tool = _match_inline_code_keyword(body=body, alternatives=alternatives)
+        assert matched_tool == expected_tool, (
+            f"Command {command!r}: expected tool {expected_tool!r}, got {matched_tool!r}"
+        )
+
+    def test_unrecognised_body_falls_back_to_tools_extraction(self, sa_kb: dict) -> None:
+        """Fallback entry ensures no command is left without a recommendation."""
+        body = "completely_unknown_bespoke_function_xyz()"
+        result = _match_inline_code_keyword(
+            body=body,
+            alternatives=sa_kb["alternatives"],
+        )
+        assert result is not None
+        assert "tools" in result or "~/.claude" in result
+
+
+# ── META_DOC_SKILLS exemption: diag-friction SKILL.md itself ─────────────────
+
+
+class TestDiagFrictionSkillMdExemption:
+    """The diag-friction SKILL.md is exempt from the cli-friction scanner.
+
+    The skill quotes raw CLI commands back to the agent as cautionary
+    examples.  cli_friction.META_DOC_SKILLS must include 'diag-friction'
+    so the scanner does not flag these intentional quotes.
+    """
+
+    def test_diag_friction_in_meta_doc_skills(self) -> None:
+        assert "diag-friction" in cli_friction_mod.META_DOC_SKILLS
+
+    def test_skill_md_produces_no_violations(self) -> None:
+        assert _SKILL_MD_PATH.is_file(), f"SKILL.md missing at {_SKILL_MD_PATH}"
+        violations = cli_friction_mod.scan_file(path=_SKILL_MD_PATH)
+        assert violations == [], (
+            "diag-friction SKILL.md should be exempt from cli-friction scanner — "
+            f"unexpected violations: {[v.format() for v in violations]}"
+        )
+
+    def test_meta_doc_skills_exemption_covers_raw_command_rules(self) -> None:
+        """Rules that scan for raw CLI commands must exempt META_DOC_SKILLS.
+
+        'no-verify' is deliberately global (no exemptions) — that rule is
+        about --no-verify in commits, not quoting bad commands.  All other
+        rules that scan for raw gh/git/pytest commands must include
+        'diag-friction' so the skill can quote those commands as examples.
+        """
+        rules_requiring_exemption = {
+            "raw-gh-pr",
+            "raw-gh-issue",
+            "raw-gh-api",
+            "raw-gh-repo",
+            "raw-git-commit",
+            "raw-git-push",
+            "raw-git-rebase",
+            "raw-git-branch",
+            "raw-pytest",
+        }
+        for rule_id in rules_requiring_exemption:
+            exempt_set = cli_friction_mod.SKILL_EXEMPTIONS.get(rule_id, frozenset())
+            assert "diag-friction" in exempt_set, (
+                f"Rule {rule_id!r} does not exempt 'diag-friction' via META_DOC_SKILLS"
+            )

--- a/tests/validators/test_command_skill_map.py
+++ b/tests/validators/test_command_skill_map.py
@@ -1,0 +1,102 @@
+"""Schema validation tests for command-skill-map.yaml.
+
+Asserts that every rule entry contains the required fields and that
+every hook-block rule has at least one compensation entry.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+_YAML_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "src"
+    / "dev10x"
+    / "validators"
+    / "command-skill-map.yaml"
+)
+
+_REQUIRED_RULE_FIELDS: frozenset[str] = frozenset(
+    {"name", "hook_block", "compensations", "reason"}
+)
+
+
+def _load_rules() -> list[dict[str, Any]]:
+    data: dict[str, Any] = yaml.safe_load(_YAML_PATH.read_text()) or {}
+    return data.get("rules", [])
+
+
+def _hook_block_rules() -> list[dict[str, Any]]:
+    return [r for r in _load_rules() if r.get("hook_block") is True]
+
+
+def _all_rule_ids() -> list[str]:
+    return [r.get("name", f"<unnamed-{i}>") for i, r in enumerate(_load_rules())]
+
+
+def _hook_block_rule_ids() -> list[str]:
+    return [r.get("name", f"<unnamed-{i}>") for i, r in enumerate(_hook_block_rules())]
+
+
+class TestYamlFileAccessible:
+    def test_yaml_file_exists(self) -> None:
+        assert _YAML_PATH.exists(), f"YAML not found at {_YAML_PATH}"
+
+    def test_yaml_parses_without_error(self) -> None:
+        data = yaml.safe_load(_YAML_PATH.read_text())
+        assert isinstance(data, dict)
+
+    def test_rules_list_is_non_empty(self) -> None:
+        rules = _load_rules()
+        assert len(rules) > 0
+
+
+class TestRequiredFields:
+    @pytest.mark.parametrize("rule_name", _all_rule_ids())
+    def test_rule_has_name(self, rule_name: str) -> None:
+        rules = {r.get("name", f"<unnamed-{i}>"): r for i, r in enumerate(_load_rules())}
+        rule = rules[rule_name]
+        assert "name" in rule, f"Rule {rule_name!r} is missing 'name'"
+
+    @pytest.mark.parametrize("rule_name", _all_rule_ids())
+    def test_rule_has_hook_block(self, rule_name: str) -> None:
+        rules = {r.get("name", f"<unnamed-{i}>"): r for i, r in enumerate(_load_rules())}
+        rule = rules[rule_name]
+        assert "hook_block" in rule, f"Rule {rule_name!r} is missing 'hook_block'"
+
+    @pytest.mark.parametrize("rule_name", _all_rule_ids())
+    def test_rule_has_compensations(self, rule_name: str) -> None:
+        rules = {r.get("name", f"<unnamed-{i}>"): r for i, r in enumerate(_load_rules())}
+        rule = rules[rule_name]
+        assert "compensations" in rule, f"Rule {rule_name!r} is missing 'compensations'"
+
+    @pytest.mark.parametrize("rule_name", _all_rule_ids())
+    def test_rule_has_reason(self, rule_name: str) -> None:
+        rules = {r.get("name", f"<unnamed-{i}>"): r for i, r in enumerate(_load_rules())}
+        rule = rules[rule_name]
+        assert "reason" in rule, f"Rule {rule_name!r} is missing 'reason'"
+
+
+class TestHookBlockCompensations:
+    @pytest.mark.parametrize("rule_name", _hook_block_rule_ids())
+    def test_hook_block_rule_has_non_empty_compensations(self, rule_name: str) -> None:
+        rules = {r.get("name", f"<unnamed-{i}>"): r for i, r in enumerate(_hook_block_rules())}
+        rule = rules[rule_name]
+        compensations = rule.get("compensations", [])
+        assert isinstance(compensations, list), (
+            f"Rule {rule_name!r} 'compensations' must be a list"
+        )
+        assert len(compensations) > 0, (
+            f"Hook-block rule {rule_name!r} must have at least one compensation"
+        )
+
+    @pytest.mark.parametrize("rule_name", _hook_block_rule_ids())
+    def test_hook_block_compensation_has_type(self, rule_name: str) -> None:
+        rules = {r.get("name", f"<unnamed-{i}>"): r for i, r in enumerate(_hook_block_rules())}
+        rule = rules[rule_name]
+        for idx, comp in enumerate(rule.get("compensations", [])):
+            assert "type" in comp, f"Rule {rule_name!r} compensation[{idx}] is missing 'type'"


### PR DESCRIPTION
**When** a recently-shipped MCP handler or CLI path changes, **I want to** have regression tests guarding it, **so I can** trust that PR comments, review requests, thread resolution, install-check, playbook diff, and config schemas keep working without manual re-verification.

---

[`5a72bbc7`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/325/commits/5a72bbc74b82ec16a28729035b7e4d8862b99c38) ✅ GH-247 Cover untested MCP tools and CLI shipping paths
Closes #247
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/247

---