### PR TITLE
♻️ GH-245 Ensure subprocess calls honor the caller's worktree

### DIFF
--- a/.claude/rules/INDEX.md
+++ b/.claude/rules/INDEX.md
@@ -51,6 +51,7 @@ The code review system uses a **multi-agent architecture**:
 | `.claude/rules/github-workflows.md` | When editing `.github/workflows/**` | GitHub Actions patterns |
 | `.claude/rules/hook-state-schema.md` | When editing `hooks/**` state writers | Hook JSON state documentation |
 | `.claude/rules/hook-patterns.md` | When editing `hooks/**` with dual implementations | Python-shell hook equivalence |
+| `.claude/rules/cwd-discipline.md` | When editing `src/dev10x/**` Python that runs subprocesses or reads CWD | GH-979 effective-CWD routing, no module-scope GitContext |
 | `.claude/rules/performance.md` | Reference: post-dependency change monitoring | CLI startup baseline, profiling instructions |
 | `.claude/rules/skill-body-extraction.md` | When editing `skills/**` | SKILL.md body extraction pattern, token reduction |
 | `.claude/rules/agent-body-extraction.md` | When editing `agents/**` | Agent spec body extraction pattern, token reduction |

--- a/.claude/rules/cwd-discipline.md
+++ b/.claude/rules/cwd-discipline.md
@@ -1,0 +1,36 @@
+# CWD Discipline (GH-979)
+
+In-process package code must respect the caller's effective working
+directory. MCP server processes are long-lived and inherit the CWD they
+were spawned in, so direct CWD access silently targets the wrong root
+after `EnterWorktree`.
+
+## Rules
+
+- **Subprocess**: never call `subprocess.run(...)` directly. Use
+  `subprocess_utils.run(...)` (sync), `async_run(...)` /
+  `async_run_script(...)` (async), or `GitContext()` for git. All default
+  `cwd` to the bound effective CWD.
+- **Working directory**: never call `os.getcwd()` bare. Use
+  `subprocess_utils.effective_cwd() or os.getcwd()` so a bound worktree
+  wins and the process CWD remains the fallback.
+- **No module-level `GitContext()`**: a module singleton caches the
+  first-call toplevel permanently. Construct a fresh `GitContext()` per
+  call (or `lambda: GitContext().toplevel`). Enforced by
+  `tests/test_no_module_scope_gitcontext.py`.
+
+## Standalone uv-script exception
+
+Standalone uv-scripts (PEP 723 shebang, `dependencies = [...]`) run in
+fresh isolated processes that cannot import `dev10x`, so their CWD is
+already correct — leave them on `os.getcwd()` / `subprocess.run`. When
+such a script is *also* imported as a module (dual-use, e.g.
+`skills/audit/analyze_permissions.py` imported by `audit/analyze.py`),
+apply the effective-CWD fallback at the importing package seam, not
+inside the script.
+
+## Enforcement
+
+`tests/test_cwd_enforcement.py` checks MCP handlers with a `cwd`
+parameter bind it; `tests/test_no_module_scope_gitcontext.py` checks no
+module-scope `GitContext()` exists.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,13 @@ invoke the skill without approving tool access each time. See
 - **Shell scripts**: shellcheck, `set -e`, POSIX-compatible where possible
 - **Markdown**: one sentence per line, 80-char soft wrap
 
+### CWD Discipline (GH-979)
+
+Route subprocess/CWD access through `subprocess_utils` (`run`,
+`async_run`, `effective_cwd()`) and `GitContext()` — never bare
+`subprocess.run` / `os.getcwd()` / module-scope `GitContext()`. Standalone
+uv-scripts are exempt. Full rules: `.claude/rules/cwd-discipline.md`.
+
 ## Skill Naming Convention
 
 - **Directory name**: plain feature name — `git-worktree/`, `skill-audit/`

--- a/src/dev10x/audit/analyze.py
+++ b/src/dev10x/audit/analyze.py
@@ -34,6 +34,7 @@ from dev10x.skills.audit.analyze_permissions import (
 from dev10x.skills.audit.analyze_permissions import (
     analyze_permissions as _analyze_permissions,
 )
+from dev10x.subprocess_utils import effective_cwd
 
 
 @dataclass
@@ -77,10 +78,15 @@ def build_audit_report(
     findings = _analyze_permissions(calls=calls, rules=rules)
     findings = count_nuisance_patterns(findings=findings)
 
+    # GH-979 (H6): analyze_permissions is a deps-less standalone uv-script
+    # that cannot import dev10x, so the effective-CWD fallback lands here at
+    # the importing seam. When an MCP caller bound the worktree via use_cwd,
+    # default the project root to it; standalone CLI callers pass None and
+    # detect_known_friction falls back to os.getcwd() as before.
     extra = detect_known_friction(
         calls=calls,
         additional_dirs=additional_dirs,
-        project_root=project_root,
+        project_root=project_root if project_root is not None else effective_cwd(),
     )
     base_count = len(findings)
     for offset, finding in enumerate(extra, start=1):

--- a/src/dev10x/domain/events/hook_input.py
+++ b/src/dev10x/domain/events/hook_input.py
@@ -6,6 +6,8 @@ import sys
 from dataclasses import dataclass
 from typing import Any, NoReturn
 
+from dev10x.subprocess_utils import effective_cwd
+
 
 @dataclass(frozen=True)
 class HookInput:
@@ -24,7 +26,7 @@ class HookInput:
             tool_name=data.get("tool_name", ""),
             command=data.get("tool_input", {}).get("command", ""),
             raw=data,
-            cwd=os.getcwd(),
+            cwd=effective_cwd() or os.getcwd(),
         )
 
     @classmethod

--- a/src/dev10x/hooks/permission_diagnostics.py
+++ b/src/dev10x/hooks/permission_diagnostics.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import Any
 
 from dev10x.domain.claude_paths import ClaudeDir
+from dev10x.subprocess_utils import effective_cwd
 
 
 @dataclass(frozen=True)
@@ -199,7 +200,7 @@ def diagnose(raw: dict[str, Any], *, cwd: str = "") -> DiagnosticResult | None:
         return None
 
     if not cwd:
-        cwd = os.getcwd()
+        cwd = effective_cwd() or os.getcwd()
 
     settings_files = _resolve_settings_files(cwd=cwd)
     matches: list[RuleMatch] = []

--- a/src/dev10x/hooks/session_dispatch.py
+++ b/src/dev10x/hooks/session_dispatch.py
@@ -35,10 +35,10 @@ from dev10x.session.queries import (
     format_reload_context,
 )
 
-_git = GitContext()
-
 
 def _get_toplevel() -> str | None:
+    # GH-979 (H11): fresh GitContext per call — no module-level singleton,
+    # which would pin the first-call CWD across MCP invocations.
     return GitContext().toplevel
 
 

--- a/src/dev10x/hooks/skill.py
+++ b/src/dev10x/hooks/skill.py
@@ -9,20 +9,21 @@ from __future__ import annotations
 
 import hashlib
 import json
-import subprocess
 import sys
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+from dev10x import subprocess_utils
 from dev10x.domain.claude_paths import ClaudeDir
 from dev10x.domain.common.skill_name import SkillName
 from dev10x.domain.git_context import GitContext
 
-_git = GitContext()
-
 
 def _get_toplevel() -> str:
-    return _git.toplevel or "unknown"
+    # GH-979 (H11): construct a fresh GitContext per call so each lookup
+    # respects the current effective CWD. A module-level singleton would
+    # cache the first-call directory permanently across MCP invocations.
+    return GitContext().toplevel or "unknown"
 
 
 def _load_stdin() -> dict:
@@ -98,5 +99,5 @@ def ruff_format(data: dict | None = None) -> None:
     if path.suffix != ".py" or not path.is_file():
         sys.exit(0)
 
-    subprocess.run(["ruff", "format", file_path], check=False)
-    subprocess.run(["ruff", "check", "--fix", file_path], check=False)
+    subprocess_utils.run(["ruff", "format", file_path], check=False)
+    subprocess_utils.run(["ruff", "check", "--fix", file_path], check=False)

--- a/src/dev10x/skills/permission/doctor.py
+++ b/src/dev10x/skills/permission/doctor.py
@@ -32,6 +32,8 @@ from pathlib import Path
 
 import yaml
 
+from dev10x import subprocess_utils
+
 PLUGIN_NAMES = r"(?:Dev10x|dev10x-claude)"
 
 PINNED_VERSION_RE = re.compile(
@@ -158,7 +160,7 @@ class WorkspaceContext:
 def detect_workspace(cwd: Path) -> WorkspaceContext:
     """Detect project root and (if worktree) source repo via git."""
     try:
-        toplevel = subprocess.run(
+        toplevel = subprocess_utils.run(
             ["git", "rev-parse", "--show-toplevel"],
             cwd=cwd,
             capture_output=True,
@@ -168,7 +170,7 @@ def detect_workspace(cwd: Path) -> WorkspaceContext:
     except (subprocess.CalledProcessError, FileNotFoundError):
         return WorkspaceContext(project_root=cwd)
     try:
-        common_dir = subprocess.run(
+        common_dir = subprocess_utils.run(
             ["git", "rev-parse", "--git-common-dir"],
             cwd=cwd,
             capture_output=True,

--- a/src/dev10x/subprocess_utils.py
+++ b/src/dev10x/subprocess_utils.py
@@ -108,6 +108,29 @@ def resolve_script_path(script_path: str) -> Path:
     return get_plugin_root() / script_path
 
 
+def run(
+    args: list[str],
+    *,
+    cwd: str | None = None,
+    **kwargs: Any,
+) -> subprocess.CompletedProcess[str]:
+    """Synchronous subprocess.run that routes `cwd` to the effective CWD.
+
+    The single sync chokepoint for invoking external binaries (git, gh,
+    ruff, ...) from in-process code. When `cwd` is None it falls back to
+    the effective-CWD ContextVar bound by `use_cwd` (GH-979), so calls made
+    inside a long-lived MCP server hit the caller's worktree instead of the
+    server's startup directory. All other `subprocess.run` keyword arguments
+    (`capture_output`, `text`, `check`, `env`, `timeout`, ...) pass through
+    unchanged.
+    """
+    return subprocess.run(
+        args,
+        cwd=cwd if cwd is not None else _effective_cwd.get(),
+        **kwargs,
+    )
+
+
 def run_script(
     script_path: str,
     *args: str,

--- a/src/dev10x/validators/pr_base.py
+++ b/src/dev10x/validators/pr_base.py
@@ -10,10 +10,10 @@ main > master > trunk). Allows --force to bypass.
 from __future__ import annotations
 
 import re
-import subprocess
 from dataclasses import dataclass
 from typing import ClassVar
 
+from dev10x import subprocess_utils
 from dev10x.domain import HookInput, HookResult
 from dev10x.domain.profile_tier import ProfileTier
 from dev10x.validators.base import ValidatorBase
@@ -25,7 +25,7 @@ BRANCH_CANDIDATES = ["develop", "development", "main", "master", "trunk"]
 
 def _detect_base_branch() -> str | None:
     for candidate in BRANCH_CANDIDATES:
-        result = subprocess.run(
+        result = subprocess_utils.run(
             ["git", "rev-parse", "--verify", f"origin/{candidate}"],
             capture_output=True,
             text=True,

--- a/tests/test_cwd_discipline_sweep.py
+++ b/tests/test_cwd_discipline_sweep.py
@@ -1,0 +1,162 @@
+"""Acceptance tests for the GH-979 CWD discipline sweep (GH-245).
+
+Each touched module must resolve its working directory through
+`subprocess_utils.effective_cwd()` when a worktree is bound (MCP path),
+and fall back to the process CWD when unbound (standalone path).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from dev10x.subprocess_utils import use_cwd
+
+
+class TestHookInputCwd:
+    """domain/events/hook_input.py:27 — H6."""
+
+    def test_from_stdin_honors_bound_cwd(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from dev10x.domain.events.hook_input import HookInput
+
+        payload = json.dumps({"tool_name": "Bash", "tool_input": {"command": "ls"}})
+        monkeypatch.setattr(sys, "stdin", io.StringIO(payload))
+
+        with use_cwd("/bound/worktree"):
+            inp = HookInput.from_stdin()
+
+        assert inp.cwd == "/bound/worktree"
+
+    def test_from_stdin_falls_back_to_process_cwd(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from dev10x.domain.events.hook_input import HookInput
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps({})))
+
+        inp = HookInput.from_stdin()
+
+        assert inp.cwd == os.getcwd()
+
+
+class TestPermissionDiagnosticsCwd:
+    """hooks/permission_diagnostics.py:202 — H6."""
+
+    @pytest.fixture()
+    def write_raw(self) -> dict:
+        return {
+            "tool_name": "Write",
+            "tool_input": {"file_path": "/tmp/Dev10x/gh-issue/review.md"},
+        }
+
+    @pytest.fixture(autouse=True)
+    def _relative_settings(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from dev10x.hooks.permission_diagnostics import SettingsFile
+
+        monkeypatch.setattr(
+            "dev10x.hooks.permission_diagnostics.SETTINGS_PRECEDENCE",
+            [
+                SettingsFile(
+                    label="project local",
+                    path=Path(".claude/settings.local.json"),
+                    precedence=3,
+                ),
+            ],
+        )
+
+    def test_diagnose_uses_bound_cwd_when_cwd_omitted(self, write_raw: dict) -> None:
+        from dev10x.hooks.permission_diagnostics import diagnose
+
+        with use_cwd("/bound/worktree"):
+            result = diagnose(raw=write_raw)
+
+        assert result is not None
+        assert "No matching allow rule found" in result.diagnosis
+
+    def test_diagnose_falls_back_to_process_cwd(
+        self,
+        tmp_path: Path,
+        write_raw: dict,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from dev10x.hooks.permission_diagnostics import diagnose
+
+        monkeypatch.chdir(tmp_path)
+        result = diagnose(raw=write_raw)
+
+        assert result is not None
+        assert "No matching allow rule found" in result.diagnosis
+
+
+class TestBuildAuditReportCwd:
+    """audit/analyze.py — H6 seam for the deps-less analyze_permissions uv-script."""
+
+    @pytest.fixture()
+    def settings_file(self, tmp_path: Path) -> Path:
+        path = tmp_path / "settings.json"
+        path.write_text(json.dumps({"permissions": {"allow": []}}))
+        return path
+
+    def test_defaults_project_root_to_effective_cwd(
+        self,
+        settings_file: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from dev10x.audit import analyze
+
+        captured: dict[str, str | None] = {}
+
+        def fake_detect(
+            *, calls: object, additional_dirs: object, project_root: str | None
+        ) -> list:
+            captured["project_root"] = project_root
+            return []
+
+        monkeypatch.setattr(analyze, "detect_known_friction", fake_detect)
+
+        with use_cwd("/bound/worktree"):
+            analyze.build_audit_report(
+                transcript="",
+                settings_path=settings_file,
+                skills_dir=tmp_path,
+                tools_dir=tmp_path,
+            )
+
+        assert captured["project_root"] == "/bound/worktree"
+
+    def test_explicit_project_root_wins(
+        self,
+        settings_file: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from dev10x.audit import analyze
+
+        captured: dict[str, str | None] = {}
+
+        def fake_detect(
+            *, calls: object, additional_dirs: object, project_root: str | None
+        ) -> list:
+            captured["project_root"] = project_root
+            return []
+
+        monkeypatch.setattr(analyze, "detect_known_friction", fake_detect)
+
+        analyze.build_audit_report(
+            transcript="",
+            settings_path=settings_file,
+            skills_dir=tmp_path,
+            tools_dir=tmp_path,
+            project_root="/explicit/root",
+        )
+
+        assert captured["project_root"] == "/explicit/root"

--- a/tests/test_no_module_scope_gitcontext.py
+++ b/tests/test_no_module_scope_gitcontext.py
@@ -1,0 +1,58 @@
+"""Lint test: no module-scope `GitContext()` instantiation (GH-979 H11).
+
+A `GitContext` constructed at module scope caches the toplevel from
+whichever CWD the module was first imported in. Long-lived MCP server
+processes then resolve every later call against that stale directory —
+the root-cause class of GH-979. Construct a fresh `GitContext()` per
+call (or `lambda: GitContext().toplevel`) instead.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from dev10x.subprocess_utils import get_plugin_root
+
+
+def _src_root() -> Path:
+    return get_plugin_root() / "src" / "dev10x"
+
+
+def _is_gitcontext_call(value: ast.expr) -> bool:
+    if not isinstance(value, ast.Call):
+        return False
+    func = value.func
+    if isinstance(func, ast.Name):
+        return func.id == "GitContext"
+    if isinstance(func, ast.Attribute):
+        return func.attr == "GitContext"
+    return False
+
+
+def _module_scope_gitcontext_assignments(tree: ast.Module) -> list[int]:
+    offenders: list[int] = []
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and _is_gitcontext_call(node.value):
+            offenders.append(node.lineno)
+        elif (
+            isinstance(node, ast.AnnAssign)
+            and node.value is not None
+            and _is_gitcontext_call(node.value)
+        ):
+            offenders.append(node.lineno)
+    return offenders
+
+
+def test_no_module_scope_gitcontext_singletons() -> None:
+    offenders: list[str] = []
+    for path in sorted(_src_root().rglob("*.py")):
+        tree = ast.parse(path.read_text())
+        for lineno in _module_scope_gitcontext_assignments(tree):
+            offenders.append(f"{path.relative_to(_src_root())}:{lineno}")
+
+    assert not offenders, (
+        "Module-scope `GitContext()` caches the first-call CWD permanently "
+        "across MCP invocations (GH-979 H11). Build a fresh GitContext() per "
+        "call instead. Offenders:\n  - " + "\n  - ".join(offenders)
+    )

--- a/tests/test_subprocess_utils.py
+++ b/tests/test_subprocess_utils.py
@@ -163,6 +163,66 @@ class TestRunScript:
         assert call_args[1]["check"] is False
 
 
+class TestRun:
+    """GH-979: the sync run() chokepoint defaults cwd to the effective CWD."""
+
+    @patch("dev10x.subprocess_utils.subprocess.run")
+    def test_explicit_cwd_wins(self, mock_run: patch) -> None:
+        from dev10x.subprocess_utils import run
+
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="", stderr=""
+        )
+        run(["git", "status"], cwd="/explicit")
+
+        assert mock_run.call_args[1]["cwd"] == "/explicit"
+
+    @patch("dev10x.subprocess_utils.subprocess.run")
+    def test_defaults_to_effective_cwd_when_bound(self, mock_run: patch) -> None:
+        from dev10x.subprocess_utils import run, use_cwd
+
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="", stderr=""
+        )
+        with use_cwd("/bound"):
+            run(["git", "status"])
+
+        assert mock_run.call_args[1]["cwd"] == "/bound"
+
+    @patch("dev10x.subprocess_utils.subprocess.run")
+    def test_cwd_is_none_when_unbound(self, mock_run: patch) -> None:
+        from dev10x.subprocess_utils import run
+
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="", stderr=""
+        )
+        run(["git", "status"])
+
+        assert mock_run.call_args[1]["cwd"] is None
+
+    @patch("dev10x.subprocess_utils.subprocess.run")
+    def test_passes_through_other_kwargs(self, mock_run: patch) -> None:
+        from dev10x.subprocess_utils import run
+
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="", stderr=""
+        )
+        run(["ruff", "format", "x.py"], check=False, capture_output=True, text=True)
+
+        kwargs = mock_run.call_args[1]
+        assert kwargs["check"] is False
+        assert kwargs["capture_output"] is True
+        assert kwargs["text"] is True
+
+    def test_runs_real_command(self) -> None:
+        from dev10x.subprocess_utils import run
+
+        result = run(["echo", "hi"], capture_output=True, text=True)
+
+        assert result.returncode == 0
+        assert result.stdout.strip() == "hi"
+
+
 class TestParseKeyValueOutput:
     def test_parses_single_pair(self) -> None:
         result = parse_key_value_output("KEY=value")


### PR DESCRIPTION
**When** I run Dev10x MCP tools or hooks from a git worktree, **I want to** have every subprocess and working-directory lookup resolve against the worktree I am actually in, **so I can** trust plan-sync, permission diagnostics, and audit output instead of silently hitting the main repo's root (GH-979).

---

[`59cf96cf`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/328/commits/59cf96cf8fcee4dc44ceb44d9873184fe713a05e) ♻️ GH-245 Ensure subprocess calls honor the caller's worktree
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/245

---