### PR TITLE
✨ GH-326 Block privilege escalation commands by default

### DIFF
--- a/skills/upgrade-cleanup/projects.yaml
+++ b/skills/upgrade-cleanup/projects.yaml
@@ -533,3 +533,33 @@ base_denies:
   - "mcp__claude_ai_Linear__delete_comment"
   - "mcp__claude_ai_Linear__delete_attachment"
   - "mcp__claude_ai_Linear__delete_status_update"
+
+  # --- Privilege-escalation tier (GH-326) ---
+  # `sudo` and friends are denied for ANY shape, not just the option-2
+  # catch-all. Unlike the GH-310 `<verb> *` footguns (which merely widen a
+  # verb's argument surface), privilege escalation INVERTS the privilege
+  # model: the wrapped command runs as root, bypassing every user-level
+  # permission rule and hook. A single successful `sudo` allow therefore
+  # defeats every other deny in this catalog (rm guards, write gates, the
+  # Linear deletes above). That makes this tier categorically above
+  # `destructive` — it invalidates all other tiers.
+  #
+  # Trigger: GH-271 evidence #212 — the agent attempted
+  # `sudo -n rm -rf /work/bl/.worktrees/bl-zebra-4` (privilege escalation +
+  # non-interactive + recursive destructive removal on a workspace).
+  #
+  # Per deny-overrides, these stay in force even if a user accidentally
+  # allow-lists `sudo` somewhere. Users who genuinely want routine package
+  # management opt into the narrow `sudo-apt` group (see
+  # baseline-permissions.yaml) — which requires the doctor to scope this
+  # deny down, since deny-first precedence means a blanket allow cannot
+  # override a blanket deny.
+  - "Bash(sudo:*)"      # any sudo invocation
+  - "Bash(sudo *)"      # catch-all shape (option-2 footgun)
+  - "Bash(sudo -n *)"   # non-interactive — silently bypasses the password prompt
+  - "Bash(sudo -i *)"   # interactive root login shell
+  - "Bash(sudoedit:*)"
+  - "Bash(doas:*)"      # OpenBSD/Alpine equivalent
+  - "Bash(doas *)"
+  - "Bash(pkexec:*)"    # polkit-based privilege escalation
+  - "Bash(pkexec *)"

--- a/src/dev10x/skills/permission/baseline-permissions.yaml
+++ b/src/dev10x/skills/permission/baseline-permissions.yaml
@@ -367,6 +367,27 @@ groups:
 
   # ─── TIER 3 ─────────────────────────────────────────────────────────
 
+  sudo-apt:
+    tier: 3
+    description: >
+      Escape valve (GH-326) for users who routinely run package management
+      under sudo. NOT shipped by default — `sudo` is denied for any shape in
+      the privilege-escalation tier (see base_denies in projects.yaml).
+      Enabling this group is a two-step operation, because deny-first
+      precedence means these narrow allows alone cannot override the blanket
+      `Bash(sudo:*)` deny: the permission doctor must first narrow that deny
+      (drop `Bash(sudo:*)` / `Bash(sudo *)`, keep the destructive shapes such
+      as `Bash(sudo -n *)` and `Bash(sudo rm:*)`), then seed these rules.
+      Scope stays limited to apt/apt-get package management — never a blanket
+      sudo allow.
+    rules:
+      - Bash(sudo apt update:*)
+      - Bash(sudo apt-get update:*)
+      - Bash(sudo apt install:*)
+      - Bash(sudo apt-get install:*)
+      - Bash(sudo apt upgrade:*)
+      - Bash(sudo apt-get upgrade:*)
+
   media-and-format:
     tier: 3
     description: Image/video/PDF tooling. Opt-in for content/design workflows.

--- a/src/dev10x/skills/permission/doctor.py
+++ b/src/dev10x/skills/permission/doctor.py
@@ -162,7 +162,7 @@ def detect_workspace(cwd: Path) -> WorkspaceContext:
     try:
         toplevel = subprocess_utils.run(
             ["git", "rev-parse", "--show-toplevel"],
-            cwd=cwd,
+            cwd=str(cwd),
             capture_output=True,
             text=True,
             check=True,
@@ -172,7 +172,7 @@ def detect_workspace(cwd: Path) -> WorkspaceContext:
     try:
         common_dir = subprocess_utils.run(
             ["git", "rev-parse", "--git-common-dir"],
-            cwd=cwd,
+            cwd=str(cwd),
             capture_output=True,
             text=True,
             check=True,

--- a/tests/skills/upgrade-cleanup/test_ensure_base.py
+++ b/tests/skills/upgrade-cleanup/test_ensure_base.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 import pytest
+import yaml
 
 from dev10x.skills.permission import update_paths
 from dev10x.skills.permission.update_paths import (
@@ -538,3 +539,52 @@ class TestEnsureBaseDenies:
         data = json.loads(settings.read_text())
         assert "mcp__claude_ai_Linear__get_issue" in data["permissions"]["allow"]
         assert "mcp__claude_ai_Linear__delete_customer" in data["permissions"]["deny"]
+
+
+class TestPrivilegeEscalationDenies:
+    """GH-326: sudo/doas/pkexec ship as plugin-default deny rules."""
+
+    PRIVILEGE_ESCALATION_DENIES = [
+        "Bash(sudo:*)",
+        "Bash(sudo *)",
+        "Bash(sudo -n *)",
+        "Bash(sudo -i *)",
+        "Bash(sudoedit:*)",
+        "Bash(doas:*)",
+        "Bash(doas *)",
+        "Bash(pkexec:*)",
+        "Bash(pkexec *)",
+    ]
+
+    @pytest.fixture()
+    def shipped_base_denies(self) -> list[str]:
+        projects_yaml = (
+            Path(__file__).resolve().parents[3] / "skills" / "upgrade-cleanup" / "projects.yaml"
+        )
+        config = yaml.safe_load(projects_yaml.read_text())
+        return config.get("base_denies", [])
+
+    @pytest.mark.parametrize("rule", PRIVILEGE_ESCALATION_DENIES)
+    def test_catalog_ships_privilege_escalation_deny(
+        self,
+        rule: str,
+        shipped_base_denies: list[str],
+    ) -> None:
+        assert rule in shipped_base_denies
+
+    def test_evidence_212_sudo_rm_is_blocked(
+        self,
+        tmp_path: Path,
+        shipped_base_denies: list[str],
+    ) -> None:
+        """GH-271 evidence #212: `sudo -n rm -rf <workspace>` must render a
+        deny that blocks it. The non-interactive shape is the dangerous one
+        because it silently bypasses the password prompt."""
+        settings = tmp_path / "settings.local.json"
+        settings.write_text(json.dumps({"permissions": {"allow": [], "deny": []}}))
+
+        update_paths.ensure_base_denies(settings, shipped_base_denies)
+
+        deny = json.loads(settings.read_text())["permissions"]["deny"]
+        assert "Bash(sudo -n *)" in deny
+        assert "Bash(sudo:*)" in deny


### PR DESCRIPTION
**When** an agent or a careless allow-rule lets `sudo`, `doas`, or `pkexec` through, **I want to** deny every privilege-escalation shape by default, **so I can** stop a single root command from bypassing every other permission rule and hook.

---

[`0c2e1055`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/330/commits/0c2e1055dd4be7ace9b466032ff7ba703eff30f9) ✨ GH-326 Block privilege escalation commands by default
[`cb803da6`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/330/commits/cb803da6f17f1fbdf1af7722c1cb1df974224545) 🐛 GH-245 Resolve mypy cwd type mismatch in doctor
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/326

---