### PR TITLE
♻️ GH-311 Enable env-prefix-free JIRA and aws-vault calls

### DIFF
--- a/skills/aws-vault/scripts/kubectl.sh
+++ b/skills/aws-vault/scripts/kubectl.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Usage: kubectl.sh <env> <kubectl-verb> [args...]
+# Usage: kubectl.sh [--registry PATH] <env> <kubectl-verb> [args...]
 #
 # Strictly READ-ONLY wrapper for kubectl operations via aws-vault.
 # Claude MUST use this script instead of calling kubectl directly.
@@ -50,6 +50,13 @@ DENIED_FLAG_PREFIXES=(
     --kubeconfig
     --insecure-skip-tls-verify
 )
+
+# Optional leading `--registry <path>` flag (GH-311) — avoids the env-prefix
+# invocation friction. Falls back to the DEV10X_AWS_VAULT_REGISTRY env var.
+if [[ "${1:-}" == "--registry" ]]; then
+    DEV10X_AWS_VAULT_REGISTRY="${2:?--registry requires a path}"
+    shift 2
+fi
 
 REGISTRY="${DEV10X_AWS_VAULT_REGISTRY:-$HOME/.config/Dev10x/aws-vault/service-registry.yaml}"
 

--- a/skills/aws-vault/scripts/secrets.sh
+++ b/skills/aws-vault/scripts/secrets.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Usage: secrets.sh <env> <service|secret-id> [--key KEY_NAME]
+# Usage: secrets.sh [--registry PATH] <env> <service|secret-id> [--key KEY_NAME]
 #
 # Approved wrapper for AWS Secrets Manager access via aws-vault.
 # Claude MUST use this script instead of calling aws secretsmanager directly.
@@ -14,6 +14,13 @@
 # (copy the plugin's references/service-registry.example.yaml to seed it)
 
 set -euo pipefail
+
+# Optional leading `--registry <path>` flag (GH-311) — avoids the env-prefix
+# invocation friction. Falls back to the DEV10X_AWS_VAULT_REGISTRY env var.
+if [[ "${1:-}" == "--registry" ]]; then
+    DEV10X_AWS_VAULT_REGISTRY="${2:?--registry requires a path}"
+    shift 2
+fi
 
 REGISTRY="${DEV10X_AWS_VAULT_REGISTRY:-$HOME/.config/Dev10x/aws-vault/service-registry.yaml}"
 

--- a/skills/jira/SKILL.md
+++ b/skills/jira/SKILL.md
@@ -10,9 +10,16 @@ allowed-tools:
 
 ## Prerequisites
 
-Set the `JIRA_TENANT` env var to your Atlassian tenant name
-(e.g., `mycompany` for `mycompany.atlassian.net`). All scripts
-require it — there is no default.
+Supply your Atlassian tenant name (e.g., `mycompany` for
+`mycompany.atlassian.net`) one of two ways — there is no default:
+
+- **Per call (recommended):** pass `--tenant <name>` as the first
+  argument, e.g. `jira-get.sh --tenant mycompany PROJ-100`. The flag
+  binds the tenant as a command *argument*, so the
+  `Bash(.../scripts/:*)` allow rule still matches — no env-prefix
+  friction (GH-311).
+- **Session-wide:** set the `JIRA_TENANT` env var (used as the
+  fallback when `--tenant` is absent).
 
 Store credentials in the system keyring:
 ```bash
@@ -50,8 +57,18 @@ prefix, so **no** `Bash(.../scripts/jira-get.sh:*)` allow rule can
 ever match — every call hits the permission gate. This is the same
 prefix-shift class as the global "No env-var prefix on git" rule.
 
-**Instead, ship a wrapper script** that binds the tenant *inside* the
-command, so the wrapper's own path is what the allow rule matches:
+**For one-off or multi-tenant calls, pass `--tenant <name>` as the
+first argument** (see Prerequisites) — the tenant binds as a command
+argument, so the allow rule still matches and no wrapper is needed:
+
+```bash
+# ✅ Flag form — tenant is an argument, allow rule matches (GH-311)
+${CLAUDE_PLUGIN_ROOT}/skills/jira/scripts/jira-get.sh --tenant acme PROJ-1
+```
+
+**To bind a *fixed* tenant across many ops, ship a wrapper script**
+that sets the tenant *inside* the command, so the wrapper's own path
+is what the allow rule matches:
 
 ```bash
 # ✅ Wrapper script — tenant binding inside, one allow rule, no friction

--- a/skills/jira/scripts/_jira-env.sh
+++ b/skills/jira/scripts/_jira-env.sh
@@ -2,10 +2,18 @@
 # Shared JIRA environment for all jira-*.sh scripts.
 # Sources credentials from system keyring and builds base URL.
 #
-# Required: JIRA_TENANT env var (e.g., "mycompany" for mycompany.atlassian.net)
+# Tenant resolution (GH-311): prefer a leading `--tenant <name>` flag so
+# the tenant binds as a command argument that the allow-rule prefix still
+# matches. Falls back to the JIRA_TENANT env var when the flag is absent.
+# Sourced with no args, so `$1`/`shift` operate on the caller's positional
+# parameters — every jira-*.sh script gains the flag without changes.
+if [ "${1:-}" = "--tenant" ]; then
+  JIRA_TENANT="${2:?--tenant requires a tenant name}"
+  shift 2
+fi
 
 if [ -z "${JIRA_TENANT:-}" ]; then
-  echo "Error: JIRA_TENANT env var is required (e.g., 'mycompany' for mycompany.atlassian.net)" >&2
+  echo "Error: pass --tenant <name> or set JIRA_TENANT (e.g., 'mycompany' for mycompany.atlassian.net)" >&2
   exit 1
 fi
 

--- a/tests/test_shell_script_flags.py
+++ b/tests/test_shell_script_flags.py
@@ -1,0 +1,45 @@
+"""Syntax + flag-wiring checks for skill shell scripts (GH-311).
+
+The repo behaviourally tests Python entry points only
+(``test_script_loadability.py``); shell scripts are keyring/network
+dependent and are validated at the syntax level here. These tests lock
+in the GH-311 refactor that lets the jira and aws-vault scripts take
+their config as a flag (avoiding the env-var-prefix invocation friction)
+while keeping the env var as a fallback.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+SHELL_SCRIPTS = sorted(REPO_ROOT.glob("skills/**/scripts/*.sh"))
+
+
+@pytest.mark.parametrize("script", SHELL_SCRIPTS, ids=lambda p: str(p.relative_to(REPO_ROOT)))
+def test_shell_script_syntax_is_valid(script: Path) -> None:
+    result = subprocess.run(
+        ["bash", "-n", str(script)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"{script} failed bash -n: {result.stderr}"
+
+
+def test_jira_env_accepts_tenant_flag() -> None:
+    source = (REPO_ROOT / "skills" / "jira" / "scripts" / "_jira-env.sh").read_text()
+    assert '"${1:-}" = "--tenant"' in source
+    # Env var remains the fallback for one release.
+    assert "JIRA_TENANT" in source
+
+
+@pytest.mark.parametrize("name", ["secrets.sh", "kubectl.sh"])
+def test_aws_vault_scripts_accept_registry_flag(name: str) -> None:
+    source = (REPO_ROOT / "skills" / "aws-vault" / "scripts" / name).read_text()
+    assert '"${1:-}" == "--registry"' in source
+    # Env var remains the fallback.
+    assert "DEV10X_AWS_VAULT_REGISTRY" in source


### PR DESCRIPTION
**When** a skill script reads its tenant or registry only from an env var, **I want to** pass that config as a `--tenant`/`--registry` command flag, **so I can** invoke the script without an env-var prefix that shifts the Bash command prefix and defeats every `Bash(.../scripts/:*)` allow rule.

---

[`a17ca5bb`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/331/commits/a17ca5bb20093182df337a948818ca02fb7943e8) ♻️ GH-311 Enable env-prefix-free JIRA and aws-vault calls
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/311

---