### PR TITLE
♻️ GH-242 Resolve contradictory allow-rule diagnostics

### DIFF
--- a/src/dev10x/domain/common/allow_rule.py
+++ b/src/dev10x/domain/common/allow_rule.py
@@ -1,0 +1,130 @@
+"""AllowRule value object — a single Claude Code permission allow rule.
+
+Consolidates four drifted ``Tool(pattern)`` matching implementations and
+five settings loaders that had diverged semantically (audit finding C2/C3,
+2026-05-18). Before this module the same allow rule could be reported as
+matched by one diagnostic and unmatched by another.
+
+The canonical matching semantics are the space-boundary-aware ones that
+``hooks/permission_diagnostics`` already used (the strictest, most correct
+of the four):
+
+- ``mcp__`` rules and bare globs (no parentheses): ``fnmatch`` over the
+  whole signature.
+- ``Bash`` rules with a ``:*`` suffix: the command must equal the prefix
+  exactly or continue past a space boundary — so ``Bash(git:*)`` matches
+  ``git status`` but NOT ``github-cli``.
+- ``Read``/``Write``/``Edit`` rules with a ``**`` suffix: directory prefix
+  match. Other path patterns fall back to ``fnmatch``.
+
+``~`` and ``$HOME`` are expanded on both sides of prefix comparisons so a
+``~/.claude/skills`` rule matches a ``/home/<user>/.claude/skills`` command.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+_PATH_TOOLS = frozenset({"Read", "Write", "Edit"})
+
+
+def _expand(value: str) -> str:
+    return os.path.expandvars(os.path.expanduser(value))
+
+
+@dataclass(frozen=True)
+class AllowRule:
+    tool: str
+    pattern: str
+    raw: str
+
+    def __str__(self) -> str:
+        return self.raw
+
+    @classmethod
+    def parse(cls, rule: str) -> AllowRule:
+        if "(" not in rule or not rule.endswith(")"):
+            return cls(tool=rule, pattern="", raw=rule)
+        paren = rule.index("(")
+        return cls(tool=rule[:paren], pattern=rule[paren + 1 : -1], raw=rule)
+
+    @classmethod
+    def bash(cls, pattern: str) -> AllowRule:
+        return cls.parse(f"Bash({pattern})")
+
+    @classmethod
+    def read(cls, pattern: str) -> AllowRule:
+        return cls.parse(f"Read({pattern})")
+
+    @classmethod
+    def write(cls, pattern: str) -> AllowRule:
+        return cls.parse(f"Write({pattern})")
+
+    @classmethod
+    def edit(cls, pattern: str) -> AllowRule:
+        return cls.parse(f"Edit({pattern})")
+
+    @classmethod
+    def skill(cls, name: str) -> AllowRule:
+        return cls.parse(f"Skill({name})")
+
+    def matches(self, signature: str) -> bool:
+        if "(" not in self.raw or not self.raw.endswith(")"):
+            return fnmatch.fnmatch(name=signature, pat=self.raw)
+
+        sig_paren = signature.find("(")
+        if sig_paren == -1:
+            return fnmatch.fnmatch(name=signature, pat=self.raw)
+
+        if signature[:sig_paren] != self.tool:
+            return False
+
+        value = signature[sig_paren + 1 :].rstrip(")")
+        return self._matches_value(value=value)
+
+    def _matches_value(self, *, value: str) -> bool:
+        if self.tool == "Bash" and self.pattern.endswith(":*"):
+            prefix = _expand(self.pattern[:-2])
+            expanded = _expand(value)
+            return expanded == prefix or expanded.startswith(prefix + " ")
+
+        if self.tool in _PATH_TOOLS and self.pattern.endswith("**"):
+            prefix = _expand(self.pattern[:-2])
+            return _expand(value).startswith(prefix)
+
+        return fnmatch.fnmatch(name=value, pat=self.pattern)
+
+
+class AllowRuleLoader:
+    """Loads ``permissions.allow`` rule strings from a settings JSON file."""
+
+    @staticmethod
+    def load_optional(path: str | Path) -> list[str] | None:
+        """Return the allow list, or ``None`` when the file has no valid one.
+
+        ``None`` distinguishes "no allow list present" (missing file,
+        malformed JSON, absent or non-list ``allow`` key) from an explicitly
+        empty ``[]``. Callers that need that distinction (e.g. permission
+        diagnostics reporting ``has_allow_list``) use this; callers that just
+        want rules use :meth:`load`.
+        """
+        p = Path(path)
+        if not p.is_file():
+            return None
+        try:
+            data = json.loads(p.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return None
+        allow = data.get("permissions", {}).get("allow")
+        if not isinstance(allow, list):
+            return None
+        return allow
+
+    @staticmethod
+    def load(path: str | Path) -> list[str]:
+        """Return the allow list, or ``[]`` on missing/malformed input."""
+        return AllowRuleLoader.load_optional(path=path) or []

--- a/src/dev10x/hooks/permission_diagnostics.py
+++ b/src/dev10x/hooks/permission_diagnostics.py
@@ -19,14 +19,13 @@ permissions.allow list.
 
 from __future__ import annotations
 
-import fnmatch
-import json
 import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from dev10x.domain.claude_paths import ClaudeDir
+from dev10x.domain.common.allow_rule import AllowRule, AllowRuleLoader
 from dev10x.subprocess_utils import effective_cwd
 
 
@@ -109,72 +108,18 @@ def extract_tool_signature(raw: dict[str, Any]) -> str | None:
 
 
 def _load_allow_rules(path: Path) -> list[str] | None:
-    if not path.is_file():
-        return None
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return None
-    permissions = data.get("permissions", {})
-    allow = permissions.get("allow")
-    if allow is None:
-        return None
-    if not isinstance(allow, list):
-        return None
-    return allow
-
-
-class PermissionResolutionPolicy:
-    """Encapsulates how an allow-rule string is matched against a tool signature.
-
-    Lives as a named class so the matching semantics — MCP tools by
-    fnmatch over the whole signature, Bash rules by tool+pattern with
-    ``:*`` prefix expansion — can be unit-tested and extended without
-    touching ``diagnose()``.
-    """
-
-    @staticmethod
-    def matches(*, signature: str, rule: str) -> bool:
-        if signature.startswith("mcp__"):
-            return fnmatch.fnmatch(name=signature, pat=rule)
-
-        paren_idx = rule.find("(")
-        if paren_idx == -1:
-            return fnmatch.fnmatch(name=signature, pat=rule)
-
-        rule_tool = rule[:paren_idx]
-        rule_pattern = rule[paren_idx + 1 :].rstrip(")")
-
-        sig_paren_idx = signature.find("(")
-        if sig_paren_idx == -1:
-            return False
-
-        sig_tool = signature[:sig_paren_idx]
-        sig_value = signature[sig_paren_idx + 1 :].rstrip(")")
-
-        if rule_tool != sig_tool:
-            return False
-
-        if rule_pattern.endswith(":*"):
-            prefix = rule_pattern[:-2]
-            return sig_value == prefix or sig_value.startswith(prefix + " ")
-
-        return fnmatch.fnmatch(name=sig_value, pat=rule_pattern)
-
-    @classmethod
-    def find_matching(cls, *, signature: str, rules: list[str]) -> str | None:
-        for rule in rules:
-            if cls.matches(signature=signature, rule=rule):
-                return rule
-        return None
+    return AllowRuleLoader.load_optional(path=path)
 
 
 def _matches_rule(*, signature: str, rule: str) -> bool:
-    return PermissionResolutionPolicy.matches(signature=signature, rule=rule)
+    return AllowRule.parse(rule).matches(signature)
 
 
 def _find_matching_rule(*, signature: str, rules: list[str]) -> str | None:
-    return PermissionResolutionPolicy.find_matching(signature=signature, rules=rules)
+    for rule in rules:
+        if AllowRule.parse(rule).matches(signature):
+            return rule
+    return None
 
 
 def _resolve_settings_files(*, cwd: str) -> list[SettingsFile]:

--- a/src/dev10x/skills/audit/analyze_permissions.py
+++ b/src/dev10x/skills/audit/analyze_permissions.py
@@ -19,7 +19,6 @@ If settings.json is omitted, uses ~/.claude/settings.local.json.
 If output.md is omitted, writes to stdout.
 """
 
-import fnmatch
 import json
 import os
 import re
@@ -28,6 +27,8 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TextIO
+
+from dev10x.domain.common.allow_rule import AllowRule, AllowRuleLoader
 
 TURN_RE = re.compile(
     r"^## Turn (\d+) \[([^\]]+)\] (USER|ASSISTANT)",
@@ -94,13 +95,6 @@ class ToolCall:
         if self.tool.startswith("mcp__"):
             return self.tool
         return f"{self.tool}()"
-
-
-@dataclass
-class AllowRule:
-    tool: str
-    pattern: str
-    raw: str
 
 
 @dataclass
@@ -198,20 +192,11 @@ def parse_tool_calls(text: str) -> list[ToolCall]:
 
 
 def parse_allow_rules(settings_path: str) -> list[AllowRule]:
-    path = Path(settings_path)
-    if not path.exists():
-        return []
-
-    data = json.loads(path.read_text())
     rules: list[AllowRule] = []
-
-    allow_list = data.get("permissions", {}).get("allow", [])
-    for entry in allow_list:
+    for entry in AllowRuleLoader.load(settings_path):
         raw = entry if isinstance(entry, str) else str(entry)
-        m = ALLOW_RULE_RE.match(raw)
-        if m:
-            rules.append(AllowRule(tool=m.group(1), pattern=m.group(2), raw=raw))
-
+        if ALLOW_RULE_RE.match(raw):
+            rules.append(AllowRule.parse(raw))
     return rules
 
 
@@ -312,32 +297,10 @@ def detect_known_friction(
 
 
 def matches_allow_rule(tc: ToolCall, rules: list[AllowRule]) -> bool:
-    for rule in rules:
-        if rule.tool != tc.tool:
-            continue
-
-        pattern = rule.pattern
-        if tc.tool == "Bash":
-            if pattern.endswith(":*"):
-                prefix = pattern[:-2]
-                if tc.command.startswith(prefix):
-                    return True
-            elif pattern.endswith("*"):
-                prefix = pattern[:-1]
-                if tc.command.startswith(prefix):
-                    return True
-            elif tc.command == pattern:
-                return True
-        else:
-            target = tc.file_path or tc.command
-            if pattern.endswith("**"):
-                dir_prefix = pattern[:-2]
-                if target.startswith(dir_prefix):
-                    return True
-            elif fnmatch.fnmatch(target, pattern):
-                return True
-
-    return True if not rules else False
+    if not rules:
+        return True
+    signature = tc.signature()
+    return any(rule.matches(signature) for rule in rules)
 
 
 def classify_toxicity(command: str) -> str | None:

--- a/src/dev10x/skills/doctor/strategies/missing_linear_mcp_allow.py
+++ b/src/dev10x/skills/doctor/strategies/missing_linear_mcp_allow.py
@@ -16,9 +16,9 @@ only incidentally.
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
+from dev10x.domain.common.allow_rule import AllowRuleLoader
 from dev10x.skills.doctor.strategy import (
     Context,
     Finding,
@@ -52,12 +52,7 @@ def _missing_baseline(rules: list[str]) -> list[str]:
 
 
 def _read_allow_rules(path: Path) -> list[str]:
-    try:
-        data = json.loads(path.read_text())
-    except (OSError, json.JSONDecodeError):
-        return []
-    perms = data.get("permissions", {})
-    return list(perms.get("allow", []))
+    return AllowRuleLoader.load(path)
 
 
 def detect(context: Context) -> list[Finding]:

--- a/src/dev10x/skills/permission/cluster_paths.py
+++ b/src/dev10x/skills/permission/cluster_paths.py
@@ -15,6 +15,8 @@ import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from dev10x.domain.common.allow_rule import AllowRule
+
 # Project-internal paths skip clustering — they're already covered
 # by the project root and don't need user-wide allow rules.
 PROJECT_ROOT_MARKERS = ("/work/", "/src/", "/.worktrees/")
@@ -116,11 +118,11 @@ def propose_patch(*, cluster: PathCluster) -> CoveragePatch:
         additional_directory=ancestor,
         placement=placement,
         rules=[
-            f"Read({ancestor}/**)",
-            f"Write({ancestor}/**)",
-            f"Edit({ancestor}/**)",
-            f"Bash(find {ancestor}:*)",
-            f"Bash(ls {ancestor}:*)",
-            f"Bash(grep -r {ancestor}:*)",
+            str(AllowRule.read(f"{ancestor}/**")),
+            str(AllowRule.write(f"{ancestor}/**")),
+            str(AllowRule.edit(f"{ancestor}/**")),
+            str(AllowRule.bash(f"find {ancestor}:*")),
+            str(AllowRule.bash(f"ls {ancestor}:*")),
+            str(AllowRule.bash(f"grep -r {ancestor}:*")),
         ],
     )

--- a/src/dev10x/skills/permission/update_paths.py
+++ b/src/dev10x/skills/permission/update_paths.py
@@ -22,6 +22,7 @@ from pathlib import Path
 import yaml
 
 from dev10x.domain.claude_paths import ClaudeDir
+from dev10x.domain.common.allow_rule import AllowRule
 from dev10x.domain.dev10x_paths import Dev10xConfigDir
 
 MEMORY_CONFIG = Dev10xConfigDir.projects_yaml()
@@ -343,8 +344,7 @@ def build_script_allow_rules(
     rules: list[str] = []
     for script in scripts:
         relative = script.relative_to(plugin_root)
-        rule = f"Bash({plugin_root}/{relative}:*)"
-        rules.append(rule)
+        rules.append(str(AllowRule.bash(f"{plugin_root}/{relative}:*")))
     return rules
 
 
@@ -422,8 +422,8 @@ def build_marketplaces_read_rules(
     home = user_home.expanduser().resolve()
     rel = f".claude/plugins/marketplaces/{publisher}"
     return [
-        f"Read(~/{rel}/**)",
-        f"Read({home}/{rel}/**)",
+        str(AllowRule.read(f"~/{rel}/**")),
+        str(AllowRule.read(f"{home}/{rel}/**")),
     ]
 
 
@@ -457,8 +457,8 @@ def build_read_allow_rules(
 
     rules: list[str] = []
     for rel in relpaths:
-        rules.append(f"Read(~/{rel}/*)")
-        rules.append(f"Read({home}/{rel}/*)")
+        rules.append(str(AllowRule.read(f"~/{rel}/*")))
+        rules.append(str(AllowRule.read(f"{home}/{rel}/*")))
     return rules
 
 
@@ -590,7 +590,7 @@ def collapse_legacy_upgrade_cleanup_rule(entry: str) -> str | None:
     target_cmd = _LEGACY_UPGRADE_CLEANUP_SCRIPTS.get(script)
     if target_cmd is None:
         return None
-    return f"Bash({target_cmd}:*)"
+    return str(AllowRule.bash(f"{target_cmd}:*"))
 
 
 def collapse_legacy_upgrade_cleanup_rules(

--- a/src/dev10x/skills/permission_investigator/report.py
+++ b/src/dev10x/skills/permission_investigator/report.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from dev10x.domain.common.allow_rule import AllowRule
 from dev10x.skills.permission_investigator.matrix import (
     Matrix,
     MatrixResult,
@@ -153,7 +154,5 @@ def _classify_rule(rule: str) -> tuple[PathPrefix | None, WildcardShape | None]:
 def _extract_path(rule: str) -> str | None:
     if "(" not in rule or not rule.endswith(")"):
         return None
-    inner = rule.split("(", 1)[1][:-1]
-    if ":" in inner:
-        inner = inner.split(":", 1)[0]
-    return inner
+    inner = AllowRule.parse(rule).pattern
+    return inner.split(":", 1)[0] if ":" in inner else inner

--- a/src/dev10x/validators/prefix_friction.py
+++ b/src/dev10x/validators/prefix_friction.py
@@ -11,7 +11,6 @@ allow-rule matching:
 
 from __future__ import annotations
 
-import json
 import os
 import re
 from dataclasses import dataclass, field
@@ -19,6 +18,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 from dev10x.domain import HookInput, HookResult
 from dev10x.domain.claude_paths import ClaudeDir
+from dev10x.domain.common.allow_rule import AllowRule, AllowRuleLoader
 from dev10x.domain.profile_tier import ProfileTier
 from dev10x.validators.base import ValidatorBase
 
@@ -226,15 +226,10 @@ MERGE_BASE_MSG = (
 def _load_all_allow_patterns() -> list[str]:
     patterns: list[str] = []
     for path in SETTINGS_FILES:
-        try:
-            with open(path) as f:
-                data = json.load(f)
-            for rule in data.get("permissions", {}).get("allow", []):
-                m = re.match(r"^Bash\((.+?)(?::\*)?\)$", rule)
-                if m:
-                    patterns.append(m.group(1))
-        except (FileNotFoundError, json.JSONDecodeError):
-            pass
+        for rule in AllowRuleLoader.load(path):
+            m = re.match(r"^Bash\((.+?)(?::\*)?\)$", rule)
+            if m:
+                patterns.append(m.group(1))
     return patterns
 
 
@@ -256,10 +251,9 @@ def _matches_allow_rule(
     segment: str,
     patterns: list[str],
 ) -> str | None:
-    expanded_seg = os.path.expanduser(segment)
+    signature = f"Bash({segment})"
     for pattern in patterns:
-        expanded_pat = os.path.expanduser(pattern)
-        if expanded_seg.startswith(expanded_pat) or segment.startswith(pattern):
+        if AllowRule.bash(f"{pattern}:*").matches(signature):
             return pattern
     return None
 

--- a/tests/domain/common/test_allow_rule.py
+++ b/tests/domain/common/test_allow_rule.py
@@ -1,0 +1,174 @@
+"""Tests for the AllowRule value object and AllowRuleLoader.
+
+The ``TestSemanticDivergence`` class pins the cases where the four
+pre-consolidation matchers disagreed (audit C2, 2026-05-18). Each test
+documents what a now-removed implementation used to return so the unified
+behavior is auditable.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dev10x.domain.common.allow_rule import AllowRule, AllowRuleLoader
+
+
+class TestParse:
+    def test_bash_rule(self) -> None:
+        rule = AllowRule.parse("Bash(git status:*)")
+        assert rule.tool == "Bash"
+        assert rule.pattern == "git status:*"
+        assert rule.raw == "Bash(git status:*)"
+
+    def test_path_rule(self) -> None:
+        rule = AllowRule.parse("Write(/tmp/Dev10x/**)")
+        assert rule.tool == "Write"
+        assert rule.pattern == "/tmp/Dev10x/**"
+
+    def test_mcp_rule_has_no_pattern(self) -> None:
+        rule = AllowRule.parse("mcp__plugin_Dev10x_cli__*")
+        assert rule.tool == "mcp__plugin_Dev10x_cli__*"
+        assert rule.pattern == ""
+        assert rule.raw == "mcp__plugin_Dev10x_cli__*"
+
+    def test_bare_token_without_parens(self) -> None:
+        rule = AllowRule.parse("WebFetch")
+        assert rule.tool == "WebFetch"
+        assert rule.pattern == ""
+
+    def test_str_returns_raw(self) -> None:
+        assert str(AllowRule.parse("Bash(ls:*)")) == "Bash(ls:*)"
+
+
+class TestFactories:
+    @pytest.mark.parametrize(
+        ("factory", "arg", "expected"),
+        [
+            (AllowRule.bash, "find /x:*", "Bash(find /x:*)"),
+            (AllowRule.read, "/x/**", "Read(/x/**)"),
+            (AllowRule.write, "/x/**", "Write(/x/**)"),
+            (AllowRule.edit, "/x/**", "Edit(/x/**)"),
+            (AllowRule.skill, "Dev10x:git-commit", "Skill(Dev10x:git-commit)"),
+        ],
+    )
+    def test_factory_builds_rule(self, factory, arg: str, expected: str) -> None:
+        rule = factory(arg)
+        assert rule.raw == expected
+        assert str(rule) == expected
+
+
+class TestBashMatching:
+    def test_prefix_exact(self) -> None:
+        assert AllowRule.parse("Bash(git status:*)").matches("Bash(git status)")
+
+    def test_prefix_with_args(self) -> None:
+        assert AllowRule.parse("Bash(git push:*)").matches("Bash(git push --force)")
+
+    def test_prefix_token_boundary_rejects_partial(self) -> None:
+        # `git` must not match `github-cli` — the space boundary guards it.
+        assert not AllowRule.parse("Bash(git:*)").matches("Bash(github-cli auth)")
+
+    def test_different_tool_rejected(self) -> None:
+        assert not AllowRule.parse("Bash(npm:*)").matches("Bash(git status)")
+
+    def test_exact_pattern_without_wildcard(self) -> None:
+        assert AllowRule.parse("Bash(ls)").matches("Bash(ls)")
+        assert not AllowRule.parse("Bash(ls)").matches("Bash(ls -la)")
+
+    def test_tilde_expands_against_home_command(self) -> None:
+        home = str(Path.home())
+        rule = AllowRule.parse("Bash(~/.claude/skills/foo.sh:*)")
+        assert rule.matches(f"Bash({home}/.claude/skills/foo.sh --x)")
+
+
+class TestPathMatching:
+    def test_double_star_directory_prefix(self) -> None:
+        rule = AllowRule.parse("Write(/tmp/Dev10x/**)")
+        assert rule.matches("Write(/tmp/Dev10x/msg.txt)")
+        assert rule.matches("Write(/tmp/Dev10x/git/msg.txt)")
+
+    def test_double_star_rejects_outside_prefix(self) -> None:
+        assert not AllowRule.parse("Read(/tmp/Dev10x/**)").matches("Read(/etc/passwd)")
+
+    def test_single_star_glob(self) -> None:
+        assert AllowRule.parse("Read(/x/*.py)").matches("Read(/x/mod.py)")
+
+    def test_single_star_crosses_slash_via_fnmatch(self) -> None:
+        # Non-``**`` path patterns fall back to fnmatch, whose ``*`` matches
+        # ``/`` — the same behavior permission_diagnostics had before
+        # consolidation. Documented so the fnmatch fallback is intentional.
+        assert AllowRule.parse("Read(/x/*.py)").matches("Read(/x/sub/mod.py)")
+
+
+class TestMcpMatching:
+    def test_wildcard_matches_server_tools(self) -> None:
+        rule = AllowRule.parse("mcp__plugin_Dev10x_cli__*")
+        assert rule.matches("mcp__plugin_Dev10x_cli__detect_tracker")
+
+    def test_wildcard_rejects_other_server(self) -> None:
+        rule = AllowRule.parse("mcp__plugin_Dev10x_cli__*")
+        assert not rule.matches("mcp__other_server__tool")
+
+    def test_signature_without_parens_falls_back_to_fnmatch(self) -> None:
+        # A non-mcp parenless signature (e.g. "WebFetch()") still resolves.
+        assert AllowRule.parse("WebFetch*").matches("WebFetch")
+
+    def test_paren_rule_against_parenless_signature(self) -> None:
+        # A ``Tool(pattern)`` rule cannot match a bare signature.
+        assert not AllowRule.parse("Bash(git:*)").matches("WebSearch")
+
+    def test_different_tool_with_parens_rejected(self) -> None:
+        assert not AllowRule.parse("Read(/x/y)").matches("Write(/x/y)")
+
+
+class TestSemanticDivergence:
+    """Regression fixtures pinning the unified behavior (audit C2)."""
+
+    def test_partial_token_false_positive_now_rejected(self) -> None:
+        # prefix_friction / analyze_permissions used loose ``startswith`` and
+        # would have matched ``git`` against ``gitfoo``. The unified matcher
+        # enforces a space boundary and rejects it.
+        assert not AllowRule.parse("Bash(git:*)").matches("Bash(gitfoo)")
+
+    def test_empty_rule_set_does_not_match_everything(self) -> None:
+        # analyze_permissions.matches_allow_rule returned ``True`` when the
+        # rule list was empty (match-all). The unified matcher leaves that
+        # policy to the caller: a single rule only matches its own signature.
+        assert not AllowRule.parse("Bash(ls:*)").matches("Bash(rm -rf /)")
+
+
+class TestLoader:
+    def _write(self, tmp_path: Path, payload: dict) -> Path:
+        p = tmp_path / "settings.json"
+        p.write_text(json.dumps(payload), encoding="utf-8")
+        return p
+
+    def test_load_returns_rules(self, tmp_path: Path) -> None:
+        p = self._write(tmp_path, {"permissions": {"allow": ["Bash(git:*)"]}})
+        assert AllowRuleLoader.load(p) == ["Bash(git:*)"]
+
+    def test_load_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        assert AllowRuleLoader.load(tmp_path / "nope.json") == []
+
+    def test_load_malformed_json_returns_empty(self, tmp_path: Path) -> None:
+        p = tmp_path / "settings.json"
+        p.write_text("{not json", encoding="utf-8")
+        assert AllowRuleLoader.load(p) == []
+
+    def test_load_non_list_allow_returns_empty(self, tmp_path: Path) -> None:
+        p = self._write(tmp_path, {"permissions": {"allow": "Bash(git:*)"}})
+        assert AllowRuleLoader.load(p) == []
+
+    def test_load_optional_distinguishes_empty_from_absent(self, tmp_path: Path) -> None:
+        empty = self._write(tmp_path, {"permissions": {"allow": []}})
+        assert AllowRuleLoader.load_optional(empty) == []
+
+        absent = tmp_path / "absent.json"
+        absent.write_text(json.dumps({"permissions": {}}), encoding="utf-8")
+        assert AllowRuleLoader.load_optional(absent) is None
+
+    def test_load_optional_missing_file_is_none(self, tmp_path: Path) -> None:
+        assert AllowRuleLoader.load_optional(tmp_path / "nope.json") is None


### PR DESCRIPTION
**When** I run permission diagnostics or skill-audit against an allow rule, **I want to** get one consistent matched/unmatched verdict instead of four implementations disagreeing, **so I can** trust the friction analysis and stop chasing phantom permission gaps.

---

[`6937339c`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/334/commits/6937339c3c480326dee12930c5a725157782d499) ♻️ GH-242 Resolve contradictory allow-rule diagnostics
Closes #242
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/242

---