### PR TITLE
♻️ GH-242 Ensure consistent allow-rule diagnostics

### DIFF
--- a/src/dev10x/domain/common/allow_rule.py
+++ b/src/dev10x/domain/common/allow_rule.py
@@ -1,0 +1,119 @@
+"""AllowRule value object — canonical ``Tool(pattern)`` permission rule.
+
+Consolidates four drifted matching/parsing implementations that
+produced contradictory diagnostics from the same allow rule
+(audit finding C2, 2026-05-18):
+
+- ``hooks/permission_diagnostics.PermissionResolutionPolicy`` — signature
+  matching with ``:*`` space-boundary expansion (the correct semantics,
+  adopted here as canonical).
+- ``skills/audit/analyze_permissions.matches_allow_rule`` /
+  ``parse_allow_rules`` — diverged on ``:*`` (bare ``startswith``) and an
+  empty-rules quirk.
+- ``validators/prefix_friction._matches_allow_rule`` /
+  ``_load_all_allow_patterns`` — path-coverage matching + a settings loader.
+- ``skills/permission_investigator/report._extract_path`` — inner-path
+  extraction.
+
+The settings loader duplicated across 8+ sites (finding C3) lives here as
+``AllowRuleLoader``; the factory helpers (finding C9) build canonical rule
+strings without hand-formatting ``Tool(pattern)``.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+_RULE_RE = re.compile(r"^(?P<tool>[A-Za-z_]\w*)\((?P<pattern>.*)\)$")
+
+
+@dataclass(frozen=True)
+class AllowRule:
+    tool: str
+    pattern: str
+    raw: str
+
+    @classmethod
+    def parse(cls, rule: str) -> AllowRule:
+        stripped = rule.strip()
+        match = _RULE_RE.match(stripped)
+        if match:
+            return cls(tool=match.group("tool"), pattern=match.group("pattern"), raw=rule)
+        return cls(tool=stripped, pattern="", raw=rule)
+
+    @classmethod
+    def try_parse(cls, rule: str) -> AllowRule | None:
+        if not isinstance(rule, str) or not rule.strip():
+            return None
+        return cls.parse(rule)
+
+    def matches(self, signature: str) -> bool:
+        rule = self.raw.strip()
+        if signature.startswith("mcp__") or "(" not in rule:
+            return fnmatch.fnmatch(name=signature, pat=rule)
+
+        target = AllowRule.parse(signature)
+        if target.tool != self.tool:
+            return False
+        return self._pattern_matches(value=target.pattern)
+
+    def _pattern_matches(self, *, value: str) -> bool:
+        pattern = self.pattern
+        if pattern.endswith(":*"):
+            prefix = pattern[:-2]
+            return value == prefix or value.startswith(prefix + " ")
+        if pattern.endswith("**"):
+            return value.startswith(pattern[:-2])
+        return fnmatch.fnmatch(name=value, pat=pattern)
+
+    @property
+    def is_prefix(self) -> bool:
+        return self.pattern.endswith(":*")
+
+    @property
+    def inner_path(self) -> str:
+        if ":" in self.pattern:
+            return self.pattern.split(":", 1)[0]
+        return self.pattern
+
+    def covers_path(self, segment: str) -> bool:
+        base = self.inner_path
+        if not base:
+            return False
+        expanded_segment = os.path.expanduser(segment)
+        expanded_base = os.path.expanduser(base)
+        return expanded_segment.startswith(expanded_base) or segment.startswith(base)
+
+    @classmethod
+    def bash(cls, pattern: str) -> AllowRule:
+        return cls(tool="Bash", pattern=pattern, raw=f"Bash({pattern})")
+
+    @classmethod
+    def read(cls, pattern: str) -> AllowRule:
+        return cls(tool="Read", pattern=pattern, raw=f"Read({pattern})")
+
+    @classmethod
+    def skill(cls, pattern: str) -> AllowRule:
+        return cls(tool="Skill", pattern=pattern, raw=f"Skill({pattern})")
+
+
+class AllowRuleLoader:
+    @staticmethod
+    def load(path: str | Path) -> list[str]:
+        try:
+            data = json.loads(Path(path).read_text())
+        except (FileNotFoundError, json.JSONDecodeError):
+            return []
+        allow = data.get("permissions", {}).get("allow", [])
+        if not isinstance(allow, list):
+            return []
+        return [entry if isinstance(entry, str) else str(entry) for entry in allow]
+
+    @classmethod
+    def rules(cls, path: str | Path) -> list[AllowRule]:
+        return [rule for raw in cls.load(path) if (rule := AllowRule.try_parse(raw))]

--- a/src/dev10x/hooks/permission_diagnostics.py
+++ b/src/dev10x/hooks/permission_diagnostics.py
@@ -19,7 +19,6 @@ permissions.allow list.
 
 from __future__ import annotations
 
-import fnmatch
 import json
 import os
 from dataclasses import dataclass
@@ -27,6 +26,7 @@ from pathlib import Path
 from typing import Any
 
 from dev10x.domain.claude_paths import ClaudeDir
+from dev10x.domain.common.allow_rule import AllowRule
 from dev10x.subprocess_utils import effective_cwd
 
 
@@ -124,57 +124,15 @@ def _load_allow_rules(path: Path) -> list[str] | None:
     return allow
 
 
-class PermissionResolutionPolicy:
-    """Encapsulates how an allow-rule string is matched against a tool signature.
-
-    Lives as a named class so the matching semantics — MCP tools by
-    fnmatch over the whole signature, Bash rules by tool+pattern with
-    ``:*`` prefix expansion — can be unit-tested and extended without
-    touching ``diagnose()``.
-    """
-
-    @staticmethod
-    def matches(*, signature: str, rule: str) -> bool:
-        if signature.startswith("mcp__"):
-            return fnmatch.fnmatch(name=signature, pat=rule)
-
-        paren_idx = rule.find("(")
-        if paren_idx == -1:
-            return fnmatch.fnmatch(name=signature, pat=rule)
-
-        rule_tool = rule[:paren_idx]
-        rule_pattern = rule[paren_idx + 1 :].rstrip(")")
-
-        sig_paren_idx = signature.find("(")
-        if sig_paren_idx == -1:
-            return False
-
-        sig_tool = signature[:sig_paren_idx]
-        sig_value = signature[sig_paren_idx + 1 :].rstrip(")")
-
-        if rule_tool != sig_tool:
-            return False
-
-        if rule_pattern.endswith(":*"):
-            prefix = rule_pattern[:-2]
-            return sig_value == prefix or sig_value.startswith(prefix + " ")
-
-        return fnmatch.fnmatch(name=sig_value, pat=rule_pattern)
-
-    @classmethod
-    def find_matching(cls, *, signature: str, rules: list[str]) -> str | None:
-        for rule in rules:
-            if cls.matches(signature=signature, rule=rule):
-                return rule
-        return None
-
-
 def _matches_rule(*, signature: str, rule: str) -> bool:
-    return PermissionResolutionPolicy.matches(signature=signature, rule=rule)
+    return AllowRule.parse(rule).matches(signature)
 
 
 def _find_matching_rule(*, signature: str, rules: list[str]) -> str | None:
-    return PermissionResolutionPolicy.find_matching(signature=signature, rules=rules)
+    for rule in rules:
+        if _matches_rule(signature=signature, rule=rule):
+            return rule
+    return None
 
 
 def _resolve_settings_files(*, cwd: str) -> list[SettingsFile]:

--- a/src/dev10x/skills/audit/analyze_permissions.py
+++ b/src/dev10x/skills/audit/analyze_permissions.py
@@ -19,7 +19,6 @@ If settings.json is omitted, uses ~/.claude/settings.local.json.
 If output.md is omitted, writes to stdout.
 """
 
-import fnmatch
 import json
 import os
 import re
@@ -28,6 +27,8 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TextIO
+
+from dev10x.domain.common.allow_rule import AllowRule, AllowRuleLoader
 
 TURN_RE = re.compile(
     r"^## Turn (\d+) \[([^\]]+)\] (USER|ASSISTANT)",
@@ -42,8 +43,6 @@ TOOL_INPUT_BLOCK_RE = re.compile(
 TOOL_RE = re.compile(r"^\*\*Tool: `([^`]+)`\*\*", re.MULTILINE)
 
 PERMISSION_TOOLS = {"Bash", "Read", "Write", "Edit"}
-
-ALLOW_RULE_RE = re.compile(r"^(\w+)\((.+)\)$")
 
 CHAIN_RE = re.compile(r"&&|;\s")
 SUBSHELL_RE = re.compile(r"\$\(")
@@ -94,13 +93,6 @@ class ToolCall:
         if self.tool.startswith("mcp__"):
             return self.tool
         return f"{self.tool}()"
-
-
-@dataclass
-class AllowRule:
-    tool: str
-    pattern: str
-    raw: str
 
 
 @dataclass
@@ -198,21 +190,11 @@ def parse_tool_calls(text: str) -> list[ToolCall]:
 
 
 def parse_allow_rules(settings_path: str) -> list[AllowRule]:
-    path = Path(settings_path)
-    if not path.exists():
-        return []
-
-    data = json.loads(path.read_text())
-    rules: list[AllowRule] = []
-
-    allow_list = data.get("permissions", {}).get("allow", [])
-    for entry in allow_list:
-        raw = entry if isinstance(entry, str) else str(entry)
-        m = ALLOW_RULE_RE.match(raw)
-        if m:
-            rules.append(AllowRule(tool=m.group(1), pattern=m.group(2), raw=raw))
-
-    return rules
+    return [
+        rule
+        for raw in AllowRuleLoader.load(settings_path)
+        if (rule := AllowRule.try_parse(raw)) and rule.pattern
+    ]
 
 
 def parse_additional_directories(settings_path: str) -> list[str]:
@@ -312,32 +294,10 @@ def detect_known_friction(
 
 
 def matches_allow_rule(tc: ToolCall, rules: list[AllowRule]) -> bool:
-    for rule in rules:
-        if rule.tool != tc.tool:
-            continue
-
-        pattern = rule.pattern
-        if tc.tool == "Bash":
-            if pattern.endswith(":*"):
-                prefix = pattern[:-2]
-                if tc.command.startswith(prefix):
-                    return True
-            elif pattern.endswith("*"):
-                prefix = pattern[:-1]
-                if tc.command.startswith(prefix):
-                    return True
-            elif tc.command == pattern:
-                return True
-        else:
-            target = tc.file_path or tc.command
-            if pattern.endswith("**"):
-                dir_prefix = pattern[:-2]
-                if target.startswith(dir_prefix):
-                    return True
-            elif fnmatch.fnmatch(target, pattern):
-                return True
-
-    return True if not rules else False
+    if not rules:
+        return True
+    signature = tc.signature()
+    return any(rule.matches(signature) for rule in rules)
 
 
 def classify_toxicity(command: str) -> str | None:

--- a/src/dev10x/skills/permission_investigator/report.py
+++ b/src/dev10x/skills/permission_investigator/report.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from dev10x.domain.common.allow_rule import AllowRule
 from dev10x.skills.permission_investigator.matrix import (
     Matrix,
     MatrixResult,
@@ -153,7 +154,4 @@ def _classify_rule(rule: str) -> tuple[PathPrefix | None, WildcardShape | None]:
 def _extract_path(rule: str) -> str | None:
     if "(" not in rule or not rule.endswith(")"):
         return None
-    inner = rule.split("(", 1)[1][:-1]
-    if ":" in inner:
-        inner = inner.split(":", 1)[0]
-    return inner
+    return AllowRule.parse(rule).inner_path

--- a/src/dev10x/validators/prefix_friction.py
+++ b/src/dev10x/validators/prefix_friction.py
@@ -11,7 +11,6 @@ allow-rule matching:
 
 from __future__ import annotations
 
-import json
 import os
 import re
 from dataclasses import dataclass, field
@@ -19,6 +18,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 from dev10x.domain import HookInput, HookResult
 from dev10x.domain.claude_paths import ClaudeDir
+from dev10x.domain.common.allow_rule import AllowRule, AllowRuleLoader
 from dev10x.domain.profile_tier import ProfileTier
 from dev10x.validators.base import ValidatorBase
 
@@ -226,15 +226,12 @@ MERGE_BASE_MSG = (
 def _load_all_allow_patterns() -> list[str]:
     patterns: list[str] = []
     for path in SETTINGS_FILES:
-        try:
-            with open(path) as f:
-                data = json.load(f)
-            for rule in data.get("permissions", {}).get("allow", []):
-                m = re.match(r"^Bash\((.+?)(?::\*)?\)$", rule)
-                if m:
-                    patterns.append(m.group(1))
-        except (FileNotFoundError, json.JSONDecodeError):
-            pass
+        for rule in AllowRuleLoader.rules(path):
+            if rule.tool == "Bash" and rule.pattern:
+                pattern = rule.pattern
+                if pattern.endswith(":*"):
+                    pattern = pattern[:-2]
+                patterns.append(pattern)
     return patterns
 
 
@@ -256,10 +253,8 @@ def _matches_allow_rule(
     segment: str,
     patterns: list[str],
 ) -> str | None:
-    expanded_seg = os.path.expanduser(segment)
     for pattern in patterns:
-        expanded_pat = os.path.expanduser(pattern)
-        if expanded_seg.startswith(expanded_pat) or segment.startswith(pattern):
+        if AllowRule.bash(pattern).covers_path(segment):
             return pattern
     return None
 

--- a/tests/domain/common/test_allow_rule.py
+++ b/tests/domain/common/test_allow_rule.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dev10x.domain.common.allow_rule import AllowRule, AllowRuleLoader
+
+
+class TestParse:
+    def test_parses_tool_and_pattern(self) -> None:
+        rule = AllowRule.parse("Bash(git status:*)")
+
+        assert rule.tool == "Bash"
+        assert rule.pattern == "git status:*"
+        assert rule.raw == "Bash(git status:*)"
+
+    def test_parses_pattern_containing_parens(self) -> None:
+        rule = AllowRule.parse("Bash(git log --format=%H)")
+
+        assert rule.tool == "Bash"
+        assert rule.pattern == "git log --format=%H"
+
+    def test_bare_tool_has_empty_pattern(self) -> None:
+        rule = AllowRule.parse("Read")
+
+        assert rule.tool == "Read"
+        assert rule.pattern == ""
+
+    def test_mcp_tool_parses_as_bare(self) -> None:
+        rule = AllowRule.parse("mcp__plugin_Dev10x_cli__mktmp")
+
+        assert rule.tool == "mcp__plugin_Dev10x_cli__mktmp"
+        assert rule.pattern == ""
+
+
+class TestTryParse:
+    @pytest.mark.parametrize("raw", ["", "   ", None])
+    def test_returns_none_for_blank(self, raw: object) -> None:
+        assert AllowRule.try_parse(raw) is None  # type: ignore[arg-type]
+
+    def test_returns_rule_for_valid(self) -> None:
+        rule = AllowRule.try_parse("Bash(ls:*)")
+
+        assert rule is not None
+        assert rule.tool == "Bash"
+
+
+class TestMatches:
+    @pytest.mark.parametrize(
+        "rule,signature,expected",
+        [
+            # `:*` prefix expansion — exact match
+            ("Bash(git status:*)", "Bash(git status)", True),
+            # `:*` prefix expansion — space-boundary match
+            ("Bash(git push:*)", "Bash(git push --force)", True),
+            # divergence fixture: bare `startswith` would WRONGLY match a
+            # different command sharing the prefix; canonical requires a
+            # space (or exact) boundary so `git pushy` is NOT covered.
+            ("Bash(git push:*)", "Bash(git pushy)", False),
+            ("Bash(git:*)", "Bash(github)", False),
+            ("Bash(git:*)", "Bash(git log)", True),
+            # tool mismatch never matches
+            ("Bash(git:*)", "Read(/etc/hosts)", False),
+            # plain fnmatch pattern (no `:*`)
+            ("Bash(npm test)", "Bash(npm test)", True),
+            ("Bash(npm *)", "Bash(npm test)", True),
+            # path tools — `**` recursive prefix
+            ("Read(/work/**)", "Read(/work/foo/bar.py)", True),
+            ("Read(/work/**)", "Read(/other/bar.py)", False),
+            # MCP rules match by fnmatch over the whole signature
+            ("mcp__plugin_Dev10x_cli__*", "mcp__plugin_Dev10x_cli__mktmp", True),
+            ("mcp__plugin_Dev10x_db__*", "mcp__plugin_Dev10x_cli__mktmp", False),
+            # paren-less rules are fnmatch globs over the whole signature
+            ("Bash*", "Bash(git status)", True),
+            ("Read*", "Bash(git status)", False),
+        ],
+    )
+    def test_matches(self, rule: str, signature: str, expected: bool) -> None:
+        assert AllowRule.parse(rule).matches(signature) is expected
+
+    def test_bare_tool_is_literal_not_match_all(self) -> None:
+        # A bare ``Read`` rule is a literal fnmatch (impl #1 semantics),
+        # so it does NOT cover a parameterised ``Read(...)`` signature.
+        assert AllowRule.parse("Read").matches("Read(/etc/hosts)") is False
+
+
+class TestProperties:
+    def test_is_prefix_true_for_star_colon(self) -> None:
+        assert AllowRule.parse("Bash(git:*)").is_prefix is True
+
+    def test_is_prefix_false_for_plain(self) -> None:
+        assert AllowRule.parse("Bash(git log)").is_prefix is False
+
+    def test_inner_path_strips_colon_suffix(self) -> None:
+        assert AllowRule.parse("Bash(~/.claude/tools/foo:*)").inner_path == "~/.claude/tools/foo"
+
+    def test_inner_path_without_colon(self) -> None:
+        assert AllowRule.parse("Read(/work/src)").inner_path == "/work/src"
+
+
+class TestCoversPath:
+    def test_covers_exact_prefix(self) -> None:
+        assert AllowRule.bash("/work/dx/bin/run").covers_path("/work/dx/bin/run --all") is True
+
+    def test_expands_tilde(self) -> None:
+        rule = AllowRule.bash("~/.claude/tools/x")
+        home_path = str(Path("~/.claude/tools/x/go").expanduser())
+
+        assert rule.covers_path(home_path) is True
+
+    def test_does_not_cover_unrelated(self) -> None:
+        assert AllowRule.bash("/work/dx/bin").covers_path("/other/path") is False
+
+    def test_empty_inner_path_covers_nothing(self) -> None:
+        assert AllowRule.parse("Bash").covers_path("anything") is False
+
+
+class TestFactories:
+    @pytest.mark.parametrize(
+        "factory,tool,raw",
+        [
+            (AllowRule.bash, "Bash", "Bash(git:*)"),
+            (AllowRule.read, "Read", "Read(git:*)"),
+            (AllowRule.skill, "Skill", "Skill(git:*)"),
+        ],
+    )
+    def test_factory_builds_rule(self, factory, tool: str, raw: str) -> None:
+        rule = factory("git:*")
+
+        assert rule.tool == tool
+        assert rule.pattern == "git:*"
+        assert rule.raw == raw
+
+
+class TestAllowRuleLoader:
+    def test_load_returns_allow_strings(self, tmp_path: Path) -> None:
+        settings = tmp_path / "settings.json"
+        settings.write_text(
+            json.dumps({"permissions": {"allow": ["Bash(git:*)", "Read(/work/**)"]}})
+        )
+
+        assert AllowRuleLoader.load(settings) == ["Bash(git:*)", "Read(/work/**)"]
+
+    def test_load_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        assert AllowRuleLoader.load(tmp_path / "absent.json") == []
+
+    def test_load_malformed_json_returns_empty(self, tmp_path: Path) -> None:
+        settings = tmp_path / "settings.json"
+        settings.write_text("{not json")
+
+        assert AllowRuleLoader.load(settings) == []
+
+    def test_load_non_list_allow_returns_empty(self, tmp_path: Path) -> None:
+        settings = tmp_path / "settings.json"
+        settings.write_text(json.dumps({"permissions": {"allow": "Bash(git:*)"}}))
+
+        assert AllowRuleLoader.load(settings) == []
+
+    def test_load_coerces_non_string_entries(self, tmp_path: Path) -> None:
+        settings = tmp_path / "settings.json"
+        settings.write_text(json.dumps({"permissions": {"allow": [123]}}))
+
+        assert AllowRuleLoader.load(settings) == ["123"]
+
+    def test_rules_parses_each_entry(self, tmp_path: Path) -> None:
+        settings = tmp_path / "settings.json"
+        settings.write_text(json.dumps({"permissions": {"allow": ["Bash(git:*)", ""]}}))
+
+        rules = AllowRuleLoader.rules(settings)
+
+        assert [rule.tool for rule in rules] == ["Bash"]
+        assert rules[0].pattern == "git:*"


### PR DESCRIPTION
**When** I run permission diagnostics on the same allow rule across the hook, audit, validator, and investigator tools, **I want to** have them agree on whether that rule matches a given tool signature, **so I can** trust a single deterministic verdict instead of reconciling contradictory output.

---

[`f65ed277`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/355/commits/f65ed2772309435bd7ada6547b14dbf4317f5edb) ♻️ GH-242 Ensure consistent allow-rule diagnostics
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/242

---