### PR TITLE
✅ GH-332 Prevent plan_sync tests polluting repo root

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+from collections.abc import Generator
+from pathlib import Path
+
 import pytest
 
 from dev10x.domain.claude_paths import ClaudeDir
@@ -9,6 +12,35 @@ from tests.fakers import (
     HookInputFaker,
     RuleFaker,
 )
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _repo_root_magicmock_files() -> set[Path]:
+    return {entry for entry in _REPO_ROOT.iterdir() if entry.name.startswith("<MagicMock")}
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _guard_repo_root_magicmock_pollution() -> Generator[None, None, None]:
+    """Fail the session if a test leaks a MagicMock-named file at repo root.
+
+    When a mock's chained attribute (e.g. ``get_plan_path().with_suffix()``)
+    is passed to ``os.open()``/``write_text()``, the write lands at the
+    mock's repr, creating a literal ``<MagicMock name=... id=...>`` file in
+    the CWD that pollutes ``git add -A``. Catch and remove any such files so
+    they never reach a commit, then fail loudly so the offending mock is
+    fixed at the source (GH-332).
+    """
+    before = _repo_root_magicmock_files()
+    yield
+    leaked = sorted(entry for entry in _repo_root_magicmock_files() if entry not in before)
+    for entry in leaked:
+        entry.unlink()
+    assert not leaked, (
+        "Tests leaked MagicMock-named files at repo root (GH-332): "
+        f"{[entry.name for entry in leaked]}. A MagicMock was passed to a "
+        "file-write; configure the path mock to return a real tmp_path."
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/plan/test_plan.py
+++ b/tests/plan/test_plan.py
@@ -32,7 +32,9 @@ class TestSetContext:
         mock_plan_cls: MagicMock,
         mock_plan_path: MagicMock,
         mock_toplevel: MagicMock,
+        tmp_path: Path,
     ) -> None:
+        mock_plan_path.return_value = tmp_path / "plan.yaml"
         mock_plan = MagicMock()
         mock_plan_cls.load.return_value = mock_plan
         result = await plan_mod.set_context(args=["no-equals-sign"])
@@ -47,7 +49,9 @@ class TestSetContext:
         mock_plan_cls: MagicMock,
         mock_plan_path: MagicMock,
         mock_toplevel: MagicMock,
+        tmp_path: Path,
     ) -> None:
+        mock_plan_path.return_value = tmp_path / "plan.yaml"
         mock_plan = MagicMock()
         mock_plan.context_keys.return_value = ["key"]
         mock_plan_cls.load.return_value = mock_plan


### PR DESCRIPTION
**When** I run the full pytest suite before shipping, **I want to** keep plan_sync's mocked path writes inside a temp dir, **so I can** stage with `git add -A` without committing stray `<MagicMock ...>` files.

---

[`18eb553e`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/356/commits/18eb553ec51045ec2c511298fe1e27c289cead3a) ✅ GH-332 Prevent plan_sync tests polluting repo root
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/332

---