### PR TITLE
🐛 GH-333 Gate draft conversion on real inline-comment count

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -145,13 +145,15 @@ jobs:
             Leave reviews with any unresolved threads visible.
 
             STEP 7 — CONVERT TO DRAFT IF ISSUES FOUND:
-            After completing the review, if you posted ANY inline comments
-            (via create_inline_comment), convert the PR to draft:
+            After completing the review, check the real inline-comment count
+            from the GitHub API — do NOT rely on your own recollection of
+            whether you called create_inline_comment:
+              `gh pr view ${{ github.event.pull_request.number }} --json reviewComments --jq '.reviewComments | length'`
+            If the returned count is greater than 0, convert the PR to draft:
               `gh pr ready --undo ${{ github.event.pull_request.number }}`
             This lets the author fix all issues without triggering re-reviews
             on each fixup push. The author marks "Ready for review" when done.
-            If the review was clean (no inline comments posted), do NOT
-            convert to draft.
+            If the count is 0 (no inline comments), do NOT convert to draft.
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           claude_args: '--model haiku --allowed-tools "Read,Grep,Glob,mcp__github_inline_comment__create_inline_comment,mcp__github__get_pull_request_review_comments,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr review:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr ready:*),Bash(gh api:*)"'


### PR DESCRIPTION
**When** a claude-code-review run completes with no inline comments posted, **I want to** gate draft conversion on the actual GitHub API comment count, **so I can** avoid spurious draft conversions that block merge without surfacing any actionable finding.

---

[`84f16126`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/358/commits/84f16126f0a8df3d45bb4567bfe9d22e66c4a1a5) 🐛 GH-333 Gate draft conversion on real inline-comment count
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/333

---