### PR TITLE
🐛 GH-315 Fix permission generalizer mid-string :* and stale rules

### DIFF
--- a/skills/upgrade-cleanup/projects.yaml
+++ b/skills/upgrade-cleanup/projects.yaml
@@ -151,8 +151,10 @@ base_permissions:
   - "Read(.claude/Dev10x/**)"
   - "Write(.claude/Dev10x/**)"
   - "Edit(.claude/Dev10x/**)"
-  - "Bash(grep:*~/.claude/memory/Dev10x/**)"
-  - "Bash(grep:*~/.claude/plugins/cache/Dev10x-Guru/**)"
+  # GH-315: the two Bash(grep:*<path>) rules below were removed.
+  # Claude Code rejects :* in a non-trailing position ("The :* pattern
+  # must be at the end"). They were also redundant — Bash(grep:*)
+  # already covers all grep invocations.
 
   # --- Dev10x MCP tools: cli server (GH-878) ---
   - "mcp__plugin_Dev10x_cli__detect_tracker"

--- a/src/dev10x/skills/permission/update_paths.py
+++ b/src/dev10x/skills/permission/update_paths.py
@@ -12,6 +12,17 @@ Config lookup order (post-GH-215):
   3. ${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/projects.yaml (plugin default)
 
 CLI entry point: ``dev10x permission update-paths`` (and siblings).
+
+GH-315 Bug C (deferred): ``merge-worktree`` and ``clean`` read
+``~/.config/Dev10x/upgrade-cleanup-projects.yaml`` (USERSPACE_CONFIG),
+while all other subcommands (``update-paths``, ``ensure-base``,
+``generalize``, ``ensure-reads``, ``ensure-scripts``,
+``ensure-workspace``, ``enumerate-mcp``) read
+``~/.config/Dev10x/projects.yaml`` (MEMORY_CONFIG). Both files
+contain a ``roots`` / ``plugin_cache`` section; ``merge-worktree``
+and ``clean`` do not consume ``base_permissions``, so the split is
+currently harmless. Consolidate both commands to read MEMORY_CONFIG
+in a follow-up ticket so the two files do not drift.
 """
 
 import json
@@ -648,7 +659,7 @@ GENERALIZE_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"(gh-pr-detect\.sh)\s+[^)]+"), r"\1:*"),
     (re.compile(r"(generate-commit-list\.sh)\s+[^)]+"), r"\1:*"),
     (re.compile(r"(extract-session\.sh)\s+[^)]+"), r"\1:*"),
-    (re.compile(r"(\.(?:sh|py))\s+[^):]+(?::\*)?"), r"\1:*"),
+    (re.compile(r"(\.(?:sh|py))\s+[^)]+"), r"\1:*"),
     (re.compile(r"(/tmp/Dev10x/[^/]+/)[^/)]+\.[A-Za-z0-9]{6,}\.(txt|md|json)"), r"\1*"),
     (re.compile(r"(git reset --hard) origin/\S+"), r"\1"),
     (re.compile(r"(git reset --soft) [A-Fa-f0-9]{6,}"), r"\1"),

--- a/tests/skills/upgrade-cleanup/test_generalize.py
+++ b/tests/skills/upgrade-cleanup/test_generalize.py
@@ -46,6 +46,44 @@ class TestGeneralizePermission:
 
         assert result == "Write(/tmp/Dev10x/git/*)"
 
+    def test_generalizes_quoted_json_blob_arg(self) -> None:
+        """GH-315: single quoted JSON-blob arg must collapse to Bash(<script>:*).
+
+        The argument contains colons (e.g. ``"week":"2026-W21"``).  The old
+        ``[^):]+`` pattern stopped at the first colon, leaving a malformed
+        ``Bash(<script>:*:<rest>)`` rule that Claude Code rejects at load time.
+        """
+        entry = (
+            "Bash(~/.claude/tools/append-weekly-history.py"
+            ' \'{"week":"2026-W21","start":"2026-05-18","reviews":13}\')'
+        )
+
+        result = update_paths.generalize_permission(entry)
+
+        assert result == "Bash(~/.claude/tools/append-weekly-history.py:*)"
+
+    @pytest.mark.parametrize(
+        "entry,expected",
+        [
+            (
+                "Bash(~/.claude/tools/my-script.sh --flag value)",
+                "Bash(~/.claude/tools/my-script.sh:*)",
+            ),
+            (
+                "Bash(~/.claude/tools/my-script.py arg1 arg2)",
+                "Bash(~/.claude/tools/my-script.py:*)",
+            ),
+        ],
+    )
+    def test_generalizes_script_with_args_no_colon(
+        self,
+        entry: str,
+        expected: str,
+    ) -> None:
+        result = update_paths.generalize_permission(entry)
+
+        assert result == expected
+
 
 class TestGeneralizePermissions:
     @pytest.fixture()


### PR DESCRIPTION
When I run Dev10x:plugin-maintenance after upgrading to 0.75.0, I want to avoid Claude Code startup warnings about invalid permission rules so I can start sessions without noise and know my settings are valid.

---

[`33c667cf`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/359/commits/33c667cf5662406298080cdedab60188a86ca450) 🐛 GH-315 Fix permission generalizer mid-string :* and stale rules
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/315

---