### PR TITLE
🐛 GH-329 Fix broken pr_get and resolve_review_thread MCP tools

### DIFF
--- a/skills/gh-context/scripts/gh-pr-get.sh
+++ b/skills/gh-context/scripts/gh-pr-get.sh
@@ -15,4 +15,4 @@ NUMBER="${1:?Usage: gh-pr-get.sh NUMBER [REPO]}"
 REPO="${2:-$(gh repo view --json nameWithOwner -q '.nameWithOwner')}"
 
 gh pr view "$NUMBER" --repo "$REPO" \
-    --json number,title,body,state,baseRefName,headRefName,merged,mergedAt,closedAt,labels,milestone,assignees,author,url
+    --json number,title,body,state,baseRefName,headRefName,mergedAt,closedAt,labels,milestone,assignees,author,url

--- a/skills/gh-context/scripts/gh-pr-get.sh
+++ b/skills/gh-context/scripts/gh-pr-get.sh
@@ -7,7 +7,8 @@
 # If REPO is omitted, detects from current directory.
 #
 # Output: JSON with number, title, body, state, baseRefName, headRefName,
-# merged, mergedAt, closedAt, labels, milestone, assignees, author, url.
+# mergedAt, closedAt, labels, milestone, assignees, author, url.
+# Note: ``merged`` is not a valid gh pr view field (GH-329); use mergedAt.
 
 set -euo pipefail
 

--- a/skills/request-review/SKILL.md
+++ b/skills/request-review/SKILL.md
@@ -11,7 +11,7 @@ description: >
 user-invocable: true
 invocation-name: Dev10x:request-review
 allowed-tools:
-  - Bash(${CLAUDE_PLUGIN_ROOT}/skills/gh-context/scripts/:*)
+  - mcp__plugin_Dev10x_cli__pr_detect
   - Skill(Dev10x:gh-pr-request-review)
   - Skill(Dev10x:slack-review-request)
   - Bash(gh pr view:*)
@@ -34,13 +34,13 @@ Mark completed when done: `TaskUpdate(taskId, status="completed")`
 
 ### Step 1: Detect PR context
 
-Use the `Dev10x:gh-context` script to detect PR number and repo:
+Use the MCP tool to detect PR number and repo:
 
-```bash
-${CLAUDE_PLUGIN_ROOT}/skills/gh-context/scripts/gh-pr-detect.sh "$ARG"
+```
+mcp__plugin_Dev10x_cli__pr_detect(arg="$ARG")
 ```
 
-Parse `PR_NUMBER`, `REPO`, `PR_URL` from KEY=VALUE stdout.
+Parse `PR_NUMBER`, `REPO`, `PR_URL` from the returned dict.
 Pass `$ARG` as the skill argument (PR URL, bare number, or empty).
 
 If detection fails, report the error and stop.

--- a/src/dev10x/github/__init__.py
+++ b/src/dev10x/github/__init__.py
@@ -406,6 +406,14 @@ async def _pr_comment_resolve(
     comment_ids: list[str] | None = None,
     **_: Any,
 ) -> Result[dict[str, Any]]:
+    """Resolve one or more PR review threads by comment node ID.
+
+    GitHub's GraphQL API does not expose
+    ``PullRequestReviewComment.pullRequestReviewThread`` (GH-329).
+    Instead we fetch ``databaseId`` and the parent PR's ``reviewThreads``,
+    then match threads whose first comment's ``databaseId`` equals the
+    one returned for the requested node ID.
+    """
     ids_to_resolve: list[str] = []
     if comment_ids:
         ids_to_resolve = comment_ids
@@ -414,10 +422,16 @@ async def _pr_comment_resolve(
     else:
         return err("comment_id or comment_ids required for 'resolve' action")
 
+    # One GraphQL query per comment: fetch databaseId and the PR's reviewThreads
+    # so we can match thread by first-comment databaseId without a separate
+    # PR-number parameter (GH-329).
     node_fragments = " ".join(
         f"n{i}: node(id: {json.dumps(cid)}) "
-        f"{{ ... on PullRequestReviewComment "
-        f"{{ pullRequestReviewThread {{ id }} }} }}"
+        "{ ... on PullRequestReviewComment { "
+        "databaseId "
+        "pullRequest { reviewThreads(first: 100) { nodes { "
+        "id comments(first: 1) { nodes { databaseId } } } } } "
+        "} }"
         for i, cid in enumerate(ids_to_resolve)
     )
     query_result = await _gh_api_raw(
@@ -432,9 +446,23 @@ async def _pr_comment_resolve(
     errors: list[str] = []
     for i, cid in enumerate(ids_to_resolve):
         node = query_data.get("data", {}).get(f"n{i}")
-        thread = node.get("pullRequestReviewThread") if node else None
-        if thread and thread["id"].startswith("PRRT_"):
-            thread_ids.append(thread["id"])
+        if node is None:
+            errors.append(
+                f"Could not find thread for comment {cid}. "
+                "The resolve action requires a GraphQL node_id, not a REST "
+                "integer ID. Use the node_id field from a comment response."
+            )
+            continue
+        comment_db_id = node.get("databaseId")
+        threads = node.get("pullRequest", {}).get("reviewThreads", {}).get("nodes", [])
+        matched_thread_id: str | None = None
+        for thread in threads:
+            first_comments = thread.get("comments", {}).get("nodes", [])
+            if first_comments and first_comments[0].get("databaseId") == comment_db_id:
+                matched_thread_id = thread.get("id")
+                break
+        if matched_thread_id and matched_thread_id.startswith("PRRT_"):
+            thread_ids.append(matched_thread_id)
         else:
             errors.append(
                 f"Could not find thread for comment {cid}. "

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -1995,7 +1995,9 @@ class TestPrGet:
         )
         content = script_path.read_text()
         assert "merged," not in content
-        assert ",merged" not in content
+        # ",mergedAt" is valid; assert the standalone ",merged" field is absent
+        assert ",merged," not in content
+        assert ",merged\n" not in content
         # mergedAt is the valid replacement field
         assert "mergedAt" in content
 

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -37,10 +37,39 @@ def _completed(
     )
 
 
+def _thread_lookup_response(
+    alias: str,
+    db_id: int,
+    thread_id: str,
+) -> dict:
+    """Build the new-style query response for _pr_comment_resolve (GH-329).
+
+    The query fetches databaseId and reviewThreads on the parent PR,
+    then matches the thread whose first comment has the same databaseId.
+    """
+    return {
+        "data": {
+            alias: {
+                "databaseId": db_id,
+                "pullRequest": {
+                    "reviewThreads": {
+                        "nodes": [
+                            {
+                                "id": thread_id,
+                                "comments": {"nodes": [{"databaseId": db_id}]},
+                            }
+                        ]
+                    }
+                },
+            }
+        }
+    }
+
+
 class TestPrCommentsResolveSingle:
     @pytest.fixture
     def query_response(self) -> str:
-        return json.dumps({"data": {"n0": {"pullRequestReviewThread": {"id": "PRRT_thread123"}}}})
+        return json.dumps(_thread_lookup_response("n0", db_id=111, thread_id="PRRT_thread123"))
 
     @pytest.fixture
     def mutation_response(self) -> str:
@@ -69,6 +98,29 @@ class TestPrCommentsResolveSingle:
 
         assert result.value["data"]["r0"]["thread"]["isResolved"] is True
         assert mock_api.call_count == 2
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github._gh_api_raw", new_callable=AsyncMock)
+    async def test_query_uses_database_id_lookup(
+        self,
+        mock_api: AsyncMock,
+        mock_resolve_repo: AsyncMock,
+        query_response: str,
+        mutation_response: str,
+    ) -> None:
+        """Query must use databaseId+reviewThreads, not pullRequestReviewThread (GH-329)."""
+        mock_api.side_effect = [
+            _completed(stdout=query_response),
+            _completed(stdout=mutation_response),
+        ]
+
+        await gh.pr_comments(action="resolve", comment_id="PRRC_comment123")
+
+        query_call = mock_api.call_args_list[0]
+        query_str = query_call.kwargs["fields"]["query"]
+        assert "databaseId" in query_str
+        assert "reviewThreads" in query_str
+        assert "pullRequestReviewThread" not in query_str
 
     @pytest.mark.asyncio
     @patch("dev10x.github._gh_api_raw", new_callable=AsyncMock)
@@ -108,12 +160,27 @@ class TestPrCommentsResolveBatch:
 
     @pytest.fixture
     def batch_query_response(self) -> str:
+        def _node(db_id: int, thread_id: str) -> dict:
+            return {
+                "databaseId": db_id,
+                "pullRequest": {
+                    "reviewThreads": {
+                        "nodes": [
+                            {
+                                "id": thread_id,
+                                "comments": {"nodes": [{"databaseId": db_id}]},
+                            }
+                        ]
+                    }
+                },
+            }
+
         return json.dumps(
             {
                 "data": {
-                    "n0": {"pullRequestReviewThread": {"id": "PRRT_t1"}},
-                    "n1": {"pullRequestReviewThread": {"id": "PRRT_t2"}},
-                    "n2": {"pullRequestReviewThread": {"id": "PRRT_t3"}},
+                    "n0": _node(101, "PRRT_t1"),
+                    "n1": _node(102, "PRRT_t2"),
+                    "n2": _node(103, "PRRT_t3"),
                 }
             }
         )
@@ -188,7 +255,7 @@ class TestPrCommentsResolveBatch:
     ) -> None:
         mock_api.side_effect = [
             _completed(
-                stdout=json.dumps({"data": {"n0": {"pullRequestReviewThread": {"id": "PRRT_t1"}}}})
+                stdout=json.dumps(_thread_lookup_response("n0", db_id=99, thread_id="PRRT_t1"))
             ),
             _completed(
                 stdout=json.dumps(
@@ -250,14 +317,31 @@ class TestPrCommentsResolveErrors:
 
     @pytest.mark.asyncio
     @patch("dev10x.github._gh_api_raw", new_callable=AsyncMock)
-    async def test_returns_error_when_thread_id_invalid(
+    async def test_returns_error_when_no_matching_thread(
         self,
         mock_api: AsyncMock,
         mock_resolve_repo: AsyncMock,
     ) -> None:
+        # databaseId 42 is returned, but reviewThreads has a different databaseId
         mock_api.return_value = _completed(
             stdout=json.dumps(
-                {"data": {"n0": {"pullRequestReviewThread": {"id": "INVALID_123"}}}}
+                {
+                    "data": {
+                        "n0": {
+                            "databaseId": 42,
+                            "pullRequest": {
+                                "reviewThreads": {
+                                    "nodes": [
+                                        {
+                                            "id": "PRRT_other",
+                                            "comments": {"nodes": [{"databaseId": 999}]},
+                                        }
+                                    ]
+                                }
+                            },
+                        }
+                    }
+                }
             ),
         )
 
@@ -281,7 +365,19 @@ class TestPrCommentsResolveErrors:
                 stdout=json.dumps(
                     {
                         "data": {
-                            "n0": {"pullRequestReviewThread": {"id": "PRRT_good"}},
+                            "n0": {
+                                "databaseId": 55,
+                                "pullRequest": {
+                                    "reviewThreads": {
+                                        "nodes": [
+                                            {
+                                                "id": "PRRT_good",
+                                                "comments": {"nodes": [{"databaseId": 55}]},
+                                            }
+                                        ]
+                                    }
+                                },
+                            },
                             "n1": None,
                         }
                     }
@@ -312,7 +408,7 @@ class TestPrCommentsResolveErrors:
     ) -> None:
         mock_api.side_effect = [
             _completed(
-                stdout=json.dumps({"data": {"n0": {"pullRequestReviewThread": {"id": "PRRT_t1"}}}})
+                stdout=json.dumps(_thread_lookup_response("n0", db_id=77, thread_id="PRRT_t1"))
             ),
             _completed(returncode=1, stderr="Mutation failed"),
         ]
@@ -359,7 +455,7 @@ class TestResolveReviewThreadDirect:
     ) -> None:
         mock_api.side_effect = [
             _completed(
-                stdout=json.dumps({"data": {"n0": {"pullRequestReviewThread": {"id": "PRRT_t1"}}}})
+                stdout=json.dumps(_thread_lookup_response("n0", db_id=88, thread_id="PRRT_t1"))
             ),
             _completed(
                 stdout=json.dumps(
@@ -1865,13 +1961,15 @@ class TestPrGet:
     @pytest.mark.asyncio
     @patch("dev10x.github.async_run_script", new_callable=AsyncMock)
     async def test_parses_pr_json(self, mock_run: AsyncMock) -> None:
+        # ``merged`` was removed from gh-pr-get.sh (GH-329).
+        # Derive merged-ness from state == "MERGED" or mergedAt != null.
         mock_run.return_value = _completed(
             stdout=json.dumps(
                 {
                     "number": 42,
                     "title": "Fix things",
                     "state": "OPEN",
-                    "merged": False,
+                    "mergedAt": None,
                     "url": "https://github.com/owner/repo/pull/42",
                 }
             )
@@ -1882,10 +1980,24 @@ class TestPrGet:
         assert isinstance(result, SuccessResult)
         assert result.value["number"] == 42
         assert result.value["state"] == "OPEN"
+        assert "merged" not in result.value
         called_args = mock_run.call_args.args
         assert "skills/gh-context/scripts/gh-pr-get.sh" in called_args[0]
         assert "42" in called_args
         assert "owner/repo" in called_args
+
+    def test_gh_pr_get_script_excludes_merged_field(self) -> None:
+        """gh-pr-get.sh must not request the invalid ``merged`` JSON field (GH-329)."""
+        from pathlib import Path
+
+        script_path = (
+            Path(__file__).parents[2] / "skills" / "gh-context" / "scripts" / "gh-pr-get.sh"
+        )
+        content = script_path.read_text()
+        assert "merged," not in content
+        assert ",merged" not in content
+        # mergedAt is the valid replacement field
+        assert "mergedAt" in content
 
     @pytest.mark.asyncio
     @patch("dev10x.github.async_run_script", new_callable=AsyncMock)

--- a/tests/mcp/test_cli_server.py
+++ b/tests/mcp/test_cli_server.py
@@ -955,12 +955,14 @@ class TestPrGet:
         self,
         mock_fn: AsyncMock,
     ) -> None:
+        # ``merged`` was removed from gh-pr-get.sh (GH-329) — derive
+        # merged-ness from state == "MERGED" or mergedAt != null instead.
         mock_fn.return_value = ok(
             {
                 "number": 42,
                 "title": "T",
                 "state": "OPEN",
-                "merged": False,
+                "mergedAt": None,
             }
         )
 
@@ -968,6 +970,7 @@ class TestPrGet:
 
         assert result["number"] == 42
         assert result["state"] == "OPEN"
+        assert "merged" not in result
         assert mock_fn.call_args.kwargs == {"number": 42, "repo": "o/r"}
 
     @pytest.mark.asyncio


### PR DESCRIPTION
**When** pr_get or resolve_review_thread MCP tools fail with GraphQL errors, **I want to** have them return correct data, **so I can** use the MCP-routed path without falling back to raw gh CLI invocations.

---

[`1a20c36b`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/360/commits/1a20c36b25f359281bf3e09ebab6f58ecdb92137) 🐛 GH-329 Fix broken pr_get and resolve_review_thread MCP tools
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/329

---