### PR TITLE
✨ GH-319 Enable draft-vs-submit gate in gh-pr-review

### DIFF
--- a/skills/gh-pr-review/SKILL.md
+++ b/skills/gh-pr-review/SKILL.md
@@ -3,7 +3,8 @@ name: Dev10x:gh-pr-review
 description: >
   Review a GitHub pull request and post findings with inline comments.
   Fetches PR diff, reads changed files, checks for interface impact,
-  applies project review guidelines, and posts a COMMENT review to GitHub.
+  applies project review guidelines, and posts a review to GitHub.
+  Supports Draft (PENDING) and submitted review modes via Step 8a gate.
   TRIGGER when: reviewing an external PR and posting review comments.
   DO NOT TRIGGER when: reviewing own branch changes before PR creation
   (use Dev10x:review), or PR does not exist yet.
@@ -16,6 +17,7 @@ allowed-tools:
   - Write(/tmp/Dev10x/git/**)
   - mcp__plugin_Dev10x_cli__pr_detect
   - mcp__plugin_Dev10x_cli__mktmp
+  - AskUserQuestion
 ---
 
 # GitHub PR Review
@@ -52,14 +54,17 @@ Never pause between steps to ask "should I continue?".
 1. `TaskCreate(subject="Fetch PR diff", activeForm="Fetching PR context")`
 2. `TaskCreate(subject="Run spec compliance gate", activeForm="Checking spec compliance")`
 3. `TaskCreate(subject="Review changes", activeForm="Reviewing changes")`
-4. `TaskCreate(subject="Post findings", activeForm="Posting review")`
+4. `TaskCreate(subject="Choose draft or submit", activeForm="Selecting review mode")`
+5. `TaskCreate(subject="Post findings", activeForm="Posting review")`
 
 Set sequential dependencies: spec gate blocked by fetch, review
-blocked by spec gate, post blocked by review.
+blocked by spec gate, draft gate blocked by review, post blocked
+by draft gate.
 
-No user decision gates — this skill runs fully automated once
-invoked. All review decisions (what to flag, severity) are made by
-applying `review-guidelines.md` and `review-checks-common.md`.
+No user decision gates before Step 8a. All review decisions (what
+to flag, severity) are made by applying `review-guidelines.md` and
+`review-checks-common.md`. The Step 8a gate is the single user
+interaction point.
 
 ## Workflow
 
@@ -236,10 +241,62 @@ recipe (MCP-first mktmp, no heredocs), Transport B prerequisites
 body-rewriting recipe that converts inline comments into a
 single top-level findings block.
 
+**Transport B bypasses Step 8a** — bot comments have no PENDING
+state. Proceed directly to posting and then Step 9.
+
+### Step 8a: Draft vs Submit Gate (GH-319)
+
+**Only for Transport A (open PR, normal diff).** Before writing
+the review JSON and posting, decide the `event` value.
+
+**Intent detection:** Scan the original invocation argument for
+draft-intent phrases:
+- "draft", "hold", "before submitting", "leave as draft",
+  "let me review", "let me submit", "do not submit", "don't submit"
+
+If any phrase matches, default to **Draft (PENDING)**.
+Otherwise default to **Submit as COMMENT**.
+
+Also check: if the current user is the PR author (compare
+`pr_detect` `author` field with `gh api /user` login), bias the
+default toward Draft and surface a note that APPROVE is
+unavailable to PR authors.
+
+**REQUIRED: Call `AskUserQuestion`** (do NOT use plain text).
+
+Options:
+- **Draft (PENDING)** — Post without `event`; only you see it until
+  you finish on GitHub. *[set as default when draft-intent detected]*
+- **Submit as COMMENT** — Post and publish immediately as a
+  comment. *[default otherwise]*
+- **Submit as REQUEST_CHANGES** — Post and publish; blocks merge.
+  Surface a warning before selecting.
+- **Submit as APPROVE** — Post and publish as approval.
+  Disabled when reviewer is the PR author.
+
+**After the gate:**
+- Draft (PENDING): omit `event` from the payload; record
+  `review_state=PENDING` for Step 9.
+- Submit as COMMENT: set `"event": "COMMENT"`; record
+  `review_state=SUBMITTED`.
+- Submit as REQUEST_CHANGES: set `"event": "REQUEST_CHANGES"`;
+  record `review_state=SUBMITTED`.
+- Submit as APPROVE: set `"event": "APPROVE"`; record
+  `review_state=SUBMITTED`.
+
 ### Step 9: Report to User
 
-Confirm what was posted:
-- Link to the review on GitHub
+Branch on `review_state`:
+
+**`PENDING` (draft posted):**
+- "Draft review posted (only you can see it). Open the
+  Files changed tab on the PR and click 'Finish your review'
+  to submit."
+- Include `html_url` from the API response.
+- Count of inline comments queued in the draft.
+
+**`SUBMITTED`:**
+- Link to the review on GitHub (`html_url`)
 - Count of inline comments
 - Brief summary of findings
 

--- a/skills/gh-pr-review/references/transport-selection.md
+++ b/skills/gh-pr-review/references/transport-selection.md
@@ -53,12 +53,45 @@ Use the Write tool to create the review JSON, then post via
 > is blocked by `validate-bash-security.py`. Always Write to a
 > file first.
 
+### `event` field and PENDING semantics (GH-319)
+
+The `event` field controls whether the review is submitted
+immediately or left as a draft visible only to you:
+
+| `event` value | Result | Visible to others? |
+|---|---|---|
+| `"COMMENT"` | Submitted immediately as a comment | Yes |
+| `"REQUEST_CHANGES"` | Submitted, blocks merge | Yes |
+| `"APPROVE"` | Submitted, approves the PR | Yes |
+| *(omitted entirely)* | `state: PENDING` — draft only | No (only you) |
+
+**PENDING visibility:** When `event` is omitted, the GitHub API
+returns `state: PENDING` and `submitted_at: null`. Only the
+review author can see the draft until they submit it by visiting
+the PR's "Files changed" tab and clicking "Finish your review",
+or by calling `PUT .../reviews/{review_id}/events` with
+`{"event": "COMMENT"}` (or another event value).
+
+**Why prefer Draft-first for self-review handoff:** When the
+reviewer is also the PR author — or when the invocation
+explicitly says "leave as draft", "hold", "before submitting",
+"do not submit", or "let me review/submit" — the intent is to
+create the review payload on GitHub but let a human finalize it.
+Omitting `event` achieves exactly this.
+
 ### Rules
 
-- Always use `"event": "COMMENT"` — never REQUEST_CHANGES or
-  APPROVE
-- Include `commit_id` from the PR's latest commit
-- Inline comments must reference lines that exist in the PR diff
+- Default `event` is driven by the Step 8a decision gate (see
+  SKILL.md Step 8a); do NOT hard-code `"COMMENT"` without first
+  running the gate.
+- `"APPROVE"` is blocked when the reviewer is the PR author —
+  GitHub returns HTTP 422 for self-approval. Detect via
+  `pr_detect` author field vs current user.
+- `"REQUEST_CHANGES"` blocks merge; confirm explicitly with the
+  user before selecting this event.
+- Include `commit_id` from the PR's latest commit for all
+  submitted events.
+- Inline comments must reference lines that exist in the PR diff.
 
 ## B. Bot top-level comment (merged PR / oversize diff)
 
@@ -89,6 +122,10 @@ review attribution after merge. For oversize diffs, inline
 anchors are unavailable (no diff fetched). In both cases,
 restructure the review into a single top-level issue comment
 posted as the GitHub App.
+
+**Transport B bypasses the Step 8a draft gate** — bot comments
+have no PENDING state. The review is always posted immediately
+under the App identity.
 
 ### Steps
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -356,3 +356,13 @@ work-on shipping pipeline
 Complements:
 - `Dev10x:gh-pr-review` — posts findings to GitHub (remote PRs)
 - `Dev10x:gh-pr-respond` — responds to PR review comments
+
+## Design Note: Future `--post-to-pr` Mode (GH-319)
+
+If `Dev10x:review` ever gains a `--post-to-pr` flag that hands off
+findings to a GitHub PR review, that mode MUST default to Draft
+(PENDING) rather than submitting immediately. The self-review
+author is almost always the PR author — who should finalize the
+review as a human action, not have it auto-submitted on their
+behalf. Codify "draft-first" at design time to avoid retro-fitting
+the same gap that GH-319 addressed in `Dev10x:gh-pr-review`.


### PR DESCRIPTION
**When** I ask Dev10x:gh-pr-review to review a PR, **I want to** choose between leaving the review as a GitHub draft (PENDING) or submitting it immediately as COMMENT / REQUEST_CHANGES / APPROVE, **so** I can finalize the review on GitHub's Files changed tab before it becomes visible to others.

---

[`5d0188a8`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/362/commits/5d0188a83f60f16dd3a4def88f9585ac174851af) ✨ GH-319 Enable draft-vs-submit gate in gh-pr-review
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/319

---