### PR TITLE
✨ GH-314 Enable reaction-signal triage for gh-pr-triage + gh-pr-respond

### DIFF
--- a/skills/gh-pr-respond/instructions.md
+++ b/skills/gh-pr-respond/instructions.md
@@ -719,13 +719,13 @@ Present the full plan to the user as a table:
 Found {N} unaddressed comments on PR #{pr_number}:
   JTBD: "{PR JTBD outcome phrase}"
 
-| # | Author | File:Line | Summary | Verdict | Priority | Proposed Response |
-|---|--------|-----------|---------|---------|----------|-------------------|
-| 1 | mike   | sender.py:19 | Use SubFactory | VALID | now | Change LazyFunction → SubFactory |
-| 2 | mike   | fakers.py:21 | Randomize values | VALID | fast-follow | Tracked as test-quality enhancement |
-| 3 | claude[bot] | dto.py:5 | TYPE_CHECKING | INVALID | n/a | 38+ files use this pattern |
-| 4 | claude[bot] | tasks.py:12 | Missing type ann | INVALID | n/a | mypy infers from assignment |
-| 5 | mike   | feature.py:8  | Denorm drift | YAGNI | n/a | Bundle r{ids} → propose removal |
+| # | Author | File:Line | Summary | Verdict | Signal | Priority | Proposed Response |
+|---|--------|-----------|---------|---------|--------|----------|-------------------|
+| 1 | mike   | sender.py:19 | Use SubFactory | VALID | text | now | Change LazyFunction → SubFactory |
+| 2 | mike   | fakers.py:21 | Randomize values | VALID | reaction:👍 | fast-follow | Tracked as test-quality enhancement |
+| 3 | claude[bot] | dto.py:5 | TYPE_CHECKING | INVALID | text | n/a | 38+ files use this pattern |
+| 4 | claude[bot] | tasks.py:12 | Missing type ann | INVALID | reaction:👎 | n/a | Declining — maintainer 👎 (no prose). Confirm? |
+| 5 | mike   | feature.py:8  | Denorm drift | YAGNI | text | n/a | Bundle r{ids} → propose removal |
 
 Bundles:
 - YAGNI bundle "speculative-feature-X" (rows 5,7,8,9) → single
@@ -733,6 +733,25 @@ Bundles:
 
 Approve all, or specify which to modify/skip?
 ```
+
+**Signal column (GH-314).** Every row carries a `Signal` value showing
+whether the triage verdict came from prose in the comment body or from
+an emoji reaction left by the maintainer. Reaction-sourced verdicts are
+auditable before the approval gate — the reviewer can confirm or override
+them with one click.
+
+| Signal | Meaning |
+|--------|---------|
+| `text` | Verdict derived from comment prose (normal path) |
+| `reaction:👍` | Maintainer 👍 (VALID lean, no prose) |
+| `reaction:❤️` | Maintainer ❤️ (VALID lean, no prose) |
+| `reaction:🚀` | Maintainer 🚀 (VALID lean, no prose) |
+| `reaction:👎` | Maintainer 👎 (INVALID/decline lean, no prose) |
+| `reaction:😕` | Maintainer 😕 (INVALID/decline lean, no prose) |
+
+Reaction-sourced rows in the `Proposed Response` column include a
+"Confirm?" suffix so the approver knows the verdict needs validation
+before execution.
 
 **Priority column (Finding 2, GH-297).** Every row carries a
 `Priority` value so the batch plan no longer leaves defer-vs-handle

--- a/skills/gh-pr-triage/SKILL.md
+++ b/skills/gh-pr-triage/SKILL.md
@@ -133,6 +133,31 @@ Extract:
 - `html_url` — Direct link
 - `user.login` — Who left the comment
 - `in_reply_to_id` — Parent comment (null for root comments)
+- `reactions` — Emoji reaction counts (`+1`, `-1`, `laugh`, `hooray`,
+  `confused`, `heart`, `rocket`, `eyes`, `total_count`)
+
+**Reaction signal:** When `reactions.total_count > 0`, record which
+reactions the PR author (or other reviewers) left and apply a lean:
+
+| Reactions present | Lean | Meaning |
+|-------------------|------|---------|
+| `+1` and/or `heart` and/or `rocket` | VALID lean | Maintainer approves the suggestion |
+| `-1` and/or `confused` | INVALID/decline lean | Maintainer rejects the suggestion |
+| `eyes` only | No lean | Maintainer is watching, no stance yet |
+| Mixed (`+1` + `-1`) | No lean | Conflicting signals, fall through |
+| None (`total_count == 0`) | No lean | No reaction signal |
+
+The lean is **advisory** — it overrides investigation only when **no
+directing prose exists** in the comment body (body is empty or contains
+only a code suggestion block with no explanatory text). When prose is
+present, treat the lean as corroborating evidence but always investigate.
+
+When applying a reaction lean, surface an inferred rationale for
+confirmation, e.g.:
+- VALID lean: "Applying — maintainer 👍 this suggestion (no prose verdict)"
+- INVALID lean: "Declining — maintainer 👎 this suggestion. Inferred
+  rationale: inconsistent with sibling pattern / out of scope.
+  Confirm or override?"
 
 ### Step 2: Fetch All PR Threads
 
@@ -149,7 +174,21 @@ Look for:
 
 ### Step 3: Classify the Comment
 
-Determine what type of comment this is:
+**Reaction lean check:** Before classifying by prose, check whether
+a reaction lean was recorded in Step 1 and whether the comment body
+lacks directing prose (empty body or pure code-suggestion block with
+no explanatory text). If both conditions hold, short-circuit:
+
+- VALID lean → proceed directly to Step 5 (VALID verdict) with
+  `reaction_signal: true`. Surface the inferred rationale for
+  confirmation: "Applying — maintainer 👍 this suggestion".
+- INVALID/decline lean → proceed directly to Step 5 (INVALID
+  verdict) with `reaction_signal: true`. Surface the inferred
+  rationale: "Declining — maintainer 👎 this suggestion. Inferred
+  rationale: [best-match reason from diff_hunk context]. Confirm
+  or override?"
+
+If prose is present (or no reaction lean), classify normally:
 
 | Type | Signals |
 |------|---------|
@@ -261,6 +300,7 @@ delegate to `Dev10x:gh-pr-fixup`.
 ```
 Verdict: VALID
 Reason: {brief explanation of why the comment is correct}
+Signal: text | reaction:👍 | reaction:❤️ | reaction:🚀
 ```
 
 #### YAGNI — Real issue, but code is out-of-scope for the PR's JTBD
@@ -306,6 +346,7 @@ Post an evidence-based reply. Do **NOT** resolve the thread.
 Verdict: INVALID
 Reason: {brief explanation}
 Action: Replied with evidence (thread left open for user to resolve)
+Signal: text | reaction:👎 | reaction:😕
 ```
 
 #### QUESTION — No code change needed

--- a/src/dev10x/github/__init__.py
+++ b/src/dev10x/github/__init__.py
@@ -317,6 +317,7 @@ async def _list_unresolved_threads(
         "databaseId body path line "
         "author { login } "
         "pullRequestReview { databaseId } "
+        "reactionGroups { content users { totalCount } } "
         "} } "
         "} } } } }"
     )
@@ -337,14 +338,52 @@ async def _list_unresolved_threads(
             continue
         comments = thread.get("comments", {}).get("nodes", [])
         first = comments[0] if comments else {}
-        unresolved.append(
-            {
-                "thread_id": thread.get("id"),
-                "is_outdated": thread.get("isOutdated"),
-                **first,
-            }
-        )
+        normalized = {
+            "thread_id": thread.get("id"),
+            "is_outdated": thread.get("isOutdated"),
+            **first,
+        }
+        reaction_groups = normalized.pop("reactionGroups", None)
+        if reaction_groups is not None:
+            normalized["reactions"] = _normalize_reaction_groups(reaction_groups)
+        unresolved.append(normalized)
     return ok({"unresolved_threads": unresolved, "count": len(unresolved)})
+
+
+_REACTION_GROUP_CONTENT_TO_KEY: dict[str, str] = {
+    "THUMBS_UP": "+1",
+    "THUMBS_DOWN": "-1",
+    "LAUGH": "laugh",
+    "HOORAY": "hooray",
+    "CONFUSED": "confused",
+    "HEART": "heart",
+    "ROCKET": "rocket",
+    "EYES": "eyes",
+}
+
+
+def _normalize_reaction_groups(reaction_groups: list[dict[str, Any]]) -> dict[str, Any]:
+    """Convert GraphQL reactionGroups to the REST reactions dict shape.
+
+    The REST API returns:
+      {"reactions": {"+1": 2, "-1": 0, "laugh": 0, ..., "total_count": 3}}
+
+    The GraphQL API returns:
+      [{"content": "THUMBS_UP", "users": {"totalCount": 2}}, ...]
+
+    This normalises the GraphQL shape so callers always see the REST shape.
+    """
+    result: dict[str, Any] = {key: 0 for key in _REACTION_GROUP_CONTENT_TO_KEY.values()}
+    total = 0
+    for group in reaction_groups:
+        content = group.get("content", "")
+        count = group.get("users", {}).get("totalCount", 0)
+        key = _REACTION_GROUP_CONTENT_TO_KEY.get(content)
+        if key is not None:
+            result[key] = count
+            total += count
+    result["total_count"] = total
+    return result
 
 
 async def _pr_comment_reply(

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -2129,3 +2129,204 @@ class TestIssueReopen:
 
         assert isinstance(result, ErrorResult)
         assert "not found" in result.error
+
+
+class TestNormalizeReactionGroups:
+    def test_thumbs_up_only(self) -> None:
+        groups = [
+            {"content": "THUMBS_UP", "users": {"totalCount": 3}},
+            {"content": "THUMBS_DOWN", "users": {"totalCount": 0}},
+        ]
+        result = gh._normalize_reaction_groups(groups)
+        assert result["+1"] == 3
+        assert result["-1"] == 0
+        assert result["total_count"] == 3
+
+    def test_thumbs_down_only(self) -> None:
+        groups = [
+            {"content": "THUMBS_UP", "users": {"totalCount": 0}},
+            {"content": "THUMBS_DOWN", "users": {"totalCount": 1}},
+        ]
+        result = gh._normalize_reaction_groups(groups)
+        assert result["+1"] == 0
+        assert result["-1"] == 1
+        assert result["total_count"] == 1
+
+    def test_multiple_reactions(self) -> None:
+        groups = [
+            {"content": "THUMBS_UP", "users": {"totalCount": 2}},
+            {"content": "HEART", "users": {"totalCount": 1}},
+            {"content": "ROCKET", "users": {"totalCount": 0}},
+            {"content": "CONFUSED", "users": {"totalCount": 1}},
+        ]
+        result = gh._normalize_reaction_groups(groups)
+        assert result["+1"] == 2
+        assert result["heart"] == 1
+        assert result["rocket"] == 0
+        assert result["confused"] == 1
+        assert result["total_count"] == 4
+
+    def test_empty_groups(self) -> None:
+        result = gh._normalize_reaction_groups([])
+        assert result["total_count"] == 0
+        assert result["+1"] == 0
+        assert result["-1"] == 0
+
+    def test_all_reaction_keys_present(self) -> None:
+        result = gh._normalize_reaction_groups([])
+        expected_keys = {
+            "+1",
+            "-1",
+            "laugh",
+            "hooray",
+            "confused",
+            "heart",
+            "rocket",
+            "eyes",
+            "total_count",
+        }
+        assert set(result.keys()) == expected_keys
+
+    def test_unknown_content_ignored(self) -> None:
+        groups = [{"content": "UNKNOWN_EMOJI", "users": {"totalCount": 5}}]
+        result = gh._normalize_reaction_groups(groups)
+        assert result["total_count"] == 0
+
+
+class TestUnresolvedThreadsIncludesReactions:
+    @pytest.mark.asyncio
+    @patch("dev10x.github._gh_api_raw", new_callable=AsyncMock)
+    async def test_reactions_normalized_from_reaction_groups(
+        self,
+        mock_api: AsyncMock,
+        mock_resolve_repo: AsyncMock,
+    ) -> None:
+        mock_api.return_value = _completed(
+            stdout=json.dumps(
+                {
+                    "data": {
+                        "repository": {
+                            "pullRequest": {
+                                "reviewThreads": {
+                                    "nodes": [
+                                        {
+                                            "id": "PRRT_1",
+                                            "isResolved": False,
+                                            "isOutdated": False,
+                                            "comments": {
+                                                "nodes": [
+                                                    {
+                                                        "databaseId": 11,
+                                                        "body": "",
+                                                        "path": "a.py",
+                                                        "line": 1,
+                                                        "author": {"login": "alice"},
+                                                        "pullRequestReview": {"databaseId": 100},
+                                                        "reactionGroups": [
+                                                            {
+                                                                "content": "THUMBS_UP",
+                                                                "users": {"totalCount": 2},
+                                                            },
+                                                            {
+                                                                "content": "THUMBS_DOWN",
+                                                                "users": {"totalCount": 0},
+                                                            },
+                                                        ],
+                                                    }
+                                                ]
+                                            },
+                                        },
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            ),
+        )
+
+        result = await gh.pr_comments(
+            action="list",
+            pr_number=42,
+            unresolved_only=True,
+        )
+
+        assert isinstance(result, SuccessResult)
+        thread = result.value["unresolved_threads"][0]
+        assert "reactions" in thread
+        assert thread["reactions"]["+1"] == 2
+        assert thread["reactions"]["-1"] == 0
+        assert thread["reactions"]["total_count"] == 2
+        assert "reactionGroups" not in thread
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github._gh_api_raw", new_callable=AsyncMock)
+    async def test_no_reaction_groups_leaves_reactions_absent(
+        self,
+        mock_api: AsyncMock,
+        mock_resolve_repo: AsyncMock,
+    ) -> None:
+        mock_api.return_value = _completed(
+            stdout=json.dumps(
+                {
+                    "data": {
+                        "repository": {
+                            "pullRequest": {
+                                "reviewThreads": {
+                                    "nodes": [
+                                        {
+                                            "id": "PRRT_1",
+                                            "isResolved": False,
+                                            "isOutdated": False,
+                                            "comments": {
+                                                "nodes": [
+                                                    {
+                                                        "databaseId": 11,
+                                                        "body": "comment",
+                                                        "path": "a.py",
+                                                        "line": 1,
+                                                        "author": {"login": "alice"},
+                                                        "pullRequestReview": {"databaseId": 100},
+                                                    }
+                                                ]
+                                            },
+                                        },
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            ),
+        )
+
+        result = await gh.pr_comments(
+            action="list",
+            pr_number=42,
+            unresolved_only=True,
+        )
+
+        assert isinstance(result, SuccessResult)
+        thread = result.value["unresolved_threads"][0]
+        assert "reactionGroups" not in thread
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github._gh_api_raw", new_callable=AsyncMock)
+    async def test_graphql_query_includes_reaction_groups(
+        self,
+        mock_api: AsyncMock,
+        mock_resolve_repo: AsyncMock,
+    ) -> None:
+        mock_api.return_value = _completed(
+            stdout=json.dumps(
+                {"data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": []}}}}}
+            ),
+        )
+
+        await gh.pr_comments(action="list", pr_number=42, unresolved_only=True)
+
+        called_fields = mock_api.call_args.kwargs.get("fields") or mock_api.call_args[1].get(
+            "fields", {}
+        )
+        query = called_fields.get("query", "")
+        assert "reactionGroups" in query


### PR DESCRIPTION
**When** a busy maintainer reacts to PR review comments with emoji (👍/👎/❤️)
instead of typing prose verdicts, **I want to** use those reactions as quick
triage signals, **so I can** confirm or override the inferred verdict before it
executes — turning an undocumented improvisation into a first-class, auditable
triage input.

---

[`af6c8602`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/363/commits/af6c8602bb32470cb73a866bd50bb473608a7311) ✨ GH-314 Enable reaction-signal triage for pr-triage + pr-respond

Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/314