### PR TITLE
✨ GH-320 Enable PyCharm/uv IDE normalization for git worktrees

### DIFF
--- a/skills/git-worktree/SKILL.md
+++ b/skills/git-worktree/SKILL.md
@@ -224,6 +224,13 @@ Source: [`templates/post-checkout-python-uv.sh`](./templates/post-checkout-pytho
 Copies `.env`, `development.secrets.env`, `.claude/` (excluding WIP), `.idea/`,
 and runs `uv sync`.
 
+**After creating a Python/uv worktree**, run `Dev10x:ide-normalize` to fix
+stale PyCharm `.idea/` module-name references, disable
+`ADD_CONTENT_ROOTS` / `ADD_SOURCE_ROOTS` flags (which conflict with editable
+installs — see [PEP 660 / PYTHONPATH conflict](../ide-normalize/references/pep660-pythonpath-conflict.md)),
+and detect the PyCharm uv-SDK `FLAVOR_DATA` gap that causes `ModuleNotFoundError`
+on first launch.
+
 ### Template B: Node.js + Husky (write to `.husky/post-checkout`)
 
 Source: [`templates/post-checkout-node-husky.sh`](./templates/post-checkout-node-husky.sh)
@@ -280,3 +287,24 @@ Common failure causes:
 - Husky v4 hooks require `node_modules` (see Step A1b)
 - Yarn Berry needs `--immutable` not `--frozen-lockfile`
 - Hook file not executable (ensure `chmod +x` after writing)
+
+### PyCharm Crashes After Opening a New Worktree
+
+**Symptom**: `uv run /full/path/.venv/bin/python manage.py …` crashes with
+`ModuleNotFoundError: No module named 'collections.abc'`.
+
+**Causes** (may be compounding):
+
+1. **PyCharm uv-SDK FLAVOR_DATA gap** — PyCharm auto-creates an SDK entry
+   with empty `FLAVOR_DATA="{}"`, missing `UV_VENV_PATH` / `UV_TOOL_PATH`.
+   Result: PyCharm constructs the wrong launch command. Fix: run
+   `Dev10x:ide-normalize` (Step 5) or follow the manual recipe in
+   [`../ide-normalize/references/pycharm-uv-sdk-gap.md`](../ide-normalize/references/pycharm-uv-sdk-gap.md).
+
+2. **ADD_CONTENT_ROOTS / ADD_SOURCE_ROOTS injecting PYTHONPATH** — These
+   run-config defaults activate `sitecustomize` bootstrappers (New Relic,
+   DataDog APM, etc.) that crash under uv-managed Python. Fix: run
+   `Dev10x:ide-normalize` (Step 3) to set both flags to `false`.
+   Background: [`../ide-normalize/references/pep660-pythonpath-conflict.md`](../ide-normalize/references/pep660-pythonpath-conflict.md).
+
+**Quick fix**: `Dev10x:ide-normalize` addresses both causes.

--- a/skills/ide-normalize/SKILL.md
+++ b/skills/ide-normalize/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: Dev10x:ide-normalize
+description: >
+  Normalize PyCharm .idea/ configuration after creating or copying a new git
+  worktree. Fixes stale module-name references, disables ADD_CONTENT_ROOTS /
+  ADD_SOURCE_ROOTS defaults that conflict with editable installs, backfills the
+  Django facet settingsModule, and detects the PyCharm uv-SDK FLAVOR_DATA gap.
+  TRIGGER when: a new worktree has been created and the .idea/ directory was
+  copied from a sibling worktree or the main repo, OR when PyCharm crashes on
+  launch with ModuleNotFoundError after opening a new worktree.
+  DO NOT TRIGGER when: the project has no .idea/ directory or does not use
+  PyCharm / JetBrains IDEs.
+user-invocable: true
+invocation-name: Dev10x:ide-normalize
+allowed-tools:
+  - Bash(find:*)
+  - Bash(grep:*)
+  - Bash(ls:*)
+  - Read
+  - Edit
+---
+
+# IDE Normalize
+
+Fix PyCharm `.idea/` configuration drift that occurs when a `.idea/` directory
+is copied from a parent repo into a new git worktree. Also detects the PyCharm
+uv-SDK `FLAVOR_DATA` gap that causes crashes on first launch.
+
+## Design Decision
+
+This is a **separate skill** rather than a step inside `Dev10x:git-worktree`
+for two reasons:
+
+1. **Retroactive use**: teams often create worktrees without this skill, or
+   before this fix landed. A standalone skill lets them normalize existing
+   worktrees without recreating them.
+2. **Separation of concerns**: `Dev10x:git-worktree` handles git mechanics.
+   IDE configuration is a separate concern that may apply to non-worktree
+   scenarios (e.g., first-time clone on a new machine).
+
+`Dev10x:git-worktree` documents this skill in its Python/uv template notes as
+a recommended post-checkout step.
+
+## Orchestration
+
+**REQUIRED: Create a task at invocation.** Execute at startup:
+
+1. `TaskCreate(subject="Normalize IDE configuration", activeForm="Normalizing .idea/")`
+
+Mark completed when done: `TaskUpdate(taskId, status="completed")`
+
+**Announce:** "Using Dev10x:ide-normalize to fix PyCharm .idea/ configuration."
+
+## Workflow
+
+### Step 1: Locate .idea/ and Detect Project Context
+
+Run:
+- `find . -maxdepth 1 -name ".idea" -type d` — confirm `.idea/` exists
+- `find . -maxdepth 1 -name "modules.xml" -type f` — fallback if no `.idea/`
+- Read `.idea/modules.xml` to get the canonical module name(s)
+- Read `.idea/workspace.xml` to identify stale module name references
+- Check `git worktree list` to get current worktree path and parent repo path
+
+If `.idea/` is not found, report "No .idea/ directory found — nothing to
+normalize" and mark the task complete.
+
+### Step 2: Fix Stale Module-Name References
+
+In `.idea/workspace.xml`, module names often refer to the parent repo name
+(e.g., `<module name="encom-corp" />`) instead of the current project name
+(e.g., `<module name="encom-pos" />`).
+
+Detection:
+- Read `.idea/modules.xml` — the `<module>` elements name the correct
+  module(s) for this project.
+- Grep `.idea/workspace.xml` for `<module name="` — compare against the
+  canonical names from `modules.xml`.
+
+Fix: use Edit to replace each stale reference with the correct module name.
+
+Report how many references were updated (e.g., "Updated 3 module-name
+references in workspace.xml").
+
+### Step 3: Disable ADD_CONTENT_ROOTS and ADD_SOURCE_ROOTS
+
+`.idea/workspace.xml` run configs often have:
+
+```xml
+<option name="ADD_CONTENT_ROOTS" value="true" />
+<option name="ADD_SOURCE_ROOTS" value="true" />
+```
+
+These defaults inject `<repo>/src` onto `PYTHONPATH`, which conflicts with
+editable installs (PEP 660 / `pip install -e .` / uv workspace members).
+When New Relic or any other `sitecustomize`-bootstrapping agent is installed,
+this side channel activates the bootstrap loader, which then fails under
+uv-managed interpreters.
+
+Fix: Edit every occurrence in `.idea/workspace.xml` to `value="false"`.
+
+See [`references/pep660-pythonpath-conflict.md`](references/pep660-pythonpath-conflict.md)
+for full explanation and background.
+
+Report: "Disabled ADD_CONTENT_ROOTS/ADD_SOURCE_ROOTS on N run configurations."
+
+### Step 4: Backfill Django settingsModule
+
+In `.idea/workspace.xml`, Django run configs often have:
+
+```xml
+<option name="settingsModule" value="" />
+```
+
+Detection:
+- Grep for `settingsModule.*value=""` — empty settingsModule entries
+- Look for the Django settings module path by checking:
+  - `manage.py` — `os.environ.setdefault('DJANGO_SETTINGS_MODULE', ...)` line
+  - `pyproject.toml` or `setup.cfg` — `[tool.django]` or `DJANGO_SETTINGS_MODULE`
+
+If the settings module can be determined, fill in each empty `settingsModule`
+value. If it cannot be determined, report the empty entries and ask the user to
+provide the correct module path before continuing.
+
+**REQUIRED: Call `AskUserQuestion`** if the Django settings module cannot be
+auto-detected. Options:
+- "Enter the settings module path (e.g. `config.settings.local`)"
+- "Skip — I'll fix this manually"
+
+### Step 5: Detect PyCharm uv-SDK FLAVOR_DATA Gap
+
+After PyCharm creates a `uv (<worktree-name>)` SDK entry for a new worktree,
+the `jdk.table.xml` entry is missing `UV_VENV_PATH` / `UV_TOOL_PATH` and has
+an empty `FLAVOR_DATA="{}"`. This causes PyCharm to construct
+`uv run /full/path/.venv/bin/python manage.py …` (wrong) instead of
+`uv run python manage.py …` (correct), crashing with:
+
+```
+ModuleNotFoundError: No module named 'collections.abc'
+```
+
+Detection:
+- Read `~/.config/JetBrains/PyCharm*/options/jdk.table.xml` (glob — ask
+  user for path if multiple PyCharm versions exist)
+- Find SDK entries whose `ASSOCIATED_PROJECT_PATH` matches the current
+  worktree path
+- Check if `FLAVOR_DATA` is `"{}"` or if `UV_VENV_PATH` / `UV_TOOL_PATH`
+  attributes are missing
+
+See [`references/pycharm-uv-sdk-gap.md`](references/pycharm-uv-sdk-gap.md)
+for the full diagnosis, broken vs working SDK comparison, and patch recipe.
+
+**If gap detected:**
+
+**REQUIRED: Call `AskUserQuestion`** — PyCharm must be closed to patch
+`jdk.table.xml` safely (the IDE overwrites the file on exit). Options:
+- "Patch automatically (PyCharm must be closed)"
+- "Show me the manual fix instead"
+- "Skip — I'll handle this later"
+
+If patching: mirror `UV_VENV_PATH`, `UV_TOOL_PATH`, and `FLAVOR_DATA` from
+the parent project's SDK entry. Report the patch applied.
+
+If showing manual fix: display the `references/pycharm-uv-sdk-gap.md` recipe.
+
+### Step 6: Summary Report
+
+Print a summary:
+
+```
+IDE normalize complete:
+  module-name fixes: N references updated
+  run config flags:  N ADD_CONTENT_ROOTS/ADD_SOURCE_ROOTS set to false
+  Django settings:   <filled / skipped / N entries still empty>
+  uv SDK gap:        <patched / shown / not detected / skipped>
+```
+
+Mark the task complete.

--- a/skills/ide-normalize/references/pep660-pythonpath-conflict.md
+++ b/skills/ide-normalize/references/pep660-pythonpath-conflict.md
@@ -1,0 +1,74 @@
+# PEP 660 / Editable-Install vs ADD_CONTENT_ROOTS Conflict
+
+## Root Cause
+
+PyCharm's Python run-config defaults ship with:
+
+```xml
+<option name="ADD_CONTENT_ROOTS" value="true" />
+<option name="ADD_SOURCE_ROOTS" value="true" />
+```
+
+These flags inject `<repo>/src` (and other content/source roots) onto
+`PYTHONPATH` before the interpreter starts. They exist as a workaround for
+scripting projects that never grew a `pyproject.toml` and therefore have no
+installed package path.
+
+## Why This Breaks Editable Installs
+
+**Editable install** (PEP 660, `pip install -e .`, `uv pip install -e .`,
+uv workspace members) installs the package into the venv's site-packages via
+a `.pth` file or a direct `.dist-info/direct_url.json` link. The package
+import path comes from the venv — `PYTHONPATH` is not needed and actively
+harmful.
+
+When `ADD_CONTENT_ROOTS=true` is combined with an editable install:
+
+1. PyCharm prepends `<repo>/src` to `PYTHONPATH`
+2. Python's import machinery resolves packages from `PYTHONPATH` first
+3. `site.py` runs, processes `.pth` files from the venv
+4. Any `sitecustomize.py` in the venv's site-packages is executed
+5. **New Relic's bootstrap loader** (canonical victim): `newrelic/bootstrap/sitecustomize.py`
+   patches `sys.modules['collections']` before `collections.abc` is importable
+   under uv-managed Python, causing:
+
+```
+ModuleNotFoundError: No module named 'collections.abc'; 'collections' is not a package
+```
+
+The same failure appears for any other `sitecustomize`-bootstrapping agent
+(DataDog APM, OpenTelemetry auto-instrumentation, coverage.py bootstrap, etc.).
+
+## The Two-Step Trap
+
+The failure symptom (`uv run /path/.venv/bin/python …`) and the root cause
+(PYTHONPATH side-channel activating `sitecustomize`) are two steps apart:
+
+1. PyCharm uv-SDK FLAVOR_DATA gap causes the wrong launch command
+2. ADD_CONTENT_ROOTS activates sitecustomize which crashes under that command
+
+Each step alone is survivable. Combined, they produce a crash that costs
+30–45 minutes of debugging because the traceback points to `sitecustomize`
+rather than the run-config flags.
+
+## Fix
+
+Disable both flags on every Python run config in `.idea/workspace.xml`:
+
+```xml
+<option name="ADD_CONTENT_ROOTS" value="false" />
+<option name="ADD_SOURCE_ROOTS" value="false" />
+```
+
+Projects using editable installs (the correct pattern for any project with
+`pyproject.toml`) never need these flags. Disabling them is safe and the
+correct default for modern Python projects.
+
+## Public Documentation
+
+- PEP 660: Editable installs for `pyproject.toml`-based builds
+  <https://peps.python.org/pep-0660/>
+- uv workspace members: editable by default
+  <https://docs.astral.sh/uv/concepts/workspaces/>
+- PyCharm: "Add content roots to PYTHONPATH" setting
+  (JetBrains docs, Python run/debug configuration)

--- a/skills/ide-normalize/references/pycharm-uv-sdk-gap.md
+++ b/skills/ide-normalize/references/pycharm-uv-sdk-gap.md
@@ -1,0 +1,107 @@
+# PyCharm uv-SDK FLAVOR_DATA Gap
+
+## Symptom
+
+After PyCharm auto-creates a `uv (<worktree-name>)` SDK for a new worktree,
+`manage.py runserver` (or any other run config) crashes with:
+
+```
+$ uv run /work/.../encom-pos-6/.venv/bin/python manage.py runserver ...
+Error in sitecustomize; set PYTHONVERBOSE for traceback:
+ModuleNotFoundError: No module named 'collections.abc'; 'collections' is not a package
+```
+
+The launch command `uv run /full/path/.venv/bin/python ...` is wrong.
+The correct command is `uv run python ...` (uv resolves the venv implicitly).
+
+## Root Cause
+
+When PyCharm discovers a new worktree's `.venv/` and creates a SDK entry, it
+writes an `<additional>` block in `jdk.table.xml` with empty `FLAVOR_DATA`:
+
+```xml
+<!-- Broken (auto-created for worktree): -->
+<additional ASSOCIATED_PROJECT_PATH="/work/.../encom-pos-6"
+            IS_UV="true"
+            UV_WORKING_DIR="/work/.../encom-pos-6">
+  <setting name="FLAVOR_DATA" value="{}" />
+</additional>
+```
+
+Without `UV_VENV_PATH` and `UV_TOOL_PATH`, PyCharm does not know how to
+invoke `uv` as a launcher and falls back to the interpreter binary directly,
+passing it as a `uv run <binary>` argument instead of letting uv manage the
+venv.
+
+## Working SDK (Parent Project)
+
+```xml
+<!-- Working (manually configured for parent project): -->
+<additional ASSOCIATED_PROJECT_PATH="/work/.../encom-pos"
+            IS_UV="true"
+            UV_WORKING_DIR="/work/.../encom-pos"
+            UV_VENV_PATH="/work/.../encom-pos/.venv"
+            UV_TOOL_PATH="/home/user/.local/bin/uv">
+  <setting name="FLAVOR_DATA"
+           value="{&quot;uvWorkingDirectory&quot;:&quot;/work/.../encom-pos&quot;,
+                   &quot;usePip&quot;:false,
+                   &quot;venvPath&quot;:&quot;/work/.../encom-pos/.venv&quot;,
+                   &quot;uvPath&quot;:&quot;/home/user/.local/bin/uv&quot;}" />
+</additional>
+```
+
+## Detection
+
+1. Locate `jdk.table.xml`:
+   - Linux: `~/.config/JetBrains/PyCharm<version>/options/jdk.table.xml`
+   - macOS: `~/Library/Application Support/JetBrains/PyCharm<version>/options/jdk.table.xml`
+2. Find SDK entries with `ASSOCIATED_PROJECT_PATH` matching the worktree path
+3. Check for `FLAVOR_DATA="{}"` or missing `UV_VENV_PATH` / `UV_TOOL_PATH`
+
+## Patch Recipe (PyCharm must be closed)
+
+PyCharm overwrites `jdk.table.xml` on exit. The file must be patched while
+PyCharm is **not running**.
+
+Replace the broken `<additional>` block with a copy of the parent project's
+block, substituting the worktree path values:
+
+```xml
+<additional ASSOCIATED_PROJECT_PATH="<worktree-path>"
+            IS_UV="true"
+            UV_WORKING_DIR="<worktree-path>"
+            UV_VENV_PATH="<worktree-path>/.venv"
+            UV_TOOL_PATH="<uv-binary-path>">
+  <setting name="FLAVOR_DATA"
+           value="{&quot;uvWorkingDirectory&quot;:&quot;<worktree-path>&quot;,
+                   &quot;usePip&quot;:false,
+                   &quot;venvPath&quot;:&quot;<worktree-path>/.venv&quot;,
+                   &quot;uvPath&quot;:&quot;<uv-binary-path>&quot;}" />
+</additional>
+```
+
+Values to substitute:
+- `<worktree-path>`: absolute path to the worktree (e.g. `/work/encom/encom-pos-6`)
+- `<uv-binary-path>`: `which uv` output (e.g. `/home/user/.local/bin/uv`)
+
+## Manual Fix (Alternative)
+
+If you prefer not to patch the file directly:
+
+1. Close PyCharm
+2. Open PyCharm, open the worktree project
+3. Go to **Settings → Project → Python Interpreter**
+4. Click the interpreter selector → **Add New Interpreter → Add Local Interpreter**
+5. Select **uv** and pick the `.venv/` inside the worktree
+6. Apply and close Settings
+
+This re-creates the SDK entry correctly via the IDE UI.
+
+## Upstream Status
+
+This is a PyCharm bug: the IDE should populate `UV_VENV_PATH`, `UV_TOOL_PATH`,
+and `FLAVOR_DATA` when auto-creating a uv SDK entry for a worktree that already
+has a `.venv/`. No upstream fix is available as of PyCharm 2024.x.
+
+Workaround: use `Dev10x:ide-normalize` immediately after creating a new
+worktree, before opening PyCharm against it.


### PR DESCRIPTION
**When** I create a new git worktree for a Python/uv project, **I want to** have the copied `.idea/` configuration normalized automatically so that PyCharm opens the worktree without stale module references, broken run configs, or the uv-SDK FLAVOR_DATA crash, **so I can** start coding immediately instead of spending 30–45 minutes debugging IDE misconfigurations.

---

[`3b61cfd7`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/364/commits/3b61cfd70838e10d8aaf3e7ec6655c82f2fb85b6) ✨ GH-320 Enable PyCharm/uv IDE normalization for git worktrees
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/320

---