### PR TITLE
✨ GH-335 Enable dual-mode MCP server transport

### DIFF
--- a/src/dev10x/mcp/server_cli.py
+++ b/src/dev10x/mcp/server_cli.py
@@ -42,4 +42,6 @@ from dev10x.mcp.plan_tools import *  # noqa: E402, F401, F403
 
 
 def main() -> None:
-    server.run()
+    from dev10x.mcp.transport import select_transport
+
+    server.run(transport=select_transport())

--- a/src/dev10x/mcp/server_db.py
+++ b/src/dev10x/mcp/server_db.py
@@ -32,4 +32,6 @@ async def query(
 
 
 def main() -> None:
-    server.run()
+    from dev10x.mcp.transport import select_transport
+
+    server.run(transport=select_transport())

--- a/src/dev10x/mcp/transport.py
+++ b/src/dev10x/mcp/transport.py
@@ -1,0 +1,60 @@
+"""Transport selection for Dev10x MCP servers.
+
+STDIO is the default and keeps existing Claude Code wiring unchanged.
+HTTP transports are opt-in via the DEV10X_MCP_TRANSPORT environment
+variable — required for daemon mode (GH-336 and beyond).
+
+Environment variables
+---------------------
+DEV10X_MCP_TRANSPORT
+    Transport to use.  Accepted values (case-insensitive):
+
+    * ``stdio``            — default; standard input/output (Claude Code)
+    * ``streamable-http``  — StreamableHTTP over HTTP (daemon mode)
+    * ``sse``              — Server-Sent Events over HTTP (legacy HTTP)
+
+    Any other value raises ``ValueError`` at server start-up so
+    misconfigured deployments fail loudly instead of silently falling
+    back to STDIO.
+
+FASTMCP_HOST / FASTMCP_PORT
+    Host and port for HTTP transports.  These are FastMCP's own env
+    vars (prefix ``FASTMCP_``) and are read directly by FastMCP.
+    Defaults: ``127.0.0.1`` / ``8000``.
+
+Example — run over StreamableHTTP on all interfaces, port 9000::
+
+    DEV10X_MCP_TRANSPORT=streamable-http \\
+    FASTMCP_HOST=0.0.0.0 \\
+    FASTMCP_PORT=9000 \\
+        ./servers/cli_server.py
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Literal
+
+_VALID_TRANSPORTS = frozenset({"stdio", "streamable-http", "sse"})
+
+TransportLiteral = Literal["stdio", "streamable-http", "sse"]
+
+
+def select_transport() -> TransportLiteral:
+    """Return the transport name to pass to ``FastMCP.run()``.
+
+    Reads ``DEV10X_MCP_TRANSPORT`` (case-insensitive).  Defaults to
+    ``"stdio"`` when the variable is absent or empty.
+
+    Raises:
+        ValueError: When the variable is set to an unrecognised value.
+    """
+    raw = os.environ.get("DEV10X_MCP_TRANSPORT", "").strip().lower()
+    if not raw:
+        return "stdio"
+    if raw not in _VALID_TRANSPORTS:
+        raise ValueError(
+            f"DEV10X_MCP_TRANSPORT={raw!r} is not valid. "
+            f"Accepted values: {', '.join(sorted(_VALID_TRANSPORTS))}."
+        )
+    return raw  # type: ignore[return-value]

--- a/tests/mcp/test_transport.py
+++ b/tests/mcp/test_transport.py
@@ -1,0 +1,123 @@
+"""Tests for transport selection logic (GH-335).
+
+Covers:
+- Default returns "stdio" when env var is absent
+- Explicit values for all three transports
+- Case-insensitive matching
+- Invalid value raises ValueError with an informative message
+- Both server main() functions delegate to select_transport()
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev10x.mcp.transport import select_transport
+
+
+class TestSelectTransport:
+    def test_defaults_to_stdio_when_env_absent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("DEV10X_MCP_TRANSPORT", raising=False)
+        assert select_transport() == "stdio"
+
+    def test_defaults_to_stdio_when_env_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_MCP_TRANSPORT", "")
+        assert select_transport() == "stdio"
+
+    def test_returns_streamable_http(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_MCP_TRANSPORT", "streamable-http")
+        assert select_transport() == "streamable-http"
+
+    def test_returns_sse(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_MCP_TRANSPORT", "sse")
+        assert select_transport() == "sse"
+
+    def test_returns_stdio_explicit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_MCP_TRANSPORT", "stdio")
+        assert select_transport() == "stdio"
+
+    def test_case_insensitive_uppercase(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_MCP_TRANSPORT", "STREAMABLE-HTTP")
+        assert select_transport() == "streamable-http"
+
+    def test_case_insensitive_mixed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_MCP_TRANSPORT", "Sse")
+        assert select_transport() == "sse"
+
+    def test_strips_surrounding_whitespace(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_MCP_TRANSPORT", "  stdio  ")
+        assert select_transport() == "stdio"
+
+    def test_invalid_value_raises_valueerror(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_MCP_TRANSPORT", "websocket")
+        with pytest.raises(ValueError, match="DEV10X_MCP_TRANSPORT"):
+            select_transport()
+
+    def test_error_message_lists_valid_values(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_MCP_TRANSPORT", "grpc")
+        with pytest.raises(ValueError) as exc_info:
+            select_transport()
+        message = str(exc_info.value)
+        assert "sse" in message
+        assert "stdio" in message
+        assert "streamable-http" in message
+
+
+class TestServerMainDelegation:
+    """Verify both server main() functions pass transport to server.run()."""
+
+    def test_cli_server_main_uses_select_transport(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from unittest.mock import patch
+
+        monkeypatch.setenv("DEV10X_MCP_TRANSPORT", "stdio")
+
+        import dev10x.mcp.server_cli as cli_mod
+
+        with patch.object(cli_mod.server, "run") as mock_run:
+            cli_mod.main()
+            mock_run.assert_called_once_with(transport="stdio")
+
+    def test_cli_server_main_passes_streamable_http(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from unittest.mock import patch
+
+        monkeypatch.setenv("DEV10X_MCP_TRANSPORT", "streamable-http")
+
+        import dev10x.mcp.server_cli as cli_mod
+
+        with patch.object(cli_mod.server, "run") as mock_run:
+            cli_mod.main()
+            mock_run.assert_called_once_with(transport="streamable-http")
+
+    def test_db_server_main_uses_select_transport(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from unittest.mock import patch
+
+        monkeypatch.setenv("DEV10X_MCP_TRANSPORT", "stdio")
+
+        import dev10x.mcp.server_db as db_mod
+
+        with patch.object(db_mod.server, "run") as mock_run:
+            db_mod.main()
+            mock_run.assert_called_once_with(transport="stdio")
+
+    def test_db_server_main_passes_sse(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from unittest.mock import patch
+
+        monkeypatch.setenv("DEV10X_MCP_TRANSPORT", "sse")
+
+        import dev10x.mcp.server_db as db_mod
+
+        with patch.object(db_mod.server, "run") as mock_run:
+            db_mod.main()
+            mock_run.assert_called_once_with(transport="sse")


### PR DESCRIPTION
**When** I need to run the Dev10x MCP server as a long-running HTTP daemon, **I want to** select StreamableHTTP or SSE transport via an environment variable, **so I can** connect Claude Code and other MCP clients over HTTP without restarting.

---

[`e797d141`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/365/commits/e797d141f36fbe587d6724730dfa93351188a07e) ✨ GH-335 Enable dual-mode MCP server transport
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/335

---