### PR TITLE
♻️ GH-244 Seal context boundaries with domain protocols

### DIFF
--- a/docs/adr/0007-rule-policy-archetype-unification.md
+++ b/docs/adr/0007-rule-policy-archetype-unification.md
@@ -1,0 +1,255 @@
+# 7. Rule/Policy archetype unification
+
+Date: 2026-05-31
+
+## Status
+
+Accepted
+
+## Context
+
+The architecture audit (`docs/memos/005-2026-05-18-architecture-audit.md`
+§ 7, cross-phase convergence) found **three parallel "rule"
+abstractions** in the codebase, each named with "Rule" or acting as a
+rule, with no documented relationship between them. New contributors
+cannot tell which one to reach for, and the policy tier silently mixes
+decision logic with file I/O.
+
+### Current State
+
+| Archetype | Location | Shape | Lifecycle |
+|-----------|----------|-------|-----------|
+| **Matching Rule** (data) | `domain/rules/validation_rule.py::Rule` | Frozen dataclass: patterns + `matches_command()` / `matches_file()` predicates | Loaded from YAML, iterated by `RuleEngine` |
+| **Policy Rule** | `hooks/session_policy.py::*Rule` | Frozen dataclass with `apply() -> T`; encapsulates one named decision | Instantiated per-call, `apply()`d once |
+| **Validator** | `validators/base.py::Validator(Protocol)` | `should_run()` + `validate()` (+ optional `correct()`) | Lazy-loaded into a profile-filtered `ValidatorChain` |
+
+The Policy Rule tier (`ReadFrictionLevelRule`,
+`DecisionGuidanceRule`, `MigratePluginPermissionsRule`,
+`BuildAutonomyReassuranceRule`) all expose `apply()`, but nothing
+declares that as a contract — it is "true by reading the source".
+
+### Problems
+
+1. **No named hierarchy (A9).** Three mechanisms, all called "rule"
+   in conversation, with no documentation of when each applies.
+   Behavioral dispatch (`if/elif` chains in `analyze_actions.py`,
+   `session_policy.py`, `skill_redirect.py`) reinvents selection
+   instead of leaning on any of them.
+2. **Untyped policy contract (A9).** The `*Rule` policy classes share
+   the `apply()` shape by convention only. A new policy that forgets
+   `apply()`, or names it `run()`, is caught by neither the type
+   checker nor a Protocol.
+3. **Policy logic doing I/O (D3).**
+   `MigratePluginPermissionsRule.apply()` reads, parses, mutates and
+   atomically rewrites `settings.json` / `settings.local.json`
+   itself. A "decision" object is doing file persistence — the same
+   anti-pattern the Document layer (`domain/documents/`) exists to
+   prevent. This makes the rule hard to unit-test without a real
+   filesystem and blurs the policy/persistence boundary.
+
+### Prerequisites
+
+This ADR must be accepted **before** the A9 + D3 implementation
+lands — introducing `PolicyRule(Protocol)` and extracting
+`SettingsDocument` reshapes the policy tier's public contract.
+Tracked by GH-244 (Audit-2026-05-18 Milestone 5). Source:
+`docs/memos/005-2026-05-18-architecture-audit.md` § 7 and §
+"ADR Candidates" (A9 + D3 + F4).
+
+## Decision
+
+We **formalise the three archetypes** rather than collapse them — they
+have genuinely different shapes and lifecycles — and we **codify the
+Policy Rule contract** with a Protocol plus an I/O-free invariant.
+
+### The Three Archetypes (documented hierarchy)
+
+1. **Matching Rule** — declarative *data*. A pattern set plus pure
+   predicates (`matches_*`). Carries no side effects and no `apply()`.
+   Reach for it when behavior is fully describable in YAML and
+   evaluated by `RuleEngine`.
+2. **Policy Rule** — one named *decision*. A small immutable object
+   that computes a single result via `apply()`. MUST be free of I/O:
+   it reads its inputs from its fields and returns a value or a
+   plan-of-record; persistence is delegated to the Document layer.
+3. **Validator** — a *chain element* for the `PreToolUse` /
+   `PermissionDenied` hooks. `should_run()` gate + `validate()` /
+   `correct()`. Lives in a profile-filtered registry with its own
+   capabilities metadata. Stays distinct because its lifecycle
+   (lazy load, tier filtering, capability dispatch) is unlike a
+   one-shot policy.
+
+### `PolicyRule` Protocol
+
+Introduce a generic, `@runtime_checkable` Protocol that the existing
+`*Rule` policy classes already satisfy structurally:
+
+```python
+# src/dev10x/domain/rules/policy_rule.py
+@runtime_checkable
+class PolicyRule[T](Protocol):
+    def apply(self) -> T: ...
+```
+
+The four policy classes are annotated as `PolicyRule[...]`
+implementations. No behavior changes — the Protocol formalises the
+contract that was previously implicit.
+
+### I/O-free invariant (D3)
+
+A Policy Rule MUST NOT perform file I/O. `MigratePluginPermissionsRule`
+keeps the *decision* (which paths to migrate, building the
+replacement list, whether the rule is applicable) and delegates the
+read-mutate-write to a new `SettingsDocument` in the Document layer.
+
+### New Components
+
+| Component | Location | Responsibility |
+|-----------|----------|----------------|
+| `PolicyRule[T]` | `src/dev10x/domain/rules/policy_rule.py` | `@runtime_checkable` Protocol declaring `apply(self) -> T` |
+| `SettingsDocument` | `src/dev10x/domain/documents/settings_document.py` | Owns `settings.json` `apply_replacements()` — one locked read-modify-write under `file_lock` + `atomic_write_text` |
+
+### Code Examples
+
+```python
+# D3: before — Rule does its own I/O
+class MigratePluginPermissionsRule:
+    def apply(self) -> tuple[int, list[str]]:
+        ...
+        with file_lock(settings_file):
+            settings = json.loads(settings_file.read_text())
+            ...
+            atomic_write_text(settings_file, json.dumps(settings, ...))
+
+# after — Rule decides, Document persists
+class MigratePluginPermissionsRule:
+    def apply(self) -> tuple[int, list[str]]:
+        replacements = _build_migration_replacements(...)
+        total = 0
+        changed: list[str] = []
+        for settings_file in self._settings_files():
+            count = SettingsDocument(path=settings_file).apply_replacements(
+                replacements=replacements
+            )
+            if count:
+                total += count
+                changed.append(settings_file.name)
+        return total, changed
+```
+
+## Alternatives Considered
+
+### Alternative 1: Collapse all three into one mechanism
+
+One base class / Protocol that Matching Rules, Policy Rules, and
+Validators all implement.
+
+**Pros:**
+- A single "rule" word with one meaning.
+
+**Cons:**
+- Forces unlike lifecycles together: Matching Rules are inert data
+  loaded from YAML; Validators carry registry/tier/capability
+  machinery; Policy Rules are one-shot decisions. A union type would
+  be a lowest-common-denominator `apply()` that fits none of them and
+  would require rewriting `RuleEngine` and `ValidatorChain`.
+
+**Verdict:** Rejected — conflates three deliberately different shapes;
+maximal churn for a cosmetic win.
+
+### Alternative 2: Leave the contract implicit (status quo)
+
+Document nothing; rely on the shared `apply()` convention.
+
+**Pros:**
+- Zero code change.
+
+**Cons:**
+- The finding itself: no named hierarchy, untyped contract, and
+  policy objects doing I/O. The next policy author has no guidance.
+
+**Verdict:** Rejected — this is the problem being solved.
+
+### Alternative 3 (Selected): Document three archetypes; formalise the Policy tier only
+
+**Pros:**
+- Names the hierarchy so contributors know which to use.
+- `PolicyRule(Protocol)` makes the policy contract type-checkable with
+  zero behavior change (the classes already satisfy it).
+- The I/O-free invariant + `SettingsDocument` extraction makes
+  `MigratePluginPermissionsRule` unit-testable and restores the
+  policy/persistence boundary.
+- Matching Rule and Validator keep their fit-for-purpose shapes.
+
+**Cons:**
+- Three archetypes still exist — but now intentionally and documented,
+  rather than accidentally.
+
+**Verdict:** Selected — formalises what works, fixes what is broken
+(D3), and avoids a churny false unification.
+
+## Consequences
+
+### What Becomes Easier
+
+1. A contributor picks an archetype from a documented table instead of
+   copying the nearest "Rule".
+2. `PolicyRule[T]` lets the type checker confirm a new policy exposes
+   `apply()`; a forgotten/renamed method is caught statically.
+3. `MigratePluginPermissionsRule` is testable with an in-memory
+   `SettingsDocument`; the policy/persistence split mirrors the rest
+   of `domain/documents/`.
+
+### What Becomes More Difficult
+
+1. New policies must keep `apply()` pure and route persistence through
+   a Document. This is the intended constraint, not an accident.
+
+### Risks and Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| `SettingsDocument` extraction changes migration behavior | Low | Medium | Preserve `file_lock` + `atomic_write_text` semantics exactly; existing migration tests must pass unchanged |
+| `@runtime_checkable` checks method presence, not signature | Low | Low | Documented limitation; `apply()` shape is covered by per-rule unit tests |
+| "Three archetypes" still confuses readers | Low | Low | The documented table in this ADR and in `domain/rules/` docstrings is the single reference |
+
+## Implementation Plan
+
+Shipped together under GH-244 (one PR, atomic commits per finding):
+
+### Phase 1: Policy contract (this ADR)
+
+1. `src/dev10x/domain/rules/policy_rule.py` — add
+   `@runtime_checkable PolicyRule[T]` Protocol (A9).
+2. Annotate the four `*Rule` policy classes as `PolicyRule[...]`
+   implementations; document the three-archetype table in the
+   `domain/rules/` package docstring.
+
+### Phase 2: Policy/persistence split
+
+3. `src/dev10x/domain/documents/settings_document.py` — add
+   `SettingsDocument` with `apply_replacements()` (one locked
+   read-modify-write); relocate the `_migrate_rules` /
+   `_deduplicate_rules` transforms here (D3).
+4. `hooks/session_policy.py::MigratePluginPermissionsRule.apply()` —
+   delegate I/O to `SettingsDocument`; keep decision logic only.
+
+## References
+
+### Internal References
+
+- [GH-244](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/244) —
+  Audit-2026-05-18 M5: Context Boundary Sealing
+- Audit memo: `docs/memos/005-2026-05-18-architecture-audit.md` § 7
+- [ADR-0008](0008-context-boundary-protocol.md) — Context boundary
+  protocol (sibling M5 ADR; relocates the policy rules to `domain/`)
+- [ADR-0009](0009-result-contract-at-mcp-boundary.md) — the
+  `ResultProtocol` precedent for a `@runtime_checkable` domain
+  contract
+
+### External References
+
+- [PEP 544](https://peps.python.org/pep-0544/) — Protocols (structural
+  subtyping)
+- [PEP 695](https://peps.python.org/pep-0695/) — Type parameter syntax
+  (`PolicyRule[T]`)

--- a/docs/adr/0008-context-boundary-protocol.md
+++ b/docs/adr/0008-context-boundary-protocol.md
@@ -1,0 +1,254 @@
+# 8. Context boundary protocol (domain ⟂ hooks ⟂ audit ⟂ skills)
+
+Date: 2026-05-31
+
+## Status
+
+Accepted
+
+## Context
+
+The architecture audit (`docs/memos/005-2026-05-18-architecture-audit.md`
+§ 3, cross-phase convergence #3) found that the same root cause —
+**no stable protocol demarcating context boundaries** — surfaced in
+five findings spanning four packages. Outer layers reach sideways into
+each other's internals, and one cycle is papered over with deferred
+imports.
+
+### Current State
+
+`src/dev10x/` is organised in concentric layers, but the dependency
+direction is only enforced by convention:
+
+| Layer | Packages | Role |
+|-------|----------|------|
+| Core | `domain/` | Pure data, value objects, policies, Protocols |
+| Adapters | `hooks/`, `audit/`, `session/`, `skills/` | I/O, Claude Code event handlers, CLI shims |
+
+The boundary inversions found:
+
+| Finding | Coupling | Direction |
+|---------|----------|-----------|
+| **D1** | `domain/session_document` → `hooks.task_plan_sync` | core → adapter (inverted) |
+| **I1** | `audit/analyze.py` → `skills.audit.analyze_permissions` internals | adapter → adapter |
+| **I6** | `hooks/audit_emit.py` → `audit.log_reader` internals | adapter → adapter |
+| **I2 + I10** | `session/queries.py` defers `hooks.session_policy` imports | adapter ⇄ adapter cycle |
+
+Cumulative chain: `hooks → audit → skills`. The `session.queries`
+case is the most telling — it imports `ReadFrictionLevelRule` and
+`DecisionGuidanceRule` *inside function bodies* (four deferred
+imports) purely to break the import cycle
+`hooks.session_dispatch → session.queries → hooks.session_policy`.
+A deferred import is a cycle made invisible, not a cycle removed.
+
+### Problems
+
+1. **No declared direction (I1, I6).** Nothing states that an adapter
+   may depend on `domain/` but never on another adapter's internals.
+   `audit/analyze.py` and `hooks/audit_emit.py` each reach directly
+   into a sibling package's implementation, so refactoring either
+   side silently breaks the other.
+2. **Cycles hidden behind lazy imports (I2 + I10).** Module-scope
+   imports would raise `ImportError`; moving them into function
+   bodies suppresses the symptom while the architectural cycle
+   remains. The coupling is invisible to static tooling and to
+   readers scanning the import block.
+3. **Policy logic stranded in the adapter layer (I2 + I10).**
+   `ReadFrictionLevelRule` and `DecisionGuidanceRule` are pure
+   policies (they already depend only on `domain/`), yet they live in
+   `hooks/session_policy.py`, forcing every non-hook consumer to
+   reach *up* into `hooks/`.
+
+### Prerequisites
+
+This ADR must be accepted **before** the I2/I10 and I6 implementations
+land — both relocate symbols across package boundaries, which is
+import-path-breaking for any external caller. Tracked by GH-244
+(Audit-2026-05-18 Milestone 5). Source:
+`docs/memos/005-2026-05-18-architecture-audit.md` § 3 and §
+"Proposed Milestones" → M5.
+
+## Decision
+
+We adopt an explicit **dependency-direction rule** and a single
+mechanism for crossing it.
+
+### The Rule
+
+1. `domain/` is the stable core. It depends on nothing outside
+   `domain/` and the standard library.
+2. Adapter packages (`hooks/`, `audit/`, `session/`, `skills/`) may
+   depend **inward** on `domain/`. They MUST NOT import another
+   adapter package's internals.
+3. When one adapter needs a capability another adapter provides,
+   the contract is declared as a **`Protocol` in `domain/`** and the
+   concrete implementation is **injected** (Dependency Inversion).
+   The depending adapter imports the Protocol from `domain/`, never
+   the providing adapter's module.
+4. Pure policies — classes whose only dependency is `domain/` —
+   belong in `domain/`, not in an adapter package.
+
+### Per-Finding Application
+
+| Finding | Resolution |
+|---------|------------|
+| **D1** | Already resolved. `read_plan_summary` now imports `domain.documents.plan` directly (core → core). No further work. |
+| **I2 + I10** | Move `ReadFrictionLevelRule` and `DecisionGuidanceRule` into `domain/session_rules.py`. `session/queries.py` and `hooks/session_policy.py` both import inward from `domain/`; the deferred imports become module-scope. Cycle removed (rule #4). |
+| **I6** | Define `AuditWriter(Protocol)` in `domain/audit_writer.py`. `audit/log_reader` provides the concrete writer; `hooks/audit_emit` depends on the domain Protocol and resolves the concrete impl through a single injection seam (rule #3). |
+| **I1** | **Deferred to M7.** Sealing `audit → skills` cleanly requires moving the analysis logic out of `skills/audit/analyze_permissions.py`, but that file is a standalone `uv run --script` with `dependencies = []` and cannot import `dev10x`. Choosing between duplication and a `dev10x` dependency is the **ADR-0010** decision (uv-script vs importable module), scoped to M7. See "Known Exceptions". |
+
+### New Components
+
+| Component | Location | Responsibility |
+|-----------|----------|----------------|
+| `AuditWriter` | `src/dev10x/domain/audit_writer.py` | `@runtime_checkable` Protocol declaring the audit write surface (`append_record`, `audit_enabled`) the hooks layer consumes |
+| `ReadFrictionLevelRule`, `DecisionGuidanceRule` | `src/dev10x/domain/session_rules.py` | Pure session policies relocated from `hooks/session_policy.py` |
+
+`hooks/session_policy.py` keeps `MigratePluginPermissionsRule` and
+`BuildAutonomyReassuranceRule` (genuine hook-layer policies) and
+re-exports the two moved rules so existing callers keep working
+during transition.
+
+### Code Examples
+
+```python
+# src/dev10x/domain/audit_writer.py
+@runtime_checkable
+class AuditWriter(Protocol):
+    def audit_enabled(self) -> bool: ...
+    def append_record(self, *, record: dict[str, Any]) -> None: ...
+```
+
+```python
+# src/dev10x/session/queries.py — before
+def gather_reload(cls, *, toplevel: str):
+    from dev10x.hooks.session_policy import ReadFrictionLevelRule  # cycle break
+    ...
+
+# after
+from dev10x.domain.session_rules import ReadFrictionLevelRule  # module scope
+```
+
+## Alternatives Considered
+
+### Alternative 1: Keep deferred imports (status quo for I2/I10)
+
+Leave the function-body imports in place.
+
+**Pros:**
+- Zero migration.
+
+**Cons:**
+- The finding itself: the cycle is hidden, not removed. Static
+  import-graph tooling cannot see it; a reader scanning the import
+  block is misled. Policy logic stays stranded in `hooks/`.
+
+**Verdict:** Rejected — this is the problem being solved.
+
+### Alternative 2: Merge the coupled adapters
+
+Fold `audit_emit`'s write side into `audit/`, and the session rules
+into `session/`.
+
+**Pros:**
+- Removes the cross-package import directly.
+
+**Cons:**
+- `audit_emit` provides the `@audit_hook` decorator the *hooks* layer
+  applies to hook bodies — it cannot live in `audit/`. Merging
+  adapters trades a direction problem for a cohesion problem and does
+  not generalise to the next boundary.
+
+**Verdict:** Rejected — addresses the symptom, not the direction.
+
+### Alternative 3 (Selected): Domain-owned Protocols + relocate pure policies
+
+**Pros:**
+- One rule covers every current and future boundary: depend inward on
+  `domain/`, cross via a `domain/` Protocol.
+- Removes the cycle outright (module-scope imports), so static tooling
+  can enforce it.
+- Pure policies land where they belong; consumers stop reaching up
+  into `hooks/`.
+
+**Cons:**
+- Relocating symbols is import-path-breaking — mitigated by
+  re-export shims and a one-PR atomic migration.
+
+**Verdict:** Selected — generalises, removes (not hides) the cycle,
+and aligns layer membership with dependency direction.
+
+## Consequences
+
+### What Becomes Easier
+
+1. New cross-adapter needs have one obvious answer: declare a
+   `Protocol` in `domain/` and inject. No new sideways imports.
+2. The import graph becomes acyclic and statically checkable; a
+   future lint rule can forbid `hooks → audit`, `audit → skills`,
+   etc.
+3. Session policies are reusable from any layer without importing
+   `hooks/`.
+
+### What Becomes More Difficult
+
+1. Adding a capability that one adapter needs from another now costs
+   a Protocol declaration plus an injection seam, rather than a bare
+   import. This is the deliberate cost of an enforced boundary.
+
+### Risks and Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| A moved-symbol import site is missed and breaks at runtime | Medium | Medium | Re-export shims in `hooks/session_policy.py`; grep every import site before merge; full test suite must pass |
+| `@runtime_checkable` Protocol checks method presence, not signature | Low | Low | Documented limitation; the injection seam is internal, exercised by unit tests |
+| I1 deferral leaves one inversion live | Certain | Low | Explicitly recorded below and in the PR; `audit → skills` is read-only and stable until ADR-0010 |
+
+### Known Exceptions
+
+`audit/analyze.py → skills.audit.analyze_permissions` (I1) remains
+until **ADR-0010** decides the uv-script question. This is a recorded,
+bounded exception — not an oversight.
+
+## Implementation Plan
+
+Shipped together under GH-244 (one PR, atomic commits per finding):
+
+### Phase 1: Boundary Protocols (this ADR)
+
+1. `src/dev10x/domain/audit_writer.py` — add `@runtime_checkable
+   AuditWriter` Protocol (I6 contract).
+2. `src/dev10x/domain/session_rules.py` — relocate
+   `ReadFrictionLevelRule` + `DecisionGuidanceRule` (I2 + I10).
+
+### Phase 2: Adapter rewiring
+
+3. `hooks/audit_emit.py` — depend on `AuditWriter`; resolve the
+   concrete `log_reader` impl through one injection seam (I6).
+4. `session/queries.py`, `hooks/session.py`,
+   `hooks/session_dispatch.py` — switch to module-scope imports from
+   `domain.session_rules`; `hooks/session_policy.py` re-exports the
+   moved rules (I2 + I10).
+
+### Deferred
+
+5. I1 (`audit → skills`) — tracked for M7 under ADR-0010.
+
+## References
+
+### Internal References
+
+- [GH-244](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/244) —
+  Audit-2026-05-18 M5: Context Boundary Sealing
+- Audit memo: `docs/memos/005-2026-05-18-architecture-audit.md` § 3
+- [ADR-0007](0007-rule-policy-archetype-unification.md) —
+  Rule/Policy archetype unification (sibling M5 ADR)
+- CWD discipline: `.claude/rules/cwd-discipline.md` (the same
+  "domain owns the contract, adapters inject" shape)
+
+### External References
+
+- [The Clean Architecture](https://8thlight.com/blog/uncle-bob/2012/08/13/the-clean-architecture.html)
+  — dependency rule (dependencies point inward)
+- [PEP 544](https://peps.python.org/pep-0544/) — Protocols (structural
+  subtyping)

--- a/src/dev10x/audit/log_reader.py
+++ b/src/dev10x/audit/log_reader.py
@@ -201,6 +201,32 @@ def summarize(*, records: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
     return hook_stats
 
 
+class LogReaderAuditWriter:
+    """Concrete ``AuditWriter`` backed by this module's JSONL log surface.
+
+    The audit memo I6 inversion (``hooks → audit``) is sealed by having
+    ``hooks.audit_emit`` depend on ``domain.audit_writer.AuditWriter`` and
+    receive this concrete adapter through one injection seam. Methods
+    delegate to the module-level functions so the on-disk behaviour is
+    unchanged.
+    """
+
+    def audit_enabled(self) -> bool:
+        return audit_enabled()
+
+    def append_record(self, *, record: dict[str, Any]) -> None:
+        append_record(record=record)
+
+    def new_span_id(self) -> str:
+        return new_span_id()
+
+    def current_span_id(self) -> str:
+        return current_span_id()
+
+    def classify_outcome(self, *, exit_code: int) -> HookOutcome:
+        return classify_outcome(exit_code=exit_code)
+
+
 def prune(*, retain_days: int | None = None, base_dir: Path | None = None) -> int:
     """Remove log files older than retain_days. Returns count deleted."""
     days = retain_days

--- a/src/dev10x/domain/audit_writer.py
+++ b/src/dev10x/domain/audit_writer.py
@@ -1,0 +1,47 @@
+"""AuditWriter — domain-owned contract for the hook audit log surface.
+
+The hooks layer (``dev10x.hooks.audit_emit``) needs to mint span ids,
+classify outcomes, and append audit records, but it must not import the
+``audit/`` adapter's internals directly (audit memo Finding I6 — the
+``hooks → audit`` inversion). This Protocol declares the surface in the
+core; ``dev10x.audit.log_reader`` provides the concrete implementation,
+and the hooks layer depends on the Protocol and receives the concrete
+writer through a single injection seam.
+
+See ADR-0008 (context boundary protocol) for the dependency-direction
+rule this enforces.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from dev10x.domain.hook_telemetry import HookOutcome
+
+
+@runtime_checkable
+class AuditWriter(Protocol):
+    """The audit-log surface consumed by the hooks layer."""
+
+    def audit_enabled(self) -> bool:
+        """Return True when audit logging is enabled for this process."""
+        ...
+
+    def append_record(self, *, record: dict[str, Any]) -> None:
+        """Append a single audit record. Failures never propagate."""
+        ...
+
+    def new_span_id(self) -> str:
+        """Mint a fresh span id correlating wrap and body phases."""
+        ...
+
+    def current_span_id(self) -> str:
+        """Return the inherited span id, or a fresh one when unset."""
+        ...
+
+    def classify_outcome(self, *, exit_code: int) -> HookOutcome:
+        """Map a process exit code to a :class:`HookOutcome`."""
+        ...
+
+
+__all__ = ["AuditWriter"]

--- a/src/dev10x/domain/documents/settings_document.py
+++ b/src/dev10x/domain/documents/settings_document.py
@@ -1,0 +1,82 @@
+"""SettingsDocument — owns settings.json read / transform / atomic write.
+
+Extracted from ``MigratePluginPermissionsRule`` (audit memo D3,
+ADR-0007): a Policy Rule must not perform I/O. The rule keeps the
+decision (which replacements to apply, which files exist); this Document
+owns the locked read-modify-write of the ``permissions`` allow/deny
+lists, mirroring the rest of ``domain/documents/``.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from dev10x.domain.file_locks import atomic_write_text, file_lock
+
+
+def _migrate_rules(
+    *,
+    rules: list[str],
+    replacements: list[tuple[str, str]],
+) -> tuple[list[str], int]:
+    migrated = 0
+    result = []
+    for rule in rules:
+        new_rule = rule
+        for old, new in replacements:
+            if old in rule:
+                new_rule = rule.replace(old, new)
+                migrated += 1
+                break
+        result.append(new_rule)
+    return result, migrated
+
+
+def _deduplicate_rules(rules: list[str]) -> list[str]:
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for rule in rules:
+        if rule not in seen:
+            seen.add(rule)
+            deduped.append(rule)
+    return deduped
+
+
+@dataclass(frozen=True)
+class SettingsDocument:
+    """A Claude Code ``settings.json`` / ``settings.local.json`` file."""
+
+    path: Path
+
+    def apply_replacements(self, *, replacements: list[tuple[str, str]]) -> int:
+        """Rewrite stale prefixes in the ``permissions`` allow/deny lists.
+
+        Performs the full locked read-modify-write so a concurrent
+        session never observes a half-written file. Returns the count of
+        rules rewritten; writes only when something changed. Raises
+        ``json.JSONDecodeError`` / ``OSError`` on read/parse/write failure
+        so the caller can decide whether to skip the file.
+        """
+        with file_lock(self.path):
+            settings = json.loads(self.path.read_text())
+            permissions = settings.get("permissions", {})
+            migrated = 0
+            changed = False
+            for key in ("allow", "deny"):
+                raw = permissions.get(key, [])
+                if not raw:
+                    continue
+                new_rules, count = _migrate_rules(rules=raw, replacements=replacements)
+                new_rules = _deduplicate_rules(rules=new_rules)
+                migrated += count
+                if count:
+                    permissions[key] = new_rules
+                    changed = True
+            if changed:
+                atomic_write_text(self.path, json.dumps(settings, indent=2) + "\n")
+        return migrated
+
+
+__all__ = ["SettingsDocument", "_migrate_rules", "_deduplicate_rules"]

--- a/src/dev10x/domain/rules/policy_rule.py
+++ b/src/dev10x/domain/rules/policy_rule.py
@@ -1,0 +1,31 @@
+"""PolicyRule — the Policy Rule archetype contract (ADR-0007).
+
+A Policy Rule is a small immutable object that computes one named
+decision via ``apply()`` and performs no I/O — persistence is delegated
+to the Document layer (``domain/documents/``). This Protocol formalises
+the contract the ``*Rule`` policy classes previously satisfied only by
+convention.
+
+The codebase has three deliberately distinct "rule" archetypes
+(ADR-0007); this Protocol formalises only the Policy Rule tier:
+
+- **Matching Rule** (``domain.rules.validation_rule.Rule``) — declarative
+  data + ``matches_*`` predicates, no ``apply()``.
+- **Policy Rule** (this Protocol) — one named decision via ``apply()``.
+- **Validator** (``validators.base.Validator``) — ``should_run()`` +
+  ``validate()`` chain element with its own registry lifecycle.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class PolicyRule[T](Protocol):
+    """One named decision computed by ``apply()`` with no side effects."""
+
+    def apply(self) -> T: ...
+
+
+__all__ = ["PolicyRule"]

--- a/src/dev10x/domain/session_rules.py
+++ b/src/dev10x/domain/session_rules.py
@@ -1,0 +1,98 @@
+"""Session policy rules — pure decisions owned by the domain core.
+
+These were previously defined in ``dev10x.hooks.session_policy``, which
+forced ``session.queries`` to defer its imports into function bodies to
+break the cycle ``hooks.session_dispatch → session.queries →
+hooks.session_policy`` (audit memo Findings I2 + I10). Both rules depend
+only on ``domain/`` types, so they belong in the core: adapters now
+import them inward instead of reaching up into ``hooks/``.
+
+See ADR-0008 (context boundary protocol) for the dependency-direction
+rule and ADR-0007 for the Policy Rule archetype these satisfy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from dev10x.domain.documents.session_state import PlanSummary
+from dev10x.domain.friction_level import FrictionLevel
+from dev10x.domain.rules.policy_rule import PolicyRule
+
+
+class UnknownFrictionLevelError(ValueError):
+    """Raised when decision guidance is asked to format an unknown friction level."""
+
+
+@dataclass(frozen=True)
+class ReadFrictionLevelRule(PolicyRule[FrictionLevel]):
+    """Read the friction level from ``.claude/Dev10x/session.yaml``.
+
+    Returns ``FrictionLevel.default()`` when the file is missing or
+    unreadable — that is the soft fallback. Use ``DecisionGuidanceRule``
+    for strict behaviour at format time.
+    """
+
+    toplevel: str
+
+    def apply(self) -> FrictionLevel:
+        session_yaml = Path(self.toplevel) / ".claude" / "Dev10x" / "session.yaml"
+        if not session_yaml.exists():
+            return FrictionLevel.default()
+        try:
+            import yaml
+
+            with open(session_yaml) as f:
+                data = yaml.safe_load(f) or {}
+            return FrictionLevel.from_yaml(data.get("friction_level"))
+        except Exception:
+            return FrictionLevel.default()
+
+
+@dataclass(frozen=True)
+class DecisionGuidanceRule(PolicyRule[str]):
+    """Format resume guidance for the agent based on plan + friction level.
+
+    Raises ``UnknownFrictionLevelError`` when ``friction_level`` is not
+    a recognised :class:`FrictionLevel` member. Audit M7 #D2 calls out
+    the prior fall-through (which silently produced strict-style guidance
+    for adaptive sessions) as a latent bug.
+    """
+
+    plan: dict[str, Any]
+    friction_level: FrictionLevel
+
+    def apply(self) -> str:
+        if not isinstance(self.friction_level, FrictionLevel):
+            raise UnknownFrictionLevelError(f"Unknown friction level: {self.friction_level!r}")
+
+        summary = PlanSummary.from_dict(data=self.plan)
+        decisions = summary.pending_decisions
+        if not decisions:
+            has_remaining = bool(summary.pending_tasks)
+            if has_remaining:
+                return "Session resumed with tasks remaining. Auto-advance through the task list."
+            return ""
+
+        if self.friction_level is FrictionLevel.ADAPTIVE:
+            return (
+                "Session resumed with pending decisions. Friction level is adaptive — "
+                "auto-select recommended options for all queued decisions and continue "
+                "advancing through the task list without calling AskUserQuestion."
+            )
+        if self.friction_level in (FrictionLevel.STRICT, FrictionLevel.GUIDED):
+            return (
+                "Session resumed with pending decisions. "
+                "Re-ask each pending decision using AskUserQuestion — "
+                "invoke Dev10x:ask before advancing."
+            )
+        raise UnknownFrictionLevelError(f"Unhandled friction level: {self.friction_level!r}")
+
+
+__all__ = [
+    "UnknownFrictionLevelError",
+    "ReadFrictionLevelRule",
+    "DecisionGuidanceRule",
+]

--- a/src/dev10x/hooks/audit_emit.py
+++ b/src/dev10x/hooks/audit_emit.py
@@ -1,10 +1,14 @@
 """Hook audit emitters (write side) — decorator + wrap-record helpers.
 
-Companion to `dev10x.audit.log_reader`. This module owns the
-`@audit_hook` decorator wrapped around hook bodies and the
-wrap-phase record helpers called by `hooks/scripts/audit-wrap`.
-All writes flow through `log_reader.append_record` so the reader
-remains the single source of truth for log layout.
+This module owns the `@audit_hook` decorator wrapped around hook bodies
+and the wrap-phase record helpers called by `hooks/scripts/audit-wrap`.
+
+Per ADR-0008 (audit memo I6) it depends on the domain-owned
+`AuditWriter` Protocol rather than importing `dev10x.audit.log_reader`
+internals directly; the concrete `LogReaderAuditWriter` is resolved
+through the single `_get_writer()` seam, so all writes still flow
+through `log_reader.append_record` (the reader remains the single
+source of truth for log layout).
 """
 
 from __future__ import annotations
@@ -16,16 +20,30 @@ from datetime import UTC, datetime
 from functools import wraps
 from typing import Any, TypeVar
 
-from dev10x.audit.log_reader import (
-    append_record,
-    audit_enabled,
-    classify_outcome,
-    current_span_id,
-    new_span_id,
-)
+from dev10x.domain.audit_writer import AuditWriter
 from dev10x.domain.hook_telemetry import HookPhase
 
 F = TypeVar("F", bound=Callable[..., Any])
+
+_writer: AuditWriter | None = None
+
+
+def _get_writer() -> AuditWriter:
+    """Resolve the audit writer — the single seam touching the ``audit``
+    adapter (audit memo I6). Swap via :func:`set_audit_writer` in tests."""
+    global _writer
+    if _writer is None:
+        from dev10x.audit.log_reader import LogReaderAuditWriter
+
+        _writer = LogReaderAuditWriter()
+    return _writer
+
+
+def set_audit_writer(writer: AuditWriter | None) -> None:
+    """Inject an alternative ``AuditWriter`` (tests / alternative backends).
+    Pass ``None`` to reset to the default log-backed writer."""
+    global _writer
+    _writer = writer
 
 
 def audit_hook(name: str, *, event: str = "") -> Callable[[F], F]:
@@ -43,10 +61,11 @@ def audit_hook(name: str, *, event: str = "") -> Callable[[F], F]:
     def decorator(func: F) -> F:
         @wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
-            if not audit_enabled():
+            writer = _get_writer()
+            if not writer.audit_enabled():
                 return func(*args, **kwargs)
 
-            span_id = current_span_id()
+            span_id = writer.current_span_id()
             session_id = ""
             start = time.perf_counter()
             exit_code = 0
@@ -78,11 +97,11 @@ def audit_hook(name: str, *, event: str = "") -> Callable[[F], F]:
                     "span_id": span_id,
                     "session_id": session_id,
                     "body_ms": body_ms,
-                    "outcome": classify_outcome(exit_code=exit_code),
+                    "outcome": writer.classify_outcome(exit_code=exit_code),
                 }
                 if error is not None and not isinstance(error, SystemExit):
                     record["error_type"] = type(error).__name__
-                append_record(record=record)
+                writer.append_record(record=record)
 
         return wrapper  # type: ignore[return-value]
 
@@ -101,7 +120,8 @@ def write_wrap_record(
     via `dev10x hook audit wrap-record` — or directly by Python tooling
     for testing.
     """
-    if not audit_enabled():
+    writer = _get_writer()
+    if not writer.audit_enabled():
         return
     record = {
         "phase": HookPhase.WRAP,
@@ -111,16 +131,16 @@ def write_wrap_record(
         "span_id": span_id,
         "total_ms": total_ms,
         "exit_code": exit_code,
-        "outcome": classify_outcome(exit_code=exit_code),
+        "outcome": writer.classify_outcome(exit_code=exit_code),
     }
-    append_record(record=record)
+    writer.append_record(record=record)
 
 
 def new_wrap_context() -> tuple[str, float]:
     """Called by the wrapper (via CLI shim) to mint a span id and
     record the start time. Returns (span_id, start_perf_counter).
     """
-    return new_span_id(), time.perf_counter()
+    return _get_writer().new_span_id(), time.perf_counter()
 
 
 def finish_wrap_context(

--- a/src/dev10x/hooks/session_policy.py
+++ b/src/dev10x/hooks/session_policy.py
@@ -1,9 +1,14 @@
-"""Session policy — named Rule objects for friction parsing, permission
-migration, and decision-guidance synthesis.
+"""Session policy — named Rule objects for permission migration and
+autonomy-reassurance synthesis.
 
-Rule archetype: each class encapsulates one named decision the session
-hooks make. Pulling these out of ``hooks/session.py`` keeps the
-dispatcher thin and makes the policies testable in isolation.
+Rule archetype (see ADR-0007): each class encapsulates one named
+decision the session hooks make. Pulling these out of
+``hooks/session.py`` keeps the dispatcher thin and makes the policies
+testable in isolation.
+
+The friction-parsing and decision-guidance rules moved to
+``dev10x.domain.session_rules`` (ADR-0008) because they are pure
+domain policies; they are re-exported here for backward compatibility.
 """
 
 from __future__ import annotations
@@ -11,15 +16,19 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
-from dev10x.domain.documents.session_state import PlanSummary
-from dev10x.domain.file_locks import atomic_write_text, file_lock
+from dev10x.domain.documents.settings_document import (
+    SettingsDocument,
+    _deduplicate_rules,
+    _migrate_rules,
+)
 from dev10x.domain.friction_level import FrictionLevel
-
-
-class UnknownFrictionLevelError(ValueError):
-    """Raised when decision guidance is asked to format an unknown friction level."""
+from dev10x.domain.rules.policy_rule import PolicyRule
+from dev10x.domain.session_rules import (
+    DecisionGuidanceRule,
+    ReadFrictionLevelRule,
+    UnknownFrictionLevelError,
+)
 
 
 def _build_migration_replacements(
@@ -48,61 +57,8 @@ def _build_migration_replacements(
     return replacements
 
 
-def _migrate_rules(
-    *,
-    rules: list[str],
-    replacements: list[tuple[str, str]],
-) -> tuple[list[str], int]:
-    migrated = 0
-    result = []
-    for rule in rules:
-        new_rule = rule
-        for old, new in replacements:
-            if old in rule:
-                new_rule = rule.replace(old, new)
-                migrated += 1
-                break
-        result.append(new_rule)
-    return result, migrated
-
-
-def _deduplicate_rules(rules: list[str]) -> list[str]:
-    seen: set[str] = set()
-    deduped: list[str] = []
-    for rule in rules:
-        if rule not in seen:
-            seen.add(rule)
-            deduped.append(rule)
-    return deduped
-
-
 @dataclass(frozen=True)
-class ReadFrictionLevelRule:
-    """Read the friction level from ``.claude/Dev10x/session.yaml``.
-
-    Returns ``FrictionLevel.default()`` when the file is missing or
-    unreadable — that is the soft fallback. Use ``DecisionGuidanceRule``
-    for strict behaviour at format time.
-    """
-
-    toplevel: str
-
-    def apply(self) -> FrictionLevel:
-        session_yaml = Path(self.toplevel) / ".claude" / "Dev10x" / "session.yaml"
-        if not session_yaml.exists():
-            return FrictionLevel.default()
-        try:
-            import yaml
-
-            with open(session_yaml) as f:
-                data = yaml.safe_load(f) or {}
-            return FrictionLevel.from_yaml(data.get("friction_level"))
-        except Exception:
-            return FrictionLevel.default()
-
-
-@dataclass(frozen=True)
-class BuildAutonomyReassuranceRule:
+class BuildAutonomyReassuranceRule(PolicyRule[str]):
     """Build a reassurance block for autonomous sessions (GH-261).
 
     Fires only when ``friction_level: adaptive`` AND ``solo-maintainer`` is in
@@ -151,47 +107,7 @@ class BuildAutonomyReassuranceRule:
 
 
 @dataclass(frozen=True)
-class DecisionGuidanceRule:
-    """Format resume guidance for the agent based on plan + friction level.
-
-    Raises ``UnknownFrictionLevelError`` when ``friction_level`` is not
-    a recognised :class:`FrictionLevel` member. Audit M7 #D2 calls out
-    the prior fall-through (which silently produced strict-style guidance
-    for adaptive sessions) as a latent bug.
-    """
-
-    plan: dict[str, Any]
-    friction_level: FrictionLevel
-
-    def apply(self) -> str:
-        if not isinstance(self.friction_level, FrictionLevel):
-            raise UnknownFrictionLevelError(f"Unknown friction level: {self.friction_level!r}")
-
-        summary = PlanSummary.from_dict(data=self.plan)
-        decisions = summary.pending_decisions
-        if not decisions:
-            has_remaining = bool(summary.pending_tasks)
-            if has_remaining:
-                return "Session resumed with tasks remaining. Auto-advance through the task list."
-            return ""
-
-        if self.friction_level is FrictionLevel.ADAPTIVE:
-            return (
-                "Session resumed with pending decisions. Friction level is adaptive — "
-                "auto-select recommended options for all queued decisions and continue "
-                "advancing through the task list without calling AskUserQuestion."
-            )
-        if self.friction_level in (FrictionLevel.STRICT, FrictionLevel.GUIDED):
-            return (
-                "Session resumed with pending decisions. "
-                "Re-ask each pending decision using AskUserQuestion — "
-                "invoke Dev10x:ask before advancing."
-            )
-        raise UnknownFrictionLevelError(f"Unhandled friction level: {self.friction_level!r}")
-
-
-@dataclass(frozen=True)
-class MigratePluginPermissionsRule:
+class MigratePluginPermissionsRule(PolicyRule[tuple[int, list[str]]]):
     """Rewrite stale plugin-cache paths in user settings.{json,local.json}.
 
     Only meaningful when installed via the plugin cache — direct
@@ -228,26 +144,14 @@ class MigratePluginPermissionsRule:
 
         for settings_file in settings_files:
             try:
-                with file_lock(settings_file):
-                    settings = json.loads(settings_file.read_text())
-                    permissions = settings.get("permissions", {})
-                    changed = False
-                    for key in ("allow", "deny"):
-                        raw = permissions.get(key, [])
-                        if not raw:
-                            continue
-                        new_rules, count = _migrate_rules(rules=raw, replacements=replacements)
-                        new_rules = _deduplicate_rules(rules=new_rules)
-                        total_migrated += count
-                        if count:
-                            permissions[key] = new_rules
-                            changed = True
-                    if not changed:
-                        continue
-                    atomic_write_text(settings_file, json.dumps(settings, indent=2) + "\n")
-                files_changed.append(settings_file.name)
+                count = SettingsDocument(path=settings_file).apply_replacements(
+                    replacements=replacements
+                )
             except (json.JSONDecodeError, OSError):
                 continue
+            if count:
+                total_migrated += count
+                files_changed.append(settings_file.name)
 
         return total_migrated, files_changed
 

--- a/src/dev10x/session/queries.py
+++ b/src/dev10x/session/queries.py
@@ -22,6 +22,7 @@ from dev10x.domain.session_document import (
     read_plan_summary,
     state_path_for_toplevel,
 )
+from dev10x.domain.session_rules import DecisionGuidanceRule, ReadFrictionLevelRule
 
 
 def _run_git_safe(git: GitContext, *args: str) -> str:
@@ -50,8 +51,6 @@ class SessionContextQuery:
     @classmethod
     def gather_reload(cls, *, toplevel: str) -> SessionContextQuery:
         """Gather context for SessionStart reload — consumes state file once."""
-        from dev10x.hooks.session_policy import ReadFrictionLevelRule
-
         state = claim_state_file(path=state_path_for_toplevel(toplevel=toplevel))
         plan_path = plan_path_for_toplevel(toplevel=toplevel)
         plan_exists = plan_path.exists()
@@ -69,8 +68,6 @@ class SessionContextQuery:
     @classmethod
     def gather_compaction(cls, *, toplevel: str) -> SessionContextQuery:
         """Gather context for PreCompact — reads git state, plan, friction."""
-        from dev10x.hooks.session_policy import ReadFrictionLevelRule
-
         git = GitContext(cwd=toplevel)
         branch = git.branch
 
@@ -111,7 +108,6 @@ def _format_files(*, files: list[str]) -> str:
 def format_reload_context(*, ctx: SessionContextQuery) -> str:
     """Render a SessionContextQuery as the SessionStart additionalContext."""
     from dev10x.domain.documents.session_state import PlanSummary, SessionState
-    from dev10x.hooks.session_policy import DecisionGuidanceRule
 
     if not ctx.state and not ctx.plan_exists:
         return ""
@@ -136,7 +132,6 @@ def format_reload_context(*, ctx: SessionContextQuery) -> str:
 def format_compaction_summary(*, ctx: SessionContextQuery, plugin_root: Path) -> str:
     """Render a SessionContextQuery as the PreCompact systemMessage body."""
     from dev10x.domain.documents.session_state import PlanSummary
-    from dev10x.hooks.session_policy import DecisionGuidanceRule
 
     essentials_file = plugin_root / ".claude" / "rules" / "essentials.md"
     essentials = essentials_file.read_text() if essentials_file.exists() else ""

--- a/tests/domain/documents/test_settings_document.py
+++ b/tests/domain/documents/test_settings_document.py
@@ -1,0 +1,105 @@
+"""Tests for SettingsDocument — D3 / ADR-0007 I/O extraction."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dev10x.domain.documents.settings_document import (
+    SettingsDocument,
+    _deduplicate_rules,
+    _migrate_rules,
+)
+
+REPLACEMENTS = [("/old/v1/", "/new/v2/")]
+
+
+@pytest.fixture()
+def settings_path(tmp_path: Path) -> Path:
+    return tmp_path / "settings.json"
+
+
+def _write(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data, indent=2) + "\n")
+
+
+def test_rewrites_allow_and_deny(settings_path: Path) -> None:
+    _write(
+        settings_path,
+        {
+            "permissions": {
+                "allow": ["Bash(/old/v1/run.sh:*)"],
+                "deny": ["Read(/old/v1/secret)"],
+            }
+        },
+    )
+
+    migrated = SettingsDocument(path=settings_path).apply_replacements(replacements=REPLACEMENTS)
+
+    written = json.loads(settings_path.read_text())
+    assert migrated == 2
+    assert written["permissions"]["allow"] == ["Bash(/new/v2/run.sh:*)"]
+    assert written["permissions"]["deny"] == ["Read(/new/v2/secret)"]
+
+
+def test_deduplicates_after_rewrite(settings_path: Path) -> None:
+    _write(
+        settings_path,
+        {"permissions": {"allow": ["Bash(/old/v1/x)", "Bash(/new/v2/x)"]}},
+    )
+
+    migrated = SettingsDocument(path=settings_path).apply_replacements(replacements=REPLACEMENTS)
+
+    written = json.loads(settings_path.read_text())
+    assert migrated == 1
+    assert written["permissions"]["allow"] == ["Bash(/new/v2/x)"]
+
+
+def test_no_match_returns_zero_and_leaves_file_unchanged(settings_path: Path) -> None:
+    original = json.dumps({"permissions": {"allow": ["Bash(/other/run.sh)"]}}, indent=2) + "\n"
+    settings_path.write_text(original)
+
+    migrated = SettingsDocument(path=settings_path).apply_replacements(replacements=REPLACEMENTS)
+
+    assert migrated == 0
+    assert settings_path.read_text() == original
+
+
+def test_missing_permissions_key_returns_zero(settings_path: Path) -> None:
+    _write(settings_path, {"model": "opus"})
+
+    migrated = SettingsDocument(path=settings_path).apply_replacements(replacements=REPLACEMENTS)
+
+    assert migrated == 0
+
+
+def test_invalid_json_raises(settings_path: Path) -> None:
+    settings_path.write_text("{not valid json")
+
+    with pytest.raises(json.JSONDecodeError):
+        SettingsDocument(path=settings_path).apply_replacements(replacements=REPLACEMENTS)
+
+
+def test_migrate_rules_counts_each_rewrite() -> None:
+    result, count = _migrate_rules(
+        rules=["/old/a", "/old/b", "/keep/c"], replacements=REPLACEMENTS
+    )
+
+    assert count == 0
+    assert result == ["/old/a", "/old/b", "/keep/c"]
+
+
+def test_migrate_rules_applies_first_matching_replacement() -> None:
+    result, count = _migrate_rules(
+        rules=["x /old/v1/ y"],
+        replacements=REPLACEMENTS,
+    )
+
+    assert count == 1
+    assert result == ["x /new/v2/ y"]
+
+
+def test_deduplicate_rules_preserves_order() -> None:
+    assert _deduplicate_rules(rules=["a", "b", "a", "c", "b"]) == ["a", "b", "c"]

--- a/tests/domain/test_policy_rule.py
+++ b/tests/domain/test_policy_rule.py
@@ -1,0 +1,28 @@
+"""Tests for the PolicyRule Protocol conformance (A9 / ADR-0007)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dev10x.domain.friction_level import FrictionLevel
+from dev10x.domain.rules.policy_rule import PolicyRule
+from dev10x.domain.session_rules import DecisionGuidanceRule, ReadFrictionLevelRule
+from dev10x.hooks.session_policy import (
+    BuildAutonomyReassuranceRule,
+    MigratePluginPermissionsRule,
+)
+
+
+@pytest.mark.parametrize(
+    "rule",
+    [
+        ReadFrictionLevelRule(toplevel="/tmp"),
+        DecisionGuidanceRule(plan={}, friction_level=FrictionLevel.default()),
+        BuildAutonomyReassuranceRule(toplevel="/tmp"),
+        MigratePluginPermissionsRule(plugin_root=Path("/p"), home_path=Path("/h")),
+    ],
+)
+def test_policy_classes_satisfy_protocol(rule: PolicyRule) -> None:
+    assert isinstance(rule, PolicyRule)

--- a/tests/hooks/test_audit_writer.py
+++ b/tests/hooks/test_audit_writer.py
@@ -1,0 +1,77 @@
+"""Tests for the AuditWriter Protocol seam (I6 / ADR-0008)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from dev10x.audit.log_reader import LogReaderAuditWriter
+from dev10x.domain.audit_writer import AuditWriter
+from dev10x.domain.hook_telemetry import HookOutcome
+from dev10x.hooks import audit_emit
+from dev10x.hooks.audit_emit import audit_hook, set_audit_writer
+
+
+@dataclass
+class _RecordingWriter:
+    enabled: bool = True
+    records: list[dict[str, Any]] = field(default_factory=list)
+
+    def audit_enabled(self) -> bool:
+        return self.enabled
+
+    def append_record(self, *, record: dict[str, Any]) -> None:
+        self.records.append(record)
+
+    def new_span_id(self) -> str:
+        return "span-test"
+
+    def current_span_id(self) -> str:
+        return "span-test"
+
+    def classify_outcome(self, *, exit_code: int) -> HookOutcome:
+        return HookOutcome.from_exit_code(exit_code)
+
+
+@pytest.fixture()
+def reset_writer() -> Iterator[None]:
+    yield
+    set_audit_writer(None)
+
+
+def test_log_reader_writer_satisfies_protocol() -> None:
+    assert isinstance(LogReaderAuditWriter(), AuditWriter)
+
+
+def test_default_writer_is_log_reader_backed(reset_writer: None) -> None:
+    set_audit_writer(None)
+    assert isinstance(audit_emit._get_writer(), LogReaderAuditWriter)
+
+
+def test_injected_writer_receives_body_record(reset_writer: None) -> None:
+    writer = _RecordingWriter()
+    set_audit_writer(writer)
+
+    @audit_hook(name="seam-hook", event="PreToolUse")
+    def target() -> int:
+        return 7
+
+    assert target() == 7
+    assert len(writer.records) == 1
+    assert writer.records[0]["hook"] == "seam-hook"
+    assert writer.records[0]["span_id"] == "span-test"
+
+
+def test_disabled_writer_skips_record(reset_writer: None) -> None:
+    writer = _RecordingWriter(enabled=False)
+    set_audit_writer(writer)
+
+    @audit_hook(name="seam-hook", event="PreToolUse")
+    def target() -> int:
+        return 1
+
+    assert target() == 1
+    assert writer.records == []


### PR DESCRIPTION
**When** the hooks, audit, and skills layers need to collaborate, **I want to** cross context boundaries through domain-owned protocols instead of reaching into each other's internals, **so I can** refactor any one layer without silently breaking its neighbours.

---

[`756a0fba`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/377/commits/756a0fba9e3a2702162dfdce879e218c90ed477d) ♻️ GH-244 Seal context boundaries with domain protocols

Refs: GH-244 (Audit-2026-05-18 M5; I1 deferred to M7 — see first comment for scope)

Fixes: none — self-motivated refactor

---