### PR TITLE
✨ GH-369 Cut unattended-session permission friction (GH-271 batch)

### DIFF
--- a/.claude/rules/hook-patterns.md
+++ b/.claude/rules/hook-patterns.md
@@ -168,6 +168,8 @@ higher tiers — `minimal` rules are always active.
 | DX009 | redundant-fetch | standard (experimental) |
 | DX010 | bash-aggregation | standard |
 | DX011 | pipeline-allow | standard |
+| DX012 | safe-expansion | minimal |
+| DX013 | mcp-prefix | standard |
 
 ### Configuration
 

--- a/references/permission-architecture.md
+++ b/references/permission-architecture.md
@@ -125,6 +125,30 @@ The upstream UI defect that generates the catch-all is tracked
 separately (GH-312); this allowlist is the defense-in-depth that
 keeps unattended sessions moving without it.
 
+### WebFetch documentation domains (GH-369)
+
+`WebFetch` is its own permission entity class, distinct from `Bash`.
+A rule has the shape `WebFetch(domain:<host>)` and matches a single
+fully-qualified host over HTTPS. Routine documentation lookups (read
+the Django docs, check a Pydantic page, open an MDN article) prompt
+per-domain on first access — GH-271 evidence recorded 6+ distinct doc
+domains in one session, each a fresh stall for an unattended run.
+
+The `webfetch-public-docs` group (tier 2) pre-approves a curated set
+of ~30 canonical documentation hosts so these fetches never prompt.
+Scope rules for the catalog:
+
+- **HTTPS documentation hosts only** — reference content, not API
+  endpoints. A docs host serves read-only pages; pre-approving it
+  cannot fetch-and-exec or exfiltrate.
+- **One FQDN per rule** — `WebFetch(domain:docs.python.org)`, not a
+  wildcard `*.python.org`. Explicit hosts keep the approved surface
+  auditable and prevent a broad subdomain from silently covering an
+  API or upload endpoint.
+- **Not for arbitrary URLs** — fetching a non-doc host still prompts,
+  by design. The catalog is a curated allowlist, not a blanket
+  WebFetch permit.
+
 ## References
 
 - [ADR-0003](../docs/adr/0003-allow-rules-as-hook-enablers.md) — decision record

--- a/skills/upgrade-cleanup/projects.yaml
+++ b/skills/upgrade-cleanup/projects.yaml
@@ -42,6 +42,19 @@ base_permissions:
   # --- Plugin infrastructure (GH-274, GH-101, GH-426) ---
   - "Bash(/tmp/Dev10x/bin/mktmp.sh:*)"
 
+  # --- Arbitrary-code escape destinations (GH-370) ---
+  # GH-308 steers agents to extract inline probes into /tmp/Dev10x/*.py
+  # or ~/.claude/tools/*.py. Write is already permitted; without these,
+  # executing the extracted script prompts again (GH-271 #192, #215).
+  - "Bash(/tmp/Dev10x/*.py:*)"
+  - "Bash(/tmp/Dev10x/**/*.py:*)"
+  - "Bash(/tmp/Dev10x/*.sh:*)"
+  - "Bash(/tmp/Dev10x/**/*.sh:*)"
+  - "Bash(~/.claude/tools/*:*)"
+  - "Bash(~/.claude/tools/*.py:*)"
+  - "Bash(~/.claude/tools/*.sh:*)"
+  - "Bash(/home/*/.claude/tools/*:*)"
+
   # --- Plugin scripts: bin/ ---
   - "Bash(~/.claude/plugins/cache/**/bin/release.sh:*)"
   - "Bash(~/.claude/plugins/cache/**/bin/require-tool.sh:*)"
@@ -460,6 +473,46 @@ base_permissions:
   # uv — read-only environment inspection (test/lint/run already covered)
   - "Bash(uv pip list:*)"
   - "Bash(uv tree:*)"
+
+  # --- Canonical documentation domains (GH-369) ---
+  # WebFetch is its own permission entity class. Routine doc lookups
+  # prompt per-domain on first access; GH-271 evidence showed 6+ doc
+  # domains hit in a single session. Pre-approving the canonical set
+  # keeps unattended sessions moving. HTTPS doc hosts only, one FQDN
+  # per rule (no wildcard subdomains — keeps the surface auditable).
+  # Mirrors the `webfetch-public-docs` tier-2 group in
+  # baseline-permissions.yaml.
+  - "WebFetch(domain:docs.python.org)"
+  - "WebFetch(domain:peps.python.org)"
+  - "WebFetch(domain:packaging.python.org)"
+  - "WebFetch(domain:docs.pytest.org)"
+  - "WebFetch(domain:docs.astral.sh)"
+  - "WebFetch(domain:black.readthedocs.io)"
+  - "WebFetch(domain:docs.pydantic.dev)"
+  - "WebFetch(domain:pip.pypa.io)"
+  - "WebFetch(domain:docs.djangoproject.com)"
+  - "WebFetch(domain:fastapi.tiangolo.com)"
+  - "WebFetch(domain:flask.palletsprojects.com)"
+  - "WebFetch(domain:docs.celeryq.dev)"
+  - "WebFetch(domain:docs.gunicorn.org)"
+  - "WebFetch(domain:gunicorn.org)"
+  - "WebFetch(domain:developer.mozilla.org)"
+  - "WebFetch(domain:svelte.dev)"
+  - "WebFetch(domain:kit.svelte.dev)"
+  - "WebFetch(domain:react.dev)"
+  - "WebFetch(domain:nodejs.org)"
+  - "WebFetch(domain:docs.npmjs.com)"
+  - "WebFetch(domain:docs.docker.com)"
+  - "WebFetch(domain:kubernetes.io)"
+  - "WebFetch(domain:docs.aws.amazon.com)"
+  - "WebFetch(domain:health.aws.amazon.com)"
+  - "WebFetch(domain:cloud.google.com)"
+  - "WebFetch(domain:www.postgresql.org)"
+  - "WebFetch(domain:redis.io)"
+  - "WebFetch(domain:docs.github.com)"
+  - "WebFetch(domain:docs.gitlab.com)"
+  - "WebFetch(domain:docs.sentry.io)"
+  - "WebFetch(domain:resend.com)"
 
   # --- Dev10x skills ---
   - "Skill(Dev10x:*)"

--- a/src/dev10x/skills/permission/baseline-permissions.yaml
+++ b/src/dev10x/skills/permission/baseline-permissions.yaml
@@ -112,6 +112,25 @@ groups:
       - Bash(git trunk-rebase:*)
       - Bash(git autosquash-trunk:*)
 
+  git-safe-flags:
+    tier: 2
+    description: >
+      Flag-stratified safe forms of verbs whose bare form is gated.
+      Each entry expands to Bash(<cmd> <flag>:*) allow rules (GH-372).
+    # NOTE: `find`'s "safe unless -delete/-exec" case is OUT OF SCOPE for
+    # flag_overrides — it INVERTS this additive model (denying a dangerous
+    # flag, not allowing a safe one). A companion deny-flag mechanism for
+    # `find -delete` is deferred (GH-372). Do NOT add deny-flags here.
+    flag_overrides:
+      "git clean":
+        - "-n"
+        - "--dry-run"
+      "git branch":
+        - "-d"
+        - "--delete"
+      "git reset":
+        - "--dry-run"
+
   github-cli:
     tier: 1
     description: >
@@ -157,6 +176,10 @@ groups:
       - Bash(gh run watch:*)
       - Bash(gh run download:*)
       - Bash(gh run rerun:*)
+      # gh workflow (GH-373): read-only forms pre-approved. The
+      # cost-bearing forms `gh workflow run|enable|disable` are
+      # deliberately omitted so they keep prompting (ask-tier) —
+      # they trigger CI spend or flip workflow state.
       - Bash(gh workflow list:*)
       - Bash(gh workflow view:*)
 
@@ -180,6 +203,21 @@ groups:
       - "Bash(${CLAUDE_PLUGIN_ROOT}/hooks/scripts/**)"
       - "Bash(${CLAUDE_PLUGIN_ROOT}/skills/**)"
       - "Bash(${CLAUDE_PLUGIN_ROOT}/lib/**)"
+      # GH-370: documented arbitrary-code escape destinations. When an
+      # agent follows GH-308 steering and extracts an inline probe into
+      # /tmp/Dev10x/<id>.py or ~/.claude/tools/<name>.py, the Write
+      # permission already exists — but executing the result prompts
+      # again. Same trust model as ${CLAUDE_PLUGIN_ROOT}/skills above.
+      - "Bash(/tmp/Dev10x/*.py:*)"
+      - "Bash(/tmp/Dev10x/**/*.py:*)"
+      - "Bash(/tmp/Dev10x/*.sh:*)"
+      - "Bash(/tmp/Dev10x/**/*.sh:*)"
+      - "Bash(~/.claude/tools/*:*)"
+      - "Bash(~/.claude/tools/*.py:*)"
+      - "Bash(~/.claude/tools/*.sh:*)"
+      # Twin absolute-path form — some sessions normalize ~, others use
+      # the literal /home/<user> (GH-271 evidence #192, #215).
+      - "Bash(/home/*/.claude/tools/*:*)"
 
   dev10x-cli:
     tier: 1
@@ -478,14 +516,83 @@ groups:
       - Bash(gitlint:*)
       - Bash(bump-my-version:*)
 
-  webfetch-public-docs:
+  railway-cli:
     tier: 3
-    description: Public documentation domains used by tooling skills.
+    description: >
+      Railway.app deployment CLI (GH-373, evidence GH-271 #225–#234).
+      Opt-in (tier 3) — Railway is project-specific, not universal.
+      Stratified like `gh run`: read-only inspection is pre-approved;
+      cost-bearing deploys (`up`, `deploy`, `redeploy`, `run`) are
+      deliberately ABSENT so they keep prompting. Following the GH-310
+      doctrine, there is intentionally NO blanket `Bash(railway *)` deny:
+      deny-first precedence means a catch-all deny would also block the
+      safe read surface below (the same reason GH-310 forbids
+      `Bash(git *)` denies). The safe-known `railway run` read forms
+      (printenv/env/cat) are pre-approved as explicit exceptions.
     rules:
-      - WebFetch(domain:docs.docker.com)
+      - Bash(railway --version)
+      - Bash(railway --help)
+      - Bash(railway status:*)
+      - Bash(railway whoami:*)
+      - Bash(railway projects:*)
+      - Bash(railway services:*)
+      - Bash(railway logs:*)
+      - Bash(railway variables:*)
+      - Bash(railway link:*)
+      - Bash(railway unlink:*)
+      - Bash(railway run printenv:*)
+      - Bash(railway run env:*)
+      - Bash(railway run cat:*)
+
+  webfetch-public-docs:
+    tier: 2
+    description: >
+      Canonical public documentation domains (GH-369). Promoted to tier 2
+      so it ships as a plugin default — routine doc lookups on these hosts
+      must never stall an unattended session on a WebFetch prompt. GH-271
+      evidence showed 6+ distinct doc domains hit in a single session, each
+      one a fresh prompt. Scope: HTTPS documentation hosts only, read-only
+      content fetches — no API endpoints, no fetch-and-exec. Each entry is a
+      single FQDN (`WebFetch(domain:<host>)`); wildcard subdomains are
+      deliberately avoided so the approved surface stays auditable.
+    rules:
+      # Python ecosystem
+      - WebFetch(domain:docs.python.org)
+      - WebFetch(domain:peps.python.org)
+      - WebFetch(domain:packaging.python.org)
+      - WebFetch(domain:docs.pytest.org)
+      - WebFetch(domain:docs.astral.sh)
+      - WebFetch(domain:black.readthedocs.io)
+      - WebFetch(domain:docs.pydantic.dev)
+      - WebFetch(domain:pip.pypa.io)
+      # Django / web frameworks
+      - WebFetch(domain:docs.djangoproject.com)
+      - WebFetch(domain:fastapi.tiangolo.com)
+      - WebFetch(domain:flask.palletsprojects.com)
+      - WebFetch(domain:docs.celeryq.dev)
       - WebFetch(domain:docs.gunicorn.org)
       - WebFetch(domain:gunicorn.org)
+      # Frontend
+      - WebFetch(domain:developer.mozilla.org)
+      - WebFetch(domain:svelte.dev)
+      - WebFetch(domain:kit.svelte.dev)
+      - WebFetch(domain:react.dev)
+      - WebFetch(domain:nodejs.org)
+      - WebFetch(domain:docs.npmjs.com)
+      # Infrastructure & cloud
+      - WebFetch(domain:docs.docker.com)
+      - WebFetch(domain:kubernetes.io)
+      - WebFetch(domain:docs.aws.amazon.com)
       - WebFetch(domain:health.aws.amazon.com)
+      - WebFetch(domain:cloud.google.com)
+      # Datastores
+      - WebFetch(domain:www.postgresql.org)
+      - WebFetch(domain:redis.io)
+      # Dev platforms & tooling services
+      - WebFetch(domain:docs.github.com)
+      - WebFetch(domain:docs.gitlab.com)
+      - WebFetch(domain:docs.sentry.io)
+      - WebFetch(domain:resend.com)
 
   obsidian-cli:
     tier: 3

--- a/src/dev10x/skills/permission/doctor.py
+++ b/src/dev10x/skills/permission/doctor.py
@@ -284,6 +284,42 @@ def _is_within(child: Path, parent: Path) -> bool:
     return True
 
 
+def expand_flag_overrides(flag_overrides: dict[str, list[str]]) -> list[str]:
+    """Expand a ``flag_overrides`` mapping into ``Bash(<cmd> <flag>:*)`` rules.
+
+    For each base command ``B`` and safe flag ``F``, emit ``Bash(B F:*)``.
+    Order is deterministic: mapping order, then flag-list order. Duplicate
+    rules collapse while preserving first-seen order (GH-372).
+    """
+    rules: list[str] = []
+    seen: set[str] = set()
+    for command, flags in flag_overrides.items():
+        for flag in flags:
+            rule = f"Bash({command} {flag}:*)"
+            if rule in seen:
+                continue
+            seen.add(rule)
+            rules.append(rule)
+    return rules
+
+
+def _effective_group_rules(group: dict) -> list[str]:
+    """Explicit ``rules`` first, then expanded ``flag_overrides``, de-duped."""
+    output: list[str] = []
+    seen: set[str] = set()
+    for rule in group.get("rules", []):
+        if rule in seen:
+            continue
+        seen.add(rule)
+        output.append(rule)
+    for rule in expand_flag_overrides(group.get("flag_overrides", {})):
+        if rule in seen:
+            continue
+        seen.add(rule)
+        output.append(rule)
+    return output
+
+
 @dataclass
 class Catalog:
     version: int
@@ -297,11 +333,11 @@ class Catalog:
         rules: list[str] = []
         for group in self.groups.values():
             if group.get("tier") in tier_set:
-                rules.extend(group.get("rules", []))
+                rules.extend(_effective_group_rules(group))
         return rules
 
     def group_rules(self, name: str) -> list[str]:
-        return list(self.groups.get(name, {}).get("rules", []))
+        return _effective_group_rules(self.groups.get(name, {}))
 
 
 def load_catalog(path: Path = CATALOG_PATH) -> Catalog:

--- a/src/dev10x/validators/__init__.py
+++ b/src/dev10x/validators/__init__.py
@@ -89,6 +89,12 @@ _SPECS: list[ValidatorSpec] = [
         profile=ProfileTier.STANDARD,
     ),
     ValidatorSpec(
+        module_path="dev10x.validators.mcp_prefix",
+        class_name="McpPrefixValidator",
+        rule_id="DX013",
+        profile=ProfileTier.STANDARD,
+    ),
+    ValidatorSpec(
         module_path="dev10x.validators.commit_jtbd",
         class_name="CommitJtbdValidator",
         rule_id="DX008",

--- a/src/dev10x/validators/execution_safety.py
+++ b/src/dev10x/validators/execution_safety.py
@@ -5,8 +5,9 @@ block-python3-inline.py.
 
 Blocks:
   1. Shell-based file writes (cat >, echo >, printf >)
-  2. python3 -c inline code
-  3. python3 with untrusted absolute paths
+  2. In-place file editors (sed -i, perl -i, gawk -i inplace, dd of=)
+  3. python3 -c inline code
+  4. python3 with untrusted absolute paths
 """
 
 from __future__ import annotations
@@ -31,6 +32,9 @@ SHELL_WRITE_RE = re.compile(
 
 ENV_VAR_RE = re.compile(r"^[A-Z_][A-Z0-9_]*=\S*$")
 
+# Matches dd of= writes to real files; excludes /dev/null, /dev/stdout, /dev/stderr
+_DD_OF_RE = re.compile(r"\bof=(?!/dev/(null|stdout|stderr)\b)\S")
+
 APPROVED_ABS_PREFIXES = (
     f"{ClaudeDir.tools_dir()}/",
     f"{ClaudeDir.skills_dir()}/",
@@ -42,6 +46,13 @@ SHELL_WRITE_MSG = (
     "For multi-line commit messages: create a unique file with"
     " /tmp/Dev10x/bin/mktmp.sh git commit-msg .txt,"
     " Write content to the returned path, then git commit -F <path>"
+)
+
+INPLACE_EDIT_MSG = (
+    "Use the Write/Edit tool instead of in-place stream editors"
+    " (sed -i, perl -i, gawk -i inplace, dd of=).\n"
+    "Read-only forms are fine: sed -n, sed/awk writing to stdout,"
+    " perl -ne/-pe without -i."
 )
 
 PYTHON3_INLINE_MSG = """\
@@ -83,6 +94,45 @@ def _is_approved_path(path: str) -> bool:
     return any(expanded.startswith(p) or path.startswith(p) for p in APPROVED_ABS_PREFIXES)
 
 
+def _has_inplace_flag(*, argv: list[str], cmd: str) -> bool:
+    """Return True if the argument list indicates an in-place edit operation.
+
+    Handles:
+    - sed: any short-flag cluster that contains 'i' (e.g. -i, -ni, -in, -in.bak)
+    - perl: any short-flag cluster that contains 'i' (e.g. -i, -pi, -pi.bak)
+    - gawk/awk: '-i' followed by 'inplace' as a separate token
+    - dd: delegated to caller via _DD_OF_RE
+    """
+    if cmd in ("sed", "perl"):
+        for arg in argv:
+            # Only inspect short-flag clusters (start with '-' but not '--')
+            if arg.startswith("-") and not arg.startswith("--"):
+                # Strip the leading '-' and any optional suffix after the flags
+                # e.g. '-i.bak' \u2192 flag letters = 'i', suffix = '.bak'
+                # e.g. '-ni' \u2192 flag letters = 'ni'
+                flag_body = arg[1:]
+                # Collect contiguous alpha chars as the flag cluster
+                flag_letters = ""
+                for ch in flag_body:
+                    if ch.isalpha():
+                        flag_letters += ch
+                    else:
+                        break
+                if "i" in flag_letters:
+                    return True
+        return False
+
+    if cmd in ("gawk", "awk"):
+        # gawk -i inplace: '-i' must be immediately followed by 'inplace'
+        for idx, arg in enumerate(argv):
+            if arg in ("-i", "--include") and idx + 1 < len(argv):
+                if argv[idx + 1] == "inplace":
+                    return True
+        return False
+
+    return False
+
+
 @dataclass
 class ExecutionSafetyValidator(ValidatorBase):
     name: ClassVar[str] = "execution-safety"
@@ -93,7 +143,13 @@ class ExecutionSafetyValidator(ValidatorBase):
         return True
 
     def validate(self, inp: HookInput) -> HookResult | None:
+        # Check shell writes first; if flagged, report immediately.
         result = self._check_shell_writes(command=inp.command)
+        if result:
+            return result
+        # Check in-place editors before python3 so mis-keyed sed/perl is caught
+        # early, consistent with first-block-wins ordering.
+        result = self._check_inplace_edit(command=inp.command)
         if result:
             return result
         return self._check_python3_inline(command=inp.command)
@@ -101,6 +157,41 @@ class ExecutionSafetyValidator(ValidatorBase):
     def _check_shell_writes(self, *, command: str) -> HookResult | None:
         if SHELL_WRITE_RE.search(command):
             return HookResult(message=SHELL_WRITE_MSG)
+        return None
+
+    def _check_inplace_edit(self, *, command: str) -> HookResult | None:
+        """Detect in-place file editors and steer to Write/Edit tool.
+
+        Scans each pipeline segment so `cat x | sed -i ...` is caught.
+        Returns a HookResult on the first flagged segment, None otherwise.
+        """
+        _INPLACE_CMDS = frozenset({"sed", "perl", "gawk", "awk", "dd"})
+
+        for segment in command.split("|"):
+            segment = segment.strip()
+            try:
+                parts = shlex.split(segment)
+            except ValueError:
+                return None
+
+            parts = _strip_env_prefix(parts)
+            if not parts:
+                continue
+
+            cmd = parts[0]
+            if cmd not in _INPLACE_CMDS:
+                continue
+
+            argv = parts[1:]
+
+            if cmd == "dd":
+                if _DD_OF_RE.search(segment):
+                    return HookResult(message=INPLACE_EDIT_MSG)
+                continue
+
+            if _has_inplace_flag(argv=argv, cmd=cmd):
+                return HookResult(message=INPLACE_EDIT_MSG)
+
         return None
 
     def _check_python3_inline(self, *, command: str) -> HookResult | None:

--- a/src/dev10x/validators/mcp_prefix.py
+++ b/src/dev10x/validators/mcp_prefix.py
@@ -1,0 +1,78 @@
+"""Validator: block MCP tool names pasted as Bash commands.
+
+MCP tool identifiers (``mcp__<server>__<tool>``) are Claude tool-call
+primitives. They cannot be executed as shell commands. Agents sometimes
+paste them into Bash with arguments appended, e.g.::
+
+    mcp__plugin_Dev10x_cli__check_top_level_comments pr_number=357
+
+This validator detects that anti-pattern — the command's first executable
+token IS an MCP identifier — and hard-blocks it with a steering message
+pointing back to the tool-call protocol (see .claude/rules/mcp-tools.md).
+
+It deliberately does NOT flag commands that merely contain ``mcp__`` in an
+argument or substring (e.g. ``grep mcp__ tests/``); only the command name
+position matters.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+from dataclasses import dataclass
+from typing import ClassVar
+
+from dev10x.domain import HookInput, HookResult
+from dev10x.domain.profile_tier import ProfileTier
+from dev10x.validators.base import ValidatorBase
+
+ENV_VAR_RE = re.compile(r"^[A-Z_][A-Z0-9_]*=\S*$")
+
+MCP_TOOL_RE = re.compile(r"^mcp__[a-zA-Z0-9_]+__[a-zA-Z0-9_]+")
+
+MCP_PREFIX_MSG = """\
+⛔  MCP tool name used as a shell command — blocked.
+
+`{tool}` is a Claude tool-call primitive, NOT a shell command. It
+cannot be run via Bash. Invoke it directly through the tool-call
+protocol instead:
+
+  Tool: `{tool}`
+
+Pass parameters as named tool-call arguments (e.g. `pr_number=357`),
+not as shell tokens. See `.claude/rules/mcp-tools.md` — MCP tool names
+belong only in `allowed-tools:` declarations and Claude tool-call
+invocations, never in bash blocks or shell scripts."""
+
+
+def _strip_env_prefix(parts: list[str]) -> list[str]:
+    i = 0
+    while i < len(parts) and ENV_VAR_RE.match(parts[i]):
+        i += 1
+    return parts[i:]
+
+
+@dataclass
+class McpPrefixValidator(ValidatorBase):
+    name: ClassVar[str] = "mcp-prefix"
+    rule_id: ClassVar[str] = "DX013"
+    profile: ClassVar[ProfileTier] = ProfileTier.STANDARD
+
+    def should_run(self, inp: HookInput) -> bool:
+        return "mcp__" in inp.command
+
+    def validate(self, inp: HookInput) -> HookResult | None:
+        try:
+            parts = shlex.split(inp.command)
+        except ValueError:
+            return None
+
+        parts = _strip_env_prefix(parts)
+
+        if not parts:
+            return None
+
+        if not MCP_TOOL_RE.match(parts[0]):
+            return None
+
+        return HookResult(message=MCP_PREFIX_MSG.format(tool=parts[0]))

--- a/tests/permission/test_doctor.py
+++ b/tests/permission/test_doctor.py
@@ -213,6 +213,118 @@ class TestCatalogAndDeprecations:
         assert outcomes[0].action == "remove"
 
 
+class TestExpandFlagOverrides:
+    @pytest.mark.parametrize(
+        "flag_overrides, expected",
+        [
+            ({}, []),
+            (
+                {"git clean": ["-n", "--dry-run"]},
+                ["Bash(git clean -n:*)", "Bash(git clean --dry-run:*)"],
+            ),
+            (
+                {"git branch": ["-d"], "git reset": ["--dry-run"]},
+                ["Bash(git branch -d:*)", "Bash(git reset --dry-run:*)"],
+            ),
+            (
+                {"git clean": ["-n", "-n", "--dry-run"]},
+                ["Bash(git clean -n:*)", "Bash(git clean --dry-run:*)"],
+            ),
+        ],
+    )
+    def test_expansion(
+        self,
+        flag_overrides: dict[str, list[str]],
+        expected: list[str],
+    ) -> None:
+        assert doctor.expand_flag_overrides(flag_overrides) == expected
+
+    def test_deterministic_ordering_follows_mapping_then_list(self) -> None:
+        flag_overrides = {
+            "git clean": ["-n", "--dry-run"],
+            "git branch": ["-d", "--delete"],
+        }
+        assert doctor.expand_flag_overrides(flag_overrides) == [
+            "Bash(git clean -n:*)",
+            "Bash(git clean --dry-run:*)",
+            "Bash(git branch -d:*)",
+            "Bash(git branch --delete:*)",
+        ]
+
+
+class TestGroupRulesWithFlagOverrides:
+    def test_group_rules_includes_explicit_then_expanded(self) -> None:
+        catalog = doctor.Catalog(
+            version=1,
+            last_audited="",
+            groups={
+                "mixed": {
+                    "tier": 2,
+                    "rules": ["Bash(git status:*)"],
+                    "flag_overrides": {"git clean": ["-n"]},
+                }
+            },
+            deprecations=[],
+            invariants=[],
+        )
+        assert catalog.group_rules("mixed") == [
+            "Bash(git status:*)",
+            "Bash(git clean -n:*)",
+        ]
+
+    def test_group_rules_dedupes_explicit_and_expanded(self) -> None:
+        catalog = doctor.Catalog(
+            version=1,
+            last_audited="",
+            groups={
+                "dup": {
+                    "tier": 2,
+                    "rules": ["Bash(git clean -n:*)"],
+                    "flag_overrides": {"git clean": ["-n"]},
+                }
+            },
+            deprecations=[],
+            invariants=[],
+        )
+        assert catalog.group_rules("dup") == ["Bash(git clean -n:*)"]
+
+    def test_group_without_flag_overrides_unchanged(self) -> None:
+        catalog = doctor.Catalog(
+            version=1,
+            last_audited="",
+            groups={"plain": {"tier": 1, "rules": ["Bash(git status:*)"]}},
+            deprecations=[],
+            invariants=[],
+        )
+        assert catalog.group_rules("plain") == ["Bash(git status:*)"]
+
+    def test_tier_rules_includes_expanded_overrides(self) -> None:
+        catalog = doctor.Catalog(
+            version=1,
+            last_audited="",
+            groups={
+                "plain": {"tier": 1, "rules": ["Bash(git status:*)"]},
+                "flagged": {
+                    "tier": 2,
+                    "flag_overrides": {"git branch": ["-d"]},
+                },
+            },
+            deprecations=[],
+            invariants=[],
+        )
+        tier12 = catalog.tier_rules(tiers=[1, 2])
+        assert "Bash(git status:*)" in tier12
+        assert "Bash(git branch -d:*)" in tier12
+
+
+class TestRealCatalogFlagOverrides:
+    def test_expanded_safe_flags_present_in_tier12(self) -> None:
+        catalog = doctor.load_catalog()
+        tier12 = catalog.tier_rules(tiers=[1, 2])
+        assert "Bash(git clean -n:*)" in tier12
+        assert "Bash(git branch -d:*)" in tier12
+
+
 class TestAdditionalDirectoriesDiagnosis:
     def test_returns_diagnostic_for_out_of_scope_path(self, tmp_path: Path) -> None:
         in_scope = tmp_path / "in-scope"

--- a/tests/validators/test_execution_safety.py
+++ b/tests/validators/test_execution_safety.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import pytest
 
-from dev10x.validators.execution_safety import ExecutionSafetyValidator
+from dev10x.validators.execution_safety import (
+    INPLACE_EDIT_MSG,
+    ExecutionSafetyValidator,
+)
 from tests.fakers import BashHookInputFaker
 
 
@@ -71,5 +74,151 @@ class TestPython3Inline:
 
     def test_allows_relative_path(self, validator: ExecutionSafetyValidator) -> None:
         inp = _make_input(command="python3 manage.py runserver")
+        result = validator.validate(inp=inp)
+        assert result is None
+
+
+class TestInplaceEdit:
+    @pytest.fixture()
+    def validator(self) -> ExecutionSafetyValidator:
+        return ExecutionSafetyValidator()
+
+    # --- Positive cases: in-place edits that must be blocked ---
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # sed -i basic forms
+            "sed -i 's/a/b/' file.txt",
+            "sed -i.bak 's/a/b/' file.txt",
+            # Combined short flags containing 'i'
+            "sed -ni 's/a/b/' file.txt",
+            "sed -in 's/a/b/' file.txt",
+            "sed -in.bak 's/a/b/' file.txt",
+            "sed -i.bak -e 's/a/b/' file.txt",
+            # perl -i forms
+            "perl -i -pe 's/a/b/' file.txt",
+            "perl -pi -e 's/a/b/' file.txt",
+            "perl -pi.bak -e 's/a/b/' file.txt",
+            "perl -i.bak -pe 's/a/b/' file.txt",
+            # gawk -i inplace
+            "gawk -i inplace '{print}' file.txt",
+            "awk -i inplace '{print}' file.txt",
+            # dd of= writing to a real file
+            "dd if=/dev/urandom of=/tmp/file.bin bs=1M count=1",
+            "dd if=input.img of=output.img",
+        ],
+    )
+    def test_blocks_inplace_edit(self, validator: ExecutionSafetyValidator, command: str) -> None:
+        inp = _make_input(command=command)
+        result = validator.validate(inp=inp)
+        assert result is not None
+        assert result.message == INPLACE_EDIT_MSG
+
+    def test_blocks_inplace_edit_in_pipeline(self, validator: ExecutionSafetyValidator) -> None:
+        inp = _make_input(command="cat file.txt | sed -i 's/a/b/' -")
+        result = validator.validate(inp=inp)
+        assert result is not None
+        assert result.message == INPLACE_EDIT_MSG
+
+    def test_blocks_env_prefix_stripped_sed(self, validator: ExecutionSafetyValidator) -> None:
+        inp = _make_input(command="FOO=1 sed -i 's/a/b/' file.txt")
+        result = validator.validate(inp=inp)
+        assert result is not None
+        assert result.message == INPLACE_EDIT_MSG
+
+    def test_blocks_env_prefix_stripped_perl(self, validator: ExecutionSafetyValidator) -> None:
+        inp = _make_input(command="LC_ALL=C perl -pi -e 's/foo/bar/' file.txt")
+        result = validator.validate(inp=inp)
+        assert result is not None
+        assert result.message == INPLACE_EDIT_MSG
+
+    # --- Negative cases: read-only / stdout forms that must NOT be flagged ---
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # sed read-only
+            "sed -n '1,5p' file.txt",
+            "sed 's/a/b/' file.txt",
+            "sed -e 's/a/b/' file.txt",
+            "sed -E 's/a/b/' file.txt",
+            # perl without -i
+            "perl -ne 'print if /foo/' file.txt",
+            "perl -pe 's/a/b/' file.txt",
+            # awk without -i inplace
+            "awk '{print}' file.txt",
+            "awk -F, '{print $1}' file.txt",
+            # gawk -i with something other than 'inplace'
+            "gawk -i other_extension.awk '{print}' file.txt",
+            # dd with no of= at all
+            "dd if=/dev/zero bs=512 count=1",
+            # dd of= pointing to /dev/null
+            "dd if=/dev/zero of=/dev/null bs=1M count=1",
+            # dd of= pointing to /dev/stdout
+            "dd if=/dev/zero of=/dev/stdout bs=512 count=1",
+        ],
+    )
+    def test_allows_readonly_forms(
+        self, validator: ExecutionSafetyValidator, command: str
+    ) -> None:
+        inp = _make_input(command=command)
+        result = validator.validate(inp=inp)
+        assert result is None
+
+    def test_returns_none_on_unbalanced_quotes(self, validator: ExecutionSafetyValidator) -> None:
+        inp = _make_input(command="sed -i 's/a/b")
+        result = validator.validate(inp=inp)
+        assert result is None
+
+    def test_allows_non_inplace_command_in_pipeline(
+        self, validator: ExecutionSafetyValidator
+    ) -> None:
+        # A pipeline where neither segment is an in-place editor
+        inp = _make_input(command="grep foo file.txt | sort")
+        result = validator.validate(inp=inp)
+        assert result is None
+
+    def test_allows_empty_segment_after_env_strip(
+        self, validator: ExecutionSafetyValidator
+    ) -> None:
+        # ENV=val alone (after stripping yields empty parts) in a pipeline segment
+        inp = _make_input(command="grep foo file.txt | LC_ALL=C")
+        result = validator.validate(inp=inp)
+        assert result is None
+
+
+class TestInplaceEditHelpers:
+    """Unit tests for module-level helpers in execution_safety."""
+
+    def test_has_inplace_flag_returns_false_for_unknown_cmd(self) -> None:
+        from dev10x.validators.execution_safety import _has_inplace_flag
+
+        assert _has_inplace_flag(argv=["-i", "file.txt"], cmd="unknown") is False
+
+    def test_should_run_always_true(self) -> None:
+        validator = ExecutionSafetyValidator()
+        inp = _make_input(command="ls")
+        assert validator.should_run(inp=inp) is True
+
+
+class TestPython3InlineEdgeCases:
+    @pytest.fixture()
+    def validator(self) -> ExecutionSafetyValidator:
+        return ExecutionSafetyValidator()
+
+    def test_unbalanced_quotes_in_python3_check_returns_none(
+        self, validator: ExecutionSafetyValidator
+    ) -> None:
+        # python3 is in the string but shlex.split will raise ValueError
+        inp = _make_input(command="python3 -c 'print(\"hello)")
+        result = validator.validate(inp=inp)
+        assert result is None
+
+    def test_python3_as_argument_not_command_returns_none(
+        self, validator: ExecutionSafetyValidator
+    ) -> None:
+        # python3 appears in the string but the actual command is something else
+        inp = _make_input(command="echo python3 rocks")
         result = validator.validate(inp=inp)
         assert result is None

--- a/tests/validators/test_mcp_prefix.py
+++ b/tests/validators/test_mcp_prefix.py
@@ -1,0 +1,90 @@
+"""Tests for McpPrefixValidator (DX013)."""
+
+from __future__ import annotations
+
+import pytest
+
+from dev10x.validators.mcp_prefix import McpPrefixValidator
+from tests.fakers import BashHookInputFaker
+
+
+def _make_input(*, command: str) -> BashHookInputFaker:
+    return BashHookInputFaker.build(command=command)
+
+
+@pytest.fixture()
+def validator() -> McpPrefixValidator:
+    return McpPrefixValidator()
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "mcp__plugin_Dev10x_cli__check_top_level_comments",
+        "mcp__plugin_Dev10x_cli__check_top_level_comments pr_number=357",
+        "mcp__plugin_Dev10x_cli__mktmp namespace=git prefix=msg ext=.txt",
+        "mcp__plugin_Dev10x_db__query 'SELECT 1'",
+        "FOO=bar mcp__plugin_Dev10x_cli__pr_get pr_number=1",
+        "FOO=bar BAZ=qux mcp__plugin_Dev10x_cli__issue_get",
+    ],
+)
+def test_blocks_mcp_tool_as_command(validator: McpPrefixValidator, command: str) -> None:
+    result = validator.validate(inp=_make_input(command=command))
+    assert result is not None
+    assert "tool-call" in result.message
+    assert ".claude/rules/mcp-tools.md" in result.message
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "grep mcp__plugin tests/",
+        'echo "mcp__foo__bar"',
+        "cat file_with_mcp__name",
+        "ls /tmp/mcp__plugin_Dev10x_cli__mktmp.txt",
+        "git commit -m 'mcp__plugin_Dev10x_cli__mktmp'",
+        "FOO=bar grep mcp__plugin_Dev10x_cli__mktmp src/",
+    ],
+)
+def test_allows_mcp_substring_in_args(validator: McpPrefixValidator, command: str) -> None:
+    assert validator.validate(inp=_make_input(command=command)) is None
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'echo "unbalanced',
+        "mcp__plugin_Dev10x_cli__mktmp 'unterminated",
+    ],
+)
+def test_unbalanced_quotes_returns_none(validator: McpPrefixValidator, command: str) -> None:
+    assert validator.validate(inp=_make_input(command=command)) is None
+
+
+def test_empty_command_returns_none(validator: McpPrefixValidator) -> None:
+    assert validator.validate(inp=_make_input(command="")) is None
+
+
+def test_env_prefix_only_returns_none(validator: McpPrefixValidator) -> None:
+    assert validator.validate(inp=_make_input(command="FOO=bar")) is None
+
+
+def test_single_underscore_segment_not_matched(
+    validator: McpPrefixValidator,
+) -> None:
+    assert validator.validate(inp=_make_input(command="mcp__onlyserver")) is None
+
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        ("mcp__plugin_Dev10x_cli__mktmp", True),
+        ("grep mcp__plugin tests/", True),
+        ("git status", False),
+        ("ls -la", False),
+    ],
+)
+def test_should_run_gates_on_marker(
+    validator: McpPrefixValidator, command: str, expected: bool
+) -> None:
+    assert validator.should_run(inp=_make_input(command=command)) is expected


### PR DESCRIPTION
**When** I run an unattended (AFK) Dev10x session, **I want to** have safe routine commands pre-approved and genuinely unsafe shell shortcuts steered to the correct tool, **so I can** keep the session moving without permission stalls or option-2 footguns.

This PR bundles six GH-271 permission-friction follow-ups (A, B, D, E, F, G). The seventh sub-issue (#371 / C — runtime MCP discovery + capability_group) is deliberately split into its own PR for focused review.

**Per-ticket summary**
- **#369 (A)** — promote `webfetch-public-docs` to tier 2 and expand to ~30 canonical HTTPS doc domains; document the WebFetch entity class.
- **#370 (B)** — allow executing extracted probes under `/tmp/Dev10x/*.py|sh` and `~/.claude/tools/*` (the GH-308 escape destinations).
- **#372 (D)** — add a `flag_overrides:` catalog schema + renderer; ship `git clean -n`, `git branch -d`, `git reset --dry-run`.
- **#373 (E)** — add a `railway-cli` tier-3 group; document `gh workflow run/enable/disable` as ask-tier.
- **#374 (F)** — flag-aware in-place-edit detection (`sed -i`/`perl -i`/`gawk -i inplace`/`dd of=`) that leaves read-only `sed -n` alone.
- **#375 (G)** — new `McpPrefixValidator` (DX013) hard-blocking MCP tool names pasted as shell commands.

**Two deliberate design choices (reviewer note)**
1. **railway** uses pre-approve-safe-surface, NOT a blanket `Bash(railway *)` deny — a catch-all deny would also block the safe reads (same GH-310 reasoning that forbids `Bash(git *)` denies). Deploys (`up`/`deploy`/`run`) stay ask-tier.
2. **`gh workflow run/enable/disable`** are intentionally left ask-tier (CI spend / state change), so only `list`/`view` are pre-approved.

`find -delete` flag-override is deferred — it inverts the additive `flag_overrides` model (denying a dangerous flag vs allowing a safe one).

All new code at 100% coverage; full suite green (3037 passed); ruff + mypy clean.

---

[`8da23b17`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/378/commits/8da23b1787010f9407824abc34c5a09ad30ca25f) ✨ GH-374 Steer in-place stream editors to Write/Edit tool
[`411dd578`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/378/commits/411dd5786bcf3a83c8c9973a8a8313df6a56bc4d) ✨ GH-375 Block MCP tool names pasted as shell commands
[`f5d0a375`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/378/commits/f5d0a3757822bfd7fd991db841a6f0b2286e85e9) ✨ GH-369 Pre-approve docs, tool-exec, railway, safe git flags
Closes #369
Closes #370
Closes #372
Closes #373
Closes #374
Closes #375
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/369

---