### PR TITLE
♻️ GH-244 Seal audit-skills permission analysis boundary (I1)

### DIFF
--- a/src/dev10x/audit/analyze.py
+++ b/src/dev10x/audit/analyze.py
@@ -7,9 +7,10 @@ shim so the skill-audit pipeline can still run analyze-permissions
 from a Bash entry point.
 
 The implementation reuses the parsers, classifiers, and writers
-already defined in `dev10x.skills.audit.analyze_permissions` —
-this factory is the seam that lets MCP callers skip the subprocess
-hop and consume the report as data.
+defined in `dev10x.audit.permissions_model` — keeping the analysis
+logic inside the audit context (GH-244, I1 / ADR-0008) instead of
+importing up into the skills layer. This factory is the seam that lets
+MCP callers skip the subprocess hop and consume the report as data.
 """
 
 from __future__ import annotations
@@ -18,8 +19,7 @@ import io
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from dev10x.domain.claude_paths import ClaudeDir
-from dev10x.skills.audit.analyze_permissions import (
+from dev10x.audit.permissions_model import (
     Finding,
     HygieneFinding,
     audit_script_hygiene,
@@ -31,9 +31,10 @@ from dev10x.skills.audit.analyze_permissions import (
     propose_allow_rules,
     write_output,
 )
-from dev10x.skills.audit.analyze_permissions import (
+from dev10x.audit.permissions_model import (
     analyze_permissions as _analyze_permissions,
 )
+from dev10x.domain.claude_paths import ClaudeDir
 from dev10x.subprocess_utils import effective_cwd
 
 
@@ -78,11 +79,10 @@ def build_audit_report(
     findings = _analyze_permissions(calls=calls, rules=rules)
     findings = count_nuisance_patterns(findings=findings)
 
-    # GH-979 (H6): analyze_permissions is a deps-less standalone uv-script
-    # that cannot import dev10x, so the effective-CWD fallback lands here at
-    # the importing seam. When an MCP caller bound the worktree via use_cwd,
-    # default the project root to it; standalone CLI callers pass None and
-    # detect_known_friction falls back to os.getcwd() as before.
+    # GH-979 (H6): when an MCP caller bound the worktree via use_cwd, default
+    # the project root to it at this seam. permissions_model.detect_known_friction
+    # applies the same effective_cwd() fallback for standalone CLI callers that
+    # pass None.
     extra = detect_known_friction(
         calls=calls,
         additional_dirs=additional_dirs,

--- a/src/dev10x/audit/permissions_model.py
+++ b/src/dev10x/audit/permissions_model.py
@@ -1,0 +1,570 @@
+"""Shared permission-friction analysis model (GH-244, I1 / ADR-0008).
+
+Houses the parsers, classifiers, hygiene auditor, and report writer
+that power Phase 4 permission-friction analysis. Previously this logic
+lived in ``dev10x.skills.audit.analyze_permissions`` and the audit layer
+imported 12 symbols *up* into the skills layer — a context-boundary
+inversion (audit → skills). The analysis logic is a domain concern of the
+audit context, so it lives here; the skills script is now a thin CLI
+adapter that re-exports these names for its Bash entry point.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TextIO
+
+from dev10x.domain.common.allow_rule import AllowRule, AllowRuleLoader
+from dev10x.subprocess_utils import effective_cwd
+
+TURN_RE = re.compile(
+    r"^## Turn (\d+) \[([^\]]+)\] (USER|ASSISTANT)",
+    re.MULTILINE,
+)
+
+TOOL_INPUT_BLOCK_RE = re.compile(
+    r"^\*\*Tool: `([^`]+)`\*\*\n```\n(.*?)```",
+    re.MULTILINE | re.DOTALL,
+)
+
+TOOL_RE = re.compile(r"^\*\*Tool: `([^`]+)`\*\*", re.MULTILINE)
+
+PERMISSION_TOOLS = {"Bash", "Read", "Write", "Edit"}
+
+ALLOW_RULE_RE = re.compile(r"^(\w+)\((.+)\)$")
+
+CHAIN_RE = re.compile(r"&&|;\s")
+SUBSHELL_RE = re.compile(r"\$\(")
+ENV_PREFIX_RE = re.compile(r"^[A-Z_]+=\S+\s")
+GIT_C_RE = re.compile(r"^git\s+-C\s+")
+COMMENT_PREFIX_RE = re.compile(r"^#")
+HEREDOC_RE = re.compile(r"cat\s+<<|cat\s+>|echo\s+>|printf\s+>")
+
+DANGEROUS_COMMANDS = re.compile(
+    r"git\s+push\s+--force|"
+    r"git\s+reset\s+--hard|"
+    r"git\s+clean\s+-f|"
+    r"git\s+checkout\s+\.|"
+    r"rm\s+-rf\s+(?!/tmp)|"
+    r"--no-verify|"
+    r"--force"
+)
+
+# Paths matching mktmp's high-entropy suffix — Write to these triggers
+# the Write tool's overwrite gate even with explicit allow-rules (GH-39).
+MKTMP_PATH_RE = re.compile(r"/tmp/Dev10x/[^/]+/[^/]+\.[A-Za-z0-9]{6,}\.\w+$")
+
+# Known commands that exit non-zero on benign deprecation warnings while
+# the operation actually succeeded (GH-41 — Projects classic on `gh pr edit`).
+EXIT_FALSE_POSITIVE_RE = re.compile(r"^gh\s+pr\s+edit\b")
+
+# PreToolUse hook denial signal in tool result text (best-effort —
+# only available when the parser captures result blocks).
+HOOK_BLOCK_RE = re.compile(r"^BLOCKED:|hook error", re.MULTILINE)
+
+
+@dataclass
+class ToolCall:
+    turn: int
+    time: str
+    tool: str
+    command: str
+    file_path: str = ""
+
+    def is_bash(self) -> bool:
+        return self.tool == "Bash"
+
+    def signature(self) -> str:
+        if self.is_bash():
+            return f"Bash({self.command})"
+        if self.tool in ("Write", "Read", "Edit") and self.file_path:
+            return f"{self.tool}({self.file_path})"
+        if self.tool.startswith("mcp__"):
+            return self.tool
+        return f"{self.tool}()"
+
+
+@dataclass
+class Finding:
+    index: int
+    turn: int
+    time: str
+    tool: str
+    command_display: str
+    classification: str
+    fix: str
+
+    def base_classification(self) -> str:
+        """Return the classification name without any ``(Nx)`` suffix."""
+        return self.classification.split("(")[0].strip()
+
+    def is_missing_rule(self) -> bool:
+        return self.classification == "MISSING_RULE"
+
+    def is_actionable(self) -> bool:
+        """Findings worth surfacing in the proposed-rules section."""
+        return "MISSING_RULE" in self.classification or "NUISANCE" in self.classification
+
+    def mark_nuisance(self, *, count: int) -> None:
+        self.classification = f"NUISANCE_PATTERN ({count}x)"
+
+    def first_command_word(self) -> str:
+        return self.command_display.split()[0] if self.command_display else ""
+
+    def nuisance_key(self) -> str:
+        first = self.first_command_word()
+        return f"{self.tool}:{first}" if first else self.tool
+
+
+@dataclass
+class HygieneFinding:
+    index: int
+    target: str
+    issue: str
+    classification: str
+    fix: str
+
+
+def parse_tool_calls(text: str) -> list[ToolCall]:
+    turn_matches = list(TURN_RE.finditer(text))
+    calls: list[ToolCall] = []
+
+    for i, tm in enumerate(turn_matches):
+        role = tm.group(3)
+        if role != "ASSISTANT":
+            continue
+
+        turn_num = int(tm.group(1))
+        turn_time = tm.group(2)
+        start = tm.end()
+        end = turn_matches[i + 1].start() if i + 1 < len(turn_matches) else len(text)
+        body = text[start:end]
+
+        for tool_match in TOOL_INPUT_BLOCK_RE.finditer(body):
+            tool_name = tool_match.group(1)
+            if tool_name not in PERMISSION_TOOLS:
+                continue
+            input_text = tool_match.group(2).strip()
+            tc = ToolCall(
+                turn=turn_num,
+                time=turn_time,
+                tool=tool_name,
+                command="",
+            )
+            if tool_name == "Bash":
+                cmd_match = re.search(r"command=(.+?)(?:,\s*\w+=|\Z)", input_text, re.DOTALL)
+                tc.command = cmd_match.group(1).strip() if cmd_match else input_text[:200]
+            else:
+                path_match = re.search(r"file_path=([^\s,]+)", input_text)
+                tc.file_path = path_match.group(1) if path_match else ""
+                tc.command = tc.file_path
+            calls.append(tc)
+
+        bare_tools = set()
+        for bm in TOOL_RE.finditer(body):
+            bare_tools.add(bm.group(1))
+        named = {tc.tool for tc in calls if tc.turn == turn_num}
+        for name in bare_tools - named:
+            if name in PERMISSION_TOOLS:
+                calls.append(
+                    ToolCall(
+                        turn=turn_num,
+                        time=turn_time,
+                        tool=name,
+                        command="(no input captured)",
+                    )
+                )
+
+    return calls
+
+
+def parse_allow_rules(settings_path: str) -> list[AllowRule]:
+    rules: list[AllowRule] = []
+    for entry in AllowRuleLoader.load(settings_path):
+        raw = entry if isinstance(entry, str) else str(entry)
+        if ALLOW_RULE_RE.match(raw):
+            rules.append(AllowRule.parse(raw))
+    return rules
+
+
+def parse_additional_directories(settings_path: str) -> list[str]:
+    """Return permissions.additionalDirectories entries (GH-40, GH-46)."""
+    path = Path(settings_path)
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError:
+        return []
+    return list(data.get("permissions", {}).get("additionalDirectories", []))
+
+
+def detect_known_friction(
+    calls: list[ToolCall],
+    *,
+    additional_dirs: list[str],
+    project_root: str | None = None,
+) -> list[Finding]:
+    """Detect friction patterns no allow-rule can prevent (GH-46).
+
+    The base allow-rule analysis only catches Bash command vs allow-rule
+    mismatch. Real sessions hit other gates that allow-rules cannot
+    bypass:
+
+    - WRITE_OVERWRITE_GATE — Write to an existing file (typical with
+      mktmp paths) prompts on every call.
+    - WORKSPACE_GATE — Write/Edit/Read to a path outside the project
+      root prompts unless the dir is in additionalDirectories.
+    - EXIT_CODE_FALSE_POSITIVE — `gh pr edit` exits 1 on the
+      Projects-classic deprecation while the operation succeeds.
+
+    These findings are added on top of the standard unmatched-call list
+    even when allow-rules formally cover the call.
+
+    ``project_root`` defaults to the bound effective CWD (GH-979) so an
+    MCP caller's worktree wins; standalone CLI callers pass ``None`` and
+    fall back to the process CWD.
+    """
+    findings: list[Finding] = []
+    idx = 0
+    project_prefix = (project_root or effective_cwd() or os.getcwd()).rstrip("/") + "/"
+    home_prefix = os.path.expanduser("~/").rstrip("/") + "/"
+
+    for tc in calls:
+        if tc.tool == "Bash":
+            if EXIT_FALSE_POSITIVE_RE.match(tc.command):
+                idx += 1
+                findings.append(
+                    Finding(
+                        index=idx,
+                        turn=tc.turn,
+                        time=tc.time,
+                        tool=tc.tool,
+                        command_display=tc.command[:60],
+                        classification="EXIT_CODE_FALSE_POSITIVE",
+                        fix="Use REST API (`gh api PATCH …/pulls/<n>`) instead",
+                    )
+                )
+            continue
+
+        target = tc.file_path or tc.command
+        if not target:
+            continue
+
+        if tc.tool == "Write" and MKTMP_PATH_RE.search(target):
+            idx += 1
+            findings.append(
+                Finding(
+                    index=idx,
+                    turn=tc.turn,
+                    time=tc.time,
+                    tool=tc.tool,
+                    command_display=target[:60],
+                    classification="WRITE_OVERWRITE_GATE",
+                    fix="Make mktmp return path without pre-creating (GH-39)",
+                )
+            )
+
+        if not (target.startswith(project_prefix) or target.startswith(home_prefix)):
+            covered = any(target.startswith(d.rstrip("/") + "/") for d in additional_dirs)
+            if not covered:
+                idx += 1
+                findings.append(
+                    Finding(
+                        index=idx,
+                        turn=tc.turn,
+                        time=tc.time,
+                        tool=tc.tool,
+                        command_display=target[:60],
+                        classification="WORKSPACE_GATE",
+                        fix=(
+                            f"Register parent dir under additionalDirectories"
+                            f" (e.g. `/permissions add {Path(target).parent}`)"
+                        ),
+                    )
+                )
+
+    return findings
+
+
+def matches_allow_rule(tc: ToolCall, rules: list[AllowRule]) -> bool:
+    if not rules:
+        return True
+    signature = tc.signature()
+    return any(rule.matches(signature) for rule in rules)
+
+
+def classify_toxicity(command: str) -> str | None:
+    if COMMENT_PREFIX_RE.match(command):
+        return "PREFIX_POISONED_COMMENT"
+    if ENV_PREFIX_RE.match(command):
+        return "PREFIX_POISONED_ENVVAR"
+    if GIT_C_RE.match(command):
+        return "PREFIX_POISONED_GIT_C"
+    if SUBSHELL_RE.search(command) and CHAIN_RE.search(command):
+        return "PREFIX_POISONED_SUBSHELL"
+    if CHAIN_RE.search(command) and not SUBSHELL_RE.search(command):
+        return "PREFIX_POISONED_CHAIN"
+    if HEREDOC_RE.search(command):
+        return "HOOK_BLOCKED_HEREDOC"
+    return None
+
+
+MULTI_WORD_COMMANDS = {"gh", "git", "uv", "docker", "kubectl", "aws"}
+
+
+def _extract_command_prefix(command: str) -> str:
+    parts = command.split()
+    if not parts:
+        return command
+    if parts[0] in MULTI_WORD_COMMANDS and len(parts) >= 2:
+        subcommand = parts[1]
+        if not subcommand.startswith("-"):
+            return f"{parts[0]} {subcommand}"
+    return parts[0]
+
+
+def classify_unmatched(
+    tc: ToolCall,
+    rules: list[AllowRule],
+) -> tuple[str, str]:
+    if tc.tool == "Bash":
+        toxicity = classify_toxicity(command=tc.command)
+        if toxicity:
+            if "PREFIX_POISONED" in toxicity:
+                return toxicity, "Restructure to avoid prefix poisoning"
+            return toxicity, "Use Write tool + file reference instead"
+
+        if DANGEROUS_COMMANDS.search(tc.command):
+            return "CORRECTLY_PROMPTED", "No action — risky command"
+
+        has_similar = any(
+            r.tool == "Bash" and tc.command[:10].startswith(r.pattern[:10]) for r in rules
+        )
+        if has_similar:
+            return "PATTERN_TOO_NARROW", "Widen existing allow rule pattern"
+
+        prefix = _extract_command_prefix(command=tc.command)
+        return "MISSING_RULE", f"Add: Bash({prefix}:*)"
+
+    target = tc.file_path or tc.command
+    has_similar = any(r.tool == tc.tool and target[:10].startswith(r.pattern[:10]) for r in rules)
+    if has_similar:
+        return "PATH_NOT_COVERED", f"Widen {tc.tool} glob pattern"
+
+    parent = str(Path(target).parent) if target else ""
+    return "MISSING_RULE", f"Add: {tc.tool}({parent}/**)"
+
+
+def analyze_permissions(
+    calls: list[ToolCall],
+    rules: list[AllowRule],
+) -> list[Finding]:
+    findings: list[Finding] = []
+    idx = 0
+
+    for tc in calls:
+        if matches_allow_rule(tc=tc, rules=rules):
+            continue
+
+        idx += 1
+        classification, fix = classify_unmatched(tc=tc, rules=rules)
+        cmd_display = tc.command[:60] if tc.command else tc.file_path[:60]
+        findings.append(
+            Finding(
+                index=idx,
+                turn=tc.turn,
+                time=tc.time,
+                tool=tc.tool,
+                command_display=cmd_display,
+                classification=classification,
+                fix=fix,
+            )
+        )
+
+    return findings
+
+
+def count_nuisance_patterns(findings: list[Finding]) -> list[Finding]:
+    pattern_counts: dict[str, list[Finding]] = {}
+    for f in findings:
+        if f.is_missing_rule():
+            pattern_counts.setdefault(f.nuisance_key(), []).append(f)
+
+    for group in pattern_counts.values():
+        if len(group) >= 3:
+            for f in group:
+                f.mark_nuisance(count=len(group))
+
+    return findings
+
+
+def audit_script_hygiene(skills_dir: str, tools_dir: str) -> list[HygieneFinding]:
+    findings: list[HygieneFinding] = []
+    idx = 0
+    dirs_to_scan = []
+
+    if os.path.isdir(skills_dir):
+        dirs_to_scan.append(Path(skills_dir))
+    if os.path.isdir(tools_dir):
+        dirs_to_scan.append(Path(tools_dir))
+
+    for scan_dir in dirs_to_scan:
+        for py_file in scan_dir.rglob("*.py"):
+            if not py_file.is_file():
+                continue
+
+            try:
+                content = py_file.read_text()
+            except (OSError, UnicodeDecodeError):
+                continue
+
+            first_line = content.split("\n", 1)[0] if content else ""
+
+            if first_line.startswith("#!") and "uv run" not in first_line:
+                if "python" in first_line:
+                    idx += 1
+                    findings.append(
+                        HygieneFinding(
+                            index=idx,
+                            target=str(py_file),
+                            issue=f"Shebang: {first_line}",
+                            classification="WRONG_SHEBANG",
+                            fix="Change to: #!/usr/bin/env -S uv run --script",
+                        )
+                    )
+
+            if "uv run" in first_line and "# /// script" not in content:
+                idx += 1
+                findings.append(
+                    HygieneFinding(
+                        index=idx,
+                        target=str(py_file),
+                        issue="Has uv shebang but no PEP 723 metadata block",
+                        classification="MISSING_PEP723",
+                        fix="Add # /// script block after shebang",
+                    )
+                )
+
+            file_stat = py_file.stat()
+            if not (file_stat.st_mode & stat.S_IXUSR):
+                if first_line.startswith("#!"):
+                    idx += 1
+                    findings.append(
+                        HygieneFinding(
+                            index=idx,
+                            target=str(py_file),
+                            issue=f"Mode {oct(file_stat.st_mode)[-3:]} — not executable",
+                            classification="NOT_EXECUTABLE",
+                            fix="chmod +x",
+                        )
+                    )
+
+    for scan_dir in dirs_to_scan:
+        for skill_md in scan_dir.rglob("SKILL.md"):
+            try:
+                content = skill_md.read_text()
+            except (OSError, UnicodeDecodeError):
+                continue
+
+            for m in re.finditer(r"uv run --script\s+(\S+\.py)", content):
+                script_path = m.group(1)
+                expanded = os.path.expanduser(script_path)
+                if os.path.isfile(expanded):
+                    try:
+                        script_content = Path(expanded).read_text()
+                        if "uv run" in script_content.split("\n", 1)[0]:
+                            idx += 1
+                            findings.append(
+                                HygieneFinding(
+                                    index=idx,
+                                    target=f"{skill_md}",
+                                    issue=f"Redundant uv run --script for {script_path}",
+                                    classification="REDUNDANT_UV_PREFIX",
+                                    fix="Call script directly (has uv shebang)",
+                                )
+                            )
+                    except (OSError, UnicodeDecodeError):
+                        pass
+
+    return findings
+
+
+def propose_allow_rules(findings: list[Finding]) -> list[str]:
+    seen: set[str] = set()
+    proposals: list[str] = []
+
+    for f in findings:
+        if f.is_actionable():
+            if "Add:" in f.fix:
+                rule = f.fix.split("Add: ", 1)[1]
+                if rule not in seen:
+                    seen.add(rule)
+                    proposals.append(rule)
+
+    return proposals
+
+
+def write_output(
+    findings: list[Finding],
+    hygiene: list[HygieneFinding],
+    proposals: list[str],
+    out: TextIO,
+) -> None:
+    out.write("# Phase 4: Permission Friction Analysis\n\n")
+
+    out.write("## Unmatched Tool Calls\n\n")
+    if findings:
+        out.write("| # | Turn | Time | Tool | Command (truncated) | Classification | Fix |\n")
+        out.write("|---|------|------|------|---------------------|----------------|-----|\n")
+        for f in findings:
+            cmd = f.command_display.replace("|", "\\|")
+            fix = f.fix.replace("|", "\\|")
+            out.write(
+                f"| {f.index} | {f.turn} | {f.time} | {f.tool} "
+                f"| {cmd} | {f.classification} | {fix} |\n"
+            )
+    else:
+        out.write("No unmatched tool calls found.\n")
+
+    out.write("\n---\n\n")
+
+    out.write("## Script Hygiene Audit\n\n")
+    if hygiene:
+        out.write("| # | Target | Issue | Classification | Fix |\n")
+        out.write("|---|--------|-------|----------------|-----|\n")
+        for h in hygiene:
+            target = h.target.replace("|", "\\|")
+            issue = h.issue.replace("|", "\\|")
+            out.write(f"| {h.index} | {target} | {issue} | {h.classification} | {h.fix} |\n")
+    else:
+        out.write("No script hygiene issues found.\n")
+
+    out.write("\n---\n\n")
+
+    out.write("## Proposed Allow Rules\n\n")
+    if proposals:
+        for p in proposals:
+            out.write(f"- `{p}`\n")
+    else:
+        out.write("No new allow rules proposed.\n")
+
+    out.write("\n---\n\n")
+
+    summary: dict[str, int] = {}
+    for f in findings:
+        base = f.base_classification()
+        summary[base] = summary.get(base, 0) + 1
+    out.write("## Summary\n\n")
+    out.write(f"**Total unmatched calls:** {len(findings)}\n")
+    out.write(f"**Script hygiene issues:** {len(hygiene)}\n")
+    out.write(f"**Proposed allow rules:** {len(proposals)}\n\n")
+    if summary:
+        out.write("**By classification:**\n")
+        for cls, count in sorted(summary.items(), key=lambda x: -x[1]):
+            out.write(f"- {cls}: {count}\n")

--- a/src/dev10x/skills/audit/analyze_permissions.py
+++ b/src/dev10x/skills/audit/analyze_permissions.py
@@ -5,12 +5,11 @@
 # ///
 """Deterministic Phase 4 permission friction analysis for skill-audit.
 
-Parses a normalized markdown transcript, loads allow rules from
-settings.json, and reports:
-- Unmatched tool calls with classification
-- Toxicity detection for structural friction
-- Script hygiene audit
-- Proposed allow rules
+Thin CLI adapter (GH-244, I1 / ADR-0008). The parsers, classifiers,
+hygiene auditor, and report writer now live in
+``dev10x.audit.permissions_model`` — the audit context owns the analysis
+logic. This module re-exports those names for backward compatibility and
+provides the ``main`` entry point used by the skill-audit Bash pipeline.
 
 Usage:
     analyze-permissions.py <transcript.md> [settings.json] [output.md]
@@ -19,559 +18,78 @@ If settings.json is omitted, uses ~/.claude/settings.local.json.
 If output.md is omitted, writes to stdout.
 """
 
-import json
 import os
-import re
-import stat
 import sys
-from dataclasses import dataclass
 from pathlib import Path
-from typing import TextIO
 
-from dev10x.domain.common.allow_rule import AllowRule, AllowRuleLoader
-
-TURN_RE = re.compile(
-    r"^## Turn (\d+) \[([^\]]+)\] (USER|ASSISTANT)",
-    re.MULTILINE,
+from dev10x.audit.permissions_model import (
+    ALLOW_RULE_RE,
+    CHAIN_RE,
+    COMMENT_PREFIX_RE,
+    DANGEROUS_COMMANDS,
+    ENV_PREFIX_RE,
+    EXIT_FALSE_POSITIVE_RE,
+    GIT_C_RE,
+    HEREDOC_RE,
+    HOOK_BLOCK_RE,
+    MKTMP_PATH_RE,
+    MULTI_WORD_COMMANDS,
+    PERMISSION_TOOLS,
+    SUBSHELL_RE,
+    TOOL_INPUT_BLOCK_RE,
+    TOOL_RE,
+    TURN_RE,
+    Finding,
+    HygieneFinding,
+    ToolCall,
+    analyze_permissions,
+    audit_script_hygiene,
+    classify_toxicity,
+    classify_unmatched,
+    count_nuisance_patterns,
+    detect_known_friction,
+    matches_allow_rule,
+    parse_additional_directories,
+    parse_allow_rules,
+    parse_tool_calls,
+    propose_allow_rules,
+    write_output,
 )
 
-TOOL_INPUT_BLOCK_RE = re.compile(
-    r"^\*\*Tool: `([^`]+)`\*\*\n```\n(.*?)```",
-    re.MULTILINE | re.DOTALL,
-)
-
-TOOL_RE = re.compile(r"^\*\*Tool: `([^`]+)`\*\*", re.MULTILINE)
-
-PERMISSION_TOOLS = {"Bash", "Read", "Write", "Edit"}
-
-ALLOW_RULE_RE = re.compile(r"^(\w+)\((.+)\)$")
-
-CHAIN_RE = re.compile(r"&&|;\s")
-SUBSHELL_RE = re.compile(r"\$\(")
-ENV_PREFIX_RE = re.compile(r"^[A-Z_]+=\S+\s")
-GIT_C_RE = re.compile(r"^git\s+-C\s+")
-COMMENT_PREFIX_RE = re.compile(r"^#")
-HEREDOC_RE = re.compile(r"cat\s+<<|cat\s+>|echo\s+>|printf\s+>")
-
-DANGEROUS_COMMANDS = re.compile(
-    r"git\s+push\s+--force|"
-    r"git\s+reset\s+--hard|"
-    r"git\s+clean\s+-f|"
-    r"git\s+checkout\s+\.|"
-    r"rm\s+-rf\s+(?!/tmp)|"
-    r"--no-verify|"
-    r"--force"
-)
-
-# Paths matching mktmp's high-entropy suffix — Write to these triggers
-# the Write tool's overwrite gate even with explicit allow-rules (GH-39).
-MKTMP_PATH_RE = re.compile(r"/tmp/Dev10x/[^/]+/[^/]+\.[A-Za-z0-9]{6,}\.\w+$")
-
-# Known commands that exit non-zero on benign deprecation warnings while
-# the operation actually succeeded (GH-41 — Projects classic on `gh pr edit`).
-EXIT_FALSE_POSITIVE_RE = re.compile(r"^gh\s+pr\s+edit\b")
-
-# PreToolUse hook denial signal in tool result text (best-effort —
-# only available when the parser captures result blocks).
-HOOK_BLOCK_RE = re.compile(r"^BLOCKED:|hook error", re.MULTILINE)
-
-
-@dataclass
-class ToolCall:
-    turn: int
-    time: str
-    tool: str
-    command: str
-    file_path: str = ""
-
-    def is_bash(self) -> bool:
-        return self.tool == "Bash"
-
-    def signature(self) -> str:
-        if self.is_bash():
-            return f"Bash({self.command})"
-        if self.tool in ("Write", "Read", "Edit") and self.file_path:
-            return f"{self.tool}({self.file_path})"
-        if self.tool.startswith("mcp__"):
-            return self.tool
-        return f"{self.tool}()"
-
-
-@dataclass
-class Finding:
-    index: int
-    turn: int
-    time: str
-    tool: str
-    command_display: str
-    classification: str
-    fix: str
-
-    def base_classification(self) -> str:
-        """Return the classification name without any ``(Nx)`` suffix."""
-        return self.classification.split("(")[0].strip()
-
-    def is_missing_rule(self) -> bool:
-        return self.classification == "MISSING_RULE"
-
-    def is_actionable(self) -> bool:
-        """Findings worth surfacing in the proposed-rules section."""
-        return "MISSING_RULE" in self.classification or "NUISANCE" in self.classification
-
-    def mark_nuisance(self, *, count: int) -> None:
-        self.classification = f"NUISANCE_PATTERN ({count}x)"
-
-    def first_command_word(self) -> str:
-        return self.command_display.split()[0] if self.command_display else ""
-
-    def nuisance_key(self) -> str:
-        first = self.first_command_word()
-        return f"{self.tool}:{first}" if first else self.tool
-
-
-@dataclass
-class HygieneFinding:
-    index: int
-    target: str
-    issue: str
-    classification: str
-    fix: str
-
-
-def parse_tool_calls(text: str) -> list[ToolCall]:
-    turn_matches = list(TURN_RE.finditer(text))
-    calls: list[ToolCall] = []
-
-    for i, tm in enumerate(turn_matches):
-        role = tm.group(3)
-        if role != "ASSISTANT":
-            continue
-
-        turn_num = int(tm.group(1))
-        turn_time = tm.group(2)
-        start = tm.end()
-        end = turn_matches[i + 1].start() if i + 1 < len(turn_matches) else len(text)
-        body = text[start:end]
-
-        for tool_match in TOOL_INPUT_BLOCK_RE.finditer(body):
-            tool_name = tool_match.group(1)
-            if tool_name not in PERMISSION_TOOLS:
-                continue
-            input_text = tool_match.group(2).strip()
-            tc = ToolCall(
-                turn=turn_num,
-                time=turn_time,
-                tool=tool_name,
-                command="",
-            )
-            if tool_name == "Bash":
-                cmd_match = re.search(r"command=(.+?)(?:,\s*\w+=|\Z)", input_text, re.DOTALL)
-                tc.command = cmd_match.group(1).strip() if cmd_match else input_text[:200]
-            else:
-                path_match = re.search(r"file_path=([^\s,]+)", input_text)
-                tc.file_path = path_match.group(1) if path_match else ""
-                tc.command = tc.file_path
-            calls.append(tc)
-
-        bare_tools = set()
-        for bm in TOOL_RE.finditer(body):
-            bare_tools.add(bm.group(1))
-        named = {tc.tool for tc in calls if tc.turn == turn_num}
-        for name in bare_tools - named:
-            if name in PERMISSION_TOOLS:
-                calls.append(
-                    ToolCall(
-                        turn=turn_num,
-                        time=turn_time,
-                        tool=name,
-                        command="(no input captured)",
-                    )
-                )
-
-    return calls
-
-
-def parse_allow_rules(settings_path: str) -> list[AllowRule]:
-    rules: list[AllowRule] = []
-    for entry in AllowRuleLoader.load(settings_path):
-        raw = entry if isinstance(entry, str) else str(entry)
-        if ALLOW_RULE_RE.match(raw):
-            rules.append(AllowRule.parse(raw))
-    return rules
-
-
-def parse_additional_directories(settings_path: str) -> list[str]:
-    """Return permissions.additionalDirectories entries (GH-40, GH-46)."""
-    path = Path(settings_path)
-    if not path.exists():
-        return []
-    try:
-        data = json.loads(path.read_text())
-    except json.JSONDecodeError:
-        return []
-    return list(data.get("permissions", {}).get("additionalDirectories", []))
-
-
-def detect_known_friction(
-    calls: list[ToolCall],
-    *,
-    additional_dirs: list[str],
-    project_root: str | None = None,
-) -> list[Finding]:
-    """Detect friction patterns no allow-rule can prevent (GH-46).
-
-    The base allow-rule analysis only catches Bash command vs allow-rule
-    mismatch. Real sessions hit other gates that allow-rules cannot
-    bypass:
-
-    - WRITE_OVERWRITE_GATE — Write to an existing file (typical with
-      mktmp paths) prompts on every call.
-    - WORKSPACE_GATE — Write/Edit/Read to a path outside the project
-      root prompts unless the dir is in additionalDirectories.
-    - EXIT_CODE_FALSE_POSITIVE — `gh pr edit` exits 1 on the
-      Projects-classic deprecation while the operation succeeds.
-
-    These findings are added on top of the standard unmatched-call list
-    even when allow-rules formally cover the call.
-    """
-    findings: list[Finding] = []
-    idx = 0
-    project_prefix = (project_root or os.getcwd()).rstrip("/") + "/"
-    home_prefix = os.path.expanduser("~/").rstrip("/") + "/"
-
-    for tc in calls:
-        if tc.tool == "Bash":
-            if EXIT_FALSE_POSITIVE_RE.match(tc.command):
-                idx += 1
-                findings.append(
-                    Finding(
-                        index=idx,
-                        turn=tc.turn,
-                        time=tc.time,
-                        tool=tc.tool,
-                        command_display=tc.command[:60],
-                        classification="EXIT_CODE_FALSE_POSITIVE",
-                        fix="Use REST API (`gh api PATCH …/pulls/<n>`) instead",
-                    )
-                )
-            continue
-
-        target = tc.file_path or tc.command
-        if not target:
-            continue
-
-        if tc.tool == "Write" and MKTMP_PATH_RE.search(target):
-            idx += 1
-            findings.append(
-                Finding(
-                    index=idx,
-                    turn=tc.turn,
-                    time=tc.time,
-                    tool=tc.tool,
-                    command_display=target[:60],
-                    classification="WRITE_OVERWRITE_GATE",
-                    fix="Make mktmp return path without pre-creating (GH-39)",
-                )
-            )
-
-        if not (target.startswith(project_prefix) or target.startswith(home_prefix)):
-            covered = any(target.startswith(d.rstrip("/") + "/") for d in additional_dirs)
-            if not covered:
-                idx += 1
-                findings.append(
-                    Finding(
-                        index=idx,
-                        turn=tc.turn,
-                        time=tc.time,
-                        tool=tc.tool,
-                        command_display=target[:60],
-                        classification="WORKSPACE_GATE",
-                        fix=(
-                            f"Register parent dir under additionalDirectories"
-                            f" (e.g. `/permissions add {Path(target).parent}`)"
-                        ),
-                    )
-                )
-
-    return findings
-
-
-def matches_allow_rule(tc: ToolCall, rules: list[AllowRule]) -> bool:
-    if not rules:
-        return True
-    signature = tc.signature()
-    return any(rule.matches(signature) for rule in rules)
-
-
-def classify_toxicity(command: str) -> str | None:
-    if COMMENT_PREFIX_RE.match(command):
-        return "PREFIX_POISONED_COMMENT"
-    if ENV_PREFIX_RE.match(command):
-        return "PREFIX_POISONED_ENVVAR"
-    if GIT_C_RE.match(command):
-        return "PREFIX_POISONED_GIT_C"
-    if SUBSHELL_RE.search(command) and CHAIN_RE.search(command):
-        return "PREFIX_POISONED_SUBSHELL"
-    if CHAIN_RE.search(command) and not SUBSHELL_RE.search(command):
-        return "PREFIX_POISONED_CHAIN"
-    if HEREDOC_RE.search(command):
-        return "HOOK_BLOCKED_HEREDOC"
-    return None
-
-
-MULTI_WORD_COMMANDS = {"gh", "git", "uv", "docker", "kubectl", "aws"}
-
-
-def _extract_command_prefix(command: str) -> str:
-    parts = command.split()
-    if not parts:
-        return command
-    if parts[0] in MULTI_WORD_COMMANDS and len(parts) >= 2:
-        subcommand = parts[1]
-        if not subcommand.startswith("-"):
-            return f"{parts[0]} {subcommand}"
-    return parts[0]
-
-
-def classify_unmatched(
-    tc: ToolCall,
-    rules: list[AllowRule],
-) -> tuple[str, str]:
-    if tc.tool == "Bash":
-        toxicity = classify_toxicity(command=tc.command)
-        if toxicity:
-            if "PREFIX_POISONED" in toxicity:
-                return toxicity, "Restructure to avoid prefix poisoning"
-            return toxicity, "Use Write tool + file reference instead"
-
-        if DANGEROUS_COMMANDS.search(tc.command):
-            return "CORRECTLY_PROMPTED", "No action — risky command"
-
-        has_similar = any(
-            r.tool == "Bash" and tc.command[:10].startswith(r.pattern[:10]) for r in rules
-        )
-        if has_similar:
-            return "PATTERN_TOO_NARROW", "Widen existing allow rule pattern"
-
-        prefix = _extract_command_prefix(command=tc.command)
-        return "MISSING_RULE", f"Add: Bash({prefix}:*)"
-
-    target = tc.file_path or tc.command
-    has_similar = any(r.tool == tc.tool and target[:10].startswith(r.pattern[:10]) for r in rules)
-    if has_similar:
-        return "PATH_NOT_COVERED", f"Widen {tc.tool} glob pattern"
-
-    parent = str(Path(target).parent) if target else ""
-    return "MISSING_RULE", f"Add: {tc.tool}({parent}/**)"
-
-
-def analyze_permissions(
-    calls: list[ToolCall],
-    rules: list[AllowRule],
-) -> list[Finding]:
-    findings: list[Finding] = []
-    idx = 0
-
-    for tc in calls:
-        if matches_allow_rule(tc=tc, rules=rules):
-            continue
-
-        idx += 1
-        classification, fix = classify_unmatched(tc=tc, rules=rules)
-        cmd_display = tc.command[:60] if tc.command else tc.file_path[:60]
-        findings.append(
-            Finding(
-                index=idx,
-                turn=tc.turn,
-                time=tc.time,
-                tool=tc.tool,
-                command_display=cmd_display,
-                classification=classification,
-                fix=fix,
-            )
-        )
-
-    return findings
-
-
-def count_nuisance_patterns(findings: list[Finding]) -> list[Finding]:
-    pattern_counts: dict[str, list[Finding]] = {}
-    for f in findings:
-        if f.is_missing_rule():
-            pattern_counts.setdefault(f.nuisance_key(), []).append(f)
-
-    for group in pattern_counts.values():
-        if len(group) >= 3:
-            for f in group:
-                f.mark_nuisance(count=len(group))
-
-    return findings
-
-
-def audit_script_hygiene(skills_dir: str, tools_dir: str) -> list[HygieneFinding]:
-    findings: list[HygieneFinding] = []
-    idx = 0
-    dirs_to_scan = []
-
-    if os.path.isdir(skills_dir):
-        dirs_to_scan.append(Path(skills_dir))
-    if os.path.isdir(tools_dir):
-        dirs_to_scan.append(Path(tools_dir))
-
-    for scan_dir in dirs_to_scan:
-        for py_file in scan_dir.rglob("*.py"):
-            if not py_file.is_file():
-                continue
-
-            try:
-                content = py_file.read_text()
-            except (OSError, UnicodeDecodeError):
-                continue
-
-            first_line = content.split("\n", 1)[0] if content else ""
-
-            if first_line.startswith("#!") and "uv run" not in first_line:
-                if "python" in first_line:
-                    idx += 1
-                    findings.append(
-                        HygieneFinding(
-                            index=idx,
-                            target=str(py_file),
-                            issue=f"Shebang: {first_line}",
-                            classification="WRONG_SHEBANG",
-                            fix="Change to: #!/usr/bin/env -S uv run --script",
-                        )
-                    )
-
-            if "uv run" in first_line and "# /// script" not in content:
-                idx += 1
-                findings.append(
-                    HygieneFinding(
-                        index=idx,
-                        target=str(py_file),
-                        issue="Has uv shebang but no PEP 723 metadata block",
-                        classification="MISSING_PEP723",
-                        fix="Add # /// script block after shebang",
-                    )
-                )
-
-            file_stat = py_file.stat()
-            if not (file_stat.st_mode & stat.S_IXUSR):
-                if first_line.startswith("#!"):
-                    idx += 1
-                    findings.append(
-                        HygieneFinding(
-                            index=idx,
-                            target=str(py_file),
-                            issue=f"Mode {oct(file_stat.st_mode)[-3:]} — not executable",
-                            classification="NOT_EXECUTABLE",
-                            fix="chmod +x",
-                        )
-                    )
-
-    for scan_dir in dirs_to_scan:
-        for skill_md in scan_dir.rglob("SKILL.md"):
-            try:
-                content = skill_md.read_text()
-            except (OSError, UnicodeDecodeError):
-                continue
-
-            for m in re.finditer(r"uv run --script\s+(\S+\.py)", content):
-                script_path = m.group(1)
-                expanded = os.path.expanduser(script_path)
-                if os.path.isfile(expanded):
-                    try:
-                        script_content = Path(expanded).read_text()
-                        if "uv run" in script_content.split("\n", 1)[0]:
-                            idx += 1
-                            findings.append(
-                                HygieneFinding(
-                                    index=idx,
-                                    target=f"{skill_md}",
-                                    issue=f"Redundant uv run --script for {script_path}",
-                                    classification="REDUNDANT_UV_PREFIX",
-                                    fix="Call script directly (has uv shebang)",
-                                )
-                            )
-                    except (OSError, UnicodeDecodeError):
-                        pass
-
-    return findings
-
-
-def propose_allow_rules(findings: list[Finding]) -> list[str]:
-    seen: set[str] = set()
-    proposals: list[str] = []
-
-    for f in findings:
-        if f.is_actionable():
-            if "Add:" in f.fix:
-                rule = f.fix.split("Add: ", 1)[1]
-                if rule not in seen:
-                    seen.add(rule)
-                    proposals.append(rule)
-
-    return proposals
-
-
-def write_output(
-    findings: list[Finding],
-    hygiene: list[HygieneFinding],
-    proposals: list[str],
-    out: TextIO,
-) -> None:
-    out.write("# Phase 4: Permission Friction Analysis\n\n")
-
-    out.write("## Unmatched Tool Calls\n\n")
-    if findings:
-        out.write("| # | Turn | Time | Tool | Command (truncated) | Classification | Fix |\n")
-        out.write("|---|------|------|------|---------------------|----------------|-----|\n")
-        for f in findings:
-            cmd = f.command_display.replace("|", "\\|")
-            fix = f.fix.replace("|", "\\|")
-            out.write(
-                f"| {f.index} | {f.turn} | {f.time} | {f.tool} "
-                f"| {cmd} | {f.classification} | {fix} |\n"
-            )
-    else:
-        out.write("No unmatched tool calls found.\n")
-
-    out.write("\n---\n\n")
-
-    out.write("## Script Hygiene Audit\n\n")
-    if hygiene:
-        out.write("| # | Target | Issue | Classification | Fix |\n")
-        out.write("|---|--------|-------|----------------|-----|\n")
-        for h in hygiene:
-            target = h.target.replace("|", "\\|")
-            issue = h.issue.replace("|", "\\|")
-            out.write(f"| {h.index} | {target} | {issue} | {h.classification} | {h.fix} |\n")
-    else:
-        out.write("No script hygiene issues found.\n")
-
-    out.write("\n---\n\n")
-
-    out.write("## Proposed Allow Rules\n\n")
-    if proposals:
-        for p in proposals:
-            out.write(f"- `{p}`\n")
-    else:
-        out.write("No new allow rules proposed.\n")
-
-    out.write("\n---\n\n")
-
-    summary: dict[str, int] = {}
-    for f in findings:
-        base = f.base_classification()
-        summary[base] = summary.get(base, 0) + 1
-    out.write("## Summary\n\n")
-    out.write(f"**Total unmatched calls:** {len(findings)}\n")
-    out.write(f"**Script hygiene issues:** {len(hygiene)}\n")
-    out.write(f"**Proposed allow rules:** {len(proposals)}\n\n")
-    if summary:
-        out.write("**By classification:**\n")
-        for cls, count in sorted(summary.items(), key=lambda x: -x[1]):
-            out.write(f"- {cls}: {count}\n")
+__all__ = [
+    "ALLOW_RULE_RE",
+    "CHAIN_RE",
+    "COMMENT_PREFIX_RE",
+    "DANGEROUS_COMMANDS",
+    "ENV_PREFIX_RE",
+    "EXIT_FALSE_POSITIVE_RE",
+    "GIT_C_RE",
+    "HEREDOC_RE",
+    "HOOK_BLOCK_RE",
+    "MKTMP_PATH_RE",
+    "MULTI_WORD_COMMANDS",
+    "PERMISSION_TOOLS",
+    "SUBSHELL_RE",
+    "TOOL_INPUT_BLOCK_RE",
+    "TOOL_RE",
+    "TURN_RE",
+    "Finding",
+    "HygieneFinding",
+    "ToolCall",
+    "analyze_permissions",
+    "audit_script_hygiene",
+    "classify_toxicity",
+    "classify_unmatched",
+    "count_nuisance_patterns",
+    "detect_known_friction",
+    "matches_allow_rule",
+    "parse_additional_directories",
+    "parse_allow_rules",
+    "parse_tool_calls",
+    "propose_allow_rules",
+    "write_output",
+    "main",
+]
 
 
 def main() -> None:

--- a/tests/audit/test_analyze.py
+++ b/tests/audit/test_analyze.py
@@ -65,7 +65,7 @@ class TestBuildAuditReport:
 
 class TestAuditReportRender:
     def test_render_markdown_includes_findings_table(self, tmp_path) -> None:
-        from dev10x.skills.audit.analyze_permissions import Finding
+        from dev10x.audit.permissions_model import Finding
 
         report = analyze.AuditReport(
             findings=[

--- a/tests/audit/test_permissions_model.py
+++ b/tests/audit/test_permissions_model.py
@@ -1,0 +1,155 @@
+"""Tests for the extended detect_known_friction (GH-46)."""
+
+import json
+from pathlib import Path
+
+from dev10x.audit.permissions_model import (
+    ToolCall,
+    detect_known_friction,
+    parse_additional_directories,
+)
+
+
+class TestParseAdditionalDirectories:
+    def test_returns_empty_when_file_missing(self, tmp_path: Path) -> None:
+        result = parse_additional_directories(str(tmp_path / "missing.json"))
+        assert result == []
+
+    def test_returns_empty_when_invalid_json(self, tmp_path: Path) -> None:
+        path = tmp_path / "broken.json"
+        path.write_text("{not valid")
+        assert parse_additional_directories(str(path)) == []
+
+    def test_returns_empty_when_section_absent(self, tmp_path: Path) -> None:
+        path = tmp_path / "settings.json"
+        path.write_text(json.dumps({"permissions": {"allow": []}}))
+        assert parse_additional_directories(str(path)) == []
+
+    def test_returns_configured_dirs(self, tmp_path: Path) -> None:
+        path = tmp_path / "settings.json"
+        path.write_text(
+            json.dumps({"permissions": {"additionalDirectories": ["/tmp/Dev10x", "/tmp/other"]}})
+        )
+        assert parse_additional_directories(str(path)) == ["/tmp/Dev10x", "/tmp/other"]
+
+
+class TestDetectKnownFriction:
+    def _call(
+        self,
+        *,
+        tool: str,
+        command: str = "",
+        file_path: str = "",
+        turn: int = 1,
+    ) -> ToolCall:
+        return ToolCall(
+            turn=turn,
+            time="00:00:00",
+            tool=tool,
+            command=command or file_path,
+            file_path=file_path,
+        )
+
+    def test_flags_write_overwrite_on_mktmp_path(self) -> None:
+        calls = [
+            self._call(
+                tool="Write",
+                file_path="/tmp/Dev10x/git/commit-msg.AbCdEf123456.txt",
+            )
+        ]
+        findings = detect_known_friction(
+            calls=calls,
+            additional_dirs=["/tmp/Dev10x"],
+        )
+        kinds = [f.classification for f in findings]
+        assert "WRITE_OVERWRITE_GATE" in kinds
+
+    def test_does_not_flag_write_to_normal_path(self, tmp_path: Path) -> None:
+        calls = [self._call(tool="Write", file_path=str(tmp_path / "regular.txt"))]
+        findings = detect_known_friction(
+            calls=calls,
+            additional_dirs=[],
+            project_root=str(tmp_path),
+        )
+        kinds = [f.classification for f in findings]
+        assert "WRITE_OVERWRITE_GATE" not in kinds
+
+    def test_flags_workspace_gate_for_unregistered_path(self) -> None:
+        calls = [self._call(tool="Edit", file_path="/var/foreign/path.txt")]
+        findings = detect_known_friction(
+            calls=calls,
+            additional_dirs=["/tmp/Dev10x"],
+            project_root="/work/example",
+        )
+        kinds = [f.classification for f in findings]
+        assert "WORKSPACE_GATE" in kinds
+
+    def test_skips_workspace_gate_when_dir_registered(self) -> None:
+        calls = [self._call(tool="Read", file_path="/tmp/Dev10x/git/foo.txt")]
+        findings = detect_known_friction(
+            calls=calls,
+            additional_dirs=["/tmp/Dev10x"],
+            project_root="/work/example",
+        )
+        # The mktmp pattern doesn't match a plain non-suffixed path,
+        # and /tmp/Dev10x is registered so workspace gate also skipped.
+        assert findings == []
+
+    def test_skips_workspace_gate_for_project_paths(self, tmp_path: Path) -> None:
+        path = tmp_path / "subdir" / "file.py"
+        calls = [self._call(tool="Read", file_path=str(path))]
+        findings = detect_known_friction(
+            calls=calls,
+            additional_dirs=[],
+            project_root=str(tmp_path),
+        )
+        assert findings == []
+
+    def test_flags_gh_pr_edit_as_exit_code_false_positive(self) -> None:
+        calls = [
+            self._call(
+                tool="Bash",
+                command="gh pr edit 37 --body-file /tmp/body.txt",
+            )
+        ]
+        findings = detect_known_friction(
+            calls=calls,
+            additional_dirs=[],
+        )
+        kinds = [f.classification for f in findings]
+        assert "EXIT_CODE_FALSE_POSITIVE" in kinds
+
+    def test_does_not_flag_other_gh_pr_subcommands(self) -> None:
+        calls = [
+            self._call(tool="Bash", command="gh pr view 37"),
+            self._call(tool="Bash", command="gh pr list"),
+        ]
+        findings = detect_known_friction(
+            calls=calls,
+            additional_dirs=[],
+        )
+        assert [f.classification for f in findings] == []
+
+    def test_combines_multiple_signals_in_one_run(self) -> None:
+        calls = [
+            self._call(
+                tool="Write",
+                file_path="/tmp/Dev10x/git/msg.AbCdEf123456.txt",
+            ),
+            self._call(
+                tool="Bash",
+                command="gh pr edit 37 --body-file /tmp/body.txt",
+            ),
+            self._call(tool="Edit", file_path="/etc/strange.conf"),
+        ]
+        findings = detect_known_friction(
+            calls=calls,
+            additional_dirs=[],
+            project_root="/work/example",
+        )
+        kinds = sorted({f.classification for f in findings})
+        assert kinds == [
+            "EXIT_CODE_FALSE_POSITIVE",
+            "WORKSPACE_GATE",
+            "WRITE_OVERWRITE_GATE",
+        ]

--- a/tests/skills/audit/test_analyze_permissions.py
+++ b/tests/skills/audit/test_analyze_permissions.py
@@ -1,155 +1,80 @@
-"""Tests for the extended detect_known_friction (GH-46)."""
+"""Tests for the skills CLI adapter (GH-244, I1 / ADR-0008).
+
+The analysis logic moved to ``dev10x.audit.permissions_model``; this
+module is now a thin adapter that re-exports those names and provides
+the ``main`` entry point used by the skill-audit Bash pipeline. These
+tests cover the adapter: that it re-exports the model symbols and that
+``main`` drives the pipeline to a file or to stdout.
+"""
 
 import json
+import sys
 from pathlib import Path
 
-from dev10x.skills.audit.analyze_permissions import (
-    ToolCall,
-    detect_known_friction,
-    parse_additional_directories,
-)
+import pytest
+
+from dev10x.skills.audit import analyze_permissions as adapter
+
+TRANSCRIPT = "## Turn 1 [12:00:00] ASSISTANT\n\n**Tool: `Bash`**\n```\ncommand=ls -la\n```\n"
 
 
-class TestParseAdditionalDirectories:
-    def test_returns_empty_when_file_missing(self, tmp_path: Path) -> None:
-        result = parse_additional_directories(str(tmp_path / "missing.json"))
-        assert result == []
+def test_reexports_logic_from_permissions_model() -> None:
+    from dev10x.audit import permissions_model
 
-    def test_returns_empty_when_invalid_json(self, tmp_path: Path) -> None:
-        path = tmp_path / "broken.json"
-        path.write_text("{not valid")
-        assert parse_additional_directories(str(path)) == []
-
-    def test_returns_empty_when_section_absent(self, tmp_path: Path) -> None:
-        path = tmp_path / "settings.json"
-        path.write_text(json.dumps({"permissions": {"allow": []}}))
-        assert parse_additional_directories(str(path)) == []
-
-    def test_returns_configured_dirs(self, tmp_path: Path) -> None:
-        path = tmp_path / "settings.json"
-        path.write_text(
-            json.dumps({"permissions": {"additionalDirectories": ["/tmp/Dev10x", "/tmp/other"]}})
-        )
-        assert parse_additional_directories(str(path)) == ["/tmp/Dev10x", "/tmp/other"]
+    assert adapter.analyze_permissions is permissions_model.analyze_permissions
+    assert adapter.Finding is permissions_model.Finding
+    assert adapter.write_output is permissions_model.write_output
+    assert "main" in adapter.__all__
 
 
-class TestDetectKnownFriction:
-    def _call(
-        self,
-        *,
-        tool: str,
-        command: str = "",
-        file_path: str = "",
-        turn: int = 1,
-    ) -> ToolCall:
-        return ToolCall(
-            turn=turn,
-            time="00:00:00",
-            tool=tool,
-            command=command or file_path,
-            file_path=file_path,
-        )
+def test_main_no_args_exits(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["analyze-permissions.py"])
+    with pytest.raises(SystemExit):
+        adapter.main()
 
-    def test_flags_write_overwrite_on_mktmp_path(self) -> None:
-        calls = [
-            self._call(
-                tool="Write",
-                file_path="/tmp/Dev10x/git/commit-msg.AbCdEf123456.txt",
-            )
-        ]
-        findings = detect_known_friction(
-            calls=calls,
-            additional_dirs=["/tmp/Dev10x"],
-        )
-        kinds = [f.classification for f in findings]
-        assert "WRITE_OVERWRITE_GATE" in kinds
 
-    def test_does_not_flag_write_to_normal_path(self, tmp_path: Path) -> None:
-        calls = [self._call(tool="Write", file_path=str(tmp_path / "regular.txt"))]
-        findings = detect_known_friction(
-            calls=calls,
-            additional_dirs=[],
-            project_root=str(tmp_path),
-        )
-        kinds = [f.classification for f in findings]
-        assert "WRITE_OVERWRITE_GATE" not in kinds
+def test_main_writes_report_to_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    transcript = tmp_path / "transcript.md"
+    # `gh pr edit` is flagged as EXIT_CODE_FALSE_POSITIVE by
+    # detect_known_friction, so main() exercises the extra-finding
+    # renumber loop in addition to the base analysis.
+    transcript.write_text(
+        TRANSCRIPT
+        + "## Turn 2 [12:01:00] ASSISTANT\n\n"
+        + "**Tool: `Bash`**\n```\ncommand=gh pr edit 5 --title x\n```\n"
+    )
+    settings = tmp_path / "settings.json"
+    settings.write_text(json.dumps({"permissions": {"allow": ["Bash(ls:*)"]}}))
+    output = tmp_path / "report.md"
 
-    def test_flags_workspace_gate_for_unregistered_path(self) -> None:
-        calls = [self._call(tool="Edit", file_path="/var/foreign/path.txt")]
-        findings = detect_known_friction(
-            calls=calls,
-            additional_dirs=["/tmp/Dev10x"],
-            project_root="/work/example",
-        )
-        kinds = [f.classification for f in findings]
-        assert "WORKSPACE_GATE" in kinds
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["analyze-permissions.py", str(transcript), str(settings), str(output)],
+    )
+    adapter.main()
 
-    def test_skips_workspace_gate_when_dir_registered(self) -> None:
-        calls = [self._call(tool="Read", file_path="/tmp/Dev10x/git/foo.txt")]
-        findings = detect_known_friction(
-            calls=calls,
-            additional_dirs=["/tmp/Dev10x"],
-            project_root="/work/example",
-        )
-        # The mktmp pattern doesn't match a plain non-suffixed path,
-        # and /tmp/Dev10x is registered so workspace gate also skipped.
-        assert findings == []
+    assert output.exists()
+    assert "# Phase 4: Permission Friction Analysis" in output.read_text()
 
-    def test_skips_workspace_gate_for_project_paths(self, tmp_path: Path) -> None:
-        path = tmp_path / "subdir" / "file.py"
-        calls = [self._call(tool="Read", file_path=str(path))]
-        findings = detect_known_friction(
-            calls=calls,
-            additional_dirs=[],
-            project_root=str(tmp_path),
-        )
-        assert findings == []
 
-    def test_flags_gh_pr_edit_as_exit_code_false_positive(self) -> None:
-        calls = [
-            self._call(
-                tool="Bash",
-                command="gh pr edit 37 --body-file /tmp/body.txt",
-            )
-        ]
-        findings = detect_known_friction(
-            calls=calls,
-            additional_dirs=[],
-        )
-        kinds = [f.classification for f in findings]
-        assert "EXIT_CODE_FALSE_POSITIVE" in kinds
+def test_main_writes_to_stdout_with_default_settings(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    transcript = tmp_path / "transcript.md"
+    transcript.write_text(TRANSCRIPT)
 
-    def test_does_not_flag_other_gh_pr_subcommands(self) -> None:
-        calls = [
-            self._call(tool="Bash", command="gh pr view 37"),
-            self._call(tool="Bash", command="gh pr list"),
-        ]
-        findings = detect_known_friction(
-            calls=calls,
-            additional_dirs=[],
-        )
-        assert [f.classification for f in findings] == []
+    # No settings/output args — settings defaults to ~/.claude/settings.local.json
+    # (absent under the tmp HOME) and the report goes to stdout.
+    monkeypatch.setattr(sys, "argv", ["analyze-permissions.py", str(transcript)])
+    adapter.main()
 
-    def test_combines_multiple_signals_in_one_run(self) -> None:
-        calls = [
-            self._call(
-                tool="Write",
-                file_path="/tmp/Dev10x/git/msg.AbCdEf123456.txt",
-            ),
-            self._call(
-                tool="Bash",
-                command="gh pr edit 37 --body-file /tmp/body.txt",
-            ),
-            self._call(tool="Edit", file_path="/etc/strange.conf"),
-        ]
-        findings = detect_known_friction(
-            calls=calls,
-            additional_dirs=[],
-            project_root="/work/example",
-        )
-        kinds = sorted({f.classification for f in findings})
-        assert kinds == [
-            "EXIT_CODE_FALSE_POSITIVE",
-            "WORKSPACE_GATE",
-            "WRITE_OVERWRITE_GATE",
-        ]
+    captured = capsys.readouterr()
+    assert "# Phase 4: Permission Friction Analysis" in captured.out


### PR DESCRIPTION
**When** the audit context analyzes permission friction, **I want to** keep its parsers, classifiers, and report writer inside the audit module instead of importing them up from the skills layer, **so I can** keep the hooks → audit → skills dependency one-directional and leave the skills script as a thin CLI adapter.

---

[`abaeed65`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/380/commits/abaeed65374ea708ce41215c4efc839baee24457) ♻️ GH-244 Seal audit-skills permission analysis boundary (I1)
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/244

---