### PR TITLE
♻️ GH-248 Enable tested orchestration and skill-index helpers

### DIFF
--- a/src/dev10x/skill_index/builder.py
+++ b/src/dev10x/skill_index/builder.py
@@ -1,0 +1,83 @@
+"""Skill-index builder logic (GH-248 G11).
+
+Ports the ``parse_skill`` front-matter parsing from
+``skills/skill-index/scripts/generate-skills-menu.sh`` into importable,
+unit-testable Python. The shell script extracts ``name`` and
+``invocation-name`` from each ``SKILL.md`` front matter, computes the
+menu key (invocation-name preferred, name as fallback), and rejects
+scaffolding placeholders. This module makes that decision testable
+without invoking ``yq``/``jq``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+_FRONT_MATTER_FENCE = "---"
+_PLACEHOLDER_NAME = "my-skill-name"
+
+
+@dataclass(frozen=True)
+class SkillEntry:
+    key: str
+    name: str
+    source: Path | None = None
+
+
+def extract_front_matter(text: str) -> dict | None:
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != _FRONT_MATTER_FENCE:
+        return None
+
+    body: list[str] = []
+    for line in lines[1:]:
+        if line.strip() == _FRONT_MATTER_FENCE:
+            try:
+                parsed = yaml.safe_load("\n".join(body))
+            except yaml.YAMLError:
+                return None
+            return parsed if isinstance(parsed, dict) else None
+        body.append(line)
+
+    # No closing fence — malformed front matter.
+    return None
+
+
+def _compute_key(*, name: str, invocation_name: str) -> str:
+    raw_key = invocation_name or name
+    return raw_key.split("#", 1)[0].strip()
+
+
+def parse_skill_frontmatter(text: str, source: Path | None = None) -> SkillEntry | None:
+    front_matter = extract_front_matter(text=text)
+    if front_matter is None:
+        return None
+
+    name = str(front_matter.get("name") or "").strip()
+    if not name or "{" in name or name == _PLACEHOLDER_NAME:
+        return None
+
+    invocation_name = str(front_matter.get("invocation-name") or "").strip()
+    key = _compute_key(name=name, invocation_name=invocation_name)
+    if not key:
+        return None
+
+    return SkillEntry(key=key, name=name, source=source)
+
+
+def scan_skill_dirs(skill_dirs: Iterable[Path]) -> list[SkillEntry]:
+    entries: list[SkillEntry] = []
+    for skill_dir in skill_dirs:
+        for skill_file in sorted(skill_dir.glob("*/SKILL.md")):
+            entry = parse_skill_frontmatter(
+                text=skill_file.read_text(encoding="utf-8"),
+                source=skill_file,
+            )
+            if entry is not None:
+                entries.append(entry)
+
+    return sorted(entries, key=lambda entry: entry.key)

--- a/src/dev10x/skills/orchestration/__init__.py
+++ b/src/dev10x/skills/orchestration/__init__.py
@@ -1,0 +1,31 @@
+"""Importable, testable helpers for work-on / fanout orchestration."""
+
+from __future__ import annotations
+
+from dev10x.skills.orchestration.batch_detection import (
+    BATCH_THRESHOLD,
+    MAX_BATCH_SIZE,
+    OverlapSignal,
+    group_into_batches,
+    tickets_share_batch,
+)
+from dev10x.skills.orchestration.subagent_protocol import (
+    STATUS_PROMPT_TEMPLATE,
+    ParsedStatus,
+    SubagentStatus,
+    parse_subagent_status,
+    requires_main_session_fallback,
+)
+
+__all__ = [
+    "BATCH_THRESHOLD",
+    "MAX_BATCH_SIZE",
+    "OverlapSignal",
+    "ParsedStatus",
+    "STATUS_PROMPT_TEMPLATE",
+    "SubagentStatus",
+    "group_into_batches",
+    "parse_subagent_status",
+    "requires_main_session_fallback",
+    "tickets_share_batch",
+]

--- a/src/dev10x/skills/orchestration/batch_detection.py
+++ b/src/dev10x/skills/orchestration/batch_detection.py
@@ -1,0 +1,61 @@
+"""Bundled-execution batch detection for work-on (GH-248 G3 / GH-196).
+
+Encodes the overlap-signal rule the work-on skill describes in prose:
+two tickets share a commit batch when at least ``BATCH_THRESHOLD``
+overlap signals hold simultaneously, and no batch grows beyond
+``MAX_BATCH_SIZE``. Extracting it here makes the bundling decision
+importable and unit-testable instead of re-derived per session.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from enum import StrEnum
+
+BATCH_THRESHOLD = 2
+MAX_BATCH_SIZE = 5
+
+
+class OverlapSignal(StrEnum):
+    SHARED_COMPONENT = "shared_component"
+    SHARED_ERROR_CLASS = "shared_error_class"
+    SAME_PARENT = "same_parent"
+    REPEATED_LABEL = "repeated_label"
+    EXPLICIT_REFERENCE = "explicit_reference"
+
+
+PairSignals = Mapping[tuple[str, str], Iterable[OverlapSignal]]
+
+
+def tickets_share_batch(shared_signals: Iterable[OverlapSignal]) -> bool:
+    return len(set(shared_signals)) >= BATCH_THRESHOLD
+
+
+def _signals_for(pair_signals: PairSignals, left: str, right: str) -> set[OverlapSignal]:
+    for key in ((left, right), (right, left)):
+        if key in pair_signals:
+            return set(pair_signals[key])
+    return set()
+
+
+def group_into_batches(
+    tickets: Sequence[str],
+    pair_signals: PairSignals,
+) -> list[list[str]]:
+    batches: list[list[str]] = []
+
+    for ticket in tickets:
+        placed = False
+        for batch in batches:
+            if len(batch) >= MAX_BATCH_SIZE:
+                continue
+            if any(
+                tickets_share_batch(_signals_for(pair_signals, ticket, member)) for member in batch
+            ):
+                batch.append(ticket)
+                placed = True
+                break
+        if not placed:
+            batches.append([ticket])
+
+    return batches

--- a/src/dev10x/skills/orchestration/subagent_protocol.py
+++ b/src/dev10x/skills/orchestration/subagent_protocol.py
@@ -1,0 +1,77 @@
+"""Subagent status-line protocol parsing (GH-248 G3).
+
+Extracted from the prose contract in
+``references/orchestration/subagent-status-protocol.md`` so the
+last-line status parsing used by every orchestration hub
+(work-on, fanout, gh-pr-monitor, skill-audit, adr-evaluate) has a
+single importable, unit-tested implementation instead of being
+re-derived in each skill body.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+STATUS_PROMPT_TEMPLATE = """\
+Report your final status as the LAST line of your output, with
+exactly one of these prefixes:
+
+- DONE                           — task complete
+- DONE_WITH_CONCERNS: <text>     — complete but flagged
+- NEEDS_CONTEXT: <what>          — re-dispatch needed
+- BLOCKED: <reason>              — cannot proceed (permission,
+                                    missing tool, unrecoverable)
+
+Do not write anything after the status line."""
+
+
+class SubagentStatus(StrEnum):
+    DONE = "DONE"
+    DONE_WITH_CONCERNS = "DONE_WITH_CONCERNS"
+    NEEDS_CONTEXT = "NEEDS_CONTEXT"
+    BLOCKED = "BLOCKED"
+    # Missing or unrecognized status line — the controller treats a
+    # protocol violation as BLOCKED (subagent-status-protocol.md).
+    MALFORMED = "MALFORMED"
+
+
+# Prefixes that carry a free-text payload after the colon.
+_PAYLOAD_PREFIXES: tuple[tuple[str, SubagentStatus], ...] = (
+    ("DONE_WITH_CONCERNS:", SubagentStatus.DONE_WITH_CONCERNS),
+    ("NEEDS_CONTEXT:", SubagentStatus.NEEDS_CONTEXT),
+    ("BLOCKED:", SubagentStatus.BLOCKED),
+)
+
+
+@dataclass(frozen=True)
+class ParsedStatus:
+    status: SubagentStatus
+    payload: str
+    raw_line: str
+
+
+def _last_non_empty_line(result: str) -> str:
+    for line in reversed(result.splitlines()):
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return ""
+
+
+def parse_subagent_status(result: str) -> ParsedStatus:
+    raw_line = _last_non_empty_line(result=result)
+
+    if raw_line == SubagentStatus.DONE.value:
+        return ParsedStatus(status=SubagentStatus.DONE, payload="", raw_line=raw_line)
+
+    for prefix, status in _PAYLOAD_PREFIXES:
+        if raw_line.startswith(prefix):
+            payload = raw_line[len(prefix) :].strip()
+            return ParsedStatus(status=status, payload=payload, raw_line=raw_line)
+
+    return ParsedStatus(status=SubagentStatus.MALFORMED, payload="", raw_line=raw_line)
+
+
+def requires_main_session_fallback(status: SubagentStatus) -> bool:
+    return status in (SubagentStatus.BLOCKED, SubagentStatus.MALFORMED)

--- a/tests/skill_index/test_builder.py
+++ b/tests/skill_index/test_builder.py
@@ -1,0 +1,141 @@
+"""Tests for the skill-index builder logic (GH-248 G11)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dev10x.skill_index.builder import (
+    SkillEntry,
+    extract_front_matter,
+    parse_skill_frontmatter,
+    scan_skill_dirs,
+)
+
+
+def _skill_md(
+    *, name: str | None = None, invocation: str | None = None, body: str = "Overview"
+) -> str:
+    lines = ["---"]
+    if name is not None:
+        lines.append(f"name: {name}")
+    if invocation is not None:
+        lines.append(f"invocation-name: {invocation}")
+    lines += ["description: x", "---", "", body]
+    return "\n".join(lines)
+
+
+class TestParseSkillFrontmatter:
+    def test_invocation_name_is_preferred_key(self):
+        text = _skill_md(name="Dev10x:git-commit", invocation="Dev10x:git-commit")
+        entry = parse_skill_frontmatter(text=text)
+        assert entry == SkillEntry(key="Dev10x:git-commit", name="Dev10x:git-commit")
+
+    def test_falls_back_to_name_when_no_invocation_name(self):
+        text = _skill_md(name="Dev10x:park")
+        entry = parse_skill_frontmatter(text=text)
+        assert entry is not None
+        assert entry.key == "Dev10x:park"
+        assert entry.name == "Dev10x:park"
+
+    def test_invocation_name_overrides_differing_name(self):
+        text = _skill_md(name="internal-name", invocation="Dev10x:public")
+        entry = parse_skill_frontmatter(text=text)
+        assert entry is not None
+        assert entry.key == "Dev10x:public"
+        assert entry.name == "internal-name"
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "no front matter here\njust prose",
+            "---\nname: Dev10x:x\ndescription: unterminated front matter",
+            "---\n: : : not valid yaml :\n  - broken\n---\nbody",
+            "---\n- just\n- a\n- list\n---\nbody",
+        ],
+    )
+    def test_malformed_or_missing_front_matter_returns_none(self, text: str):
+        assert parse_skill_frontmatter(text=text) is None
+
+    @pytest.mark.parametrize(
+        "name",
+        ["my-skill-name", "{{cookiecutter.name}}", ""],
+    )
+    def test_placeholder_and_empty_names_rejected(self, name: str):
+        assert parse_skill_frontmatter(text=_skill_md(name=name)) is None
+
+    def test_missing_name_key_returns_none(self):
+        text = "---\ndescription: only a description\n---\nbody"
+        assert parse_skill_frontmatter(text=text) is None
+
+    def test_trailing_comment_stripped_from_key(self):
+        text = _skill_md(name="Dev10x:thing", invocation="Dev10x:thing # legacy")
+        entry = parse_skill_frontmatter(text=text)
+        assert entry is not None
+        assert entry.key == "Dev10x:thing"
+
+    def test_invocation_name_that_reduces_to_empty_key_returns_none(self):
+        text = '---\nname: Dev10x:x\ninvocation-name: "#only-a-comment"\n---\nbody'
+        assert parse_skill_frontmatter(text=text) is None
+
+    def test_source_path_is_preserved(self):
+        path = Path("/skills/x/SKILL.md")
+        entry = parse_skill_frontmatter(text=_skill_md(name="Dev10x:x"), source=path)
+        assert entry is not None
+        assert entry.source == path
+
+
+class TestExtractFrontMatter:
+    def test_returns_mapping(self):
+        assert extract_front_matter(text=_skill_md(name="Dev10x:x")) == {
+            "name": "Dev10x:x",
+            "description": "x",
+        }
+
+    def test_no_opening_fence_returns_none(self):
+        assert extract_front_matter(text="plain text") is None
+
+
+class TestScanSkillDirs:
+    def _make_skill(self, root: Path, dirname: str, text: str) -> None:
+        skill_dir = root / dirname
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(text, encoding="utf-8")
+
+    def test_returns_entries_sorted_by_key(self, tmp_path: Path):
+        self._make_skill(tmp_path, "zebra", _skill_md(name="Dev10x:zebra"))
+        self._make_skill(tmp_path, "alpha", _skill_md(name="Dev10x:alpha"))
+        self._make_skill(tmp_path, "mid", _skill_md(name="Dev10x:mid"))
+
+        entries = scan_skill_dirs(skill_dirs=[tmp_path])
+        assert [entry.key for entry in entries] == [
+            "Dev10x:alpha",
+            "Dev10x:mid",
+            "Dev10x:zebra",
+        ]
+
+    def test_directory_without_skill_md_is_skipped(self, tmp_path: Path):
+        (tmp_path / "empty").mkdir()
+        self._make_skill(tmp_path, "real", _skill_md(name="Dev10x:real"))
+
+        entries = scan_skill_dirs(skill_dirs=[tmp_path])
+        assert [entry.key for entry in entries] == ["Dev10x:real"]
+
+    def test_placeholder_skill_excluded_from_scan(self, tmp_path: Path):
+        self._make_skill(tmp_path, "good", _skill_md(name="Dev10x:good"))
+        self._make_skill(tmp_path, "tmpl", _skill_md(name="my-skill-name"))
+
+        entries = scan_skill_dirs(skill_dirs=[tmp_path])
+        assert [entry.key for entry in entries] == ["Dev10x:good"]
+
+    def test_multiple_dirs_merged_and_sorted(self, tmp_path: Path):
+        local = tmp_path / "local"
+        plugin = tmp_path / "plugin"
+        local.mkdir()
+        plugin.mkdir()
+        self._make_skill(local, "b", _skill_md(name="Dev10x:b"))
+        self._make_skill(plugin, "a", _skill_md(name="Dev10x:a"))
+
+        entries = scan_skill_dirs(skill_dirs=[local, plugin])
+        assert [entry.key for entry in entries] == ["Dev10x:a", "Dev10x:b"]

--- a/tests/skills/orchestration/test_batch_detection.py
+++ b/tests/skills/orchestration/test_batch_detection.py
@@ -1,0 +1,74 @@
+"""Tests for work-on bundled-execution batch detection (GH-248 G3 / GH-196)."""
+
+from __future__ import annotations
+
+import pytest
+
+from dev10x.skills.orchestration.batch_detection import (
+    MAX_BATCH_SIZE,
+    OverlapSignal,
+    group_into_batches,
+    tickets_share_batch,
+)
+
+S = OverlapSignal
+
+
+class TestTicketsShareBatch:
+    @pytest.mark.parametrize(
+        ("signals", "expected"),
+        [
+            (set(), False),
+            ({S.SHARED_COMPONENT}, False),
+            ({S.SHARED_COMPONENT, S.REPEATED_LABEL}, True),
+            ({S.SHARED_COMPONENT, S.SHARED_ERROR_CLASS, S.SAME_PARENT}, True),
+        ],
+    )
+    def test_threshold_is_two_signals(self, signals: set[OverlapSignal], expected: bool):
+        assert tickets_share_batch(shared_signals=signals) is expected
+
+    def test_duplicate_signals_do_not_count_twice(self):
+        assert (
+            tickets_share_batch(shared_signals=[S.SHARED_COMPONENT, S.SHARED_COMPONENT]) is False
+        )
+
+
+class TestGroupIntoBatches:
+    def test_no_overlap_yields_singletons(self):
+        batches = group_into_batches(tickets=["GH-1", "GH-2", "GH-3"], pair_signals={})
+        assert batches == [["GH-1"], ["GH-2"], ["GH-3"]]
+
+    def test_two_signal_pair_shares_a_batch(self):
+        batches = group_into_batches(
+            tickets=["GH-12", "GH-14", "GH-21"],
+            pair_signals={
+                ("GH-12", "GH-14"): {S.SHARED_COMPONENT, S.REPEATED_LABEL},
+            },
+        )
+        assert batches == [["GH-12", "GH-14"], ["GH-21"]]
+
+    def test_single_signal_pair_does_not_merge(self):
+        batches = group_into_batches(
+            tickets=["GH-1", "GH-2"],
+            pair_signals={("GH-1", "GH-2"): {S.SHARED_COMPONENT}},
+        )
+        assert batches == [["GH-1"], ["GH-2"]]
+
+    def test_signal_lookup_is_order_independent(self):
+        batches = group_into_batches(
+            tickets=["GH-1", "GH-2"],
+            pair_signals={("GH-2", "GH-1"): {S.SAME_PARENT, S.REPEATED_LABEL}},
+        )
+        assert batches == [["GH-1", "GH-2"]]
+
+    def test_batch_never_exceeds_max_size(self):
+        tickets = [f"GH-{n}" for n in range(MAX_BATCH_SIZE + 2)]
+        pair_signals = {
+            (a, b): {S.SHARED_COMPONENT, S.REPEATED_LABEL}
+            for a in tickets
+            for b in tickets
+            if a != b
+        }
+        batches = group_into_batches(tickets=tickets, pair_signals=pair_signals)
+        assert len(batches[0]) == MAX_BATCH_SIZE
+        assert batches[1] == tickets[MAX_BATCH_SIZE:]

--- a/tests/skills/orchestration/test_subagent_protocol.py
+++ b/tests/skills/orchestration/test_subagent_protocol.py
@@ -1,0 +1,110 @@
+"""Tests for the subagent status-line protocol parser (GH-248 G3)."""
+
+from __future__ import annotations
+
+import pytest
+
+from dev10x.skills.orchestration.subagent_protocol import (
+    STATUS_PROMPT_TEMPLATE,
+    ParsedStatus,
+    SubagentStatus,
+    parse_subagent_status,
+    requires_main_session_fallback,
+)
+
+
+class TestParseSubagentStatus:
+    @pytest.mark.parametrize(
+        ("result", "expected_status", "expected_payload"),
+        [
+            ("DONE", SubagentStatus.DONE, ""),
+            (
+                "DONE_WITH_CONCERNS: tests skipped",
+                SubagentStatus.DONE_WITH_CONCERNS,
+                "tests skipped",
+            ),
+            (
+                "NEEDS_CONTEXT: corrected ticket id",
+                SubagentStatus.NEEDS_CONTEXT,
+                "corrected ticket id",
+            ),
+            ("BLOCKED: gh auth error", SubagentStatus.BLOCKED, "gh auth error"),
+        ],
+    )
+    def test_each_status_prefix(
+        self,
+        result: str,
+        expected_status: SubagentStatus,
+        expected_payload: str,
+    ):
+        parsed = parse_subagent_status(result=result)
+        assert parsed.status == expected_status
+        assert parsed.payload == expected_payload
+
+    def test_last_non_empty_line_wins(self):
+        result = "fetched the ticket\nsummary line\n\nBLOCKED: MCP unavailable\n\n"
+        parsed = parse_subagent_status(result=result)
+        assert parsed.status == SubagentStatus.BLOCKED
+        assert parsed.payload == "MCP unavailable"
+
+    def test_trailing_whitespace_on_done_is_tolerated(self):
+        parsed = parse_subagent_status(result="work summary\n   DONE   ")
+        assert parsed.status == SubagentStatus.DONE
+        assert parsed.raw_line == "DONE"
+
+    @pytest.mark.parametrize(
+        "result",
+        [
+            "",
+            "   \n\n  ",
+            "all done, no status line",
+            "DONEISH",
+            "DONE_WITH_CONCERNS no colon",
+            "blocked: lowercase prefix",
+        ],
+    )
+    def test_missing_or_unrecognized_line_is_malformed(self, result: str):
+        parsed = parse_subagent_status(result=result)
+        assert parsed.status == SubagentStatus.MALFORMED
+        assert parsed.payload == ""
+
+    def test_payload_whitespace_is_stripped(self):
+        parsed = parse_subagent_status(result="DONE_WITH_CONCERNS:   spaced   ")
+        assert parsed.payload == "spaced"
+
+    def test_empty_payload_after_prefix(self):
+        parsed = parse_subagent_status(result="BLOCKED:")
+        assert parsed.status == SubagentStatus.BLOCKED
+        assert parsed.payload == ""
+
+    def test_returns_parsed_status_instance(self):
+        parsed = parse_subagent_status(result="DONE")
+        assert isinstance(parsed, ParsedStatus)
+
+
+class TestRequiresMainSessionFallback:
+    @pytest.mark.parametrize(
+        ("status", "expected"),
+        [
+            (SubagentStatus.DONE, False),
+            (SubagentStatus.DONE_WITH_CONCERNS, False),
+            (SubagentStatus.NEEDS_CONTEXT, False),
+            (SubagentStatus.BLOCKED, True),
+            (SubagentStatus.MALFORMED, True),
+        ],
+    )
+    def test_fallback_only_for_blocked_and_malformed(
+        self,
+        status: SubagentStatus,
+        expected: bool,
+    ):
+        assert requires_main_session_fallback(status=status) is expected
+
+
+class TestStatusPromptTemplate:
+    @pytest.mark.parametrize(
+        "marker",
+        ["DONE", "DONE_WITH_CONCERNS:", "NEEDS_CONTEXT:", "BLOCKED:"],
+    )
+    def test_template_documents_every_status(self, marker: str):
+        assert marker in STATUS_PROMPT_TEMPLATE


### PR DESCRIPTION
**When** I maintain the work-on / fanout orchestration skills and the skill-index generator, **I want to** drive the subagent status protocol, batch-bundling rule, and SKILL.md front-matter parsing from importable, unit-tested Python instead of prose, **so I can** change that supervisor-facing logic with automated verification behind it.

---

[`7f1e22b3`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/384/commits/7f1e22b3fea385d05c603622d8d357f59433b43f) ♻️ GH-248 Enable testable subagent status and batch detection
[`4b084600`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/384/commits/4b084600d50321b8438e23b08078abea54f17ba8) ♻️ GH-248 Enable unit-tested skill-index builder

**M9 findings coverage (audit-2026-05-18):**
- **G2** (`collect_prs` classifier) — already shipped in #382, on develop
- **G3** (subagent status protocol + work-on batch detection) — this PR
- **G11** (skill-index builder) — this PR

New modules ship with parametrized tests at 100% coverage; ruff + mypy clean.

Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/248

---