### PR TITLE
♻️ GH-249 Simplify dispatch and validator wiring (M10)

### DIFF
--- a/hooks/scripts/session-start.py
+++ b/hooks/scripts/session-start.py
@@ -20,6 +20,8 @@ import io
 import json
 import sys
 import traceback
+from collections.abc import Callable
+from typing import Any, NamedTuple
 
 
 def _load_stdin() -> dict:
@@ -85,46 +87,80 @@ def _extract_additional_context(*, output: str) -> str:
     return ctx or stripped
 
 
+class SessionFeature(NamedTuple):
+    """One SessionStart feature and how to obtain its context string.
+
+    A ``NamedTuple`` (not a dataclass) so this standalone uv-script stays
+    importable under ``importlib.exec_module`` with a synthetic module
+    name — ``@dataclass`` + ``from __future__ import annotations`` does a
+    ``sys.modules`` lookup that fails outside a registered module.
+
+    ``mode`` selects the calling convention:
+      - ``"capture"`` — wrap with ``audit_hook`` and capture stdout
+        (legacy print-based features). ``pass_data`` forwards stdin.
+      - ``"build"``  — call directly and use the returned string.
+    ``emits_context`` is False for side-effect-only features (tmpdir).
+    """
+
+    name: str
+    fn: Callable[..., Any]
+    mode: str
+    pass_data: bool = False
+    emits_context: bool = True
+
+
+def _run_session_feature(*, feature: SessionFeature, data: dict, audit_hook) -> str:
+    """Run one feature, returning the context string to append (or "")."""
+    if feature.mode == "build":
+        try:
+            return feature.fn() or ""
+        except Exception:
+            traceback.print_exc(file=sys.stderr)
+            return ""
+
+    fn = (lambda: feature.fn(data=data)) if feature.pass_data else feature.fn
+    out = _run_feature(name=feature.name, fn=fn, audit_hook=audit_hook)
+    return out.strip() if feature.emits_context else ""
+
+
 def main() -> None:
     data = _load_stdin()
     s, audit_hook = _import_session_modules()
 
-    # Features that produce additionalContext (order matters for readability).
+    # Order matters for readability of the merged additionalContext.
+    features = [
+        SessionFeature(name="session-git-aliases", fn=s.session_git_aliases, mode="capture"),
+        SessionFeature(
+            name="session-tmpdir",
+            fn=s.session_tmpdir,
+            mode="capture",
+            pass_data=True,
+            emits_context=False,
+        ),
+        SessionFeature(name="session-guidance", fn=s.build_guidance_context, mode="build"),
+        SessionFeature(
+            name="session-autonomy",
+            fn=s.build_autonomy_reassurance_context,
+            mode="build",
+        ),
+        SessionFeature(
+            name="session-install-check",
+            fn=s.build_install_check_context,
+            mode="build",
+        ),
+        SessionFeature(
+            name="session-migrate-permissions",
+            fn=s.session_migrate_permissions,
+            mode="capture",
+        ),
+        SessionFeature(name="session-reload", fn=s.build_reload_context, mode="build"),
+    ]
+
     context_parts: list[str] = []
-
-    out = _run_feature(name="session-git-aliases", fn=s.session_git_aliases, audit_hook=audit_hook)
-    if out.strip():
-        context_parts.append(out.strip())
-
-    _run_feature(
-        name="session-tmpdir",
-        fn=lambda: s.session_tmpdir(data=data),
-        audit_hook=audit_hook,
-    )
-
-    guidance = s.build_guidance_context()
-    if guidance:
-        context_parts.append(guidance)
-
-    reassurance = s.build_autonomy_reassurance_context()
-    if reassurance:
-        context_parts.append(reassurance)
-
-    install_check = s.build_install_check_context()
-    if install_check:
-        context_parts.append(install_check)
-
-    out = _run_feature(
-        name="session-migrate-permissions",
-        fn=s.session_migrate_permissions,
-        audit_hook=audit_hook,
-    )
-    if out.strip():
-        context_parts.append(out.strip())
-
-    reload_ctx = s.build_reload_context()
-    if reload_ctx:
-        context_parts.append(reload_ctx)
+    for feature in features:
+        ctx = _run_session_feature(feature=feature, data=data, audit_hook=audit_hook)
+        if ctx:
+            context_parts.append(ctx)
 
     if not context_parts:
         return

--- a/src/dev10x/commands/github_app.py
+++ b/src/dev10x/commands/github_app.py
@@ -81,7 +81,44 @@ installation, the App can't post anywhere.
 """
 
 
-def _prompt_install_target() -> dict[str, str]:
+@dataclass(frozen=True)
+class InstallTarget:
+    """Where the GitHub App is registered: personal, org-owned, or manual."""
+
+    kind: str
+    org: str | None = None
+
+    @property
+    def registration_url(self) -> str:
+        if self.kind == "org":
+            return f"https://github.com/organizations/{self.org}/settings/apps/new"
+        if self.kind == "manual":
+            return "(open the GitHub App settings page yourself)"
+        return PERSONAL_NEW_APP_URL
+
+    @property
+    def install_scope_hint(self) -> str:
+        if self.kind == "org":
+            return (
+                "Where can this GitHub App be installed?\n"
+                "  Scope is implicit — the App is owned by the org and can only\n"
+                "  be installed on it. Leave the default selection."
+            )
+        if self.kind == "manual":
+            return (
+                "Where can this GitHub App be installed?\n"
+                '  Personal multi-target → "Any account".\n'
+                "  Org-owned → leave the default."
+            )
+        return (
+            "Where can this GitHub App be installed?\n"
+            '  Pick "Any account" — lets you install the App on personal\n'
+            '  repos AND any orgs you belong to. The default "Only on this\n'
+            '  account" blocks org installs.'
+        )
+
+
+def _prompt_install_target() -> InstallTarget:
     """Return the install-target choice: personal, org-owned, or manual."""
     click.echo("Step 1: Where will the App be registered?")
     click.echo("─────────────────────────────────────────")
@@ -93,45 +130,16 @@ def _prompt_install_target() -> dict[str, str]:
     while True:
         choice = click.prompt("Choose [1/2/3]", type=str, default="1").strip()
         if choice == "1":
-            return {"kind": "personal"}
+            return InstallTarget(kind="personal")
         if choice == "2":
             org = click.prompt("Org login (e.g. tiretutorinc)", type=str).strip()
             if not org:
                 click.echo("  Org login is required for an org-owned App.")
                 continue
-            return {"kind": "org", "org": org}
+            return InstallTarget(kind="org", org=org)
         if choice == "3":
-            return {"kind": "manual"}
+            return InstallTarget(kind="manual")
         click.echo("  Pick 1, 2, or 3.")
-
-
-def _registration_url(target: dict[str, str]) -> str:
-    if target["kind"] == "org":
-        return f"https://github.com/organizations/{target['org']}/settings/apps/new"
-    if target["kind"] == "manual":
-        return "(open the GitHub App settings page yourself)"
-    return PERSONAL_NEW_APP_URL
-
-
-def _install_scope_hint(target: dict[str, str]) -> str:
-    if target["kind"] == "personal":
-        return (
-            "Where can this GitHub App be installed?\n"
-            '  Pick "Any account" — lets you install the App on personal\n'
-            '  repos AND any orgs you belong to. The default "Only on this\n'
-            '  account" blocks org installs.'
-        )
-    if target["kind"] == "org":
-        return (
-            "Where can this GitHub App be installed?\n"
-            "  Scope is implicit — the App is owned by the org and can only\n"
-            "  be installed on it. Leave the default selection."
-        )
-    return (
-        "Where can this GitHub App be installed?\n"
-        '  Personal multi-target → "Any account".\n'
-        "  Org-owned → leave the default."
-    )
 
 
 def _prompt_app_id() -> str:
@@ -411,8 +419,8 @@ def setup(*, force: bool, paste: bool) -> None:
     click.echo("")
     click.echo(
         CREATE_APP_INSTRUCTIONS.format(
-            url=_registration_url(target),
-            install_scope_hint=_install_scope_hint(target),
+            url=target.registration_url,
+            install_scope_hint=target.install_scope_hint,
         )
     )
     click.pause(info="Press any key when the App is created and the .pem is downloaded… ")

--- a/src/dev10x/domain/documents/plan.py
+++ b/src/dev10x/domain/documents/plan.py
@@ -58,6 +58,7 @@ def get_plan_path(*, toplevel: str) -> Path:
 class TaskTransition:
     timestamp_field: str | None
     allowed_from: frozenset[TaskStatus | None]
+    removes: bool = False
 
 
 # Declarative transition table. `allowed_from` lists the prior statuses
@@ -95,6 +96,7 @@ TASK_TRANSITIONS: dict[TaskStatus, TaskTransition] = {
                 TaskStatus.DELETED,
             }
         ),
+        removes=True,
     ),
 }
 
@@ -135,7 +137,7 @@ class Plan:
 
     def save(self, *, path: Path) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
-        plan_data = self._to_dict()
+        plan_data = self.to_dict()
         fd, tmp_path = tempfile.mkstemp(
             dir=str(path.parent),
             prefix=".plan-",
@@ -158,7 +160,7 @@ class Plan:
                 pass
             raise
 
-    def _to_dict(self) -> dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         result: dict[str, Any] = {}
         if self.metadata:
             result["plan"] = self.metadata
@@ -229,9 +231,6 @@ class Plan:
 
         raw_status = tool_input.get("status")
         target_status = _coerce_status(raw_status)
-        if target_status is TaskStatus.DELETED:
-            self.tasks = [t for t in self.tasks if t.id != task_id]
-            return
 
         idx = self._find_index(task_id=task_id)
         if idx is None:
@@ -243,6 +242,11 @@ class Plan:
                 # Reject invalid transitions silently; the hook must keep
                 # processing other updates rather than crashing on a stale
                 # status flip caused by clock skew or replay.
+                return
+            # DELETED is declared with `removes=True` in TASK_TRANSITIONS —
+            # the operation drops the task entry instead of restamping it.
+            if TASK_TRANSITIONS[target_status].removes:
+                del self.tasks[idx]
                 return
             task = task.with_status(status=target_status, timestamp=_now_iso())
 

--- a/src/dev10x/domain/session_document.py
+++ b/src/dev10x/domain/session_document.py
@@ -78,7 +78,7 @@ def read_plan_summary(*, toplevel: str) -> dict[str, Any]:
     from dev10x.domain.documents.plan import Plan, get_plan_path
 
     plan_path = get_plan_path(toplevel=toplevel)
-    return Plan.load(path=plan_path)._to_dict()
+    return Plan.load(path=plan_path).to_dict()
 
 
 __all__ = [

--- a/src/dev10x/git/__init__.py
+++ b/src/dev10x/git/__init__.py
@@ -16,6 +16,49 @@ from dev10x.domain.common.result import Result, err, ok
 from dev10x.subprocess_utils import async_run_script, parse_key_value_output
 
 
+def _ok_json_or_kv(stdout: str) -> Result[dict[str, Any]]:
+    """Parse script stdout as JSON, falling back to KEY=VALUE lines."""
+    try:
+        return ok(json.loads(stdout))
+    except json.JSONDecodeError:
+        return ok(parse_key_value_output(stdout))
+
+
+def _conflict_error(stdout: str, *, extra: dict[str, Any] | None = None) -> Result[dict[str, Any]]:
+    """Build the shared rebase-conflict error payload from script stdout."""
+    parsed = parse_key_value_output(stdout)
+    fields: dict[str, Any] = {
+        "conflict": True,
+        "conflicted_files": [f for f in parsed.get("conflicted_files", "").split(",") if f],
+        "rebase_head": parsed.get("rebase_head", "unknown"),
+        "hint": parsed.get("hint", ""),
+    }
+    if extra:
+        fields.update(extra)
+    return err("Rebase conflict detected", **fields)
+
+
+async def _run_git_script(
+    script: str,
+    *args: str,
+    conflict_aware: bool = False,
+) -> Result[dict[str, Any]]:
+    """Run a git skill script and shape its result.
+
+    Centralizes the repeated returncode-check → JSON-or-KEY=VALUE success
+    parsing. When ``conflict_aware`` is set, a non-zero exit carrying a
+    ``CONFLICT_DETECTED`` marker yields the shared conflict error payload.
+    """
+    result = await async_run_script(script, *args)
+
+    if result.returncode != 0:
+        if conflict_aware and "CONFLICT_DETECTED" in result.stdout:
+            return _conflict_error(result.stdout.strip())
+        return err(result.stderr.strip())
+
+    return _ok_json_or_kv(result.stdout)
+
+
 async def push_safe(
     *,
     args: list[str],
@@ -26,41 +69,16 @@ async def push_safe(
         for pb in protected_branches:
             cmd_args.extend(["--protected", pb])
 
-    result = await async_run_script("skills/git/scripts/git-push-safe.sh", *cmd_args)
-
-    if result.returncode != 0:
-        return err(result.stderr.strip())
-
-    try:
-        return ok(json.loads(result.stdout))
-    except json.JSONDecodeError:
-        return ok(parse_key_value_output(result.stdout))
+    return await _run_git_script("skills/git/scripts/git-push-safe.sh", *cmd_args)
 
 
 async def rebase_groom(*, seq_path: str, base_ref: str) -> Result[dict[str, Any]]:
-    result = await async_run_script(
+    return await _run_git_script(
         "skills/git/scripts/git-rebase-groom.sh",
         seq_path,
         base_ref,
+        conflict_aware=True,
     )
-
-    if result.returncode != 0:
-        stdout = result.stdout.strip()
-        if "CONFLICT_DETECTED" in stdout:
-            parsed = parse_key_value_output(stdout)
-            return err(
-                "Rebase conflict detected",
-                conflict=True,
-                conflicted_files=[f for f in parsed.get("conflicted_files", "").split(",") if f],
-                rebase_head=parsed.get("rebase_head", "unknown"),
-                hint=parsed.get("hint", ""),
-            )
-        return err(result.stderr.strip())
-
-    try:
-        return ok(json.loads(result.stdout))
-    except json.JSONDecodeError:
-        return ok(parse_key_value_output(result.stdout))
 
 
 async def create_worktree(
@@ -84,18 +102,10 @@ async def create_worktree(
     if path is not None:
         wt_args.extend(["--path", path])
 
-    result = await async_run_script(
+    return await _run_git_script(
         "skills/git-worktree/scripts/create-worktree.sh",
         *wt_args,
     )
-
-    if result.returncode != 0:
-        return err(result.stderr.strip())
-
-    try:
-        return ok(json.loads(result.stdout))
-    except json.JSONDecodeError:
-        return ok(parse_key_value_output(result.stdout))
 
 
 async def mass_rewrite(*, config_path: str) -> Result[dict[str, Any]]:
@@ -107,15 +117,7 @@ async def mass_rewrite(*, config_path: str) -> Result[dict[str, Any]]:
     if result.returncode != 0:
         stdout = result.stdout.strip()
         if "CONFLICT_DETECTED" in stdout:
-            parsed = parse_key_value_output(stdout)
-            return err(
-                "Rebase conflict detected",
-                conflict=True,
-                conflicted_files=[f for f in parsed.get("conflicted_files", "").split(",") if f],
-                rebase_head=parsed.get("rebase_head", "unknown"),
-                hint=parsed.get("hint", ""),
-                output=stdout,
-            )
+            return _conflict_error(stdout, extra={"output": stdout})
         return err(result.stderr.strip(), output=stdout)
 
     return ok({"success": True, "output": result.stdout.strip()})

--- a/src/dev10x/hooks/task_plan_sync.py
+++ b/src/dev10x/hooks/task_plan_sync.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -28,7 +29,7 @@ from dev10x.plan.service import (
 
 def read_plan(*, plan_path: Path) -> dict[str, Any]:
     """Load plan YAML into a dict. Consumed by `dev10x.hooks.session`."""
-    return Plan.load(path=plan_path)._to_dict()
+    return Plan.load(path=plan_path).to_dict()
 
 
 def cmd_set_context(*, args: list[str]) -> None:
@@ -66,6 +67,21 @@ def cmd_json_summary() -> None:
     json.dump(summary, sys.stdout, indent=2)
 
 
+def _apply_task_create(*, plan: Plan, tool_input: dict[str, Any], tool_result: Any) -> bool:
+    return plan.handle_task_create(tool_input=tool_input, tool_result=tool_result)
+
+
+def _apply_task_update(*, plan: Plan, tool_input: dict[str, Any], tool_result: Any) -> bool:
+    plan.handle_task_update(tool_input=tool_input)
+    return True
+
+
+TOOL_HANDLERS: dict[str, Callable[..., bool]] = {
+    "TaskCreate": _apply_task_create,
+    "TaskUpdate": _apply_task_update,
+}
+
+
 def cmd_hook() -> None:
     payload_str = sys.stdin.read()
     if not payload_str.strip():
@@ -81,7 +97,9 @@ def cmd_hook() -> None:
     if isinstance(tool_result, dict):
         tool_result = tool_result.get("content", str(tool_result))
 
-    tool_name = payload.get("tool_name", "")
+    handler = TOOL_HANDLERS.get(payload.get("tool_name", ""))
+    if handler is None:
+        sys.exit(0)
 
     toplevel = get_toplevel()
     if not toplevel:
@@ -96,17 +114,7 @@ def cmd_hook() -> None:
         is_new_plan = plan.is_new
         plan.ensure_metadata()
 
-        changed = False
-        if tool_name == "TaskCreate":
-            changed = plan.handle_task_create(
-                tool_input=tool_input,
-                tool_result=tool_result,
-            )
-        elif tool_name == "TaskUpdate":
-            plan.handle_task_update(tool_input=tool_input)
-            changed = True
-        else:
-            sys.exit(0)
+        changed = handler(plan=plan, tool_input=tool_input, tool_result=tool_result)
 
         if is_new_plan and not changed:
             sys.exit(0)

--- a/src/dev10x/plan/service.py
+++ b/src/dev10x/plan/service.py
@@ -51,7 +51,7 @@ def plan_summary() -> dict[str, Any]:
     plan = Plan.load(path=plan_path)
     if plan.is_new:
         return {}
-    return plan._to_dict()
+    return plan.to_dict()
 
 
 def archive_plan() -> dict[str, Any]:

--- a/src/dev10x/skills/audit/analyze_actions.py
+++ b/src/dev10x/skills/audit/analyze_actions.py
@@ -153,32 +153,39 @@ def parse_turns(text: str) -> list[Turn]:
     return turns
 
 
+ACTION_TYPE_BY_TOOL: dict[str, str] = {
+    "Skill": "Skill",
+    "Agent": "Agent",
+    "TaskCreate": "Task",
+    "TaskUpdate": "Task",
+    "TaskList": "Task",
+    "TaskGet": "Task",
+    "AskUserQuestion": "Decision",
+    "Write": "CodeChange",
+    "Edit": "CodeChange",
+    "Read": "Read",
+    "Glob": "Search",
+    "Grep": "Search",
+    "WebFetch": "Web",
+    "WebSearch": "Web",
+}
+
+
+def _classify_bash(input_summary: str) -> str:
+    combined = f"Bash {input_summary}".lower()
+    for action_type, keywords in ACTION_KEYWORDS.items():
+        for kw in keywords:
+            if kw.lower() in combined:
+                return action_type
+    return "Other"
+
+
 def classify_action(tool_name: str, input_summary: str) -> str:
-    if tool_name == "Skill":
-        return "Skill"
-    if tool_name == "Agent":
-        return "Agent"
-    if tool_name in ("TaskCreate", "TaskUpdate", "TaskList", "TaskGet"):
-        return "Task"
-    if tool_name == "AskUserQuestion":
-        return "Decision"
-    if tool_name in ("Write", "Edit"):
-        return "CodeChange"
-    if tool_name == "Read":
-        return "Read"
-    if tool_name in ("Glob", "Grep"):
-        return "Search"
-    if tool_name in ("WebFetch", "WebSearch"):
-        return "Web"
-
-    combined = f"{tool_name} {input_summary}".lower()
-
+    mapped = ACTION_TYPE_BY_TOOL.get(tool_name)
+    if mapped is not None:
+        return mapped
     if tool_name == "Bash":
-        for action_type, keywords in ACTION_KEYWORDS.items():
-            for kw in keywords:
-                if kw.lower() in combined:
-                    return action_type
-
+        return _classify_bash(input_summary=input_summary)
     return "Other"
 
 

--- a/src/dev10x/validators/base.py
+++ b/src/dev10x/validators/base.py
@@ -41,6 +41,10 @@ class Validator(Protocol):
         """Return HookResult to block, HookAllow to auto-approve, None for no opinion."""
         ...
 
+    def run(self, inp: HookInput) -> HookResult | HookAllow | None:
+        """Template: ``should_run`` gate followed by ``validate``."""
+        ...
+
 
 @runtime_checkable
 class Corrector(Protocol):
@@ -71,3 +75,21 @@ class ValidatorBase:
     profile: ClassVar[ProfileTier] = ProfileTier.STANDARD
     experimental: ClassVar[bool] = False
     capabilities: ClassVar[frozenset[str]] = frozenset({"validate"})
+
+    def should_run(self, inp: HookInput) -> bool:
+        """Fast skip predicate — overridden by concrete validators."""
+        raise NotImplementedError  # pragma: no cover
+
+    def validate(self, inp: HookInput) -> HookResult | HookAllow | None:
+        """Block/allow/abstain decision — overridden by concrete validators."""
+        raise NotImplementedError  # pragma: no cover
+
+    def run(self, inp: HookInput) -> HookResult | HookAllow | None:
+        """Template method: skip when ``should_run`` is False, else ``validate``.
+
+        Consolidates the ``should_run`` → ``validate`` sequencing that the
+        dispatcher previously open-coded per call site.
+        """
+        if not self.should_run(inp=inp):
+            return None
+        return self.validate(inp=inp)

--- a/src/dev10x/validators/prefix_friction.py
+++ b/src/dev10x/validators/prefix_friction.py
@@ -279,6 +279,23 @@ class PrefixFrictionValidator(ValidatorBase):
     capabilities: ClassVar[frozenset[str]] = frozenset({"validate", "correct"})
     _allow_patterns: list[str] | None = field(default=None, repr=False)
 
+    # Ordered chain of prefix checks (PrefixCheck = method taking
+    # ``*, inp: HookInput`` and returning the first matching ``HookResult``).
+    # ``validate`` walks this list in order; the last entry is the
+    # fall-through ``&&``-chaining check.
+    _CHECKS: ClassVar[tuple[str, ...]] = (
+        "_check_cd_revparse_chain",
+        "_check_git_c_noop",
+        "_check_env_prefix_git",
+        "_check_merge_base",
+        "_check_cd_noop_chain",
+        "_check_cd_git_chain",
+        "_check_redirect_then_positional",
+        "_check_semicolon_chain",
+        "_check_shell_loop_wrap",
+        "_check_and_chaining",
+    )
+
     def should_run(self, inp: HookInput) -> bool:
         cmd = inp.command
         return (
@@ -297,50 +314,14 @@ class PrefixFrictionValidator(ValidatorBase):
         )
 
     def validate(self, inp: HookInput) -> HookResult | None:
-        result = self._check_cd_revparse_chain(command=inp.command)
-        if result:
-            return result
+        for check_name in self._CHECKS:
+            result: HookResult | None = getattr(self, check_name)(inp=inp)
+            if result is not None:
+                return result
+        return None
 
-        result = self._check_git_c_noop(command=inp.command, cwd=inp.cwd)
-        if result:
-            return result
-
-        result = self._check_env_prefix_git(command=inp.command)
-        if result:
-            return result
-
-        result = self._check_merge_base(command=inp.command)
-        if result:
-            return result
-
-        result = self._check_cd_noop_chain(command=inp.command, cwd=inp.cwd)
-        if result:
-            return result
-
-        result = self._check_cd_git_chain(command=inp.command)
-        if result:
-            return result
-
-        result = self._check_redirect_then_positional(command=inp.command)
-        if result:
-            return result
-
-        result = self._check_semicolon_chain(command=inp.command)
-        if result:
-            return result
-
-        result = self._check_shell_loop_wrap(command=inp.command)
-        if result:
-            return result
-
-        return self._check_and_chaining(command=inp.command)
-
-    def _check_cd_revparse_chain(
-        self,
-        *,
-        command: str,
-    ) -> HookResult | None:
-        match = CD_REVPARSE_RE.match(command)
+    def _check_cd_revparse_chain(self, *, inp: HookInput) -> HookResult | None:
+        match = CD_REVPARSE_RE.match(inp.command)
         if not match:
             return None
         bare = match.group(1).strip()
@@ -348,72 +329,62 @@ class PrefixFrictionValidator(ValidatorBase):
             message=CD_REVPARSE_MSG.format(bare_command=bare),
         )
 
-    def _check_git_c_noop(
-        self,
-        *,
-        command: str,
-        cwd: str,
-    ) -> HookResult | None:
-        if not cwd:
+    def _check_git_c_noop(self, *, inp: HookInput) -> HookResult | None:
+        if not inp.cwd:
             return None
-        match = GIT_C_RE.search(command)
+        match = GIT_C_RE.search(inp.command)
         if not match:
             return None
         target = os.path.normpath(os.path.expanduser(match.group(1).strip("\"'")))
-        normalized_cwd = os.path.normpath(cwd)
+        normalized_cwd = os.path.normpath(inp.cwd)
         if target != normalized_cwd:
             return None
-        bare = GIT_C_RE.sub("git", command, count=1).strip()
+        bare = GIT_C_RE.sub("git", inp.command, count=1).strip()
         return HookResult(
             message=GIT_C_NOOP_MSG.format(
                 path=match.group(1),
-                cwd=cwd,
+                cwd=inp.cwd,
                 bare_command=bare,
             ),
         )
 
-    def _check_cd_noop_chain(
-        self,
-        *,
-        command: str,
-        cwd: str,
-    ) -> HookResult | None:
-        if not cwd:
+    def _check_cd_noop_chain(self, *, inp: HookInput) -> HookResult | None:
+        if not inp.cwd:
             return None
-        match = CD_NOOP_RE.match(command)
+        match = CD_NOOP_RE.match(inp.command)
         if not match:
             return None
         target = os.path.normpath(os.path.expanduser(match.group(1).strip("\"'")))
-        normalized_cwd = os.path.normpath(cwd)
+        normalized_cwd = os.path.normpath(inp.cwd)
         if target != normalized_cwd:
             return None
         bare = match.group(2).strip()
         return HookResult(
             message=CD_NOOP_MSG.format(
                 path=match.group(1),
-                cwd=cwd,
+                cwd=inp.cwd,
                 bare_command=bare,
             ),
         )
 
-    def _check_env_prefix_git(self, *, command: str) -> HookResult | None:
-        if ENV_PREFIX_GIT_RE.match(command):
-            bare = _extract_bare_command(command=command)
+    def _check_env_prefix_git(self, *, inp: HookInput) -> HookResult | None:
+        if ENV_PREFIX_GIT_RE.match(inp.command):
+            bare = _extract_bare_command(command=inp.command)
             return HookResult(message=ENV_PREFIX_MSG.format(bare_command=bare))
         return None
 
-    def _check_merge_base(self, *, command: str) -> HookResult | None:
-        merge_match = MERGE_BASE_RE.search(command)
+    def _check_merge_base(self, *, inp: HookInput) -> HookResult | None:
+        merge_match = MERGE_BASE_RE.search(inp.command)
         if not merge_match:
             return None
         branch = merge_match.group(1)
-        sub_match = GIT_SUBCOMMAND_RE.search(command)
+        sub_match = GIT_SUBCOMMAND_RE.search(inp.command)
         subcommand = sub_match.group(1) if sub_match else None
         alias = _suggest_alias(branch=branch, subcommand=subcommand)
         return HookResult(message=MERGE_BASE_MSG.format(alias=alias))
 
-    def _check_cd_git_chain(self, *, command: str) -> HookResult | None:
-        match = CD_GIT_CHAIN_RE.match(command)
+    def _check_cd_git_chain(self, *, inp: HookInput) -> HookResult | None:
+        match = CD_GIT_CHAIN_RE.match(inp.command)
         if not match:
             return None
         path = match.group(1)
@@ -422,8 +393,8 @@ class PrefixFrictionValidator(ValidatorBase):
             message=CD_GIT_CHAIN_MSG.format(path=path, args=args),
         )
 
-    def _check_redirect_then_positional(self, *, command: str) -> HookResult | None:
-        match = REDIRECT_THEN_POSITIONAL_RE.match(command)
+    def _check_redirect_then_positional(self, *, inp: HookInput) -> HookResult | None:
+        match = REDIRECT_THEN_POSITIONAL_RE.match(inp.command)
         if not match:
             return None
         cmd = match.group("cmd")
@@ -439,8 +410,8 @@ class PrefixFrictionValidator(ValidatorBase):
             )
         )
 
-    def _check_semicolon_chain(self, *, command: str) -> HookResult | None:
-        match = SEMICOLON_CHAIN_RE.match(command)
+    def _check_semicolon_chain(self, *, inp: HookInput) -> HookResult | None:
+        match = SEMICOLON_CHAIN_RE.match(inp.command)
         if not match:
             return None
         head_cmd = match.group("head").strip().split()[0]
@@ -452,7 +423,8 @@ class PrefixFrictionValidator(ValidatorBase):
             )
         )
 
-    def _check_shell_loop_wrap(self, *, command: str) -> HookResult | None:
+    def _check_shell_loop_wrap(self, *, inp: HookInput) -> HookResult | None:
+        command = inp.command
         loop_match = SHELL_LOOP_HEAD_RE.match(command)
         if loop_match:
             inner = self._inner_command_from(body=loop_match.group("body"))
@@ -509,7 +481,8 @@ class PrefixFrictionValidator(ValidatorBase):
                 return head
         return None
 
-    def _check_and_chaining(self, *, command: str) -> HookResult | None:
+    def _check_and_chaining(self, *, inp: HookInput) -> HookResult | None:
+        command = inp.command
         if "&&" not in command:
             return None
 

--- a/src/dev10x/validators/registry.py
+++ b/src/dev10x/validators/registry.py
@@ -201,9 +201,7 @@ class ValidatorChain:
         results: list[HookResult | HookAllow] = []
         for validator in self.registry.active():
             try:
-                if not validator.should_run(inp=inp):
-                    continue
-                result = validator.validate(inp=inp)
+                result = validator.run(inp=inp)
             except Exception:
                 _log_validator_error(validator=validator, method="validate")
                 continue

--- a/tests/commands/test_github_app.py
+++ b/tests/commands/test_github_app.py
@@ -233,31 +233,31 @@ class TestPromptInstallTarget:
         runner = CliRunner()
         with runner.isolation(input="1\n"):
             target = gha._prompt_install_target()
-        assert target == {"kind": "personal"}
+        assert target == gha.InstallTarget(kind="personal")
 
     def test_org_choice(self) -> None:
         runner = CliRunner()
         with runner.isolation(input="2\nDev10x-Guru\n"):
             target = gha._prompt_install_target()
-        assert target == {"kind": "org", "org": "Dev10x-Guru"}
+        assert target == gha.InstallTarget(kind="org", org="Dev10x-Guru")
 
     def test_manual_choice(self) -> None:
         runner = CliRunner()
         with runner.isolation(input="3\n"):
             target = gha._prompt_install_target()
-        assert target == {"kind": "manual"}
+        assert target == gha.InstallTarget(kind="manual")
 
     def test_retries_on_invalid_choice(self) -> None:
         runner = CliRunner()
         with runner.isolation(input="9\n1\n"):
             target = gha._prompt_install_target()
-        assert target == {"kind": "personal"}
+        assert target == gha.InstallTarget(kind="personal")
 
     def test_retries_on_empty_org(self) -> None:
         runner = CliRunner()
         with runner.isolation(input="2\n\nDev10x-Guru\n"):
             target = gha._prompt_install_target()
-        assert target == {"kind": "org", "org": "Dev10x-Guru"}
+        assert target == gha.InstallTarget(kind="org", org="Dev10x-Guru")
 
 
 class TestPromptPrivateKeyPath:
@@ -328,28 +328,28 @@ class TestVerifySetupApiErrors:
 
 class TestRegistrationUrl:
     def test_personal(self) -> None:
-        assert gha._registration_url({"kind": "personal"}) == gha.PERSONAL_NEW_APP_URL
+        assert gha.InstallTarget(kind="personal").registration_url == gha.PERSONAL_NEW_APP_URL
 
     def test_org(self) -> None:
-        url = gha._registration_url({"kind": "org", "org": "tiretutorinc"})
+        url = gha.InstallTarget(kind="org", org="tiretutorinc").registration_url
         assert url == "https://github.com/organizations/tiretutorinc/settings/apps/new"
 
     def test_manual_returns_placeholder(self) -> None:
-        url = gha._registration_url({"kind": "manual"})
+        url = gha.InstallTarget(kind="manual").registration_url
         assert "yourself" in url
 
 
 class TestInstallScopeHint:
     def test_personal_steers_to_any_account(self) -> None:
-        hint = gha._install_scope_hint({"kind": "personal"})
+        hint = gha.InstallTarget(kind="personal").install_scope_hint
         assert '"Any account"' in hint
 
     def test_org_explains_implicit_scope(self) -> None:
-        hint = gha._install_scope_hint({"kind": "org", "org": "x"})
+        hint = gha.InstallTarget(kind="org", org="x").install_scope_hint
         assert "owned by the org" in hint
 
     def test_manual_covers_both(self) -> None:
-        hint = gha._install_scope_hint({"kind": "manual"})
+        hint = gha.InstallTarget(kind="manual").install_scope_hint
         assert "Any account" in hint
 
 

--- a/tests/plan/test_plan.py
+++ b/tests/plan/test_plan.py
@@ -101,7 +101,7 @@ class TestJsonSummary:
     ) -> None:
         mock_plan = MagicMock()
         mock_plan.is_new = False
-        mock_plan._to_dict.return_value = {"metadata": {"branch": "feature"}}
+        mock_plan.to_dict.return_value = {"metadata": {"branch": "feature"}}
         mock_plan_cls.load.return_value = mock_plan
         result = await plan_mod.json_summary()
         assert isinstance(result, SuccessResult)

--- a/tests/test_cli_lazy.py
+++ b/tests/test_cli_lazy.py
@@ -1,0 +1,44 @@
+"""Guards for the Click LazyGroup CLI (GH-249 H10).
+
+The lazy-loading CLI defers subcommand imports for startup speed
+(see `.claude/rules/performance.md`). These tests pin the registered
+subcommand set so a subcommand cannot silently fall out of the
+`lazy_subcommands` map, and verify every declared import path resolves
+to a real Click command.
+"""
+
+from __future__ import annotations
+
+import click
+import pytest
+
+from dev10x.cli import cli
+
+EXPECTED_SUBCOMMANDS = {
+    "config",
+    "github-app",
+    "hook",
+    "init",
+    "permission",
+    "platform",
+    "playbook",
+    "validate",
+    "skill",
+}
+
+
+def test_all_subcommands_registered_lazily() -> None:
+    assert set(cli._lazy_subcommands) == EXPECTED_SUBCOMMANDS
+
+
+def test_list_commands_includes_every_lazy_subcommand() -> None:
+    ctx = click.Context(cli)
+    listed = cli.list_commands(ctx)
+    assert EXPECTED_SUBCOMMANDS.issubset(set(listed))
+
+
+@pytest.mark.parametrize("name", sorted(EXPECTED_SUBCOMMANDS))
+def test_lazy_subcommand_loads(name: str) -> None:
+    ctx = click.Context(cli)
+    command = cli.get_command(ctx, name)
+    assert isinstance(command, click.BaseCommand)

--- a/tests/validators/test_registry.py
+++ b/tests/validators/test_registry.py
@@ -316,3 +316,25 @@ class TestValidatorChain:
         registry._instances = [_Raiser()]  # type: ignore[attr-defined]
         chain = ValidatorChain(registry=registry)
         assert chain.correct(inp=stub_input) is None
+
+
+class TestValidatorBaseTemplate:
+    def test_run_validates_when_should_run_true(self, stub_input: HookInput) -> None:
+        result = _StubValidator().run(inp=stub_input)
+        assert isinstance(result, HookResult)
+        assert result.message == "stub-blocked"
+
+    def test_run_skips_when_should_run_false(self, stub_input: HookInput) -> None:
+        @dataclass
+        class _Skipper(ValidatorBase):
+            name: ClassVar[str] = "skipper"
+            rule_id: ClassVar[str] = "DX902"
+            profile: ClassVar[ProfileTier] = ProfileTier.MINIMAL
+
+            def should_run(self, inp: HookInput) -> bool:
+                return False
+
+            def validate(self, inp: HookInput) -> HookResult | None:
+                raise AssertionError("validate must not run when should_run is False")
+
+        assert _Skipper().run(inp=stub_input) is None


### PR DESCRIPTION
**When** the M10 audit findings flag if/elif dispatch chains, repeated should_run/validate sequencing, and a bypassed task-state transition as low-risk pattern debt, **I want to** replace them with declarative dispatch tables and template-method patterns, **so I can** keep hook, validator, and state-machine logic uniform and cheap to extend without re-reading branchy code.

This is a partial M10 pass — 11 of 36 findings (F1, F2, F3, F6, F7, F8, F9, F10, B2, H10; I5 verified already resolved). The remaining 25 findings (incl. now-unblocked B9) are deferred to a follow-up; GH-249 stays open.

---

[`1bfad8c9`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/389/commits/1bfad8c9f9c6bacfe4dc8d18deb41688b7bb8dc2) ♻️ GH-249 Simplify dispatch and validator wiring (M10)

Fixes: none — self-motivated