### PR TITLE
✨ GH-387 Require --plugin-dir smoke run before tagging

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -6,11 +6,17 @@
 # tags it, resets main, and bumps develop to the next dev version.
 #
 # Usage: ./bin/release.sh {features|fixes|major}
+#
+# A dogfood smoke gate (Phase 2b) blocks tagging until you confirm
+# that you have run a real --plugin-dir session with the release candidate.
+# Skip with SKIP_DOGFOOD=1 (CI-only escape hatch — never for human releases).
 set -euo pipefail
 
 CYAN='\033[0;36m'
 GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
+RED='\033[0;31m'
+BOLD='\033[1m'
 RESET='\033[0m'
 
 VERSION_FILES=".bumpversion.toml .claude-plugin/plugin.json pyproject.toml uv.lock skills/playbook/references/playbook.yaml"
@@ -78,6 +84,96 @@ function bump_version {
     git commit -m "🔖 Bump version: ${before} → ${after}"
 }
 
+# Detect the installed marketplace plugin version, if any.
+# Prints the version string or "unknown" if not detectable.
+function installed_plugin_version {
+    local plugin_json=""
+    # Try ~/.claude/plugins/Dev10x-Claude/plugin.json (marketplace install path)
+    if [[ -f "${HOME}/.claude/plugins/Dev10x-Claude/plugin.json" ]]; then
+        plugin_json="${HOME}/.claude/plugins/Dev10x-Claude/plugin.json"
+    elif [[ -f "${HOME}/.config/claude/plugins/Dev10x-Claude/plugin.json" ]]; then
+        plugin_json="${HOME}/.config/claude/plugins/Dev10x-Claude/plugin.json"
+    fi
+    if [[ -n "$plugin_json" ]]; then
+        # Extract version field with jq if available, otherwise grep
+        if command -v jq >/dev/null 2>&1; then
+            jq -r '.version // "unknown"' "$plugin_json" 2>/dev/null || echo "unknown"
+        else
+            grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' "$plugin_json" \
+                | grep -o '"[^"]*"$' | tr -d '"' 2>/dev/null || echo "unknown"
+        fi
+    else
+        echo "unknown"
+    fi
+}
+
+# Phase 2b: Dogfood smoke gate.
+# Require the releaser to confirm a real --plugin-dir session before tagging.
+# This gate exists because CI only runs under mocks; the only true runtime
+# validation of MCP-server and permission-hook changes requires a live session
+# with the develop checkout loaded via --plugin-dir.
+function dogfood_gate {
+    local rc_version="$1"
+    local repo_root
+    repo_root="$(git rev-parse --show-toplevel)"
+
+    if [[ "${SKIP_DOGFOOD:-}" == "1" ]]; then
+        echo -e "  ${YELLOW}⚠  SKIP_DOGFOOD=1 — skipping dogfood gate (CI mode)${RESET}"
+        return 0
+    fi
+
+    header "Phase 2b · Dogfood smoke gate (REQUIRED before tagging)"
+
+    # Surface version-skew information so the releaser knows what they're testing.
+    local installed
+    installed="$(installed_plugin_version)"
+    echo ""
+    echo -e "  ${BOLD}Release candidate:${RESET} ${rc_version}"
+    if [[ "$installed" == "unknown" ]]; then
+        echo -e "  ${BOLD}Installed plugin:${RESET}  not detected (marketplace checkout absent)"
+    elif [[ "$installed" == "$rc_version" ]]; then
+        echo -e "  ${BOLD}Installed plugin:${RESET}  ${installed} ${GREEN}(matches RC — no skew)${RESET}"
+    else
+        echo -e "  ${BOLD}Installed plugin:${RESET}  ${installed} ${YELLOW}⚠ version skew — installed lags RC${RESET}"
+        echo -e "  ${YELLOW}  The in-session MCP server will be the OLD plugin until you restart${RESET}"
+        echo -e "  ${YELLOW}  claude with --plugin-dir pointing to this checkout.${RESET}"
+    fi
+
+    echo ""
+    echo -e "  ${BOLD}Before confirming, you must run a real --plugin-dir session:${RESET}"
+    echo ""
+    echo -e "    ${CYAN}claude --plugin-dir ${repo_root}${RESET}"
+    echo ""
+    echo -e "  ${BOLD}Minimum smoke checklist:${RESET}"
+    echo "    □  Start a session and verify the plugin loads without errors"
+    echo "    □  Run one Dev10x skill that exercises recent MCP-server changes"
+    echo "       e.g. Dev10x:gh-pr-review or Dev10x:gh-pr-respond"
+    echo "       (hits resolve_review_thread + pr_get — both new in this cycle)"
+    echo "    □  Run one git commit via Dev10x:git-commit"
+    echo "       (exercises bash tokenizer + privilege-escalation denies)"
+    echo "    □  Confirm no unexpected permission prompts or tool errors"
+    echo ""
+    echo -e "  ${BOLD}Optionally document the smoke run in docs/smoke-runs/:${RESET}"
+    echo "    echo \"\$(date -u +%Y-%m-%dT%H:%M:%SZ)  ${rc_version}  OK\" >> docs/smoke-runs/log.txt"
+    echo ""
+    echo -e "  ${RED}${BOLD}This gate blocks an irreversible tag. CI alone is not enough.${RESET}"
+    echo ""
+    echo -e "  Type ${BOLD}ship ${rc_version}${RESET} to confirm you have completed the smoke run:"
+    read -r confirmation
+
+    local expected="ship ${rc_version}"
+    if [[ "$confirmation" != "$expected" ]]; then
+        echo ""
+        echo -e "  ${RED}✗ Confirmation mismatch. Expected: '${expected}'${RESET}"
+        echo -e "  ${RED}  Tagging aborted. Complete the smoke run and re-run release.sh.${RESET}"
+        echo ""
+        exit 1
+    fi
+
+    echo ""
+    echo -e "  ${GREEN}✓ Dogfood smoke confirmed. Proceeding to tag.${RESET}"
+}
+
 function release {
     local pre_bump="${1:-}"
 
@@ -88,6 +184,11 @@ function release {
     finalize_version
 
     local tag="v$(current_version)"
+    local rc_version
+    rc_version="$(current_version)"
+
+    # Dogfood gate: must pass before the tag is created.
+    dogfood_gate "$rc_version"
 
     header "Phase 3 · Tag and push"
     step "Creating tag: $tag"
@@ -139,6 +240,9 @@ case "${1:-}" in
         echo "  features  Strip .dev0, tag, release, bump to next minor .dev0"
         echo "  fixes     Bump patch, strip .dev0, tag, release, bump to next minor .dev0"
         echo "  major     Bump major, strip .dev0, tag, release, bump to next minor .dev0"
+        echo ""
+        echo "Environment:"
+        echo "  SKIP_DOGFOOD=1  Skip the dogfood smoke gate (CI only)"
         exit 1
         ;;
 esac

--- a/docs/development.md
+++ b/docs/development.md
@@ -88,10 +88,46 @@ parsing patterns.
 ## Release process
 
 ```bash
-bin/release.sh patch    # bump version, tag, push
-bin/release.sh minor
+bin/release.sh features   # strip .dev0, tag, release, bump to next minor .dev0
+bin/release.sh fixes      # bump patch, strip .dev0, tag, release
+bin/release.sh major      # bump major, strip .dev0, tag, release
 ```
 
 Releases merge `develop` → `main` and create a GitHub release.
+
+### Dogfood smoke gate (Phase 2b)
+
+The release script requires a manual smoke confirmation before tagging.
+After preparing the version (Phase 2), the script pauses and prints:
+
+```
+claude --plugin-dir /path/to/Dev10x-Claude
+```
+
+You must run a real `--plugin-dir` session with the release candidate and
+verify:
+
+- Plugin loads without errors
+- One Dev10x skill that exercises recent MCP-server changes runs cleanly
+  (e.g. `Dev10x:gh-pr-review` or `Dev10x:gh-pr-respond`)
+- One `Dev10x:git-commit` to exercise the bash tokenizer and
+  privilege-escalation denies
+- No unexpected permission prompts or tool errors
+
+The script also surfaces a version-skew warning when the installed
+marketplace plugin lags the develop checkout, so you know which MCP server
+is active.
+
+Type `ship <version>` at the prompt to confirm and proceed to tagging.
+
+**Why**: CI runs under mocks. The only true runtime validation of
+MCP-server and permission-hook changes requires a live session with the
+develop checkout loaded via `--plugin-dir`.
+
+To skip in CI (automated pipelines only):
+
+```bash
+SKIP_DOGFOOD=1 bin/release.sh features
+```
 
 [Back to README](../README.md)


### PR DESCRIPTION
**When** I cut a release that includes MCP-server or permission-hook changes, **I want to** be required to exercise the release candidate code in a real `--plugin-dir` session before tagging, **so I can** avoid shipping a server/hook surface that only ever ran under mocks and a stale installed plugin.

---

[`046a0f46`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/392/commits/046a0f461e89ce90bc4d224f5c8e01d86519a86a) ✨ GH-387 Require --plugin-dir smoke run before tagging
Closes #387
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/387

---