### PR TITLE
🐛 GH-391 Prevent clean from silently removing covered rules

### DIFF
--- a/references/permission-architecture.md
+++ b/references/permission-architecture.md
@@ -184,6 +184,33 @@ When evaluating a new permission group:
   stall? Include evidence from issue/PR discussion (e.g., "6+ doc domains hit")
 - **Tier 3**: Document why the group is project-specific; confirm no universal use
 
+## Docs-vs-Evidence Caveat (finding #47)
+
+Official Claude Code docs state that permission rules merge across
+scopes rather than override ("rules from global settings are inherited
+into project settings"). **Treat this as intended, not actual
+behavior.**
+
+Empirical evidence from [#47](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/47)
+(closed by [#50](https://github.com/Dev10x-Guru/Dev10x-Claude/issues/50))
+establishes the opposite: when a project has its own
+`settings.local.json`, the **local file wins** and global rules are
+not always inherited. Practical consequences:
+
+- A project-level rule that is an exact duplicate of a global rule is
+  NOT necessarily redundant — the project copy may be the only active
+  copy for that project's sessions.
+- `dev10x permission clean` removes exact duplicates of global rules
+  by default (historical behavior). Use `--skip-global-dedup` to
+  suppress this when inheritance cannot be verified.
+- The `permission-investigator` skill and `permission-auditor` agent
+  are the authoritative sources for per-project rule coverage; trust
+  their output over the upstream documentation.
+
+**Rule of thumb:** do not cite the "permissions merge" docs as a
+reason to remove a project rule. Run `dev10x permission investigate`
+or check `permission-auditor` findings instead.
+
 ## References
 
 - [ADR-0003](../docs/adr/0003-allow-rules-as-hook-enablers.md) — decision record

--- a/src/dev10x/commands/permission.py
+++ b/src/dev10x/commands/permission.py
@@ -304,7 +304,19 @@ def init() -> None:
     help="Print one line per changed file (count) instead of full per-file details",
 )
 @click.option("--restore", is_flag=True, help="Restore settings from most recent backups")
-def clean(*, dry_run: bool, verbose: bool, summary: bool, restore: bool) -> None:
+@click.option(
+    "--skip-global-dedup",
+    is_flag=True,
+    default=False,
+    help=(
+        "Do not remove project rules that are exact duplicates of global rules. "
+        "Use this when global→project rule inheritance cannot be verified "
+        "(finding #47: local settings.local.json may not inherit global rules)."
+    ),
+)
+def clean(
+    *, dry_run: bool, verbose: bool, summary: bool, restore: bool, skip_global_dedup: bool
+) -> None:
     """Clean redundant permissions from project settings files."""
     from dev10x.skills.permission import clean_project_files as mod
 
@@ -342,6 +354,7 @@ def clean(*, dry_run: bool, verbose: bool, summary: bool, restore: bool) -> None
     total_kept = 0
     files_changed = 0
     total_secrets = 0
+    total_global_dedup = 0
 
     for path in sorted(settings_files):
         result, messages = mod.clean_file(
@@ -352,6 +365,7 @@ def clean(*, dry_run: bool, verbose: bool, summary: bool, restore: bool) -> None
             cache_root=cache_root,
             dry_run=dry_run,
             verbose=verbose,
+            skip_global_dedup=skip_global_dedup,
         )
         if result is None:
             click.echo(f"\n{path}")
@@ -376,6 +390,7 @@ def clean(*, dry_run: bool, verbose: bool, summary: bool, restore: bool) -> None
             total_removed += result.total_removed
             total_kept += len(result.kept)
             total_secrets += len(result.leaked_secrets)
+            total_global_dedup += len(result.exact_duplicates)
             if result.total_removed > 0:
                 files_changed += 1
         else:
@@ -388,6 +403,14 @@ def clean(*, dry_run: bool, verbose: bool, summary: bool, restore: bool) -> None
         verb = "Would remove" if dry_run else "Removed"
         click.echo(f"{verb} {total_removed} rules across {files_changed} files.")
         click.echo(f"Kept {total_kept} rules total.")
+
+    if total_global_dedup > 0 and not skip_global_dedup:
+        click.echo(
+            f"\n⚠  WARNING: {total_global_dedup} rules removed as exact duplicates of global"
+            " rules. Global→project rule inheritance is NOT guaranteed when a project has its"
+            " own settings.local.json (finding #47). Re-run with --skip-global-dedup to"
+            " preserve project-local copies if you see new permission prompts."
+        )
 
     if total_secrets > 0:
         click.echo(

--- a/src/dev10x/skills/permission/clean_project_files.py
+++ b/src/dev10x/skills/permission/clean_project_files.py
@@ -2,14 +2,24 @@
 
 Compares project-level allow rules against global ~/.claude/settings.json
 and strips rules that are:
-  - Exact duplicates of global rules
-  - Covered by global wildcard patterns (MCP families, plugin path wildcards)
+  - Exact string duplicates of global rules (see WARNING below)
   - Old plugin version paths (any version older than current)
   - Env-prefixed session noise (GIT_SEQUENCE_EDITOR=*, DATABASE_URL=*, etc.)
   - Shell control flow fragments (do, done, fi, for, while, etc.)
   - Double-slash path typos (Read(//...), Write(//...))
 
 Also flags rules containing leaked secrets (env vars with plaintext values).
+
+WARNING — global-dedup assumption (#47):
+  The exact-duplicate removal assumes global ~/.claude/settings.json rules
+  are reliably inherited into every project that has its own
+  settings.local.json.  Empirical evidence (#47, closed by #50) shows this
+  is NOT always true: when a project has its own settings.local.json, the
+  local file appears to win and global rules are not always inherited.
+  Removing a project rule solely because it duplicates a global rule can
+  therefore reintroduce per-invocation permission prompts for that project.
+  Use ``--skip-global-dedup`` (or ``skip_global_dedup=True`` in code) to
+  preserve project-local copies of global rules when you need certainty.
 
 CLI entry point: ``dev10x permission clean``.
 """
@@ -253,6 +263,7 @@ def classify_rules(
     cache_root: Path | None = None,
     deny_rules: list[str] | None = None,
     ask_rules: list[str] | None = None,
+    skip_global_dedup: bool = False,
 ) -> RemovalResult:
     result = RemovalResult()
     _base = base_permissions or set()
@@ -285,7 +296,7 @@ def classify_rules(
             result.kept.append(rule)
             continue
 
-        if rule in global_rules:
+        if not skip_global_dedup and rule in global_rules:
             result.exact_duplicates.append(rule)
             continue
 
@@ -327,6 +338,7 @@ def clean_file(
     cache_root: Path | None = None,
     dry_run: bool = False,
     verbose: bool = False,
+    skip_global_dedup: bool = False,
 ) -> tuple[RemovalResult | None, list[str]]:
     content = path.read_text()
     try:
@@ -350,6 +362,7 @@ def clean_file(
         cache_root=cache_root,
         deny_rules=deny_list if deny_list else None,
         ask_rules=ask_list if ask_list else None,
+        skip_global_dedup=skip_global_dedup,
     )
 
     has_findings = (

--- a/tests/skills/upgrade-cleanup/test_clean_project_files.py
+++ b/tests/skills/upgrade-cleanup/test_clean_project_files.py
@@ -708,3 +708,156 @@ class TestVerboseFormatting:
         output = "\n".join(messages)
         assert "1 exact duplicates" in output
         assert "Bash(git log:*)" not in output
+
+
+class TestExactMatchNoSubsumptionContract:
+    """Regression tests pinning the exact-match / no-subsumption contract.
+
+    Finding #47 + GH-391: clean removes a project rule only when the rule
+    string is an EXACT match of a global rule string.  No wildcard-expansion
+    or subsumption logic is applied — a global ``**`` does NOT subsume a
+    pinned project rule.
+    """
+
+    PINNED_RULE = (
+        "Bash(/home/user/.claude/plugins/cache/Dev10x-Guru/"
+        "Dev10x/0.76.0/skills/git-commit/scripts/commit.sh:*)"
+    )
+
+    def test_global_wildcard_does_not_subsume_pinned_project_rule(self) -> None:
+        """A global ``**`` wildcard must NOT cause the pinned project rule to
+        be classified as an exact duplicate and removed."""
+        global_rules = {"Bash(/home/user/.claude/plugins/cache/Dev10x-Guru/Dev10x/**)"}
+        rules = [self.PINNED_RULE]
+
+        result = clean_mod.classify_rules(
+            rules,
+            global_rules=global_rules,
+            current_version="0.76.0",
+        )
+
+        assert self.PINNED_RULE in result.kept
+        assert result.exact_duplicates == []
+        assert result.total_removed == 0
+
+    def test_exact_string_match_is_removed(self) -> None:
+        """A project rule that is an exact copy of a global rule is classified
+        as ``exact_duplicate`` and removed by default."""
+        rule = "Bash(git status:*)"
+        global_rules = {rule}
+
+        result = clean_mod.classify_rules(
+            [rule],
+            global_rules=global_rules,
+            current_version="0.76.0",
+        )
+
+        assert result.exact_duplicates == [rule]
+        assert result.kept == []
+        assert result.total_removed == 1
+
+    def test_near_match_is_not_removed(self) -> None:
+        """A rule that differs even in prefix style (tilde vs absolute path)
+        is NOT treated as a duplicate — only identical strings qualify."""
+        global_rule = "Bash(~/.claude/plugins/cache/Dev10x-Guru/Dev10x/0.76.0/foo.sh:*)"
+        project_rule = "Bash(/home/user/.claude/plugins/cache/Dev10x-Guru/Dev10x/0.76.0/foo.sh:*)"
+        global_rules = {global_rule}
+
+        result = clean_mod.classify_rules(
+            [project_rule],
+            global_rules=global_rules,
+            current_version="0.76.0",
+        )
+
+        assert result.exact_duplicates == []
+        assert project_rule in result.kept or project_rule in result.old_versions
+
+
+class TestSkipGlobalDedup:
+    """Tests for the ``skip_global_dedup`` opt-in flag (GH-391, finding #47).
+
+    When ``skip_global_dedup=True``, rules that are exact string duplicates
+    of global rules are kept instead of being classified for removal.
+    All other removal categories (old versions, env noise, etc.) are
+    unaffected.
+    """
+
+    GLOBAL_RULES = {
+        "Bash(git log:*)",
+        "Bash(gh pr view:*)",
+    }
+
+    def test_skip_global_dedup_preserves_exact_duplicates(self) -> None:
+        rules = ["Bash(git log:*)", "Bash(docker compose up)"]
+
+        result = clean_mod.classify_rules(
+            rules,
+            global_rules=self.GLOBAL_RULES,
+            current_version="0.76.0",
+            skip_global_dedup=True,
+        )
+
+        assert result.exact_duplicates == []
+        assert "Bash(git log:*)" in result.kept
+        assert "Bash(docker compose up)" in result.kept
+        assert result.total_removed == 0
+
+    def test_skip_global_dedup_default_is_false(self) -> None:
+        """Without skip_global_dedup, exact duplicates are still removed."""
+        rules = ["Bash(git log:*)"]
+
+        result = clean_mod.classify_rules(
+            rules,
+            global_rules=self.GLOBAL_RULES,
+            current_version="0.76.0",
+        )
+
+        assert result.exact_duplicates == ["Bash(git log:*)"]
+        assert result.kept == []
+
+    def test_skip_global_dedup_does_not_suppress_other_removals(self) -> None:
+        """skip_global_dedup only exempts the global-exact-match check;
+        old-version, env-noise, and shell-fragment removal are unaffected."""
+        old_version_rule = (
+            "Bash(/home/u/.claude/plugins/cache/Dev10x-Guru/dev10x-claude/0.4.0/scripts/foo.sh:*)"
+        )
+        env_noise_rule = "Bash(GIT_SEQUENCE_EDITOR=: git rebase)"
+        global_dup_rule = "Bash(git log:*)"
+        rules = [old_version_rule, env_noise_rule, global_dup_rule]
+
+        result = clean_mod.classify_rules(
+            rules,
+            global_rules=self.GLOBAL_RULES,
+            current_version="0.76.0",
+            skip_global_dedup=True,
+        )
+
+        assert result.exact_duplicates == []
+        assert global_dup_rule in result.kept
+        assert len(result.old_versions) == 1
+        assert len(result.env_noise) == 1
+        assert result.total_removed == 2
+
+    def test_skip_global_dedup_in_clean_file(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """clean_file passes skip_global_dedup through to classify_rules."""
+        settings_file = tmp_path / "settings.local.json"
+        settings_file.write_text(
+            json.dumps({"permissions": {"allow": ["Bash(git log:*)", "Bash(docker up)"]}}) + "\n"
+        )
+        global_rules = {"Bash(git log:*)"}
+
+        result, _messages = clean_mod.clean_file(
+            settings_file,
+            global_rules=global_rules,
+            current_version="0.76.0",
+            skip_global_dedup=True,
+        )
+
+        assert result is not None
+        assert result.exact_duplicates == []
+        assert result.total_removed == 0
+        data = json.loads(settings_file.read_text())
+        assert "Bash(git log:*)" in data["permissions"]["allow"]


### PR DESCRIPTION
**When** I run `dev10x permission clean`, **I want to** trust that it won't silently remove project-local rules that might not be covered by global rules, **so I can** avoid phantom permission prompts after cleanup.

---

[`f83fe048`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/393/commits/f83fe04819045485bdadb24f4aea6cab3d7061ce) 🐛 GH-391 Prevent clean from silently removing covered rules

Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/391