### PR TITLE
📝 GH-388 Enable milestone collision-free naming across initiatives

### DIFF
--- a/.claude/rules/INDEX.md
+++ b/.claude/rules/INDEX.md
@@ -91,6 +91,7 @@ Always apply `references/review-checks-common.md`.
 | `config-resolution.md` | 3-tier config paths, project mapping format | All playbook/settings skills | Referenced, not auto-loaded |
 | `testing-patterns.md` | Pytest fixture composition, async handlers, parametrized tests | Code reviews, test authoring | Referenced, not auto-loaded |
 | `pr-backlog-deferral.md` | Deferring non-blocking review findings to a backlog | `Dev10x:gh-pr-review` skill, code review CI | Referenced, not auto-loaded |
+| `milestone-naming.md` | Milestone naming convention, initiative prefixes (AUD-Mn vs MCP-Mn) | `Dev10x:project-scope`, `Dev10x:work-on` milestone steps | Referenced, not auto-loaded |
 
 ## Agent Specs (`.claude/agents/`)
 

--- a/references/milestone-naming.md
+++ b/references/milestone-naming.md
@@ -1,0 +1,73 @@
+# Milestone Naming Convention
+
+Standards for GitHub milestone titles in this repository to prevent
+numbering collisions across initiatives and make the milestone list
+scannable at a glance.
+
+## Problem (observed 2026-05-31)
+
+Two separate initiative sets both used bare `M1`–`M9` numbering:
+
+- Audit 2026-05-18: `🛡️ M1 — Domain Boundary Safety` … `🧬 M9 — Test Coverage Architectural Gaps`
+- MCP Roadmap: `M1 · MCP daemon foundation` … `M6 · Installable GitHub bot/Action`
+
+A reader scanning the milestone list cannot tell which `M1` is meant
+without reading the full title. This also makes `milestone:` filters in
+issue searches ambiguous.
+
+## Convention
+
+Every milestone title must begin with a **namespaced prefix** that
+identifies the initiative, followed by a sequence number.
+
+```
+<INIT>-M<n>: <short title>
+```
+
+| Field | Rule |
+|-------|------|
+| `<INIT>` | 2–6 uppercase letters identifying the initiative (see table below) |
+| `-M<n>` | Hyphen, capital M, integer (no leading zeros) |
+| `: ` | Colon + space separator |
+| `<short title>` | Human-readable description, ≤ 50 characters |
+
+**Examples:**
+
+```
+AUD-M1: Domain Boundary Safety
+AUD-M9: Test Coverage Architectural Gaps
+MCP-M1: MCP daemon foundation
+MCP-M6: Installable GitHub bot/Action
+```
+
+## Registered Initiative Prefixes
+
+| Prefix | Initiative | Status |
+|--------|-----------|--------|
+| `AUD` | Architecture audit series (2026-05-18) | closed (archived) |
+| `MCP` | MCP knowledge primitives roadmap | active |
+
+When starting a new initiative that spans multiple milestones, register
+its prefix here before creating the first milestone. Pick a prefix that
+does not conflict with an existing entry.
+
+## Lifecycle Rule
+
+Close a milestone as soon as its `open_issues` count reaches 0.
+A milestone with no open issues in `open` state pollutes the active
+list and creates confusion about what is in flight.
+
+Use `mcp__plugin_Dev10x_cli__milestone_close` (not raw `gh api`)
+to close milestones — the plugin wraps the REST call with proper
+permission handling.
+
+## Retroactive renaming
+
+Milestones closed before this convention existed do not need to be
+renamed — closed milestones are invisible in the default milestone
+list. Apply the prefix only to new milestones going forward.
+
+## Reference
+
+- MCP tool: `mcp__plugin_Dev10x_cli__milestone_close`
+- MCP tools table: `.claude/rules/mcp-tools.md`


### PR DESCRIPTION
**When** I scan the milestones list to plan work, **I want to** see only active milestones with a non-colliding numbering scheme, **so I can** tell at a glance what is actually in flight versus already shipped.

---

[`604ef152`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/397/commits/604ef15203b8b75e3681fca1d1a5622d861b6c47) 📝 GH-388 Enable milestone collision-free naming across initiatives
Closes #388
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/388

---