### PR TITLE
✨ GH-390 Move plugin-maintenance-prefs.yaml to XDG config path

### DIFF
--- a/references/config-resolution.md
+++ b/references/config-resolution.md
@@ -207,6 +207,17 @@ projects:
 |------|------|
 | 2 | `~/.config/Dev10x/slack-config-code-review-requests.yaml` |
 
+### Plugin Maintenance Preferences
+
+| Tier | Path |
+|------|------|
+| 2 | `~/.config/Dev10x/plugin-maintenance-prefs.yaml` |
+
+Valid values for `update_preference`: `both | plugin | uv | skip | ask`.
+When absent or set to `ask`, `Dev10x:plugin-maintenance` prompts on
+every run. Legacy path `~/.claude/memory/Dev10x/plugin-maintenance-prefs.yaml`
+is migrated lazily on first read.
+
 ### Database Connections
 
 | Tier | Path |
@@ -233,3 +244,4 @@ projects:
 | `Dev10x:slack-review-request` | slack-config | 2 |
 | `Dev10x:request-review` | reviewers, slack-config | 2 |
 | `Dev10x:fanout` | session | 1 |
+| `Dev10x:plugin-maintenance` | preferences | 2 |

--- a/skills/plugin-maintenance/SKILL.md
+++ b/skills/plugin-maintenance/SKILL.md
@@ -38,8 +38,8 @@ allowed-tools:
   # GH-307: version-check preflight
   - Bash(claude plugin list:*)
   - Bash(uv tool list:*)
-  - Read(~/.claude/memory/Dev10x/*)
-  - Write(~/.claude/memory/Dev10x/*)
+  - Read(~/.config/Dev10x/*)
+  - Write(~/.config/Dev10x/*)
   - Agent(Dev10x:permission-auditor)
   - AskUserQuestion
   - TaskCreate
@@ -126,7 +126,7 @@ update when either is behind.
 ### Step 1: Read the preference file
 
 Try to load the saved update preference from
-`~/.claude/memory/Dev10x/plugin-maintenance-prefs.yaml`:
+`~/.config/Dev10x/plugin-maintenance-prefs.yaml`:
 
 ```yaml
 # example
@@ -240,7 +240,7 @@ AskUserQuestion(questions=[{
   header: "Save preference",
   options: [
     {label: "Yes, remember for future sessions (Recommended)",
-     description: "Saves preference to ~/.claude/memory/Dev10x/plugin-maintenance-prefs.yaml"},
+     description: "Saves preference to ~/.config/Dev10x/plugin-maintenance-prefs.yaml"},
     {label: "No, ask me each time",
      description: "Preference is not saved"}
   ],
@@ -249,7 +249,7 @@ AskUserQuestion(questions=[{
 ```
 
 If the user chooses to remember: write the chosen preference to
-`~/.claude/memory/Dev10x/plugin-maintenance-prefs.yaml`:
+`~/.config/Dev10x/plugin-maintenance-prefs.yaml`:
 
 ```yaml
 # Written by Dev10x:plugin-maintenance (GH-307)

--- a/src/dev10x/domain/dev10x_paths.py
+++ b/src/dev10x/domain/dev10x_paths.py
@@ -164,6 +164,13 @@ class Dev10xConfigDir:
             _legacy_settings_pr_merge_yaml,
         )
 
+    @classmethod
+    def plugin_maintenance_prefs_yaml(cls) -> Path:
+        return _with_lazy_migration(
+            cls._resolve("plugin-maintenance-prefs.yaml"),
+            _legacy_plugin_maintenance_prefs_yaml,
+        )
+
 
 def _with_lazy_migration(current: Path, legacy_provider: Callable[[], Path]) -> Path:
     migrate_path(legacy=legacy_provider(), current=current)
@@ -183,6 +190,10 @@ _legacy_github_app_yaml = ClaudeDir.github_app_yaml
 _legacy_gitmoji_yaml = ClaudeDir.gitmoji_yaml
 _legacy_github_reviewers_config_yaml = ClaudeDir.github_reviewers_config_yaml
 _legacy_settings_pr_merge_yaml = ClaudeDir.settings_pr_merge_yaml
+
+
+def _legacy_plugin_maintenance_prefs_yaml() -> Path:
+    return ClaudeDir.memory_dev10x_dir() / "plugin-maintenance-prefs.yaml"
 
 
 def _legacy_playbooks_dir() -> Path:
@@ -218,6 +229,10 @@ def _migration_pairs() -> list[tuple[Path, Path]]:
         (
             _legacy_settings_pr_merge_yaml(),
             Dev10xConfigDir._resolve("settings-pr-merge.yaml"),
+        ),
+        (
+            _legacy_plugin_maintenance_prefs_yaml(),
+            Dev10xConfigDir._resolve("plugin-maintenance-prefs.yaml"),
         ),
     ]
 

--- a/tests/domain/test_dev10x_paths.py
+++ b/tests/domain/test_dev10x_paths.py
@@ -45,6 +45,7 @@ def isolated_dirs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> tuple[Path
         ("gitmoji_yaml", "gitmoji.yaml"),
         ("github_reviewers_config_yaml", "github-reviewers-config.yaml"),
         ("settings_pr_merge_yaml", "settings-pr-merge.yaml"),
+        ("plugin_maintenance_prefs_yaml", "plugin-maintenance-prefs.yaml"),
     ],
 )
 def test_accessors_resolve_under_override(
@@ -211,6 +212,19 @@ def test_migrate_all_includes_memory_dev10x_files(
     assert "gitmoji.yaml" in migrated_names
     assert "github-reviewers-config.yaml" in migrated_names
     assert "settings-pr-merge.yaml" in migrated_names
+
+
+def test_plugin_maintenance_prefs_migrates_from_memory_dev10x(
+    isolated_dirs: tuple[Path, Path],
+) -> None:
+    legacy_root, new_root = isolated_dirs
+    legacy = legacy_root / "memory" / "Dev10x" / "plugin-maintenance-prefs.yaml"
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text("update_preference: skip\n")
+    current = Dev10xConfigDir.plugin_maintenance_prefs_yaml()
+    assert current == new_root / "plugin-maintenance-prefs.yaml"
+    assert current.read_text() == "update_preference: skip\n"
+    assert legacy.exists(), "legacy file must remain for downgrade safety"
 
 
 def test_migrate_all_is_idempotent(isolated_dirs: tuple[Path, Path]) -> None:


### PR DESCRIPTION
**When** I run `Dev10x:plugin-maintenance` after migrating to the XDG config layout (GH-215), **I want to** have the update preference file read from and written to `~/.config/Dev10x/plugin-maintenance-prefs.yaml` **so I can** ensure my saved preference persists in the same location as all other Dev10x config files and is not silently lost when the legacy `~/.claude/memory/Dev10x/` directory is cleaned up.

---

[`36717f37`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/400/commits/36717f3798d5c7de49533c4fc90e4905df4c10b5) ✨ GH-390 Move plugin-maintenance-prefs.yaml to XDG config path
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/390

---