### PR TITLE
✨ GH-398 Enable live GitHub API contract-test tier

### DIFF
--- a/.github/workflows/github-contract-tests.yml
+++ b/.github/workflows/github-contract-tests.yml
@@ -1,0 +1,50 @@
+name: GitHub API Contract Tests
+
+# Live contract tests for the GitHub MCP tools (GH-398).
+# Calls the real GitHub API against fixture PR #394; gated on GITHUB_TOKEN.
+#
+# Runs:
+#   - On a weekly schedule (Monday 06:00 UTC) to catch API drift
+#   - Manually via workflow_dispatch for on-demand verification
+#   - NEVER on every push/PR — too slow, requires token
+#
+# See docs/github-contract-test-boundary.md for the tier architecture.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"  # Weekly on Monday at 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Fixture PR number to test against (default: 394)"
+        required: false
+        default: "394"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Run live GitHub API contract tests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          uv run --extra dev pytest \
+            tests/github/test_github_contract.py \
+            -v --tb=short \
+            -o 'addopts=' \
+            --no-cov

--- a/docs/github-contract-test-boundary.md
+++ b/docs/github-contract-test-boundary.md
@@ -52,19 +52,23 @@ They validate:
 
 Primary file: `tests/github/test_graphql_static.py`
 
-### `contract` (future — gated on `GITHUB_TOKEN`)
+### `contract` (gated on `GITHUB_TOKEN`)
 
-A future tier that calls the real GitHub API for key read tools against
-a known fixture PR/issue and asserts the returned shape. Tracked as
-part of GH-386. Would run:
+Tests in this class call the real GitHub API against a known fixture PR
+and assert the returned shape (GH-398). They run:
 
-- In CI on a schedule (nightly / weekly) with a repository secret
+- In CI on a weekly schedule (Monday 06:00 UTC) via
+  `.github/workflows/github-contract-tests.yml`
 - Locally when `GITHUB_TOKEN` is set (skipped otherwise)
-- Never on every push/PR (too slow, requires token)
+- Never on every push/PR — too slow, requires a token
 
-The static-lint tier closes the GH-329 GraphQL class without any live
-call. The contract tier would additionally catch REST response-shape
-drift (e.g., a field being removed from the GitHub API response).
+**Fixture:** PR #394 in `Dev10x-Guru/Dev10x-Claude` — a merged PR
+(GH-386 Parts 2 & 3) that is stable, public, and has review comments.
+
+**What they catch that static-lint cannot:** REST response-shape drift
+(a field removed from or renamed in the real GitHub API response).
+
+Primary file: `tests/github/test_github_contract.py`
 
 ## How to classify a new test
 
@@ -83,7 +87,7 @@ When adding a new test for a GitHub MCP tool:
 3. **If you call the real GitHub API**
    → `contract-class: contract`. Skip with
    `pytest.mark.skipif(not os.getenv("GITHUB_TOKEN"), ...)`.
-   This tier is not yet implemented.
+   Add to `tests/github/test_github_contract.py`.
 
 ## Extending the static-lint tier
 

--- a/tests/github/test_github_contract.py
+++ b/tests/github/test_github_contract.py
@@ -1,0 +1,274 @@
+"""Live GitHub API contract tests for dev10x.github (GH-398).
+
+Contract class: contract
+  These tests call the real GitHub API against a known fixture PR and assert
+  the returned shape. They are gated on GITHUB_TOKEN — skipped locally
+  without one, run in CI on a schedule.
+
+  The static-lint tier (test_graphql_static.py) catches invalid GraphQL
+  field selections without any live call. This tier additionally catches
+  REST response-shape drift: fields removed from or renamed in the real
+  GitHub API response.
+
+Fixture:
+  PR #394 in Dev10x-Guru/Dev10x-Claude — a merged PR that closed GH-386
+  (Parts 2 & 3). It is stable (merged), public, and has review comments,
+  making it suitable for exercising pr_get, pr_comments, and
+  resolve_review_thread's read paths.
+
+See docs/github-contract-test-boundary.md for the full boundary doc.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+# Skip the entire module when GITHUB_TOKEN is absent.
+pytestmark = pytest.mark.skipif(
+    not os.getenv("GITHUB_TOKEN"),
+    reason="GITHUB_TOKEN not set — live contract tests skipped",
+)
+
+gh = pytest.importorskip("dev10x.github", reason="dev10x not installed")
+
+# ---------------------------------------------------------------------------
+# Fixture constants — stable merged PR in this repo (GH-386 Parts 2 & 3).
+# Changing this PR requires updating the assertions below.
+# ---------------------------------------------------------------------------
+_FIXTURE_REPO = "Dev10x-Guru/Dev10x-Claude"
+_FIXTURE_PR_NUMBER = 394
+
+
+class TestPrGetContract:
+    """contract-class: contract
+
+    Calls pr_get against the fixture PR and asserts that the required fields
+    are present and have the expected types/values.
+    """
+
+    @pytest.mark.asyncio
+    async def test_pr_get_returns_success(self) -> None:
+        """pr_get must succeed for a known-good merged PR."""
+        result = await gh.pr_get(
+            number=_FIXTURE_PR_NUMBER,
+            repo=_FIXTURE_REPO,
+        )
+        from dev10x.domain.common.result import SuccessResult
+
+        assert isinstance(result, SuccessResult), (
+            f"pr_get({_FIXTURE_PR_NUMBER!r}, repo={_FIXTURE_REPO!r}) returned an error: {result}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_pr_get_required_fields_present(self) -> None:
+        """pr_get response must contain all required top-level fields."""
+        result = await gh.pr_get(
+            number=_FIXTURE_PR_NUMBER,
+            repo=_FIXTURE_REPO,
+        )
+        from dev10x.domain.common.result import SuccessResult
+
+        assert isinstance(result, SuccessResult)
+        payload = result.value
+        required_fields = {
+            "number",
+            "title",
+            "state",
+            "url",
+        }
+        missing = required_fields - payload.keys()
+        assert not missing, (
+            f"pr_get response missing required fields: {sorted(missing)}. "
+            f"Returned keys: {sorted(payload.keys())}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_pr_get_number_matches_fixture(self) -> None:
+        """pr_get response number must match the requested PR number."""
+        result = await gh.pr_get(
+            number=_FIXTURE_PR_NUMBER,
+            repo=_FIXTURE_REPO,
+        )
+        from dev10x.domain.common.result import SuccessResult
+
+        assert isinstance(result, SuccessResult)
+        payload = result.value
+        assert payload.get("number") == _FIXTURE_PR_NUMBER, (
+            f"pr_get returned number {payload.get('number')!r}, "
+            f"expected {_FIXTURE_PR_NUMBER!r}. "
+            "Response-shape drift: 'number' field renamed or removed?"
+        )
+
+    @pytest.mark.asyncio
+    async def test_pr_get_state_is_merged(self) -> None:
+        """pr_get fixture PR #394 is merged — state must reflect that.
+
+        GitHub returns state='CLOSED' (via gh pr view) or state='closed' (REST)
+        for merged PRs, and sets mergedAt to a non-null value.
+        """
+        result = await gh.pr_get(
+            number=_FIXTURE_PR_NUMBER,
+            repo=_FIXTURE_REPO,
+        )
+        from dev10x.domain.common.result import SuccessResult
+
+        assert isinstance(result, SuccessResult)
+        payload = result.value
+        state = str(payload.get("state", "")).upper()
+        assert state in {"CLOSED", "MERGED"}, (
+            f"Fixture PR #{_FIXTURE_PR_NUMBER} is merged but pr_get returned "
+            f"state={payload.get('state')!r}. If the field was renamed, update "
+            "the gh-pr-get.sh script and this assertion."
+        )
+
+    @pytest.mark.asyncio
+    async def test_pr_get_merged_field_absent_or_falsy(self) -> None:
+        """pr_get must NOT trigger an error via the invalid 'merged' field (GH-329).
+
+        The GH-329 post-mortem found that 'merged' is not a valid
+        'gh pr view --json' field. The fix uses 'mergedAt' instead.
+        This live test confirms the command succeeds without the invalid field.
+        """
+        result = await gh.pr_get(
+            number=_FIXTURE_PR_NUMBER,
+            repo=_FIXTURE_REPO,
+        )
+        from dev10x.domain.common.result import SuccessResult
+
+        assert isinstance(result, SuccessResult), (
+            "pr_get returned an error. If the error message mentions 'merged' "
+            "or 'unknown JSON field', the GH-329 regression has reappeared."
+        )
+
+
+class TestPrCommentsContract:
+    """contract-class: contract
+
+    Calls pr_comments(action='list') against the fixture PR and asserts the
+    returned shape. The fixture PR is merged so its comment list is stable.
+    """
+
+    @pytest.mark.asyncio
+    async def test_pr_comments_list_returns_success(self) -> None:
+        """pr_comments list action must succeed for a known-good merged PR."""
+        result = await gh.pr_comments(
+            action="list",
+            pr_number=_FIXTURE_PR_NUMBER,
+            repo=_FIXTURE_REPO,
+        )
+        from dev10x.domain.common.result import SuccessResult
+
+        assert isinstance(result, SuccessResult), (
+            f"pr_comments(action='list', pr_number={_FIXTURE_PR_NUMBER!r}) "
+            f"returned an error: {result}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_pr_comments_list_returns_value_key(self) -> None:
+        """pr_comments list response must contain a 'value' key wrapping the list.
+
+        The REST endpoint returns a JSON array; the implementation wraps it
+        in {'value': [...]} to satisfy the Mapping contract (ADR-0009).
+        """
+        result = await gh.pr_comments(
+            action="list",
+            pr_number=_FIXTURE_PR_NUMBER,
+            repo=_FIXTURE_REPO,
+        )
+        from dev10x.domain.common.result import SuccessResult
+
+        assert isinstance(result, SuccessResult)
+        payload = result.value
+        assert "value" in payload, (
+            f"pr_comments list response missing 'value' key. "
+            f"Got keys: {sorted(payload.keys())}. "
+            "If the wrapping contract changed, update ADR-0009 and this assertion."
+        )
+        assert isinstance(payload["value"], list), (
+            f"pr_comments list 'value' must be a list, got {type(payload['value'])!r}."
+        )
+
+    @pytest.mark.asyncio
+    async def test_pr_comments_list_items_have_expected_shape(self) -> None:
+        """Each comment in the list must have the standard GitHub REST shape fields.
+
+        The known-valid fields are those present in the GitHub REST API response
+        for GET /repos/{owner}/{repo}/pulls/{pull_number}/comments.
+        """
+        result = await gh.pr_comments(
+            action="list",
+            pr_number=_FIXTURE_PR_NUMBER,
+            repo=_FIXTURE_REPO,
+        )
+        from dev10x.domain.common.result import SuccessResult
+
+        assert isinstance(result, SuccessResult)
+        comments = result.value.get("value", [])
+        if not comments:
+            pytest.skip(
+                f"PR #{_FIXTURE_PR_NUMBER} has no review comments — "
+                "cannot assert comment shape. Choose a fixture PR with at least one comment."
+            )
+        first = comments[0]
+        required_comment_fields = {"id", "body", "path", "url"}
+        missing = required_comment_fields - first.keys()
+        assert not missing, (
+            f"First comment in pr_comments list is missing required fields: "
+            f"{sorted(missing)}. Got keys: {sorted(first.keys())}. "
+            "Response-shape drift from GitHub REST API?"
+        )
+
+    @pytest.mark.asyncio
+    async def test_pr_comments_unresolved_threads_returns_success(self) -> None:
+        """pr_comments with unresolved_only=True must succeed against the real API.
+
+        This exercises the GraphQL _list_unresolved_threads path which was the
+        site of the GH-329 pullRequestReviewThread bug.
+        """
+        result = await gh.pr_comments(
+            action="list",
+            pr_number=_FIXTURE_PR_NUMBER,
+            unresolved_only=True,
+            repo=_FIXTURE_REPO,
+        )
+        from dev10x.domain.common.result import SuccessResult
+
+        assert isinstance(result, SuccessResult), (
+            f"pr_comments(action='list', unresolved_only=True) returned an error: {result}. "
+            "This exercises the GraphQL reviewThreads path (GH-329 fix)."
+        )
+
+    @pytest.mark.asyncio
+    async def test_pr_comments_unresolved_threads_response_shape(self) -> None:
+        """pr_comments unresolved_only response must have the normalized shape.
+
+        The _list_unresolved_threads function returns
+        {'unresolved_threads': [...], 'count': N}.
+        """
+        result = await gh.pr_comments(
+            action="list",
+            pr_number=_FIXTURE_PR_NUMBER,
+            unresolved_only=True,
+            repo=_FIXTURE_REPO,
+        )
+        from dev10x.domain.common.result import SuccessResult
+
+        assert isinstance(result, SuccessResult)
+        payload = result.value
+        assert "unresolved_threads" in payload, (
+            f"pr_comments unresolved_only response missing 'unresolved_threads' key. "
+            f"Got keys: {sorted(payload.keys())}"
+        )
+        assert "count" in payload, (
+            f"pr_comments unresolved_only response missing 'count' key. "
+            f"Got keys: {sorted(payload.keys())}"
+        )
+        assert isinstance(payload["unresolved_threads"], list), (
+            f"'unresolved_threads' must be a list, got {type(payload['unresolved_threads'])!r}."
+        )
+        assert payload["count"] == len(payload["unresolved_threads"]), (
+            f"'count' ({payload['count']}) must equal len('unresolved_threads') "
+            f"({len(payload['unresolved_threads'])})."
+        )


### PR DESCRIPTION
**When** I ship changes to GitHub-backed MCP read tools (`pr_get`, `pr_comments`), **I want to** have CI exercise them against the real GitHub REST/GraphQL surface against a known fixture PR, **so I can** catch GH-329-class runtime failures (invalid fields, response-shape drift) that mock-based and static-lint tests cannot detect.

---

[`b2c8bd56`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/402/commits/b2c8bd56c3df41221cbb01e9fe1112d3e2c1744a) ✨ GH-398 Enable live GitHub API contract-test tier
Closes #398
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/398

---