### PR TITLE
✨ GH-371 Enable MCP horizontal-duplicate detection

### DIFF
--- a/agents/permission-auditor.md
+++ b/agents/permission-auditor.md
@@ -73,6 +73,27 @@ HOOK_BLOCKED_RETRY), the rule-based pattern catalog
 the Known-Safe Patterns skip list (`git reset`, `git -C`, etc.)
 that must NOT be flagged.
 
+### Phase 4b: MCP Horizontal-Duplicate Detection (GH-371)
+
+After classifying allow rules, check whether the same logical capability
+is provided by multiple MCP server installations under different prefixes.
+The three source types are:
+
+- `mcp__claude_ai_<Service>__*`      — claude.ai-hosted
+- `mcp__<service>__*`                — user-installed via `claude mcp add`
+- `mcp__plugin_<plugin>_<srv>__*`    — plugin-distributed
+
+Run the `mcp-horizontal-duplicates` doctor strategy (registered in
+`src/dev10x/skills/doctor/registry.py`). For each finding:
+
+1. Report the capability name and how many servers expose it
+2. List each (prefix, example tool) pair
+3. Note that catalog rules targeting one prefix do NOT cover the others
+4. Surface consolidation as an option — do NOT force it
+
+Severity: **LOW** (informational). The duplication may be intentional
+(e.g., keeping a backup server). Surface it for user awareness only.
+
 ### Phase 5: Deny Rule Gap Analysis
 
 Check for missing protection on known destructive operations.

--- a/src/dev10x/skills/doctor/registry.py
+++ b/src/dev10x/skills/doctor/registry.py
@@ -17,6 +17,7 @@ DEFAULT_STRATEGY_MODULES: tuple[str, ...] = (
     "dev10x.skills.doctor.strategies.mcp_vs_script_drift",
     "dev10x.skills.doctor.strategies.missing_linear_mcp_allow",
     "dev10x.skills.doctor.strategies.forbidden_token_priming",
+    "dev10x.skills.doctor.strategies.mcp_horizontal_duplicates",
 )
 
 

--- a/src/dev10x/skills/doctor/strategies/mcp_horizontal_duplicates.py
+++ b/src/dev10x/skills/doctor/strategies/mcp_horizontal_duplicates.py
@@ -1,0 +1,118 @@
+"""Strategy: mcp-horizontal-duplicates (GH-371).
+
+Detects when the same logical capability is provided by multiple MCP
+server installations under different prefixes. The three source types
+are:
+
+  mcp__claude_ai_<Service>__*      # claude.ai-hosted
+  mcp__<service>__*                # user-installed (claude mcp add)
+  mcp__plugin_<plugin>_<srv>__*   # plugin-distributed
+
+When N servers each expose the same short tool name (e.g.
+``search_issues``), the catalog rules that target one prefix do not
+cover the other N-1. This strategy surfaces the duplication so the
+user can decide whether to consolidate or keep all sources.
+
+Evidence basis: GH-271 #222 — three distinct Sentry MCP servers on
+one machine (claude.ai, user-installed, plugin-distributed).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dev10x.skills.doctor.strategy import (
+    Context,
+    Finding,
+    Remediation,
+    Strategy,
+)
+from dev10x.skills.permission.enumerate_mcp import (
+    McpServerEntry,
+    build_capability_groups,
+    discover_all_mcp_servers,
+)
+
+
+def _settings_paths_from_context(context: Context) -> list[Path]:
+    """Collect all settings paths the strategy should scan."""
+    paths = list(context.settings_paths)
+    if not paths:
+        home = Path.home()
+        paths = [
+            home / ".claude" / "settings.json",
+            home / ".claude" / "settings.local.json",
+        ]
+    return paths
+
+
+def detect(context: Context) -> list[Finding]:
+    """Scan allow rules for MCP tools that appear under multiple prefixes."""
+    settings_paths = _settings_paths_from_context(context)
+    servers: list[McpServerEntry] = discover_all_mcp_servers(
+        settings_paths=settings_paths,
+    )
+    groups = build_capability_groups(servers)
+
+    findings: list[Finding] = []
+    for group in groups:
+        if not group.is_duplicate():
+            continue
+        prefix_list = ", ".join(f"``{prefix}``" for prefix, _ in group.entries)
+        findings.append(
+            Finding(
+                strategy_id="mcp-horizontal-duplicates",
+                severity="suggestion",
+                location="permissions.allow",
+                evidence=(
+                    f"capability ``{group.tool_name}`` is offered by "
+                    f"{group.server_count} servers: {prefix_list}"
+                ),
+                proposed_fix=(
+                    "Review feature parity across servers and consider whether "
+                    "all sources are needed. Catalog rules for one prefix do not "
+                    "cover the others — each needs its own allow entry. "
+                    "Consolidating to a single source reduces auth/connection "
+                    "overhead and simplifies the catalog."
+                ),
+                metadata={
+                    "capability_group": group.capability_group,
+                    "tool_name": group.tool_name,
+                    "server_count": group.server_count,
+                    "entries": [
+                        {"prefix": prefix, "tool": tool} for prefix, tool in group.entries
+                    ],
+                },
+            )
+        )
+    return findings
+
+
+def remediate(finding: Finding) -> Remediation:
+    """Propose surfacing the duplication as an informational file issue."""
+    return Remediation(
+        kind="file_issue",
+        target="permissions.allow",
+        action={
+            "capability_group": finding.metadata.get("capability_group"),
+            "server_count": finding.metadata.get("server_count"),
+            "entries": finding.metadata.get("entries", []),
+            "reason": (
+                "Multiple MCP servers expose the same capability. "
+                "Review and consolidate to reduce auth overhead."
+            ),
+        },
+    )
+
+
+STRATEGY = Strategy(
+    id="mcp-horizontal-duplicates",
+    description=(
+        "Surface capabilities offered by multiple MCP server sources "
+        "(claude.ai-hosted, user-installed, plugin-distributed) under "
+        "different prefixes. Catalog rules for one prefix do not cover "
+        "the others — the duplication may be intentional or accidental."
+    ),
+    detect=detect,
+    remediate=remediate,
+)

--- a/src/dev10x/skills/permission/enumerate_mcp.py
+++ b/src/dev10x/skills/permission/enumerate_mcp.py
@@ -8,6 +8,19 @@ manual approval prompt because the glob silently matches nothing.
 This module discovers Dev10x MCP tools from the plugin's own MCP
 servers and replaces matching wildcards in settings files with
 enumerated tool names.
+
+**Runtime discovery (GH-371):** `discover_all_mcp_servers` extends
+`discover_mcp_tools` (plugin-only) with all MCP servers connected to
+the current Claude session, regardless of source type:
+
+- ``mcp__claude_ai_<Service>__*``  — claude.ai-hosted servers
+- ``mcp__<service>__*``            — user-installed via ``claude mcp add``
+- ``mcp__plugin_<plugin>_<srv>__*`` — plugin-distributed servers
+
+**capability_group annotation (GH-371):** When the same capability is
+offered by multiple prefixes (horizontal duplicates), an annotation
+links the policy entries so the doctor can surface consolidation
+opportunities without forcing them.
 """
 
 from __future__ import annotations
@@ -16,6 +29,7 @@ import ast
 import json
 import re
 from collections.abc import Iterable
+from dataclasses import dataclass, field
 from pathlib import Path
 
 # Wildcard shapes that silently fail: `mcp__plugin_Dev10x_*`,
@@ -35,6 +49,53 @@ _SERVER_FILES: dict[str, list[str]] = {
     ],
     "Dev10x_db": ["src/dev10x/mcp/server_db.py"],
 }
+
+
+@dataclass
+class McpServerEntry:
+    """Represents one discovered MCP server with its tool list.
+
+    Attributes:
+        prefix: The MCP prefix pattern, e.g. ``mcp__claude_ai_Sentry__``.
+        source_type: One of ``claude_ai``, ``user_installed``, ``plugin``.
+        service_name: Human-readable service label, e.g. ``Sentry``.
+        tools: Fully-qualified tool names under this prefix.
+    """
+
+    prefix: str
+    source_type: str
+    service_name: str
+    tools: list[str] = field(default_factory=list)
+
+
+@dataclass
+class CapabilityGroupEntry:
+    """Links policy entries that share the same logical capability.
+
+    Used by the ``mcp-horizontal-duplicates`` doctor strategy to surface
+    cases where N servers each offer the same capability under different
+    prefixes. The annotation does not force consolidation; it surfaces
+    the duplication for user awareness.
+
+    Attributes:
+        capability_group: Stable slug for the capability, e.g.
+            ``sentry-search-issues``.
+        tool_name: Short tool name without the prefix, e.g.
+            ``search_issues``.
+        entries: (prefix, full_tool_name) pairs for each server that
+            offers this capability.
+    """
+
+    capability_group: str
+    tool_name: str
+    entries: list[tuple[str, str]] = field(default_factory=list)
+
+    @property
+    def server_count(self) -> int:
+        return len(self.entries)
+
+    def is_duplicate(self) -> bool:
+        return self.server_count > 1
 
 
 def plugin_root() -> Path:
@@ -102,6 +163,163 @@ def discover_mcp_tools(*, root: Path | None = None) -> dict[str, list[str]]:
         prefix = f"mcp__plugin_Dev10x_{server_key}__"
         catalog[server] = sorted(f"{prefix}{name}" for name in names)
     return catalog
+
+
+def _server_prefix_from_tool(tool_name: str) -> str | None:
+    """Return the server prefix for a fully-qualified MCP tool name.
+
+    ``mcp__claude_ai_Sentry__search_issues``
+      → ``mcp__claude_ai_Sentry__``
+
+    ``mcp__sentry__search_issues``
+      → ``mcp__sentry__``
+    """
+    # Split on __ (double underscore); the prefix ends before the final segment
+    parts = tool_name.split("__")
+    # Valid names: mcp  <server>  <func_name>
+    if len(parts) < 3:
+        return None
+    # Re-join the middle segment(s) with __ and append the trailing __
+    return "__".join(parts[:-1]) + "__"
+
+
+def _source_type_from_prefix(prefix: str) -> tuple[str, str]:
+    """Return (source_type, service_name) for a server prefix.
+
+    Examples::
+
+        mcp__claude_ai_Sentry__  → ("claude_ai", "Sentry")
+        mcp__sentry__            → ("user_installed", "sentry")
+        mcp__plugin_sentry_sentry__ → ("plugin", "sentry_sentry")
+    """
+    # Strip leading mcp__ and trailing __
+    inner = prefix.removeprefix("mcp__").removesuffix("__")
+    if inner.startswith("claude_ai_"):
+        return "claude_ai", inner.removeprefix("claude_ai_")
+    if inner.startswith("plugin_"):
+        return "plugin", inner.removeprefix("plugin_")
+    return "user_installed", inner
+
+
+def discover_all_mcp_servers(
+    *,
+    settings_paths: Iterable[Path] | None = None,
+) -> list[McpServerEntry]:
+    """Enumerate ALL MCP servers by scanning allow rules in settings files.
+
+    Unlike ``discover_mcp_tools`` (which only knows about this plugin's
+    servers), this function discovers every MCP server whose tools appear
+    in the user's allow rules — regardless of source type.
+
+    The three source types (GH-371):
+
+    - ``claude_ai``      — ``mcp__claude_ai_<Service>__*``
+    - ``user_installed`` — ``mcp__<service>__*``
+    - ``plugin``         — ``mcp__plugin_<plugin>_<server>__*``
+
+    Args:
+        settings_paths: Settings files to scan. Defaults to the standard
+            user and global settings locations when omitted.
+
+    Returns:
+        Deduplicated list of :class:`McpServerEntry` objects, one per
+        distinct server prefix found in any allow rule.
+    """
+    if settings_paths is None:
+        home = Path.home()
+        settings_paths = [
+            home / ".claude" / "settings.json",
+            home / ".claude" / "settings.local.json",
+        ]
+
+    prefix_to_entry: dict[str, McpServerEntry] = {}
+
+    for path in settings_paths:
+        if not Path(path).is_file():
+            continue
+        try:
+            data = json.loads(Path(path).read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+
+        all_rules: list[str] = []
+        perms = data.get("permissions", {})
+        for bucket in ("allow", "deny", "ask"):
+            bucket_rules = perms.get(bucket, [])
+            if isinstance(bucket_rules, list):
+                all_rules.extend(r for r in bucket_rules if isinstance(r, str))
+
+        for rule in all_rules:
+            if not rule.startswith("mcp__"):
+                continue
+            prefix = _server_prefix_from_tool(rule)
+            if prefix is None:
+                continue
+            if prefix in prefix_to_entry:
+                if rule not in prefix_to_entry[prefix].tools:
+                    prefix_to_entry[prefix].tools.append(rule)
+                continue
+            source_type, service_name = _source_type_from_prefix(prefix)
+            entry = McpServerEntry(
+                prefix=prefix,
+                source_type=source_type,
+                service_name=service_name,
+                tools=[rule],
+            )
+            prefix_to_entry[prefix] = entry
+
+    return sorted(prefix_to_entry.values(), key=lambda e: e.prefix)
+
+
+def build_capability_groups(
+    servers: Iterable[McpServerEntry],
+) -> list[CapabilityGroupEntry]:
+    """Detect horizontal duplicates across MCP servers (GH-371).
+
+    Two tool entries share a ``capability_group`` when they have the
+    same short tool name (the part after the last ``__``) AND appear
+    under different server prefixes.
+
+    This function only groups tool names that actually appear in at
+    least two distinct server entries — single-server tools are
+    omitted.
+
+    Returns:
+        List of :class:`CapabilityGroupEntry` objects for each
+        capability that spans more than one server.
+    """
+    # tool_name → [(prefix, full_tool_name)]
+    by_short_name: dict[str, list[tuple[str, str]]] = {}
+
+    for server_entry in servers:
+        for full_name in server_entry.tools:
+            parts = full_name.split("__")
+            if len(parts) < 3:
+                continue
+            short_name = parts[-1]
+            by_short_name.setdefault(short_name, []).append((server_entry.prefix, full_name))
+
+    groups: list[CapabilityGroupEntry] = []
+    for short_name, pairs in sorted(by_short_name.items()):
+        # Deduplicate by prefix — keep only one entry per server
+        seen_prefixes: set[str] = set()
+        deduped: list[tuple[str, str]] = []
+        for prefix, full_name in pairs:
+            if prefix not in seen_prefixes:
+                seen_prefixes.add(prefix)
+                deduped.append((prefix, full_name))
+        if len(deduped) < 2:
+            continue
+        # Derive a stable capability_group slug from the short name
+        capability_group = short_name.replace("_", "-")
+        groups.append(
+            CapabilityGroupEntry(
+                capability_group=capability_group,
+                tool_name=short_name,
+                entries=deduped,
+            )
+        )
+    return groups
 
 
 def _matches_wildcard(rule: str, catalog: dict[str, list[str]]) -> list[str] | None:

--- a/tests/skills/doctor/test_mcp_horizontal_duplicates.py
+++ b/tests/skills/doctor/test_mcp_horizontal_duplicates.py
@@ -1,0 +1,208 @@
+"""Tests for the mcp-horizontal-duplicates doctor strategy (GH-371)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dev10x.skills.doctor.strategies import mcp_horizontal_duplicates
+from dev10x.skills.doctor.strategy import Context
+
+
+@pytest.fixture()
+def settings_with_three_sentry_servers(tmp_path: Path) -> Path:
+    """Three Sentry servers: claude_ai, user-installed, plugin-distributed."""
+    path = tmp_path / "settings.local.json"
+    path.write_text(
+        json.dumps(
+            {
+                "permissions": {
+                    "allow": [
+                        "mcp__claude_ai_Sentry__search_issues",
+                        "mcp__claude_ai_Sentry__get_issue",
+                        "mcp__sentry__search_issues",
+                        "mcp__sentry__get_issue",
+                        "mcp__plugin_sentry_sentry__search_issues",
+                        "Bash(git status:*)",
+                    ]
+                }
+            }
+        )
+    )
+    return path
+
+
+@pytest.fixture()
+def settings_with_single_server(tmp_path: Path) -> Path:
+    """Only one Linear MCP server — no horizontal duplicates."""
+    path = tmp_path / "settings.local.json"
+    path.write_text(
+        json.dumps(
+            {
+                "permissions": {
+                    "allow": [
+                        "mcp__claude_ai_Linear__get_issue",
+                        "mcp__claude_ai_Linear__list_issues",
+                    ]
+                }
+            }
+        )
+    )
+    return path
+
+
+@pytest.fixture()
+def settings_empty(tmp_path: Path) -> Path:
+    path = tmp_path / "settings.local.json"
+    path.write_text(json.dumps({}))
+    return path
+
+
+class TestMcpHorizontalDuplicatesDetect:
+    def test_finds_duplicates_across_three_sentry_servers(
+        self, settings_with_three_sentry_servers: Path
+    ) -> None:
+        context = Context(settings_paths=(settings_with_three_sentry_servers,))
+
+        findings = mcp_horizontal_duplicates.detect(context)
+
+        assert len(findings) > 0
+        strategy_ids = {f.strategy_id for f in findings}
+        assert strategy_ids == {"mcp-horizontal-duplicates"}
+
+    def test_finding_metadata_has_capability_group(
+        self, settings_with_three_sentry_servers: Path
+    ) -> None:
+        context = Context(settings_paths=(settings_with_three_sentry_servers,))
+
+        findings = mcp_horizontal_duplicates.detect(context)
+
+        for f in findings:
+            assert "capability_group" in f.metadata
+            assert "server_count" in f.metadata
+            assert f.metadata["server_count"] >= 2
+
+    def test_finding_severity_is_suggestion(
+        self, settings_with_three_sentry_servers: Path
+    ) -> None:
+        context = Context(settings_paths=(settings_with_three_sentry_servers,))
+
+        findings = mcp_horizontal_duplicates.detect(context)
+
+        for f in findings:
+            assert f.severity == "suggestion"
+
+    def test_silent_for_single_server(self, settings_with_single_server: Path) -> None:
+        context = Context(settings_paths=(settings_with_single_server,))
+
+        findings = mcp_horizontal_duplicates.detect(context)
+
+        assert findings == []
+
+    def test_silent_for_empty_settings(self, settings_empty: Path) -> None:
+        context = Context(settings_paths=(settings_empty,))
+
+        findings = mcp_horizontal_duplicates.detect(context)
+
+        assert findings == []
+
+    def test_silent_when_no_settings_file(self, tmp_path: Path) -> None:
+        context = Context(settings_paths=(tmp_path / "absent.json",))
+
+        findings = mcp_horizontal_duplicates.detect(context)
+
+        assert findings == []
+
+    def test_finding_evidence_names_all_prefixes(
+        self, settings_with_three_sentry_servers: Path
+    ) -> None:
+        context = Context(settings_paths=(settings_with_three_sentry_servers,))
+
+        findings = mcp_horizontal_duplicates.detect(context)
+
+        evidence_combined = " ".join(f.evidence for f in findings)
+        assert "mcp__claude_ai_Sentry__" in evidence_combined
+        assert "mcp__sentry__" in evidence_combined
+
+    def test_uses_context_settings_paths_over_default(self, tmp_path: Path) -> None:
+        """When context has settings_paths, they are used exclusively."""
+        path = tmp_path / "settings.local.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "permissions": {
+                        "allow": [
+                            "mcp__claude_ai_Sentry__search_issues",
+                            "mcp__sentry__search_issues",
+                        ]
+                    }
+                }
+            )
+        )
+        context = Context(settings_paths=(path,))
+
+        findings = mcp_horizontal_duplicates.detect(context)
+
+        assert len(findings) == 1
+
+    def test_finding_entries_metadata_lists_prefix_and_tool(
+        self, settings_with_three_sentry_servers: Path
+    ) -> None:
+        context = Context(settings_paths=(settings_with_three_sentry_servers,))
+
+        findings = mcp_horizontal_duplicates.detect(context)
+
+        for f in findings:
+            entries = f.metadata.get("entries", [])
+            assert len(entries) >= 2
+            for entry in entries:
+                assert "prefix" in entry
+                assert "tool" in entry
+
+
+class TestMcpHorizontalDuplicatesRemediate:
+    def test_remediation_kind_is_file_issue(
+        self, settings_with_three_sentry_servers: Path
+    ) -> None:
+        context = Context(settings_paths=(settings_with_three_sentry_servers,))
+        finding = mcp_horizontal_duplicates.detect(context)[0]
+
+        remediation = mcp_horizontal_duplicates.remediate(finding)
+
+        assert remediation.kind == "file_issue"
+
+    def test_remediation_includes_capability_group(
+        self, settings_with_three_sentry_servers: Path
+    ) -> None:
+        context = Context(settings_paths=(settings_with_three_sentry_servers,))
+        finding = mcp_horizontal_duplicates.detect(context)[0]
+
+        remediation = mcp_horizontal_duplicates.remediate(finding)
+
+        assert "capability_group" in remediation.action
+        assert remediation.action["capability_group"] is not None
+
+    def test_remediation_includes_server_count(
+        self, settings_with_three_sentry_servers: Path
+    ) -> None:
+        context = Context(settings_paths=(settings_with_three_sentry_servers,))
+        finding = mcp_horizontal_duplicates.detect(context)[0]
+
+        remediation = mcp_horizontal_duplicates.remediate(finding)
+
+        assert remediation.action.get("server_count", 0) >= 2
+
+
+class TestMcpHorizontalDuplicatesStrategy:
+    def test_strategy_has_correct_id(self) -> None:
+        assert mcp_horizontal_duplicates.STRATEGY.id == "mcp-horizontal-duplicates"
+
+    def test_strategy_is_callable(self) -> None:
+        assert callable(mcp_horizontal_duplicates.STRATEGY.detect)
+        assert callable(mcp_horizontal_duplicates.STRATEGY.remediate)
+
+    def test_strategy_description_mentions_source_types(self) -> None:
+        desc = mcp_horizontal_duplicates.STRATEGY.description
+        assert "claude.ai" in desc or "claude_ai" in desc or "MCP" in desc

--- a/tests/skills/doctor/test_registry.py
+++ b/tests/skills/doctor/test_registry.py
@@ -18,6 +18,12 @@ class TestLoadStrategies:
         ids = [s.id for s in strategies]
         assert "mcp-vs-script-drift" in ids
 
+    def test_default_set_includes_mcp_horizontal_duplicates(self) -> None:
+        strategies = registry.load_strategies()
+
+        ids = [s.id for s in strategies]
+        assert "mcp-horizontal-duplicates" in ids
+
     def test_returns_strategy_instances(self) -> None:
         strategies = registry.load_strategies()
 

--- a/tests/skills/upgrade-cleanup/test_mcp_runtime_discovery.py
+++ b/tests/skills/upgrade-cleanup/test_mcp_runtime_discovery.py
@@ -1,0 +1,298 @@
+"""Tests for runtime MCP server discovery and capability_group support (GH-371)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dev10x.skills.permission.enumerate_mcp import (
+    CapabilityGroupEntry,
+    McpServerEntry,
+    build_capability_groups,
+    discover_all_mcp_servers,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def settings_with_three_sentry_servers(tmp_path: Path) -> Path:
+    """Settings file with three Sentry MCP server variants (GH-271 #222)."""
+    path = tmp_path / "settings.local.json"
+    path.write_text(
+        json.dumps(
+            {
+                "permissions": {
+                    "allow": [
+                        # claude.ai-hosted
+                        "mcp__claude_ai_Sentry__search_issues",
+                        "mcp__claude_ai_Sentry__get_issue",
+                        # user-installed
+                        "mcp__sentry__search_issues",
+                        "mcp__sentry__get_issue",
+                        # plugin-distributed
+                        "mcp__plugin_sentry_sentry__search_issues",
+                        "mcp__plugin_sentry_sentry__get_issue",
+                        # unrelated
+                        "Bash(git status:*)",
+                        "mcp__plugin_Dev10x_cli__mktmp",
+                    ]
+                }
+            }
+        )
+    )
+    return path
+
+
+@pytest.fixture()
+def settings_with_single_server(tmp_path: Path) -> Path:
+    """Settings file with only one MCP server — no duplicates."""
+    path = tmp_path / "settings.local.json"
+    path.write_text(
+        json.dumps(
+            {
+                "permissions": {
+                    "allow": [
+                        "mcp__claude_ai_Linear__get_issue",
+                        "mcp__claude_ai_Linear__list_issues",
+                        "Bash(git log:*)",
+                    ]
+                }
+            }
+        )
+    )
+    return path
+
+
+@pytest.fixture()
+def empty_settings(tmp_path: Path) -> Path:
+    """Settings file with no permissions block."""
+    path = tmp_path / "settings.local.json"
+    path.write_text(json.dumps({}))
+    return path
+
+
+# ---------------------------------------------------------------------------
+# discover_all_mcp_servers
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverAllMcpServers:
+    def test_discovers_all_three_sentry_sources(
+        self, settings_with_three_sentry_servers: Path
+    ) -> None:
+        servers = discover_all_mcp_servers(settings_paths=[settings_with_three_sentry_servers])
+        prefixes = {s.prefix for s in servers}
+
+        assert "mcp__claude_ai_Sentry__" in prefixes
+        assert "mcp__sentry__" in prefixes
+        assert "mcp__plugin_sentry_sentry__" in prefixes
+
+    def test_source_types_classified_correctly(
+        self, settings_with_three_sentry_servers: Path
+    ) -> None:
+        servers = discover_all_mcp_servers(settings_paths=[settings_with_three_sentry_servers])
+        by_prefix = {s.prefix: s for s in servers}
+
+        assert by_prefix["mcp__claude_ai_Sentry__"].source_type == "claude_ai"
+        assert by_prefix["mcp__sentry__"].source_type == "user_installed"
+        assert by_prefix["mcp__plugin_sentry_sentry__"].source_type == "plugin"
+
+    def test_service_name_extracted(self, settings_with_three_sentry_servers: Path) -> None:
+        servers = discover_all_mcp_servers(settings_paths=[settings_with_three_sentry_servers])
+        by_prefix = {s.prefix: s for s in servers}
+
+        assert by_prefix["mcp__claude_ai_Sentry__"].service_name == "Sentry"
+        assert by_prefix["mcp__sentry__"].service_name == "sentry"
+
+    def test_non_mcp_rules_excluded(self, settings_with_three_sentry_servers: Path) -> None:
+        servers = discover_all_mcp_servers(settings_paths=[settings_with_three_sentry_servers])
+        for server in servers:
+            assert "Bash" not in server.prefix
+
+    def test_returns_empty_for_missing_file(self, tmp_path: Path) -> None:
+        servers = discover_all_mcp_servers(settings_paths=[tmp_path / "nonexistent.json"])
+        assert servers == []
+
+    def test_returns_empty_for_malformed_json(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad.json"
+        path.write_text("{not json}")
+        servers = discover_all_mcp_servers(settings_paths=[path])
+        assert servers == []
+
+    def test_empty_permissions_returns_empty(self, empty_settings: Path) -> None:
+        servers = discover_all_mcp_servers(settings_paths=[empty_settings])
+        assert servers == []
+
+    def test_tools_attached_to_server_entry(
+        self, settings_with_three_sentry_servers: Path
+    ) -> None:
+        servers = discover_all_mcp_servers(settings_paths=[settings_with_three_sentry_servers])
+        by_prefix = {s.prefix: s for s in servers}
+        sentry_ai = by_prefix["mcp__claude_ai_Sentry__"]
+
+        assert "mcp__claude_ai_Sentry__search_issues" in sentry_ai.tools
+        assert "mcp__claude_ai_Sentry__get_issue" in sentry_ai.tools
+
+    def test_deduplicates_across_settings_files(self, tmp_path: Path) -> None:
+        """Same tool in two files yields one server entry."""
+        path1 = tmp_path / "s1.json"
+        path2 = tmp_path / "s2.json"
+        tool = "mcp__sentry__search_issues"
+        for p in (path1, path2):
+            p.write_text(json.dumps({"permissions": {"allow": [tool]}}))
+
+        servers = discover_all_mcp_servers(settings_paths=[path1, path2])
+        sentry_entries = [s for s in servers if s.prefix == "mcp__sentry__"]
+        assert len(sentry_entries) == 1
+
+    def test_single_server_settings_has_correct_prefix(
+        self, settings_with_single_server: Path
+    ) -> None:
+        servers = discover_all_mcp_servers(settings_paths=[settings_with_single_server])
+        assert len(servers) == 1
+        assert servers[0].prefix == "mcp__claude_ai_Linear__"
+
+
+# ---------------------------------------------------------------------------
+# build_capability_groups
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCapabilityGroups:
+    def test_groups_same_tool_name_across_prefixes(self) -> None:
+        servers = [
+            McpServerEntry(
+                prefix="mcp__claude_ai_Sentry__",
+                source_type="claude_ai",
+                service_name="Sentry",
+                tools=["mcp__claude_ai_Sentry__search_issues"],
+            ),
+            McpServerEntry(
+                prefix="mcp__sentry__",
+                source_type="user_installed",
+                service_name="sentry",
+                tools=["mcp__sentry__search_issues"],
+            ),
+        ]
+
+        groups = build_capability_groups(servers)
+
+        assert len(groups) == 1
+        assert groups[0].tool_name == "search_issues"
+        assert groups[0].capability_group == "search-issues"
+        assert groups[0].server_count == 2
+
+    def test_no_group_for_single_server(self) -> None:
+        servers = [
+            McpServerEntry(
+                prefix="mcp__claude_ai_Linear__",
+                source_type="claude_ai",
+                service_name="Linear",
+                tools=["mcp__claude_ai_Linear__get_issue"],
+            )
+        ]
+
+        groups = build_capability_groups(servers)
+
+        assert groups == []
+
+    def test_three_servers_same_capability(self) -> None:
+        servers = [
+            McpServerEntry(
+                prefix=f"mcp__sentry{i}__",
+                source_type="user_installed",
+                service_name=f"sentry{i}",
+                tools=[f"mcp__sentry{i}__search_issues"],
+            )
+            for i in range(3)
+        ]
+
+        groups = build_capability_groups(servers)
+
+        assert len(groups) == 1
+        assert groups[0].server_count == 3
+
+    def test_is_duplicate_reflects_server_count(self) -> None:
+        single = CapabilityGroupEntry(
+            capability_group="search-issues",
+            tool_name="search_issues",
+            entries=[("mcp__sentry__", "mcp__sentry__search_issues")],
+        )
+        multi = CapabilityGroupEntry(
+            capability_group="search-issues",
+            tool_name="search_issues",
+            entries=[
+                ("mcp__claude_ai_Sentry__", "mcp__claude_ai_Sentry__search_issues"),
+                ("mcp__sentry__", "mcp__sentry__search_issues"),
+            ],
+        )
+
+        assert not single.is_duplicate()
+        assert multi.is_duplicate()
+
+    def test_capability_group_slug_uses_hyphens(self) -> None:
+        servers = [
+            McpServerEntry(
+                prefix=f"mcp__srv{i}__",
+                source_type="user_installed",
+                service_name=f"srv{i}",
+                tools=[f"mcp__srv{i}__search_all_issues"],
+            )
+            for i in range(2)
+        ]
+
+        groups = build_capability_groups(servers)
+
+        assert groups[0].capability_group == "search-all-issues"
+
+    def test_distinct_tools_not_grouped(self) -> None:
+        servers = [
+            McpServerEntry(
+                prefix="mcp__claude_ai_Sentry__",
+                source_type="claude_ai",
+                service_name="Sentry",
+                tools=["mcp__claude_ai_Sentry__search_issues"],
+            ),
+            McpServerEntry(
+                prefix="mcp__sentry__",
+                source_type="user_installed",
+                service_name="sentry",
+                tools=["mcp__sentry__list_projects"],
+            ),
+        ]
+
+        groups = build_capability_groups(servers)
+
+        assert groups == []
+
+    def test_mixed_overlapping_and_distinct_tools(self) -> None:
+        servers = [
+            McpServerEntry(
+                prefix="mcp__claude_ai_Sentry__",
+                source_type="claude_ai",
+                service_name="Sentry",
+                tools=[
+                    "mcp__claude_ai_Sentry__search_issues",
+                    "mcp__claude_ai_Sentry__unique_a",
+                ],
+            ),
+            McpServerEntry(
+                prefix="mcp__sentry__",
+                source_type="user_installed",
+                service_name="sentry",
+                tools=[
+                    "mcp__sentry__search_issues",
+                    "mcp__sentry__unique_b",
+                ],
+            ),
+        ]
+
+        groups = build_capability_groups(servers)
+
+        assert len(groups) == 1
+        assert groups[0].tool_name == "search_issues"


### PR DESCRIPTION
**When** I have multiple MCP servers offering the same capability under different prefixes (e.g., 3 Sentry server installations), **I want to** have the doctor surface these horizontal duplicates so **I can** decide whether to consolidate sources and ensure my catalog rules cover all active prefixes.

---

[`10815c61`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/403/commits/10815c614120db088c474a703d2c891fed883bc7) ✨ GH-371 Enable MCP horizontal-duplicate detection
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/371

---