### PR TITLE
✨ GH-395 Enable sensitivity-axis classification for PAP model

### DIFF
--- a/src/dev10x/domain/__init__.py
+++ b/src/dev10x/domain/__init__.py
@@ -8,6 +8,7 @@ from dev10x.domain.git_context import GitContext
 from dev10x.domain.rules.rule_engine import RuleEngine, RuleMatch
 from dev10x.domain.rules.sql import SqlStatement, is_read_only_sql
 from dev10x.domain.rules.validation_rule import Compensation, Rule
+from dev10x.domain.sensitivity import SensitivityClassifier, SensitivityLabel, SensitivityMatch
 
 __all__ = [
     "Compensation",
@@ -28,6 +29,9 @@ __all__ = [
     "Rule",
     "RuleEngine",
     "RuleMatch",
+    "SensitivityClassifier",
+    "SensitivityLabel",
+    "SensitivityMatch",
     "SqlStatement",
     "is_read_only_sql",
 ]

--- a/src/dev10x/domain/sensitivity.py
+++ b/src/dev10x/domain/sensitivity.py
@@ -20,10 +20,10 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 
 
-class SensitivityLabel(str, Enum):
+class SensitivityLabel(StrEnum):
     """Orthogonal sensitivity labels for PAP action classification.
 
     Each label covers a distinct threat class:

--- a/src/dev10x/domain/sensitivity.py
+++ b/src/dev10x/domain/sensitivity.py
@@ -1,0 +1,298 @@
+"""Sensitivity axis for the PAP (Permission Abstraction Protocol) model.
+
+Adds an orthogonal third axis to PAP action classification:
+
+    (tier) × (reversibility) × (sensitivity)
+
+Tier and reversibility classify *what the verb does*.
+Sensitivity classifies *what the target is*.
+
+A trivially-reversible, safe-read command against a sensitive target
+scores "harmless" on the first two axes — but plainly deserves an
+``ask``.  Effect resolution: any axis demanding ``ask``/``forbid``
+wins (deny-overrides), so a sensitivity hit elevates the effective
+effect independently of tier and reversibility.
+
+Defined in GH-395; fixtures from GH-271 evidence #267–#273.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class SensitivityLabel(str, Enum):
+    """Orthogonal sensitivity labels for PAP action classification.
+
+    Each label covers a distinct threat class:
+
+    SECRET
+        Actions that inventory or access stored secrets — e.g.
+        ``gh secret list``, ``kubectl get secret``, reads of ``.env``
+        files and credential stores.  Discovering what secrets *exist*
+        is already a reconnaissance step.
+
+    CREDENTIAL
+        Actions whose target or query matches known credential-name
+        patterns (``*_RW``, ``PRODUCTION_*``, ``*_PASSWORD``,
+        ``*_TOKEN``, ``*_SECRET``, ``export DB_``).  Distinct from
+        SECRET because the sensitive information may not be stored in
+        a dedicated secret store.
+
+    PII
+        Actions that touch customer-data tables, exports, or files
+        recognised as containing personally-identifiable information.
+
+    INFRA
+        Actions that probe, resolve, or interact with production
+        network topology — RDS endpoints, bastion / VPN hosts,
+        production IP ranges, port probes (``nc -zv``, ``dig``).
+    """
+
+    SECRET = "secret"
+    CREDENTIAL = "credential"
+    PII = "pii"
+    INFRA = "infra"
+
+    def __repr__(self) -> str:
+        return f"SensitivityLabel.{self.name}"
+
+
+@dataclass(frozen=True)
+class SensitivityMatch:
+    """Result of a sensitivity classification pass.
+
+    Attributes:
+        label: The matched sensitivity category.
+        pattern: Human-readable description of the rule that triggered.
+        matched_text: The substring from the command that triggered the rule.
+    """
+
+    label: SensitivityLabel
+    pattern: str
+    matched_text: str
+
+
+@dataclass(frozen=True)
+class SensitivityPattern:
+    """One entry in the sensitivity wordlist.
+
+    Attributes:
+        label: Which sensitivity category this pattern covers.
+        regex: Compiled pattern matched against the full command string.
+        description: Short human-readable label for error messages.
+    """
+
+    label: SensitivityLabel
+    regex: re.Pattern[str]
+    description: str
+
+
+def _compile(label: SensitivityLabel, pattern: str, description: str) -> SensitivityPattern:
+    return SensitivityPattern(
+        label=label,
+        regex=re.compile(pattern, re.IGNORECASE),
+        description=description,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Default sensitivity wordlist
+#
+# Each entry covers one class of sensitive target recognised from
+# GH-271 evidence #267–#273 and related sessions.
+# ---------------------------------------------------------------------------
+
+_DEFAULT_PATTERNS: list[SensitivityPattern] = [
+    # ── SECRET ──────────────────────────────────────────────────────────────
+    # GH-271 #267: gh secret list
+    _compile(SensitivityLabel.SECRET, r"\bgh\s+secret\b", "gh secret"),
+    # GH-271 #267: gh variable list/get
+    _compile(SensitivityLabel.SECRET, r"\bgh\s+variable\b", "gh variable"),
+    # kubectl secret access
+    _compile(
+        SensitivityLabel.SECRET,
+        r"\bkubectl\b.*\bsecret\b",
+        "kubectl secret",
+    ),
+    # .env file reads (direct read or cat/less)
+    _compile(
+        SensitivityLabel.SECRET,
+        r"(?:^|\s)(?:cat|less|head|tail|bat)\s+.*\.env\b",
+        ".env file read",
+    ),
+    _compile(
+        SensitivityLabel.SECRET,
+        r"(?:^|\s)\.env\b",
+        ".env file reference",
+    ),
+    # ── CREDENTIAL ──────────────────────────────────────────────────────────
+    # GH-271 #269: rg for *_PRODUCTION_RW
+    _compile(
+        SensitivityLabel.CREDENTIAL,
+        r"[A-Z0-9_]*PRODUCTION[A-Z0-9_]*_RW\b",
+        "PRODUCTION_RW credential pattern",
+    ),
+    # Generic _RW suffix (production read-write credentials)
+    _compile(
+        SensitivityLabel.CREDENTIAL,
+        r"\b[A-Z0-9_]{3,}_RW\b",
+        "*_RW credential suffix",
+    ),
+    # Common secret/token env-var suffixes: match env-var-style names that end
+    # with a credential suffix.  The prefix is 1+ uppercase word chars so that
+    # bare suffixes like "_PASSWORD" (no prefix) don't fire, while short names
+    # like DB_PASSWORD, API_TOKEN, JWT_SECRET all match.
+    _compile(
+        SensitivityLabel.CREDENTIAL,
+        r"\b[A-Z][A-Z0-9_]*(?:PASSWORD|TOKEN|SECRET|API_KEY|PRIVATE_KEY)\b",
+        "credential env-var pattern",
+    ),
+    # Explicit DB export patterns
+    _compile(
+        SensitivityLabel.CREDENTIAL,
+        r"\bexport\s+DB_",
+        "export DB_ credential",
+    ),
+    # GH-271 #270: ~/.config scans for credentials
+    _compile(
+        SensitivityLabel.CREDENTIAL,
+        r"~/\.config\b.*(?:cred|pass|token|secret|key)",
+        "~/.config credential scan",
+    ),
+    # ── PII ─────────────────────────────────────────────────────────────────
+    # Customer-data table names combined with bulk-export or bulk-read verbs.
+    # Matches forward (verb before table) or reverse (table before verb).
+    # SELECT * FROM <pii-table> is treated as a bulk read of PII.
+    _compile(
+        SensitivityLabel.PII,
+        r"(?:"
+        # bulk export tools: mysqldump / pg_dump / mongodump targeting PII table
+        r"\b(?:pg_dump|mysqldump|mongodump)\b.*\b(?:customers?|patients?|subscribers?|account_holders?)\b"
+        r"|"
+        # SQL SELECT *: may be followed by FROM and then the table name
+        r"SELECT\s+\*\s+FROM\s+(?:customers?|patients?|subscribers?|account_holders?)\b"
+        r"|"
+        # reverse: table name then an export/dump verb on the same command line
+        r"\b(?:customers?|patients?|subscribers?|account_holders?)\b.*\b(?:dump|export|backup)\b"
+        r")",
+        "customer-data export/dump",
+    ),
+    _compile(
+        SensitivityLabel.PII,
+        r"\bpersonally[_\s-]identifiable\b",
+        "PII keyword",
+    ),
+    # ── INFRA ────────────────────────────────────────────────────────────────
+    # GH-271 #271: dig on RDS writer endpoint
+    _compile(
+        SensitivityLabel.INFRA,
+        r"\bdig\b.*\.rds\.amazonaws\.com\b",
+        "RDS endpoint DNS resolution",
+    ),
+    # Any RDS hostname reference
+    _compile(
+        SensitivityLabel.INFRA,
+        r"\.rds\.amazonaws\.com\b",
+        "AWS RDS endpoint",
+    ),
+    # GH-271 #272–#273: nc probes to production DB ports
+    _compile(
+        SensitivityLabel.INFRA,
+        r"\bnc\b.*-[zv]+",
+        "nc port probe",
+    ),
+    # bastion / jump-host / VPN infrastructure.  wireguard may appear as
+    # "wireguard0" (interface name) so we allow optional trailing digits.
+    _compile(
+        SensitivityLabel.INFRA,
+        r"\b(?:bastion|jumphost|jump-host|wireguard\d*|cloudflared|tailscale)\b",
+        "bastion/VPN host",
+    ),
+    # Production marker in hostnames/targets
+    _compile(
+        SensitivityLabel.INFRA,
+        r"\bprod(?:uction)?[-.]",
+        "production host/resource",
+    ),
+    # RFC 1918 private IPs frequently used as prod pivot targets (10.x, 172.16-31.x, 192.168.x)
+    _compile(
+        SensitivityLabel.INFRA,
+        r"\b(?:10\.\d{1,3}\.\d{1,3}\.\d{1,3}"
+        r"|172\.(?:1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}"
+        r"|192\.168\.\d{1,3}\.\d{1,3})\b",
+        "RFC 1918 private IP",
+    ),
+]
+
+
+@dataclass
+class SensitivityClassifier:
+    """Classifies a command string against the sensitivity wordlist.
+
+    Usage::
+
+        classifier = SensitivityClassifier()
+        matches = classifier.classify(command="gh secret list")
+        # → [SensitivityMatch(label=SensitivityLabel.SECRET, ...)]
+
+    The classifier checks all registered patterns and returns every
+    match (there can be more than one — e.g. a command may touch both
+    CREDENTIAL and INFRA targets).  Callers apply deny-overrides: if
+    *any* match is returned, the effective effect is elevated to ``ask``
+    regardless of tier and reversibility.
+
+    Attributes:
+        patterns: The wordlist used for classification.  Defaults to
+            ``_DEFAULT_PATTERNS``.  Pass a custom list to narrow or
+            extend coverage without subclassing.
+    """
+
+    patterns: list[SensitivityPattern] = field(default_factory=lambda: list(_DEFAULT_PATTERNS))
+
+    def classify(self, *, command: str) -> list[SensitivityMatch]:
+        """Return all sensitivity matches for *command*.
+
+        Args:
+            command: The full shell command string to inspect.
+
+        Returns:
+            List of :class:`SensitivityMatch` objects, one per matched
+            pattern.  Empty list means no sensitivity concern was found.
+        """
+        results: list[SensitivityMatch] = []
+        for pat in self.patterns:
+            m = pat.regex.search(command)
+            if m:
+                results.append(
+                    SensitivityMatch(
+                        label=pat.label,
+                        pattern=pat.description,
+                        matched_text=m.group(0),
+                    )
+                )
+        return results
+
+    def is_sensitive(self, *, command: str) -> bool:
+        """Return True if *command* triggers any sensitivity rule."""
+        return bool(self.classify(command=command))
+
+    def highest_label(self, *, command: str) -> SensitivityLabel | None:
+        """Return the first matched label, or None if no match.
+
+        When multiple labels match, returns the first match in wordlist
+        order (which preserves the declaration order of
+        ``_DEFAULT_PATTERNS``).
+        """
+        matches = self.classify(command=command)
+        return matches[0].label if matches else None
+
+
+__all__ = [
+    "SensitivityClassifier",
+    "SensitivityLabel",
+    "SensitivityMatch",
+    "SensitivityPattern",
+]

--- a/tests/domain/test_sensitivity.py
+++ b/tests/domain/test_sensitivity.py
@@ -1,0 +1,388 @@
+"""Tests for the sensitivity axis model (GH-395).
+
+Fixtures are drawn directly from GH-271 evidence entries #267–#273,
+which document the sequence: discover credentials → discover pivot →
+resolve endpoint → probe DB ports.  Each step was individually
+tier=safe-read and reversibility=trivial, yet plainly sensitive.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev10x.domain.sensitivity import (
+    SensitivityClassifier,
+    SensitivityLabel,
+    SensitivityMatch,
+    SensitivityPattern,
+)
+
+# ---------------------------------------------------------------------------
+# SensitivityLabel
+# ---------------------------------------------------------------------------
+
+
+class TestSensitivityLabel:
+    def test_all_four_labels_exist(self) -> None:
+        labels = {label.value for label in SensitivityLabel}
+        assert labels == {"secret", "credential", "pii", "infra"}
+
+    def test_values_are_lowercase_strings(self) -> None:
+        for label in SensitivityLabel:
+            assert label.value == label.value.lower()
+
+    def test_repr_includes_name(self) -> None:
+        assert "SECRET" in repr(SensitivityLabel.SECRET)
+
+
+# ---------------------------------------------------------------------------
+# SensitivityClassifier — SECRET label
+# ---------------------------------------------------------------------------
+
+
+class TestSecretClassification:
+    @pytest.fixture()
+    def classifier(self) -> SensitivityClassifier:
+        return SensitivityClassifier()
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # GH-271 #267: inventory of secrets
+            "gh secret list",
+            "gh secret list --repo my-org/my-repo",
+            # gh variable is also secret-scoped
+            "gh variable list",
+            "gh variable get MY_VAR",
+            # kubectl secret access
+            "kubectl get secret db-credentials -o yaml",
+            "kubectl describe secret my-secret",
+        ],
+    )
+    def test_secret_commands_classified_as_secret(
+        self, classifier: SensitivityClassifier, command: str
+    ) -> None:
+        matches = classifier.classify(command=command)
+        labels = {m.label for m in matches}
+        assert SensitivityLabel.SECRET in labels, f"Expected SECRET for: {command!r}"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # .env file reads
+            "cat .env",
+            "cat /app/.env",
+            "less .env",
+            "head -20 .env",
+        ],
+    )
+    def test_env_file_reads_classified_as_secret(
+        self, classifier: SensitivityClassifier, command: str
+    ) -> None:
+        matches = classifier.classify(command=command)
+        labels = {m.label for m in matches}
+        assert SensitivityLabel.SECRET in labels, f"Expected SECRET for: {command!r}"
+
+    def test_benign_gh_pr_not_secret(self, classifier: SensitivityClassifier) -> None:
+        matches = classifier.classify(command="gh pr list")
+        assert not any(m.label == SensitivityLabel.SECRET for m in matches)
+
+    def test_kubectl_get_pods_not_secret(self, classifier: SensitivityClassifier) -> None:
+        matches = classifier.classify(command="kubectl get pods")
+        assert not any(m.label == SensitivityLabel.SECRET for m in matches)
+
+
+# ---------------------------------------------------------------------------
+# SensitivityClassifier — CREDENTIAL label
+# ---------------------------------------------------------------------------
+
+
+class TestCredentialClassification:
+    @pytest.fixture()
+    def classifier(self) -> SensitivityClassifier:
+        return SensitivityClassifier()
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # GH-271 #269: rg for PRODUCTION_RW credential pattern
+            "rg PRODUCTION_RW /work/tt",
+            "grep -r APP_PRODUCTION_RW .",
+            # Generic _RW suffix
+            "grep DB_STAGING_RW .env",
+            # Common credential suffixes
+            "env | grep DB_PASSWORD",
+            "echo $API_TOKEN",
+            "printenv APP_SECRET",
+            "printenv JWT_PRIVATE_KEY",
+            # GH-271 #270: ~/.config scan for credentials
+            "rg ~/.config --glob '*.yaml' password",
+        ],
+    )
+    def test_credential_commands_classified(
+        self, classifier: SensitivityClassifier, command: str
+    ) -> None:
+        matches = classifier.classify(command=command)
+        labels = {m.label for m in matches}
+        assert SensitivityLabel.CREDENTIAL in labels, f"Expected CREDENTIAL for: {command!r}"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "export DB_URL=postgres://localhost/dev",
+            "export DB_PASSWORD=mysecret",
+        ],
+    )
+    def test_export_db_classified_as_credential(
+        self, classifier: SensitivityClassifier, command: str
+    ) -> None:
+        matches = classifier.classify(command=command)
+        labels = {m.label for m in matches}
+        assert SensitivityLabel.CREDENTIAL in labels
+
+    def test_benign_ls_not_credential(self, classifier: SensitivityClassifier) -> None:
+        matches = classifier.classify(command="ls -la /tmp")
+        assert not any(m.label == SensitivityLabel.CREDENTIAL for m in matches)
+
+    def test_short_rw_suffix_not_matched(self, classifier: SensitivityClassifier) -> None:
+        # Single-char or two-char prefixes like "RW" alone shouldn't fire
+        matches = classifier.classify(command="chmod +rw /tmp/file")
+        assert not any(m.label == SensitivityLabel.CREDENTIAL for m in matches)
+
+
+# ---------------------------------------------------------------------------
+# SensitivityClassifier — INFRA label
+# ---------------------------------------------------------------------------
+
+
+class TestInfraClassification:
+    @pytest.fixture()
+    def classifier(self) -> SensitivityClassifier:
+        return SensitivityClassifier()
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # GH-271 #271: dig on production RDS writer endpoint
+            "dig mydb.cluster-abc123.us-east-1.rds.amazonaws.com",
+            # GH-271 #272–#273: nc probes to production DB ports
+            "nc -zv 10.0.0.5 5432",
+            "nc -zvw3 192.168.1.100 5432",
+            # bastion / VPN hosts
+            "ssh bastion.internal",
+            "wg show wireguard0",
+            "cloudflared tunnel list",
+            "tailscale status",
+            # production hostnames
+            "curl https://prod.myapp.example.com/health",
+            "ping production.db.internal",
+            # RFC 1918 private IPs
+            "curl http://10.0.1.42/api",
+            "ssh 172.16.0.10",
+            "ping 192.168.100.5",
+        ],
+    )
+    def test_infra_commands_classified(
+        self, classifier: SensitivityClassifier, command: str
+    ) -> None:
+        matches = classifier.classify(command=command)
+        labels = {m.label for m in matches}
+        assert SensitivityLabel.INFRA in labels, f"Expected INFRA for: {command!r}"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "curl https://api.github.com/repos",
+            "ping localhost",
+            "curl http://127.0.0.1:8000/health",
+            "git push origin develop",
+        ],
+    )
+    def test_safe_network_commands_not_infra(
+        self, classifier: SensitivityClassifier, command: str
+    ) -> None:
+        matches = classifier.classify(command=command)
+        assert not any(m.label == SensitivityLabel.INFRA for m in matches), (
+            f"Expected no INFRA match for: {command!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# SensitivityClassifier — PII label
+# ---------------------------------------------------------------------------
+
+
+class TestPiiClassification:
+    @pytest.fixture()
+    def classifier(self) -> SensitivityClassifier:
+        return SensitivityClassifier()
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # pg_dump / mysqldump against a PII table name
+            "pg_dump customers --table=customers > dump.sql",
+            "mysqldump customers --single-transaction",
+            # SELECT * queries against PII tables (bulk read)
+            "SELECT * FROM customers LIMIT 100",
+            "SELECT * FROM patients WHERE active=1",
+        ],
+    )
+    def test_customer_data_dumps_classified_as_pii(
+        self, classifier: SensitivityClassifier, command: str
+    ) -> None:
+        matches = classifier.classify(command=command)
+        labels = {m.label for m in matches}
+        assert SensitivityLabel.PII in labels, f"Expected PII for: {command!r}"
+
+    def test_benign_select_not_pii(self, classifier: SensitivityClassifier) -> None:
+        matches = classifier.classify(command="SELECT id, name FROM products LIMIT 10")
+        assert not any(m.label == SensitivityLabel.PII for m in matches)
+
+
+# ---------------------------------------------------------------------------
+# SensitivityClassifier — helper methods
+# ---------------------------------------------------------------------------
+
+
+class TestClassifierHelpers:
+    @pytest.fixture()
+    def classifier(self) -> SensitivityClassifier:
+        return SensitivityClassifier()
+
+    def test_is_sensitive_true_for_gh_secret(self, classifier: SensitivityClassifier) -> None:
+        assert classifier.is_sensitive(command="gh secret list") is True
+
+    def test_is_sensitive_false_for_benign(self, classifier: SensitivityClassifier) -> None:
+        assert classifier.is_sensitive(command="git status") is False
+
+    def test_highest_label_returns_none_for_clean(self, classifier: SensitivityClassifier) -> None:
+        assert classifier.highest_label(command="ls /tmp") is None
+
+    def test_highest_label_returns_label_for_sensitive(
+        self, classifier: SensitivityClassifier
+    ) -> None:
+        label = classifier.highest_label(command="gh secret list")
+        assert label == SensitivityLabel.SECRET
+
+    def test_multiple_labels_can_match(self, classifier: SensitivityClassifier) -> None:
+        # A command that rg-searches ~/.config for credentials hitting both
+        # CREDENTIAL wordlist entries
+        matches = classifier.classify(command="rg PRODUCTION_RW ~/.config/dev/settings.yaml")
+        # Should match CREDENTIAL at minimum
+        labels = {m.label for m in matches}
+        assert SensitivityLabel.CREDENTIAL in labels
+
+    def test_classify_returns_list_of_match_objects(
+        self, classifier: SensitivityClassifier
+    ) -> None:
+        matches = classifier.classify(command="gh secret list")
+        assert isinstance(matches, list)
+        assert all(isinstance(m, SensitivityMatch) for m in matches)
+
+    def test_match_has_label_pattern_text(self, classifier: SensitivityClassifier) -> None:
+        matches = classifier.classify(command="gh secret list")
+        assert len(matches) > 0
+        m = matches[0]
+        assert isinstance(m.label, SensitivityLabel)
+        assert isinstance(m.pattern, str)
+        assert isinstance(m.matched_text, str)
+        assert len(m.matched_text) > 0
+
+
+# ---------------------------------------------------------------------------
+# SensitivityClassifier — custom patterns
+# ---------------------------------------------------------------------------
+
+
+class TestCustomPatterns:
+    def test_empty_patterns_never_matches(self) -> None:
+        classifier = SensitivityClassifier(patterns=[])
+        assert classifier.classify(command="gh secret list") == []
+
+    def test_single_custom_pattern(self) -> None:
+        import re
+
+        custom = SensitivityPattern(
+            label=SensitivityLabel.INFRA,
+            regex=re.compile(r"\bmy-prod-db\b"),
+            description="custom prod db",
+        )
+        classifier = SensitivityClassifier(patterns=[custom])
+        matches = classifier.classify(command="psql my-prod-db")
+        assert len(matches) == 1
+        assert matches[0].label == SensitivityLabel.INFRA
+        assert matches[0].pattern == "custom prod db"
+
+    def test_custom_pattern_no_match(self) -> None:
+        import re
+
+        custom = SensitivityPattern(
+            label=SensitivityLabel.SECRET,
+            regex=re.compile(r"\bmy-vault\b"),
+            description="custom vault",
+        )
+        classifier = SensitivityClassifier(patterns=[custom])
+        matches = classifier.classify(command="gh secret list")
+        assert matches == []
+
+
+# ---------------------------------------------------------------------------
+# GH-271 evidence #267–#273 sequence fixture
+# ---------------------------------------------------------------------------
+
+
+class TestGH271EvidenceSequence:
+    """End-to-end: the #269→#273 attack chain each individually scores sensitive.
+
+    This is the motivating example from GH-395: each step is trivially
+    reversible and safe-read, but the sequence as a whole constitutes
+    reconnaissance → credential discovery → endpoint resolution → port probe.
+    """
+
+    @pytest.fixture()
+    def classifier(self) -> SensitivityClassifier:
+        return SensitivityClassifier()
+
+    @pytest.mark.parametrize(
+        ("command", "expected_label", "evidence_id"),
+        [
+            # #267: secret inventory
+            ("gh secret list", SensitivityLabel.SECRET, "#267"),
+            # #269: credential pattern search
+            (
+                "rg /work/tt --glob '*.env' PRODUCTION_RW",
+                SensitivityLabel.CREDENTIAL,
+                "#269",
+            ),
+            # #270: credential + infra scan
+            (
+                "rg ~/.config bastion wireguard tunnel",
+                SensitivityLabel.INFRA,
+                "#270",
+            ),
+            # #271: RDS endpoint resolution
+            (
+                "dig writer.cluster-xyz.eu-west-1.rds.amazonaws.com",
+                SensitivityLabel.INFRA,
+                "#271",
+            ),
+            # #272: nc probe to prod writer
+            ("nc -zv 10.0.5.20 5432", SensitivityLabel.INFRA, "#272"),
+            # #273: nc probe to prod reader
+            ("nc -zv 10.0.5.21 5432", SensitivityLabel.INFRA, "#273"),
+        ],
+    )
+    def test_each_step_classified_sensitive(
+        self,
+        classifier: SensitivityClassifier,
+        command: str,
+        expected_label: SensitivityLabel,
+        evidence_id: str,
+    ) -> None:
+        matches = classifier.classify(command=command)
+        assert matches, f"GH-271 evidence {evidence_id}: expected a match for {command!r}"
+        labels = {m.label for m in matches}
+        assert expected_label in labels, (
+            f"GH-271 evidence {evidence_id}: expected {expected_label} in {labels}"
+        )


### PR DESCRIPTION
**When** an agent runs a trivially-reversible, safe-read command against a sensitive target (secrets, credentials, PII, production infrastructure), **I want to** classify the action on an orthogonal sensitivity axis (`secret`/`credential`/`pii`/`infra`), **so** the PAP model can apply deny-overrides regardless of tier and reversibility — preventing unattended reconnaissance chains like GH-271 evidence #267–#273.

---

[`21292a5c`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/404/commits/21292a5cc5e4dc0f569e5f31043a2dc78fbc560f) ✨ GH-395 Enable sensitivity-axis classification for PAP model
[`d7b79f29`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/404/commits/d7b79f292369e7e64077aff05754b7ad1f149dad) 🐛 GH-395 Fix SensitivityLabel to use StrEnum (ruff UP042)

---

## Increment 1 scope (deliberately small)

- `src/dev10x/domain/sensitivity.py` — `SensitivityLabel` (StrEnum), `SensitivityMatch` (dataclass), `SensitivityPattern` (dataclass), `SensitivityClassifier` with default wordlist
- `tests/domain/test_sensitivity.py` — 64 unit tests covering all four labels; GH-271 evidence #267–#273 as parametrized fixtures

## Deferred to follow-up issues

- Cedar `@sensitivity` annotation spec (vocabulary + deny-overrides resolution rule)
- Validator wiring (new DX014 rule that calls `SensitivityClassifier`)
- Cross-references to GH-310 (sequence/unattended gate) and GH-371 (resource classification)

---

- ~[ ] Migration files added/modified~
- ~[ ] New environment variables documented~
- ~[ ] Breaking changes documented~
- [ ] Tests cover new code (64 unit tests in `tests/domain/test_sensitivity.py`)
- [ ] ruff + mypy pass (confirmed via pre-PR checks)

Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/395