### PR TITLE
✨ GH-376 Enable worktree-parent anchoring in permission doctor

### DIFF
--- a/agents/permission-auditor.md
+++ b/agents/permission-auditor.md
@@ -94,6 +94,22 @@ Run the `mcp-horizontal-duplicates` doctor strategy (registered in
 Severity: **LOW** (informational). The duplication may be intentional
 (e.g., keeping a backup server). Surface it for user awareness only.
 
+### Phase 4c: Worktree-Root Anchoring Audit (GH-376)
+
+Check whether `.worktrees` parent directories are properly anchored across
+all CWD-keyed permission scopes. Three failure modes apply: workspace
+`additionalDirectories` anchoring at the leaf instead of the parent
+(MISSING_WORKTREES_PARENT / WORKTREE_LEAF_ANCHORING), bare-relative
+skill-script allow rules that silently target the wrong directory per
+worktree (RELATIVE_SKILL_SCRIPT), and the per-leaf skill-consent scope
+gap (upstream CC defect, GH-312 — informational only, not rule-fixable).
+
+Automated fix: `uvx dev10x permission doctor anchor-worktree-roots`.
+
+See [`references/agents/permission-auditor/worktree-anchoring.md`](../references/agents/permission-auditor/worktree-anchoring.md)
+for the full failure-mode descriptions, detection steps, and severity
+table.
+
 ### Phase 5: Deny Rule Gap Analysis
 
 Check for missing protection on known destructive operations.

--- a/references/agents/permission-auditor/worktree-anchoring.md
+++ b/references/agents/permission-auditor/worktree-anchoring.md
@@ -1,0 +1,54 @@
+# Worktree-Root Anchoring Audit (GH-376)
+
+## Failure Modes
+
+Three distinct failure modes exist when working across multiple git
+worktrees:
+
+1. **Workspace scope** — `additionalDirectories` lists individual leaf
+   worktree paths (e.g. `/work/tt/.worktrees/tt-pos-7`) instead of the
+   project-level `.worktrees` parent (`/work/tt/tt-pos`). Every new
+   worktree re-prompts on first read because the leaf directory is not
+   registered. Anchoring the **parent** covers all sibling and future
+   worktrees without re-prompting per leaf.
+
+2. **Skill-script scope** — allow rules of the form
+   `Bash(.claude/skills/<name>/scripts/<name>.py:*)` use a bare-relative
+   path that resolves against the active CWD. In a worktree the CWD is
+   the worktree root, so the rule silently targets that worktree's skill
+   directory rather than the installed plugin. These rules must be
+   rewritten to absolute plugin-cache paths or replaced with
+   `Skill(<name>)` invocations.
+
+3. **Per-leaf skill-consent scope** — Claude Code scopes "don't ask again"
+   Skill() approvals to the narrowest enclosing directory (the leaf
+   worktree). There is no project-root scope in the current UI. Document
+   this gap per GH-312; do NOT flag it as a rule-fixable finding.
+
+## Detection Steps
+
+1. Scan `additionalDirectories` in each settings file. For each entry
+   that ends in `/.worktrees/<leaf>` (i.e. is a leaf, not the parent),
+   flag it as WORKTREE_LEAF_ANCHORING.
+2. Scan `permissions.allow` for rules matching
+   `Bash(.claude/skills/.*/scripts/.*:*)`. Flag each as
+   RELATIVE_SKILL_SCRIPT.
+3. Note any projects with a `.worktrees/` directory whose parent is NOT
+   in `additionalDirectories` at all — flag as MISSING_WORKTREES_PARENT.
+
+## Automated Fix
+
+Run `uvx dev10x permission doctor anchor-worktree-roots --dry-run` to
+preview, then without `--dry-run` to apply. The command:
+- Discovers all `.worktrees` parents beneath configured roots
+- Anchors each parent in `additionalDirectories` across all settings files
+- Reports relative skill-script rules for manual rewrite
+
+## Severity Table
+
+| Pattern | Severity | Rationale |
+|---------|----------|-----------|
+| MISSING_WORKTREES_PARENT | HIGH | Every new worktree re-prompts until anchored |
+| WORKTREE_LEAF_ANCHORING | MEDIUM | Partial fix, does not cover future worktrees |
+| RELATIVE_SKILL_SCRIPT | MEDIUM | Silently wrong path per worktree |
+| Per-leaf skill-consent scope gap | LOW/INFO | Upstream CC defect, no local fix — reference GH-312 |

--- a/skills/plugin-maintenance/SKILL.md
+++ b/skills/plugin-maintenance/SKILL.md
@@ -31,6 +31,7 @@ allowed-tools:
   - Bash(uvx dev10x permission ensure-workspace:*)
   - Bash(uvx dev10x permission generalize:*)
   - Bash(uvx dev10x permission doctor:*)
+  - Bash(uvx dev10x permission doctor anchor-worktree-roots:*)
   - Bash(uvx dev10x permission init:*)
   - Bash(uvx dev10x permission investigate:*)
   - Bash(uvx dev10x permission record-upgrade:*)
@@ -624,7 +625,16 @@ uvx dev10x permission doctor apply-deprecations
 uvx dev10x permission doctor cross-contamination
 ```
 
-4. Enable an opt-in Tier 3 group when needed (e.g., `kubernetes-readonly`,
+4. Anchor `.worktrees` parent roots (GH-376) — ensures project-level
+   `.worktrees` parents are registered in `additionalDirectories` and
+   flags bare-relative skill-script allow rules:
+
+```bash
+uvx dev10x permission doctor anchor-worktree-roots --dry-run
+uvx dev10x permission doctor anchor-worktree-roots
+```
+
+5. Enable an opt-in Tier 3 group when needed (e.g., `kubernetes-readonly`,
    `network-diagnostics`, `obsidian-cli`):
 
 ```bash

--- a/src/dev10x/commands/permission.py
+++ b/src/dev10x/commands/permission.py
@@ -974,6 +974,87 @@ def doctor_enable_group(*, group_name: str, dry_run: bool) -> None:
     click.echo(f"\n{verb} {total_added} rules from group {group_name!r}.")
 
 
+@doctor.command(name="anchor-worktree-roots")
+@click.option("--dry-run", is_flag=True, help="Show changes without modifying files")
+@click.option("--quiet", is_flag=True, help="Suppress per-file details")
+def doctor_anchor_worktree_roots(*, dry_run: bool, quiet: bool) -> None:
+    """Anchor .worktrees parents in additionalDirectories and flag relative skill-script rules.
+
+    Worktrees accumulate per-leaf ``additionalDirectories`` entries instead of
+    anchoring the project-level ``.worktrees`` parent. This command:
+
+    \b
+    1. Discovers every ``<project>/.worktrees`` parent beneath configured roots.
+    2. Ensures each parent is present in ``additionalDirectories`` across all
+       settings files — anchoring at the parent covers all sibling and future
+       worktrees without re-prompting per leaf (GH-376).
+    3. Flags bare-relative ``.claude/skills/.../scripts/`` allow rules that
+       silently target different skill dirs per worktree CWD.
+    """
+    from dev10x.skills.permission import doctor as mod
+    from dev10x.skills.permission import update_paths as paths_mod
+
+    config_path = paths_mod.find_config()
+    config = paths_mod.load_config(config_path)
+    roots = config.get("roots", [])
+    if not roots:
+        click.echo("No roots configured. Run `dev10x permission init` first.")
+        return
+
+    settings_files = paths_mod.find_settings_files(
+        roots=roots,
+        include_user=config.get("include_user_settings", True),
+    )
+    if not settings_files:
+        click.echo("No settings files found.")
+        return
+
+    if dry_run and not quiet:
+        click.echo("(dry run — no files will be modified)\n")
+
+    worktrees_parents = mod.discover_worktrees_parents(roots)
+    if not quiet:
+        if worktrees_parents:
+            click.echo(f"Discovered {len(worktrees_parents)} .worktrees parent(s):")
+            for parent in worktrees_parents:
+                click.echo(f"  {parent}")
+        else:
+            click.echo("No .worktrees parents found beneath configured roots.")
+
+    anchor_result = mod.anchor_worktree_roots(
+        settings_files,
+        roots=roots,
+        dry_run=dry_run,
+    )
+
+    workspace_count = anchor_result.workspace_anchored
+    skill_script_count = sum(1 for f in anchor_result.findings if f.scope == "skill-script")
+
+    for finding in anchor_result.findings:
+        if finding.scope == "workspace" and not quiet:
+            click.echo(f"\n{finding.settings_path}")
+            click.echo(f"  {finding.suggestion}")
+        elif finding.scope == "skill-script":
+            click.echo(f"\n{finding.settings_path}")
+            click.echo(f"  ! RELATIVE_SKILL_SCRIPT: {finding.rule}")
+            if not quiet:
+                click.echo(f"    {finding.suggestion}")
+
+    if workspace_count == 0 and skill_script_count == 0:
+        click.echo("\nAll settings files already have worktrees parents anchored.")
+    else:
+        if workspace_count > 0:
+            verb = "Would anchor" if dry_run else "Anchored"
+            click.echo(
+                f"\n{verb} {workspace_count} worktrees parent path(s) in additionalDirectories."
+            )
+        if skill_script_count > 0:
+            click.echo(
+                f"\nFound {skill_script_count} relative skill-script rule(s) "
+                f"— rewrite to absolute plugin-cache paths or Skill() invocations."
+            )
+
+
 @permission.command(name="record-upgrade")
 @click.option(
     "--version",

--- a/src/dev10x/skills/permission/doctor.py
+++ b/src/dev10x/skills/permission/doctor.py
@@ -419,6 +419,143 @@ def apply_deprecations(
     return output, outcomes
 
 
+@dataclass
+class WorktreeAnchorFinding:
+    worktrees_parent: Path
+    settings_path: Path
+    scope: str  # "workspace" | "skill-script"
+    rule: str | None = None  # for skill-script findings
+    suggestion: str = ""
+
+
+@dataclass
+class WorktreeAnchorResult:
+    workspace_anchored: int = 0  # total additionalDirectories entries added
+    findings: list[WorktreeAnchorFinding] = field(default_factory=list)
+
+    @property
+    def total_changes(self) -> int:
+        return self.workspace_anchored
+
+
+_RELATIVE_SKILL_SCRIPT_RE = re.compile(r"Bash\(\.claude/skills/(?P<tail>[^:)]+)")
+
+
+def discover_worktrees_parents(roots: Iterable[str]) -> list[Path]:
+    """Return unique `.worktrees` parent paths found beneath each root.
+
+    A `.worktrees` parent is a project directory that contains a
+    `.worktrees/` subdirectory. Anchoring the parent covers all
+    sibling and future worktrees without re-prompting per leaf.
+    """
+    parents: list[Path] = []
+    seen: set[Path] = set()
+    for root in roots:
+        root_path = Path(root).expanduser()
+        if not root_path.is_dir():
+            continue
+        # Depth-1 scan: check immediate children and root itself
+        candidates = [root_path] + list(root_path.iterdir())
+        for candidate in candidates:
+            if not candidate.is_dir():
+                continue
+            wt_dir = candidate / ".worktrees"
+            if wt_dir.is_dir():
+                resolved = candidate.resolve()
+                if resolved not in seen:
+                    seen.add(resolved)
+                    parents.append(candidate)
+    return parents
+
+
+def anchor_worktree_roots(
+    settings_files: Iterable[Path],
+    *,
+    roots: Iterable[str],
+    dry_run: bool = False,
+) -> WorktreeAnchorResult:
+    """Anchor `.worktrees` parent roots across workspace and skill-script scopes.
+
+    For each settings file:
+
+    1. **Workspace scope** — ensure every discovered `<project>/.worktrees`
+       parent is present in ``permissions.additionalDirectories``. Anchoring
+       the parent covers all sibling and future worktrees without re-prompting
+       per leaf (GH-376).
+
+    2. **Skill-script scope** — detect bare-relative allow rules of the form
+       ``Bash(.claude/skills/<name>/scripts/<name>.py:*)`` and flag them for
+       rewriting to the absolute, CWD-independent plugin-cache path (or
+       ``Skill(<name>)`` invocation). Relative rules silently point at
+       different skill dirs per worktree and must be absolute to be stable.
+
+    Returns a :class:`WorktreeAnchorResult` summarising changes made (or that
+    would be made on ``dry_run=True``).
+    """
+    from dev10x.skills.permission.update_paths import ensure_workspace_directories
+
+    worktrees_parents = discover_worktrees_parents(roots)
+    parent_strs = [str(p) for p in worktrees_parents]
+
+    result = WorktreeAnchorResult()
+
+    for settings_path in settings_files:
+        if not settings_path.exists():
+            continue
+
+        # 1. Workspace anchoring
+        if parent_strs:
+            count, _ = ensure_workspace_directories(
+                settings_path,
+                parent_strs,
+                dry_run=dry_run,
+            )
+            if count > 0:
+                result.workspace_anchored += count
+                result.findings.append(
+                    WorktreeAnchorFinding(
+                        worktrees_parent=worktrees_parents[0]
+                        if worktrees_parents
+                        else settings_path.parent,
+                        settings_path=settings_path,
+                        scope="workspace",
+                        suggestion=(
+                            f"Anchored {count} worktrees parent(s) in "
+                            f"additionalDirectories: {settings_path}"
+                        ),
+                    )
+                )
+
+        # 2. Skill-script rule detection
+        try:
+            import json as _json
+
+            data = _json.loads(settings_path.read_text())
+        except (OSError, ValueError):
+            continue
+        allow_rules: list[str] = data.get("permissions", {}).get("allow", [])
+        for rule in allow_rules:
+            if not isinstance(rule, str):
+                continue
+            if _RELATIVE_SKILL_SCRIPT_RE.search(rule):
+                suggestion = (
+                    "Rewrite to absolute plugin-cache path or replace "
+                    "with Skill() invocation. Relative paths resolve against "
+                    "CWD and silently target different skill dirs per worktree."
+                )
+                result.findings.append(
+                    WorktreeAnchorFinding(
+                        worktrees_parent=settings_path.parent,
+                        settings_path=settings_path,
+                        scope="skill-script",
+                        rule=rule,
+                        suggestion=suggestion,
+                    )
+                )
+
+    return result
+
+
 def diagnose_additional_directories(
     rule: str,
     *,

--- a/tests/permission/test_doctor.py
+++ b/tests/permission/test_doctor.py
@@ -352,3 +352,136 @@ class TestAdditionalDirectoriesDiagnosis:
             additional_directories=[str(in_scope)],
         )
         assert msg is None
+
+
+class TestDiscoverWorktreesParents:
+    def test_finds_project_with_worktrees_dir(self, tmp_path: Path) -> None:
+        project = tmp_path / "my-project"
+        (project / ".worktrees").mkdir(parents=True)
+        parents = doctor.discover_worktrees_parents([str(tmp_path)])
+        assert project in parents
+
+    def test_skips_projects_without_worktrees(self, tmp_path: Path) -> None:
+        no_wt = tmp_path / "no-worktrees"
+        no_wt.mkdir()
+        parents = doctor.discover_worktrees_parents([str(tmp_path)])
+        assert no_wt not in parents
+
+    def test_deduplicates_same_parent(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        (project / ".worktrees").mkdir(parents=True)
+        # Pass root twice — should deduplicate
+        parents = doctor.discover_worktrees_parents([str(tmp_path), str(tmp_path)])
+        assert parents.count(project) == 1
+
+    def test_returns_empty_for_nonexistent_root(self, tmp_path: Path) -> None:
+        parents = doctor.discover_worktrees_parents([str(tmp_path / "does-not-exist")])
+        assert parents == []
+
+    def test_root_itself_is_checked(self, tmp_path: Path) -> None:
+        # If the root itself has a .worktrees dir, it is returned
+        (tmp_path / ".worktrees").mkdir()
+        parents = doctor.discover_worktrees_parents([str(tmp_path)])
+        assert tmp_path in parents
+
+
+class TestAnchorWorktreeRoots:
+    def _make_settings(self, path: Path, allow: list[str] | None = None) -> Path:
+        settings = path / ".claude" / "settings.local.json"
+        settings.parent.mkdir(parents=True, exist_ok=True)
+        settings.write_text(
+            __import__("json").dumps(
+                {"permissions": {"allow": allow or [], "additionalDirectories": []}}
+            )
+        )
+        return settings
+
+    def test_anchors_parent_in_additional_directories(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        (project / ".worktrees").mkdir(parents=True)
+        settings = self._make_settings(tmp_path)
+
+        result = doctor.anchor_worktree_roots(
+            [settings],
+            roots=[str(tmp_path)],
+            dry_run=False,
+        )
+
+        import json
+
+        data = json.loads(settings.read_text())
+        assert str(project) in data["permissions"]["additionalDirectories"]
+        assert result.total_changes > 0
+
+    def test_dry_run_does_not_write(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        (project / ".worktrees").mkdir(parents=True)
+        settings = self._make_settings(tmp_path)
+        original = settings.read_text()
+
+        result = doctor.anchor_worktree_roots(
+            [settings],
+            roots=[str(tmp_path)],
+            dry_run=True,
+        )
+
+        assert settings.read_text() == original
+        # dry_run still reports findings
+        assert len(result.findings) > 0
+
+    def test_no_changes_when_parent_already_registered(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        (project / ".worktrees").mkdir(parents=True)
+        settings = project / ".claude" / "settings.local.json"
+        settings.parent.mkdir(parents=True, exist_ok=True)
+        import json
+
+        settings.write_text(
+            json.dumps(
+                {
+                    "permissions": {
+                        "allow": [],
+                        "additionalDirectories": [str(project)],
+                    }
+                }
+            )
+        )
+
+        result = doctor.anchor_worktree_roots(
+            [settings],
+            roots=[str(tmp_path)],
+            dry_run=False,
+        )
+        assert result.total_changes == 0
+
+    def test_flags_relative_skill_script_rule(self, tmp_path: Path) -> None:
+        settings = self._make_settings(
+            tmp_path,
+            allow=["Bash(.claude/skills/git-commit/scripts/git-commit.py:*)"],
+        )
+
+        result = doctor.anchor_worktree_roots(
+            [settings],
+            roots=[str(tmp_path)],
+            dry_run=False,
+        )
+
+        skill_script_findings = [f for f in result.findings if f.scope == "skill-script"]
+        assert len(skill_script_findings) == 1
+        assert skill_script_findings[0].rule is not None
+        assert ".claude/skills/" in skill_script_findings[0].rule
+
+    def test_stable_absolute_rule_not_flagged(self, tmp_path: Path) -> None:
+        settings = self._make_settings(
+            tmp_path,
+            allow=["Bash(~/.claude/plugins/cache/Dev10x-Guru/Dev10x/**/git-commit.py:*)"],
+        )
+
+        result = doctor.anchor_worktree_roots(
+            [settings],
+            roots=[str(tmp_path)],
+            dry_run=False,
+        )
+
+        skill_script_findings = [f for f in result.findings if f.scope == "skill-script"]
+        assert len(skill_script_findings) == 0


### PR DESCRIPTION
**When** I work across multiple git worktrees beneath a project, **I want** the Dev10x permission doctor to anchor each project's `.worktrees` parent across every permission scope keyed on CWD, **so** reads, skill consents, and downstream service prompts stop re-firing on each new worktree.

---

[`3584e0bd`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/405/commits/3584e0bd2281aab6ffce62dc444ea44b50d2f37e) ✨ GH-376 Enable worktree-parent anchoring in permission doctor

Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/376