### PR TITLE
✨ GH-387 Enable local dev-release smoke-testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ __pycache__/
 .venv/
 *.egg-info/
 .coverage
+build/
+dist/
 
 # Claude Code local settings
 .claude/settings.local.json

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -7,9 +7,10 @@
 #
 # Usage: ./bin/release.sh {features|fixes|major}
 #
-# A dogfood smoke gate (Phase 2b) blocks tagging until you confirm
-# that you have run a real --plugin-dir session with the release candidate.
-# Skip with SKIP_DOGFOOD=1 (CI-only escape hatch — never for human releases).
+# Phase 2b prints the remote side effects of a release (PyPI wheel publish,
+# marketplace ref move) before the irreversible tag. A human at a TTY
+# proceeds automatically; a non-interactive/agent run must set
+# CONFIRM_RELEASE=1 to opt in.
 set -euo pipefail
 
 CYAN='\033[0;36m'
@@ -84,94 +85,52 @@ function bump_version {
     git commit -m "🔖 Bump version: ${before} → ${after}"
 }
 
-# Detect the installed marketplace plugin version, if any.
-# Prints the version string or "unknown" if not detectable.
-function installed_plugin_version {
-    local plugin_json=""
-    # Try ~/.claude/plugins/Dev10x-Claude/plugin.json (marketplace install path)
-    if [[ -f "${HOME}/.claude/plugins/Dev10x-Claude/plugin.json" ]]; then
-        plugin_json="${HOME}/.claude/plugins/Dev10x-Claude/plugin.json"
-    elif [[ -f "${HOME}/.config/claude/plugins/Dev10x-Claude/plugin.json" ]]; then
-        plugin_json="${HOME}/.config/claude/plugins/Dev10x-Claude/plugin.json"
-    fi
-    if [[ -n "$plugin_json" ]]; then
-        # Extract version field with jq if available, otherwise grep
-        if command -v jq >/dev/null 2>&1; then
-            jq -r '.version // "unknown"' "$plugin_json" 2>/dev/null || echo "unknown"
-        else
-            grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' "$plugin_json" \
-                | grep -o '"[^"]*"$' | tr -d '"' 2>/dev/null || echo "unknown"
-        fi
-    else
-        echo "unknown"
-    fi
-}
-
-# Phase 2b: Dogfood smoke gate.
-# Require the releaser to confirm a real --plugin-dir session before tagging.
-# This gate exists because CI only runs under mocks; the only true runtime
-# validation of MCP-server and permission-hook changes requires a live session
-# with the develop checkout loaded via --plugin-dir.
-function dogfood_gate {
+# Phase 2b: Release notice + agent guard.
+# A release is NOT a local action. Pushing the tag triggers a PyPI wheel
+# publish (.github/workflows/pypi-publish.yml on v* tags) and the main reset
+# moves the marketplace's served ref — both effectively irreversible. This
+# notice states those effects plainly. A human at a TTY proceeds; a
+# non-interactive/agent run must set CONFIRM_RELEASE=1 so an agent cannot
+# trigger a publish by accident.
+function release_notice {
     local rc_version="$1"
+    local tag="$2"
     local repo_root
     repo_root="$(git rev-parse --show-toplevel)"
 
-    if [[ "${SKIP_DOGFOOD:-}" == "1" ]]; then
-        echo -e "  ${YELLOW}⚠  SKIP_DOGFOOD=1 — skipping dogfood gate (CI mode)${RESET}"
+    header "Phase 2b · Release effects (read before tagging)"
+    echo ""
+    echo -e "  Releasing ${BOLD}${tag}${RESET} is not a local action. Tagging will:"
+    echo ""
+    echo -e "    ${BOLD}•${RESET} push tag ${tag} → CI publishes the wheel to PyPI"
+    echo -e "      (https://pypi.org/project/Dev10x/ — a version cannot be reused)"
+    echo -e "    ${BOLD}•${RESET} reset main to develop HEAD → the marketplace served ref"
+    echo -e "      advances; every 'claude plugin update' jumps to ${rc_version}"
+    echo -e "    ${BOLD}•${RESET} create a GitHub release for ${tag}"
+    echo ""
+    echo -e "  ${YELLOW}These effects are remote and effectively irreversible.${RESET}"
+    echo ""
+    echo -e "  To smoke-test this candidate first (separate terminal):"
+    echo -e "    ${CYAN}${repo_root}/bin/test-local.sh${RESET}   # build + install wheel, verify structure"
+    echo -e "    ${CYAN}claude --plugin-dir ${repo_root}${RESET}  # exercise the live plugin runtime"
+    echo ""
+
+    if [[ -t 0 ]]; then
+        step "Interactive session — proceeding to tag."
         return 0
     fi
 
-    header "Phase 2b · Dogfood smoke gate (REQUIRED before tagging)"
-
-    # Surface version-skew information so the releaser knows what they're testing.
-    local installed
-    installed="$(installed_plugin_version)"
-    echo ""
-    echo -e "  ${BOLD}Release candidate:${RESET} ${rc_version}"
-    if [[ "$installed" == "unknown" ]]; then
-        echo -e "  ${BOLD}Installed plugin:${RESET}  not detected (marketplace checkout absent)"
-    elif [[ "$installed" == "$rc_version" ]]; then
-        echo -e "  ${BOLD}Installed plugin:${RESET}  ${installed} ${GREEN}(matches RC — no skew)${RESET}"
-    else
-        echo -e "  ${BOLD}Installed plugin:${RESET}  ${installed} ${YELLOW}⚠ version skew — installed lags RC${RESET}"
-        echo -e "  ${YELLOW}  The in-session MCP server will be the OLD plugin until you restart${RESET}"
-        echo -e "  ${YELLOW}  claude with --plugin-dir pointing to this checkout.${RESET}"
+    if [[ "${CONFIRM_RELEASE:-}" == "1" ]]; then
+        step "CONFIRM_RELEASE=1 — proceeding to tag (non-interactive)."
+        return 0
     fi
 
-    echo ""
-    echo -e "  ${BOLD}Before confirming, you must run a real --plugin-dir session:${RESET}"
-    echo ""
-    echo -e "    ${CYAN}claude --plugin-dir ${repo_root}${RESET}"
-    echo ""
-    echo -e "  ${BOLD}Minimum smoke checklist:${RESET}"
-    echo "    □  Start a session and verify the plugin loads without errors"
-    echo "    □  Run one Dev10x skill that exercises recent MCP-server changes"
-    echo "       e.g. Dev10x:gh-pr-review or Dev10x:gh-pr-respond"
-    echo "       (hits resolve_review_thread + pr_get — both new in this cycle)"
-    echo "    □  Run one git commit via Dev10x:git-commit"
-    echo "       (exercises bash tokenizer + privilege-escalation denies)"
-    echo "    □  Confirm no unexpected permission prompts or tool errors"
-    echo ""
-    echo -e "  ${BOLD}Optionally document the smoke run in docs/smoke-runs/:${RESET}"
-    echo "    echo \"\$(date -u +%Y-%m-%dT%H:%M:%SZ)  ${rc_version}  OK\" >> docs/smoke-runs/log.txt"
-    echo ""
-    echo -e "  ${RED}${BOLD}This gate blocks an irreversible tag. CI alone is not enough.${RESET}"
-    echo ""
-    echo -e "  Type ${BOLD}ship ${rc_version}${RESET} to confirm you have completed the smoke run:"
-    read -r confirmation
-
-    local expected="ship ${rc_version}"
-    if [[ "$confirmation" != "$expected" ]]; then
-        echo ""
-        echo -e "  ${RED}✗ Confirmation mismatch. Expected: '${expected}'${RESET}"
-        echo -e "  ${RED}  Tagging aborted. Complete the smoke run and re-run release.sh.${RESET}"
-        echo ""
-        exit 1
-    fi
-
-    echo ""
-    echo -e "  ${GREEN}✓ Dogfood smoke confirmed. Proceeding to tag.${RESET}"
+    echo -e "  ${RED}${BOLD}Non-interactive release blocked.${RESET}" >&2
+    echo -e "  ${RED}This run has no TTY (agent or CI). Set CONFIRM_RELEASE=1 to" >&2
+    echo -e "  confirm you intend to publish to PyPI and move the marketplace" >&2
+    echo -e "  ref, then re-run:${RESET}" >&2
+    echo -e "    ${CYAN}CONFIRM_RELEASE=1 $0 {features|fixes|major}${RESET}" >&2
+    exit 1
 }
 
 function release {
@@ -187,8 +146,9 @@ function release {
     local rc_version
     rc_version="$(current_version)"
 
-    # Dogfood gate: must pass before the tag is created.
-    dogfood_gate "$rc_version"
+    # State the remote side effects before the irreversible tag; block
+    # accidental non-interactive releases unless CONFIRM_RELEASE=1.
+    release_notice "$rc_version" "$tag"
 
     header "Phase 3 · Tag and push"
     step "Creating tag: $tag"
@@ -242,7 +202,7 @@ case "${1:-}" in
         echo "  major     Bump major, strip .dev0, tag, release, bump to next minor .dev0"
         echo ""
         echo "Environment:"
-        echo "  SKIP_DOGFOOD=1  Skip the dogfood smoke gate (CI only)"
+        echo "  CONFIRM_RELEASE=1  Confirm a non-interactive (agent/CI) release"
         exit 1
         ;;
 esac

--- a/bin/test-local.sh
+++ b/bin/test-local.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Smoke-test a dev release locally before shipping.
+#
+# Validates the surfaces that neither CI (runs under mocks) nor
+# `claude --plugin-dir` (runs source, not the package) exercise:
+#
+#   1. The built wheel installs cleanly into an isolated venv.
+#   2. The packaged `dev10x` CLI entry point resolves and runs.
+#   3. The packaged MCP server modules import (proves src/ + *.yaml
+#      package-data actually ship in the wheel).
+#   4. The plugin structure verifies (.claude-plugin/scripts/verify.sh).
+#
+# It then prints the `claude --plugin-dir` command that exercises the
+# live plugin runtime (MCP from src + hooks).
+#
+# This script is side-effect-light: it builds and installs into a
+# throwaway temp dir and NEVER writes to ~/.claude, never tags, never
+# pushes. Safe to run unattended.
+#
+# Usage: ./bin/test-local.sh [--keep] [--no-verify]
+#   --keep        Keep the temp build dir + venv for inspection.
+#   --no-verify   Skip the .claude-plugin/scripts/verify.sh structure check.
+set -euo pipefail
+
+CYAN='\033[0;36m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+KEEP=0
+RUN_VERIFY=1
+
+for arg in "$@"; do
+    case "$arg" in
+        --keep) KEEP=1 ;;
+        --no-verify) RUN_VERIFY=0 ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $arg" >&2
+            echo "Usage: $0 [--keep] [--no-verify]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+command -v uv >/dev/null || {
+    echo "uv not found. Install: https://docs.astral.sh/uv/" >&2
+    exit 1
+}
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/dev10x-test-local.XXXXXX")"
+
+# setuptools writes build/ and src/*.egg-info/ into the project tree during
+# the build. Track whether they pre-existed so cleanup removes only what this
+# run created and never deletes a developer's own build artifacts.
+BUILD_DIR="$REPO_ROOT/build"
+EGG_INFO="$REPO_ROOT/src/Dev10x.egg-info"
+[[ -e "$BUILD_DIR" ]] && PREEXISTING_BUILD=1 || PREEXISTING_BUILD=0
+[[ -e "$EGG_INFO" ]] && PREEXISTING_EGG=1 || PREEXISTING_EGG=0
+
+function cleanup {
+    if [[ "$KEEP" == "1" ]]; then
+        echo -e "  ${YELLOW}--keep set; left build dir at: ${WORKDIR}${RESET}"
+        return
+    fi
+    rm -rf "$WORKDIR"
+    [[ "$PREEXISTING_BUILD" == "0" ]] && rm -rf "$BUILD_DIR"
+    [[ "$PREEXISTING_EGG" == "0" ]] && rm -rf "$EGG_INFO"
+}
+trap cleanup EXIT
+
+function header {
+    echo ""
+    echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
+    echo -e "${CYAN}  $1${RESET}"
+    echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
+}
+
+function step {
+    echo -e "  ${GREEN}▸${RESET} $1"
+}
+
+header "Phase 1 · Build the wheel"
+step "Building into ${WORKDIR}/dist ..."
+uv build --project "$REPO_ROOT" --wheel --out-dir "$WORKDIR/dist"
+
+wheel="$(find "$WORKDIR/dist" -name '*.whl' | head -n1)"
+if [[ -z "$wheel" ]]; then
+    echo -e "  ${RED}✗ No wheel produced by uv build${RESET}" >&2
+    exit 1
+fi
+step "Wheel: $(basename "$wheel")"
+
+header "Phase 2 · Install into an isolated venv"
+venv="$WORKDIR/venv"
+step "Creating venv ..."
+uv venv "$venv" >/dev/null
+# Install the freshly-built wheel plus `mcp` — the plugin runtime supplies
+# `mcp` via each server's PEP 723 metadata, but it is not a wheel dependency.
+step "Installing wheel + mcp ..."
+uv pip install --python "$venv/bin/python" "$wheel" "mcp>=1.0" >/dev/null
+
+header "Phase 3 · Smoke the packaged artifact"
+step "dev10x --help ..."
+"$venv/bin/dev10x" --help >/dev/null
+step "import dev10x.mcp.server_cli, dev10x.mcp.server_db ..."
+"$venv/bin/python" -c "import dev10x.mcp.server_cli, dev10x.mcp.server_db"
+echo -e "  ${GREEN}✓ Packaged CLI + MCP server modules import cleanly${RESET}"
+
+if [[ "$RUN_VERIFY" == "1" ]]; then
+    header "Phase 4 · Verify plugin structure"
+    bash "$REPO_ROOT/.claude-plugin/scripts/verify.sh"
+fi
+
+header "Next · Exercise the live plugin runtime"
+echo ""
+echo -e "  The wheel + structure are sound. To exercise the actual plugin"
+echo -e "  runtime (MCP servers from ${BOLD}src/${RESET} + hooks), launch a real session:"
+echo ""
+echo -e "    ${CYAN}claude --plugin-dir ${REPO_ROOT}${RESET}"
+echo ""
+echo -e "  ${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
+echo -e "  ${GREEN}✅ Local smoke passed${RESET}"
+echo -e "  ${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"

--- a/docs/development.md
+++ b/docs/development.md
@@ -95,39 +95,46 @@ bin/release.sh major      # bump major, strip .dev0, tag, release
 
 Releases merge `develop` → `main` and create a GitHub release.
 
-### Dogfood smoke gate (Phase 2b)
+### A release is not a local action
 
-The release script requires a manual smoke confirmation before tagging.
-After preparing the version (Phase 2), the script pauses and prints:
+Tagging has remote, effectively irreversible side effects:
 
-```
-claude --plugin-dir /path/to/Dev10x-Claude
-```
+- The `v*` tag push triggers `.github/workflows/pypi-publish.yml`, which
+  builds the wheel and **publishes it to PyPI** — a version cannot be
+  reused or unpublished.
+- `main` is reset to develop HEAD and force-pushed. Because
+  `marketplace.json` serves the plugin from `"source": "./"`, `main` is
+  the marketplace's served ref — every `claude plugin update` jumps to
+  the new version.
+- A GitHub release is created.
 
-You must run a real `--plugin-dir` session with the release candidate and
-verify:
-
-- Plugin loads without errors
-- One Dev10x skill that exercises recent MCP-server changes runs cleanly
-  (e.g. `Dev10x:gh-pr-review` or `Dev10x:gh-pr-respond`)
-- One `Dev10x:git-commit` to exercise the bash tokenizer and
-  privilege-escalation denies
-- No unexpected permission prompts or tool errors
-
-The script also surfaces a version-skew warning when the installed
-marketplace plugin lags the develop checkout, so you know which MCP server
-is active.
-
-Type `ship <version>` at the prompt to confirm and proceed to tagging.
-
-**Why**: CI runs under mocks. The only true runtime validation of
-MCP-server and permission-hook changes requires a live session with the
-develop checkout loaded via `--plugin-dir`.
-
-To skip in CI (automated pipelines only):
+Before tagging (Phase 2b), the script prints these effects. A human at a
+TTY proceeds automatically; a non-interactive run (agent or CI) must set
+`CONFIRM_RELEASE=1` so an agent cannot trigger a publish by accident:
 
 ```bash
-SKIP_DOGFOOD=1 bin/release.sh features
+CONFIRM_RELEASE=1 bin/release.sh features
+```
+
+### Smoke-testing a dev release locally
+
+`bin/test-local.sh` validates the surfaces that neither CI (runs under
+mocks) nor `claude --plugin-dir` (runs source, not the package) exercise:
+
+```bash
+bin/test-local.sh            # build wheel, install into a throwaway venv,
+                             # smoke the dev10x CLI + MCP server imports,
+                             # run the plugin structure check
+bin/test-local.sh --keep     # keep the temp build dir + venv for inspection
+```
+
+It builds and installs into a temporary directory and **never** writes to
+`~/.claude`, tags, or pushes — safe to run unattended. To then exercise the
+live plugin runtime (MCP servers from `src/` + hooks), launch a session
+with the checkout loaded directly:
+
+```bash
+claude --plugin-dir /path/to/Dev10x-Claude
 ```
 
 [Back to README](../README.md)

--- a/tests/bin/test_release_gate.py
+++ b/tests/bin/test_release_gate.py
@@ -1,0 +1,50 @@
+"""Locks in the GH-387 release-gate rewrite (inform + guard, no smoke gate).
+
+The gate logic in bin/release.sh runs only after sync_branches (git
+checkout/pull), so it cannot be exercised end-to-end in a unit test.
+These source-level assertions guard against a regression to the removed
+dogfood smoke gate.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+RELEASE = _REPO_ROOT / "bin" / "release.sh"
+
+
+class TestSyntax:
+    def test_bash_syntax_is_valid(self) -> None:
+        result = subprocess.run(
+            ["bash", "-n", str(RELEASE)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+
+
+class TestInformGuardGate:
+    def test_uses_confirm_release_guard(self) -> None:
+        source = RELEASE.read_text()
+        assert "CONFIRM_RELEASE" in source
+        assert "release_notice" in source
+
+    def test_proceeds_for_interactive_tty(self) -> None:
+        # `[[ -t 0 ]]` is the human-at-a-TTY fast path.
+        assert "[[ -t 0 ]]" in RELEASE.read_text()
+
+
+class TestRemovedDogfoodGate:
+    def test_no_blocking_smoke_confirmation(self) -> None:
+        source = RELEASE.read_text()
+        assert "dogfood_gate" not in source
+        assert "SKIP_DOGFOOD" not in source
+        assert "ship ${rc_version}" not in source
+
+    def test_no_broken_installed_plugin_probe(self) -> None:
+        # The old probe looked for a Dev10x-Claude path that never exists.
+        source = RELEASE.read_text()
+        assert "installed_plugin_version" not in source
+        assert "Dev10x-Claude" not in source

--- a/tests/bin/test_test_local.py
+++ b/tests/bin/test_test_local.py
@@ -1,0 +1,62 @@
+"""Tests for bin/test-local.sh — the local dev-release smoke tool."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = _REPO_ROOT / "bin" / "test-local.sh"
+
+
+def _run(
+    *,
+    args: list[str],
+    home: Path,
+) -> subprocess.CompletedProcess[str]:
+    run_env = {**os.environ, "HOME": str(home)}
+    return subprocess.run(
+        [str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=run_env,
+        cwd=str(_REPO_ROOT),
+    )
+
+
+class TestSyntax:
+    def test_bash_syntax_is_valid(self) -> None:
+        result = subprocess.run(
+            ["bash", "-n", str(SCRIPT)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+
+
+class TestHelp:
+    def test_help_exits_zero(self, tmp_path: Path) -> None:
+        result = _run(args=["--help"], home=tmp_path)
+        assert result.returncode == 0, result.stderr
+
+    def test_help_documents_flags(self, tmp_path: Path) -> None:
+        result = _run(args=["--help"], home=tmp_path)
+        assert "--keep" in result.stdout
+        assert "--no-verify" in result.stdout
+
+    def test_help_makes_no_writes_under_home_claude(self, tmp_path: Path) -> None:
+        _run(args=["--help"], home=tmp_path)
+        assert not (tmp_path / ".claude").exists()
+
+
+class TestArgValidation:
+    def test_unknown_arg_exits_one(self, tmp_path: Path) -> None:
+        result = _run(args=["--bogus"], home=tmp_path)
+        assert result.returncode == 1
+        assert "Unknown argument" in result.stderr
+
+    def test_unknown_arg_makes_no_writes_under_home_claude(self, tmp_path: Path) -> None:
+        _run(args=["--bogus"], home=tmp_path)
+        assert not (tmp_path / ".claude").exists()


### PR DESCRIPTION
**When** I cut a Dev10x release that touches the MCP server or packaging, **I want to** validate the built wheel and plugin locally and see the release's real side effects before tagging, **so I can** avoid publishing a broken artifact to PyPI or moving the marketplace ref by accident.

---

[`a83d2085`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/409/commits/a83d2085d5645777f7665606f001c7bd0d4583af) ✨ GH-387 Enable local dev-release smoke-testing
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/387

---