### PR TITLE
✨ GH-406 Enable sensitivity-axis command gating via DX014

### DIFF
--- a/references/cedar-sensitivity-annotation.md
+++ b/references/cedar-sensitivity-annotation.md
@@ -1,0 +1,179 @@
+# Cedar `@sensitivity` Annotation Pattern
+
+Specification for the sensitivity axis of the PAP (Permission Abstraction
+Protocol) action model.
+Complementary to the tier and reversibility axes already defined in the PAP.
+
+## Three-Axis PAP Model
+
+The full PAP action model classifies every Bash command on three orthogonal
+axes:
+
+| Axis | Question answered | Defined in |
+|------|-------------------|------------|
+| **Tier** | What verb class does this command fall into? | `references/friction-levels.md` |
+| **Reversibility** | Can the effect be undone without specialist help? | `references/friction-levels.md` |
+| **Sensitivity** | Does the target touch secrets, credentials, PII, or infra? | This document / `src/dev10x/domain/sensitivity.py` |
+
+### Deny-Overrides Resolution
+
+Effective effect = `max(tier_effect, reversibility_effect, sensitivity_effect)`
+where the ordering is: `permit < ask < forbid`.
+
+Any axis that demands `ask` or `forbid` wins, independent of the other two.
+A trivially-reversible, safe-read command (`permit` on tier and reversibility)
+still resolves to `ask` if the sensitivity axis fires.
+
+This is the Cedar *deny-overrides* combination algorithm:
+
+```cedar
+// Conceptual Cedar pseudocode — Dev10x does not run Cedar directly;
+// Claude Code is the PDP+PEP.  This shows the policy intent.
+
+@sensitivity("secret")
+forbid(
+  principal is Agent,
+  action == Action::"Bash",
+  resource
+)
+when {
+  resource.command matches SensitivityWordlist::SECRET
+};
+
+// Deny-overrides: any forbid/ask wins over permit.
+// permit policies from the tier/reversibility axes are still evaluated,
+// but the effect resolution picks the strictest matching policy.
+```
+
+## Cedar `@sensitivity` Annotation
+
+The `@sensitivity` annotation labels a policy with the sensitivity category
+that caused it.
+It is surfaced in audit logs and human-readable hook messages so operators
+can understand why a command was blocked.
+
+### Label Vocabulary
+
+| Annotation value | Scope |
+|------------------|-------|
+| `"secret"` | Secret stores, `.env` files, `gh secret`, `kubectl secret` |
+| `"credential"` | Credential env-vars (`*_PASSWORD`, `*_TOKEN`, `*_RW`), `export DB_*` |
+| `"pii"` | Customer-data tables, PII export/dump commands |
+| `"infra"` | Production network probes (RDS, bastion, VPN, private IPs) |
+
+### Annotation Usage Pattern
+
+```cedar
+@sensitivity("secret")
+forbid(principal, action, resource)
+when { resource.command matches secret_wordlist };
+
+@sensitivity("credential")
+forbid(principal, action, resource)
+when { resource.command matches credential_wordlist };
+
+@sensitivity("pii")
+forbid(principal, action, resource)
+when { resource.command matches pii_wordlist };
+
+@sensitivity("infra")
+forbid(principal, action, resource)
+when { resource.command matches infra_wordlist };
+```
+
+## Implementation Mapping
+
+Dev10x does not execute Cedar policies directly.
+The mapping to the Claude Code hook system is:
+
+| Cedar concept | Dev10x implementation |
+|---------------|-----------------------|
+| `@sensitivity` annotation | `SensitivityLabel` enum in `sensitivity.py` |
+| `resource.command matches wordlist` | `SensitivityClassifier.classify()` |
+| `forbid` with deny-overrides | `DX014 SensitivityTargetValidator` → `HookResult` (deny) |
+| Cedar PolicySet | Validator registry (`validators/__init__.py`) |
+| PDP + PEP | Claude Code PreToolUse hook infrastructure |
+
+### Effect Mapping
+
+| Cedar effect | Claude Code hook exit |
+|-------------|----------------------|
+| `permit` | `sys.exit(0)` (no output) / `HookAllow` |
+| `ask` | `HookResult` with advisory message → `permissionDecision: deny` |
+| `forbid` | `HookResult` with hard block → `permissionDecision: deny` |
+
+DX014 maps sensitivity hits to `ask` semantics: it blocks the command and
+presents a message that asks the user to approve explicitly.
+This is more conservative than `permit` but less absolute than a silent
+`forbid` — the user sees the reason and can approve if they intended it.
+
+## Cross-References
+
+- **GH-395**: `SensitivityClassifier` domain model (Increment 1).
+  `src/dev10x/domain/sensitivity.py` — `SensitivityLabel`, `SensitivityMatch`,
+  `SensitivityPattern`, `SensitivityClassifier`.
+- **GH-406**: This document + DX014 validator wiring (Increment 2).
+  `src/dev10x/validators/sensitivity_target.py`.
+- **GH-271**: Evidence corpus.
+  Fixtures #267–#273 drove the default wordlist entries for all four labels.
+- **GH-310**: Sequence/unattended gate.
+  Complements the per-command sensitivity axis: GH-310 gates entire
+  sequences of commands in unattended runs, while DX014 gates individual
+  commands at the point of execution.
+- **GH-371**: Resource-classification / `capability_group` annotation.
+  The `capability_group` annotation on MCP server entries (horizontal
+  duplicate detection) is the resource-side analogue of the
+  `@sensitivity` annotation on the command side.
+  Together they form a two-sided classification: verb class on one side,
+  resource sensitivity on the other.
+
+## Wordlist Extension
+
+The default wordlist is defined in `src/dev10x/domain/sensitivity.py`
+as `_DEFAULT_PATTERNS`.
+To extend it per project, inject a custom `SensitivityClassifier`:
+
+```python
+from dev10x.domain.sensitivity import SensitivityClassifier, SensitivityLabel, SensitivityPattern
+import re
+
+my_classifier = SensitivityClassifier(
+    patterns=[
+        *_DEFAULT_PATTERNS,
+        SensitivityPattern(
+            label=SensitivityLabel.PII,
+            regex=re.compile(r"\bmy_pii_table\b", re.IGNORECASE),
+            description="my_pii_table",
+        ),
+    ]
+)
+```
+
+For the validator, pass it at construction time:
+
+```python
+from dev10x.validators.sensitivity_target import SensitivityTargetValidator
+
+v = SensitivityTargetValidator(classifier=my_classifier)
+# or use the factory:
+v = SensitivityTargetValidator().with_patterns([...])
+```
+
+## Tier × Reversibility × Sensitivity Matrix
+
+The table below shows the effective effect for representative combinations.
+`S` = sensitivity hit; `–` = no sensitivity hit.
+
+| Tier | Reversibility | Sensitivity | Effective effect |
+|------|---------------|-------------|-----------------|
+| safe-read | trivial | – | permit |
+| safe-read | trivial | S | **ask** ← DX014 |
+| safe-read | assisted | – | ask |
+| safe-read | assisted | S | **ask** |
+| destructive | none | – | forbid |
+| destructive | none | S | **forbid** |
+| fence-tool | trivial | – | ask |
+| fence-tool | trivial | S | **ask** |
+
+In every row where sensitivity fires, the effective effect is at least `ask`.
+The sensitivity axis never lowers the effect — it can only raise it.

--- a/src/dev10x/validators/__init__.py
+++ b/src/dev10x/validators/__init__.py
@@ -119,6 +119,12 @@ _SPECS: list[ValidatorSpec] = [
         rule_id="DX012",
         profile=ProfileTier.MINIMAL,
     ),
+    ValidatorSpec(
+        module_path="dev10x.validators.sensitivity_target",
+        class_name="SensitivityTargetValidator",
+        rule_id="DX014",
+        profile=ProfileTier.STANDARD,
+    ),
 ]
 
 

--- a/src/dev10x/validators/sensitivity_target.py
+++ b/src/dev10x/validators/sensitivity_target.py
@@ -1,0 +1,122 @@
+"""Validator: elevate effect to ``ask`` for sensitive-target commands (DX014).
+
+Wires ``SensitivityClassifier`` (from GH-395) into the bash validator
+pipeline as a standalone rule.  This implements the deny-overrides
+resolution across the three PAP axes:
+
+    (tier) × (reversibility) × (sensitivity)
+
+A command that is trivially reversible and in a safe-read tier still
+triggers ``ask`` when its target or query matches the sensitivity
+wordlist.  The sensitivity axis overrides the other two — deny-overrides
+semantics apply.
+
+This maps to the Cedar ``@sensitivity`` annotation pattern:
+
+    @sensitivity("secret|credential|pii|infra")
+    permit(principal, action, resource)
+    when { resource matches sensitive_wordlist };
+
+Deny-overrides resolution: if *any* axis emits ``ask``/``forbid``,
+that effect wins.  DX014 provides the sensitivity axis; existing
+validators cover tier (DX003, DX004) and reversibility (future).
+
+Cross-references:
+- GH-395: SensitivityClassifier domain model
+- GH-310: Sequence/unattended gate (complements per-command sensitivity)
+- GH-371: resource-classification / capability_group (horizontal MCP
+  duplicate detection; ``capability_group`` annotation is the Cedar
+  equivalent of the sensitivity label on the resource side)
+- GH-271: Evidence corpus — fixtures #267–#273 directly drove the
+  default wordlist in ``SensitivityClassifier``
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import ClassVar
+
+from dev10x.domain import HookInput, HookResult
+from dev10x.domain.profile_tier import ProfileTier
+from dev10x.domain.sensitivity import SensitivityClassifier, SensitivityMatch, SensitivityPattern
+from dev10x.validators.base import ValidatorBase
+
+_ASK_MSG_TEMPLATE = """\
+⚠️  Sensitive target detected — command requires review before execution.
+
+Rule DX014 matched {count} sensitivity pattern(s):
+{matches_detail}
+
+This command touches sensitive infrastructure, credentials, secrets,
+or PII.  Even if the operation is read-only or reversible on the tier/
+reversibility axes, the sensitivity axis elevates the effective effect
+to ``ask`` (deny-overrides).
+
+Review the command carefully.  If it is intentional and safe, approve it
+explicitly.  See `.claude/rules/hook-patterns.md` — DX014 / sensitivity
+axis — for the full resolution rules.
+"""
+
+
+def _format_matches(matches: list[SensitivityMatch]) -> str:
+    lines = []
+    for m in matches:
+        lines.append(f"  • [{m.label.value.upper()}] {m.pattern!r} — matched: {m.matched_text!r}")
+    return "\n".join(lines)
+
+
+@dataclass
+class SensitivityTargetValidator(ValidatorBase):
+    """Block commands that match the PAP sensitivity wordlist.
+
+    Uses ``SensitivityClassifier`` to check the full command string
+    against the default wordlist.  Returns a ``HookResult`` (deny with
+    message) when *any* sensitivity pattern fires, implementing the
+    deny-overrides rule: a sensitivity hit on the third axis elevates
+    the effective effect regardless of tier and reversibility scores.
+
+    The wordlist can be customised per test by injecting a ``classifier``
+    instance; production code always uses the default wordlist.
+    """
+
+    name: ClassVar[str] = "sensitivity-target"
+    rule_id: ClassVar[str] = "DX014"
+    profile: ClassVar[ProfileTier] = ProfileTier.STANDARD
+
+    classifier: SensitivityClassifier = field(
+        default_factory=SensitivityClassifier,
+        repr=False,
+    )
+
+    def should_run(self, inp: HookInput) -> bool:
+        """Fast pre-check: skip entirely if command is very short or empty.
+
+        The full classify() call happens only in validate(); should_run()
+        intentionally errs on the side of running so no sensitive command
+        is silently passed.
+        """
+        return bool(inp.command.strip())
+
+    def validate(self, inp: HookInput) -> HookResult | None:
+        """Return a HookResult if the command matches the sensitivity wordlist.
+
+        Deny-overrides: any sensitivity match wins over tier/reversibility.
+        """
+        matches = self.classifier.classify(command=inp.command)
+        if not matches:
+            return None
+        matches_detail = _format_matches(matches=matches)
+        message = _ASK_MSG_TEMPLATE.format(
+            count=len(matches),
+            matches_detail=matches_detail,
+        )
+        return HookResult(message=message)
+
+    def with_patterns(self, patterns: list[SensitivityPattern]) -> SensitivityTargetValidator:
+        """Return a new validator instance using the supplied wordlist.
+
+        Useful for tests and for project-local sensitivity overrides.
+        """
+        return SensitivityTargetValidator(
+            classifier=SensitivityClassifier(patterns=patterns),
+        )

--- a/tests/validators/test_sensitivity_target.py
+++ b/tests/validators/test_sensitivity_target.py
@@ -1,0 +1,380 @@
+"""Tests for SensitivityTargetValidator (DX014).
+
+Covers:
+- should_run() fast-skip predicate
+- validate() returning None for benign commands
+- validate() returning HookResult for each sensitivity label
+- deny-overrides semantics: multi-match accumulates all matches
+- Registry integration: DX014 appears in standard profile
+- Custom classifier injection via with_patterns()
+
+Fixtures are drawn from GH-271 evidence #267–#273 (same corpus as
+the SensitivityClassifier unit tests in tests/domain/test_sensitivity.py).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev10x.domain.profile_tier import ProfileTier
+from dev10x.domain.sensitivity import SensitivityClassifier, SensitivityLabel, SensitivityPattern
+from dev10x.validators import get_validators, reset_registry
+from dev10x.validators.sensitivity_target import SensitivityTargetValidator
+from tests.fakers import BashHookInputFaker
+
+
+def _inp(command: str) -> BashHookInputFaker:
+    return BashHookInputFaker.build(command=command)
+
+
+# ---------------------------------------------------------------------------
+# Fixture: default validator instance
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def validator() -> SensitivityTargetValidator:
+    return SensitivityTargetValidator()
+
+
+# ---------------------------------------------------------------------------
+# should_run
+# ---------------------------------------------------------------------------
+
+
+class TestShouldRun:
+    def test_empty_command_skips(self, validator: SensitivityTargetValidator) -> None:
+        assert validator.should_run(inp=_inp("")) is False
+
+    def test_whitespace_only_skips(self, validator: SensitivityTargetValidator) -> None:
+        assert validator.should_run(inp=_inp("   ")) is False
+
+    def test_non_empty_command_runs(self, validator: SensitivityTargetValidator) -> None:
+        assert validator.should_run(inp=_inp("git status")) is True
+
+    def test_sensitive_command_runs(self, validator: SensitivityTargetValidator) -> None:
+        assert validator.should_run(inp=_inp("gh secret list")) is True
+
+
+# ---------------------------------------------------------------------------
+# validate() — benign commands → None
+# ---------------------------------------------------------------------------
+
+
+class TestBenignCommands:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git status",
+            "git log --oneline -10",
+            "ls -la",
+            "uv run pytest tests/",
+            "ruff check src/",
+            "git diff origin/develop",
+            "gh pr view 42",
+            "find . -name '*.py'",
+        ],
+    )
+    def test_benign_commands_return_none(
+        self, validator: SensitivityTargetValidator, command: str
+    ) -> None:
+        result = validator.validate(inp=_inp(command))
+        assert result is None, f"Unexpected block for benign command: {command!r}"
+
+
+# ---------------------------------------------------------------------------
+# validate() — SECRET label
+# ---------------------------------------------------------------------------
+
+
+class TestSecretLabel:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # GH-271 #267: secret inventory
+            "gh secret list",
+            "gh secret list --repo my-org/my-repo",
+            "gh variable list",
+            "gh variable get MY_VAR",
+            # kubectl secret
+            "kubectl get secret db-credentials -o yaml",
+            "kubectl describe secret my-secret",
+            # .env reads
+            "cat .env",
+            "cat /app/.env",
+            "less .env",
+            "head -20 .env",
+        ],
+    )
+    def test_blocks_secret_commands(
+        self, validator: SensitivityTargetValidator, command: str
+    ) -> None:
+        result = validator.validate(inp=_inp(command))
+        assert result is not None, f"Expected block for: {command!r}"
+        assert "SECRET" in result.message
+
+    def test_message_contains_pattern_description(
+        self, validator: SensitivityTargetValidator
+    ) -> None:
+        result = validator.validate(inp=_inp("gh secret list"))
+        assert result is not None
+        assert "gh secret" in result.message
+
+    def test_message_contains_matched_text(self, validator: SensitivityTargetValidator) -> None:
+        result = validator.validate(inp=_inp("gh secret list"))
+        assert result is not None
+        assert "matched:" in result.message
+
+
+# ---------------------------------------------------------------------------
+# validate() — CREDENTIAL label
+# ---------------------------------------------------------------------------
+
+
+class TestCredentialLabel:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # GH-271 #269: searching for RW credentials
+            "rg PRODUCTION_RW .env",
+            "grep -r DB_PASSWORD src/",
+            "export DB_URL=postgres://...",
+            "env | grep API_TOKEN",
+            "echo $JWT_SECRET",
+            # general credential env-var patterns
+            "printenv | grep SSH_PRIVATE_KEY",
+        ],
+    )
+    def test_blocks_credential_commands(
+        self, validator: SensitivityTargetValidator, command: str
+    ) -> None:
+        result = validator.validate(inp=_inp(command))
+        assert result is not None, f"Expected block for: {command!r}"
+        assert "CREDENTIAL" in result.message
+
+    def test_rw_suffix_blocked(self, validator: SensitivityTargetValidator) -> None:
+        result = validator.validate(inp=_inp("echo $DATABASE_RW"))
+        assert result is not None
+        assert "CREDENTIAL" in result.message
+
+
+# ---------------------------------------------------------------------------
+# validate() — PII label
+# ---------------------------------------------------------------------------
+
+
+class TestPiiLabel:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # PII bulk-export patterns
+            "pg_dump --table customers mydb",
+            "mysqldump mydb patients",
+            "SELECT * FROM customers",
+            "SELECT * FROM subscribers",
+        ],
+    )
+    def test_blocks_pii_commands(
+        self, validator: SensitivityTargetValidator, command: str
+    ) -> None:
+        result = validator.validate(inp=_inp(command))
+        assert result is not None, f"Expected block for: {command!r}"
+        assert "PII" in result.message
+
+
+# ---------------------------------------------------------------------------
+# validate() — INFRA label
+# ---------------------------------------------------------------------------
+
+
+class TestInfraLabel:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # GH-271 #271: RDS endpoint resolution
+            "dig writer.mydb.us-east-1.rds.amazonaws.com",
+            # GH-271 #272–#273: nc port probes
+            "nc -zv 10.0.0.5 5432",
+            "nc -zvw5 prod-db.internal 3306",
+            # bastion/VPN
+            "ssh bastion.prod.internal",
+            "wg show wireguard0",
+            "tailscale status",
+        ],
+    )
+    def test_blocks_infra_commands(
+        self, validator: SensitivityTargetValidator, command: str
+    ) -> None:
+        result = validator.validate(inp=_inp(command))
+        assert result is not None, f"Expected block for: {command!r}"
+        assert "INFRA" in result.message
+
+    def test_rds_hostname_in_connection_string(
+        self, validator: SensitivityTargetValidator
+    ) -> None:
+        cmd = "psql postgres://user:pass@writer.cluster.us-east-1.rds.amazonaws.com/mydb"
+        result = validator.validate(inp=_inp(cmd))
+        assert result is not None
+        assert "INFRA" in result.message
+
+
+# ---------------------------------------------------------------------------
+# Deny-overrides: multi-label accumulation
+# ---------------------------------------------------------------------------
+
+
+class TestDenyOverrides:
+    def test_multi_label_match_reports_all(self, validator: SensitivityTargetValidator) -> None:
+        # Command that hits both CREDENTIAL and INFRA axes simultaneously.
+        cmd = "rg DB_PASSWORD 10.0.0.5"
+        result = validator.validate(inp=_inp(cmd))
+        assert result is not None
+        # Both labels must appear in the message.
+        assert "CREDENTIAL" in result.message
+        assert "INFRA" in result.message
+
+    def test_match_count_in_message(self, validator: SensitivityTargetValidator) -> None:
+        cmd = "cat .env && nc -zv 10.0.0.5 5432"
+        result = validator.validate(inp=_inp(cmd))
+        assert result is not None
+        # The count line must show > 1.
+        import re
+
+        count_match = re.search(r"matched (\d+) sensitivity pattern", result.message)
+        assert count_match is not None
+        assert int(count_match.group(1)) > 1
+
+    def test_block_regardless_of_tier_reversibility(
+        self, validator: SensitivityTargetValidator
+    ) -> None:
+        # A read-only safe command that is nonetheless sensitive.
+        result = validator.validate(inp=_inp("gh secret list"))
+        assert result is not None, (
+            "Sensitivity axis must override tier/reversibility (deny-overrides)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Message format checks
+# ---------------------------------------------------------------------------
+
+
+class TestMessageFormat:
+    def test_message_mentions_review(self, validator: SensitivityTargetValidator) -> None:
+        result = validator.validate(inp=_inp("gh secret list"))
+        assert result is not None
+        assert "review" in result.message.lower()
+
+    def test_message_references_hook_patterns(self, validator: SensitivityTargetValidator) -> None:
+        result = validator.validate(inp=_inp("gh secret list"))
+        assert result is not None
+        assert "hook-patterns.md" in result.message
+
+    def test_message_references_rule_id(self, validator: SensitivityTargetValidator) -> None:
+        result = validator.validate(inp=_inp("gh secret list"))
+        assert result is not None
+        assert "DX014" in result.message
+
+
+# ---------------------------------------------------------------------------
+# Custom classifier injection
+# ---------------------------------------------------------------------------
+
+
+class TestCustomClassifier:
+    def test_custom_wordlist_replaces_default(self) -> None:
+        import re
+
+        custom_pattern = SensitivityPattern(
+            label=SensitivityLabel.SECRET,
+            regex=re.compile(r"\bcustom_secret_tool\b"),
+            description="custom secret tool",
+        )
+        custom_classifier = SensitivityClassifier(patterns=[custom_pattern])
+        v = SensitivityTargetValidator(classifier=custom_classifier)
+
+        # Default wordlist pattern should NOT fire.
+        assert v.validate(inp=_inp("gh secret list")) is None
+
+        # Custom pattern SHOULD fire.
+        result = v.validate(inp=_inp("custom_secret_tool --list"))
+        assert result is not None
+        assert "SECRET" in result.message
+
+    def test_with_patterns_factory(self) -> None:
+        import re
+
+        base = SensitivityTargetValidator()
+        custom = base.with_patterns(
+            patterns=[
+                SensitivityPattern(
+                    label=SensitivityLabel.PII,
+                    regex=re.compile(r"\bmy_pii_table\b"),
+                    description="my_pii_table",
+                )
+            ]
+        )
+        # Original still uses default patterns.
+        assert base.validate(inp=_inp("gh secret list")) is not None
+        # Custom uses injected patterns only.
+        assert custom.validate(inp=_inp("gh secret list")) is None
+        result = custom.validate(inp=_inp("SELECT * FROM my_pii_table"))
+        assert result is not None
+        assert "PII" in result.message
+
+
+# ---------------------------------------------------------------------------
+# Registry integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def clean_registry() -> None:
+    reset_registry()
+    yield
+    reset_registry()
+
+
+class TestRegistryIntegration:
+    def test_dx014_registered_in_standard_profile(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("DEV10X_HOOK_PROFILE", raising=False)
+        validators = get_validators()
+        rule_ids = {v.rule_id for v in validators}
+        assert "DX014" in rule_ids
+
+    def test_dx014_absent_in_minimal_profile(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_HOOK_PROFILE", "minimal")
+        validators = get_validators()
+        rule_ids = {v.rule_id for v in validators}
+        assert "DX014" not in rule_ids
+
+    def test_dx014_present_in_strict_profile(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_HOOK_PROFILE", "strict")
+        validators = get_validators()
+        rule_ids = {v.rule_id for v in validators}
+        assert "DX014" in rule_ids
+
+    def test_dx014_can_be_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_HOOK_DISABLE", "DX014")
+        validators = get_validators()
+        rule_ids = {v.rule_id for v in validators}
+        assert "DX014" not in rule_ids
+
+    def test_validator_instance_is_sensitivity_target(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("DEV10X_HOOK_PROFILE", raising=False)
+        validators = get_validators()
+        sensitivity_validators = [v for v in validators if v.rule_id == "DX014"]
+        assert len(sensitivity_validators) == 1
+        assert isinstance(sensitivity_validators[0], SensitivityTargetValidator)
+
+    def test_validator_profile_is_standard(self) -> None:
+        v = SensitivityTargetValidator()
+        assert v.profile is ProfileTier.STANDARD
+
+    def test_rule_ids_remain_unique(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_HOOK_PROFILE", "strict")
+        validators = get_validators()
+        rule_ids = [v.rule_id for v in validators]
+        assert len(rule_ids) == len(set(rule_ids)), f"Duplicate rule_ids: {rule_ids}"


### PR DESCRIPTION
**When** I run bash commands that touch sensitive targets (secrets, credentials, PII, or production infra), **I want to** be blocked and asked to review before execution, **so I can** prevent accidental exposure through trivially-reversible read commands that the tier/reversibility axes would not catch alone.

---

[`0fe6b317`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/411/commits/0fe6b317cc8e981758d4445ac14674b6dd0b416e) ✨ GH-406 Enable sensitivity-axis command gating via DX014
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/406

---