### PR TITLE
✨ GH-410 Enable MCP server to survive deleted bound worktrees

### DIFF
--- a/src/dev10x/mcp/misc_tools.py
+++ b/src/dev10x/mcp/misc_tools.py
@@ -12,6 +12,7 @@ async def mktmp(
     ext: str = "",
     directory: bool = False,
     create: bool = False,
+    cwd: str | None = None,
 ) -> dict:
     """Generate a unique temp path under /tmp/Dev10x/<namespace>/.
 
@@ -27,21 +28,28 @@ async def mktmp(
         directory: If True, create a directory instead of a file.
         create: If True (and directory=False), pre-create an empty file.
             Default False — Write callers should write fresh.
+        cwd: Effective working directory (GH-410). The script writes to /tmp
+            so the CWD does not affect the output path, but pinning a valid
+            directory prevents ENOENT when the previously-bound worktree was
+            deleted. When omitted, safe_effective_cwd() provides the fallback.
 
     Returns:
         Dictionary with key: path (str) — the temp file/directory path
     """
     from dev10x import utilities as util
+    from dev10x.subprocess_utils import use_cwd
 
-    return (
-        await util.mktmp(
-            namespace=namespace,
-            prefix=prefix,
-            ext=ext,
-            directory=directory,
-            create=create,
-        )
-    ).to_dict()
+    with use_cwd(cwd):
+        return (
+            await util.mktmp(
+                namespace=namespace,
+                prefix=prefix,
+                ext=ext,
+                directory=directory,
+                create=create,
+                cwd=cwd,
+            )
+        ).to_dict()
 
 
 @server.tool()

--- a/src/dev10x/subprocess_utils.py
+++ b/src/dev10x/subprocess_utils.py
@@ -45,6 +45,30 @@ def effective_cwd() -> str | None:
     return _effective_cwd.get()
 
 
+def safe_effective_cwd() -> str | None:
+    """Return the bound effective CWD only when that directory still exists.
+
+    GH-410: long-lived MCP server processes bind a worktree path via
+    ``use_cwd``. After the worktree is removed (branch-delete on merge or
+    manual cleanup), the bound path no longer exists. Passing a deleted path
+    as ``cwd=`` to ``subprocess.run`` or ``asyncio.create_subprocess_exec``
+    raises ``[Errno 2] No such file or directory`` (ENOENT), hard-failing
+    every MCP call even when the operation itself does not need a real repo
+    directory (e.g. ``mktmp`` writes to ``/tmp``).
+
+    This function validates the bound path before returning it. When the
+    bound dir is gone it returns ``None`` so callers inherit the process CWD
+    (set by the MCP server launcher to a still-valid path, typically the
+    plugin root or the main repo checkout).
+    """
+    bound = _effective_cwd.get()
+    if bound is None:
+        return None
+    if Path(bound).is_dir():
+        return bound
+    return None
+
+
 def requires_cwd[R](
     func: Callable[..., Awaitable[R]],
 ) -> Callable[..., Awaitable[R]]:
@@ -96,9 +120,22 @@ def resolve_script_path(script_path: str) -> Path:
     lets plugin developers exercise their unsaved/uncached edits via
     MCP tools (GH-42). Otherwise fall back to the cached install
     discovered via `get_plugin_root()`.
+
+    GH-410: uses ``safe_effective_cwd()`` so a deleted bound worktree
+    path does not raise ENOENT during path resolution. Falls back to the
+    plugin root's CWD when the bound directory is gone.
     """
-    bound = _effective_cwd.get()
-    cwd = Path(bound).resolve() if bound else Path.cwd().resolve()
+    bound = safe_effective_cwd()
+    if bound:
+        cwd = Path(bound).resolve()
+    else:
+        try:
+            cwd = Path.cwd().resolve()
+        except FileNotFoundError:
+            # Process CWD was also deleted (rare but possible in tests or after
+            # aggressive worktree cleanup). Fall back to the plugin root which is
+            # always a valid path.
+            return get_plugin_root() / script_path
     for candidate in (cwd, *cwd.parents):
         if _matches_plugin_root(candidate):
             local_script = candidate / script_path
@@ -123,10 +160,14 @@ def run(
     server's startup directory. All other `subprocess.run` keyword arguments
     (`capture_output`, `text`, `check`, `env`, `timeout`, ...) pass through
     unchanged.
+
+    GH-410: uses ``safe_effective_cwd()`` so a deleted bound directory does
+    not raise ENOENT; falls back to the process CWD (None) when the bound
+    dir is gone.
     """
     return subprocess.run(
         args,
-        cwd=cwd if cwd is not None else _effective_cwd.get(),
+        cwd=cwd if cwd is not None else safe_effective_cwd(),
         **kwargs,
     )
 
@@ -160,7 +201,7 @@ def run_script(
         capture_output=True,
         text=True,
         env=env,
-        cwd=cwd if cwd is not None else _effective_cwd.get(),
+        cwd=cwd if cwd is not None else safe_effective_cwd(),
         check=False,
     )
 
@@ -172,12 +213,15 @@ async def async_run(
     timeout: float = 30,
     cwd: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
+    """GH-410: uses ``safe_effective_cwd()`` so a deleted bound worktree path
+    does not cause ENOENT when launching subprocesses.
+    """
     proc = await asyncio.create_subprocess_exec(
         *args,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
         env=env,
-        cwd=cwd if cwd is not None else _effective_cwd.get(),
+        cwd=cwd if cwd is not None else safe_effective_cwd(),
     )
     try:
         stdout_bytes, stderr_bytes = await asyncio.wait_for(

--- a/src/dev10x/utilities/__init__.py
+++ b/src/dev10x/utilities/__init__.py
@@ -20,6 +20,7 @@ async def mktmp(
     ext: str = "",
     directory: bool = False,
     create: bool = False,
+    cwd: str | None = None,
 ) -> Result[dict[str, Any]]:
     """Generate a unique temp path under /tmp/Dev10x/<namespace>/.
 
@@ -27,6 +28,18 @@ async def mktmp(
     using the Write tool don't trigger its overwrite gate (GH-39).
     Pass create=True to pre-create an empty file (legacy behavior).
     Directories are always created (directory=True).
+
+    Args:
+        namespace: Subdirectory under /tmp/Dev10x/ (e.g. "git", "skill-audit")
+        prefix: Filename prefix (e.g. "commit-msg", "pr-review")
+        ext: File extension including dot (e.g. ".txt", ".json"). Ignored for directories.
+        directory: If True, create a directory instead of a file.
+        create: If True (and directory=False), pre-create an empty file.
+        cwd: Effective working directory for the subprocess (GH-410). The
+            mktmp.sh script writes to /tmp so the CWD does not affect the
+            output path, but passing a valid directory avoids the ENOENT
+            that occurs when the previously-bound worktree was deleted.
+            When omitted, ``safe_effective_cwd()`` provides the fallback.
     """
     mk_args: list[str] = []
     if directory:
@@ -37,7 +50,7 @@ async def mktmp(
     if ext and not directory:
         mk_args.append(ext)
 
-    result = await async_run_script("bin/mktmp.sh", *mk_args)
+    result = await async_run_script("bin/mktmp.sh", *mk_args, cwd=cwd)
 
     if result.returncode != 0:
         return err(result.stderr.strip())

--- a/tests/mcp/test_cli_server.py
+++ b/tests/mcp/test_cli_server.py
@@ -324,6 +324,27 @@ class TestMktmp:
 
         assert "error" in result
 
+    @pytest.mark.asyncio
+    @patch("dev10x.utilities.async_run_script", new_callable=AsyncMock)
+    async def test_passes_cwd_to_underlying_script(
+        self,
+        mock_run: AsyncMock,
+        tmp_path,
+    ) -> None:
+        """GH-410: mktmp must accept cwd to survive a deleted bound worktree."""
+        mock_run.return_value = _completed(stdout="/tmp/Dev10x/git/msg.abc.txt")
+
+        result = await cli_server.mktmp(
+            namespace="git",
+            prefix="msg",
+            ext=".txt",
+            cwd=str(tmp_path),
+        )
+
+        assert result["path"] == "/tmp/Dev10x/git/msg.abc.txt"
+        # cwd forwarded to the underlying async_run_script call
+        assert mock_run.call_args.kwargs.get("cwd") == str(tmp_path)
+
 
 class TestIssueCreate:
     @pytest.mark.asyncio
@@ -1387,6 +1408,10 @@ CWD_HANDLERS: list[tuple[str, dict]] = [
     (
         "issue_reopen",
         {"number": 1},
+    ),
+    (
+        "mktmp",
+        {"namespace": "git", "prefix": "msg"},
     ),
 ]
 

--- a/tests/test_subprocess_utils.py
+++ b/tests/test_subprocess_utils.py
@@ -178,16 +178,18 @@ class TestRun:
         assert mock_run.call_args[1]["cwd"] == "/explicit"
 
     @patch("dev10x.subprocess_utils.subprocess.run")
-    def test_defaults_to_effective_cwd_when_bound(self, mock_run: patch) -> None:
+    def test_defaults_to_effective_cwd_when_bound(self, mock_run: patch, tmp_path: Path) -> None:
         from dev10x.subprocess_utils import run, use_cwd
 
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="", stderr=""
         )
-        with use_cwd("/bound"):
+        # GH-410: safe_effective_cwd() validates the directory exists before
+        # passing it to subprocess. Use a real tmp_path so the check passes.
+        with use_cwd(str(tmp_path)):
             run(["git", "status"])
 
-        assert mock_run.call_args[1]["cwd"] == "/bound"
+        assert mock_run.call_args[1]["cwd"] == str(tmp_path)
 
     @patch("dev10x.subprocess_utils.subprocess.run")
     def test_cwd_is_none_when_unbound(self, mock_run: patch) -> None:
@@ -506,3 +508,92 @@ class TestGitContextHonorsCwd:
         with use_cwd(str(b)):
             ctx = GitContext()
             assert Path(ctx.toplevel).resolve() == b.resolve()
+
+
+class TestSafeEffectiveCwd:
+    """GH-410: safe_effective_cwd() must not return a deleted directory."""
+
+    def test_returns_none_when_unbound(self) -> None:
+        from dev10x.subprocess_utils import safe_effective_cwd
+
+        assert safe_effective_cwd() is None
+
+    def test_returns_bound_dir_when_it_exists(self, tmp_path: Path) -> None:
+        from dev10x.subprocess_utils import safe_effective_cwd, use_cwd
+
+        with use_cwd(str(tmp_path)):
+            result = safe_effective_cwd()
+
+        assert result == str(tmp_path)
+
+    def test_returns_none_when_bound_dir_is_deleted(self, tmp_path: Path) -> None:
+        from dev10x.subprocess_utils import safe_effective_cwd, use_cwd
+
+        deleted = tmp_path / "gone"
+        deleted.mkdir()
+        deleted.rmdir()
+
+        with use_cwd(str(deleted)):
+            result = safe_effective_cwd()
+
+        assert result is None
+
+    def test_returns_none_when_bound_is_a_file_not_dir(self, tmp_path: Path) -> None:
+        from dev10x.subprocess_utils import safe_effective_cwd, use_cwd
+
+        a_file = tmp_path / "file.txt"
+        a_file.write_text("x")
+
+        with use_cwd(str(a_file)):
+            result = safe_effective_cwd()
+
+        assert result is None
+
+
+class TestResolveScriptPathWithDeletedCwd:
+    """GH-410: resolve_script_path must survive a deleted bound worktree."""
+
+    def test_falls_back_to_plugin_root_when_bound_dir_deleted(self, tmp_path: Path) -> None:
+        from dev10x.subprocess_utils import use_cwd
+
+        deleted = tmp_path / "gone"
+        deleted.mkdir()
+        deleted.rmdir()
+
+        with use_cwd(str(deleted)):
+            resolved = resolve_script_path("bin/mktmp.sh")
+
+        assert resolved == get_plugin_root() / "bin/mktmp.sh"
+
+
+class TestAsyncRunWithDeletedCwd:
+    """GH-410: async_run must not ENOENT when bound worktree was deleted."""
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_process_cwd_when_bound_dir_deleted(self, tmp_path: Path) -> None:
+        from dev10x.subprocess_utils import async_run, use_cwd
+
+        deleted = tmp_path / "gone"
+        deleted.mkdir()
+        deleted.rmdir()
+
+        with use_cwd(str(deleted)):
+            # echo should succeed: async_run falls back to None (process CWD)
+            result = await async_run(args=["echo", "ok"])
+
+        assert result.returncode == 0
+        assert result.stdout.strip() == "ok"
+
+    @pytest.mark.asyncio
+    async def test_run_with_deleted_bound_cwd_succeeds(self, tmp_path: Path) -> None:
+        from dev10x.subprocess_utils import run, use_cwd
+
+        deleted = tmp_path / "gone"
+        deleted.mkdir()
+        deleted.rmdir()
+
+        with use_cwd(str(deleted)):
+            result = run(["echo", "hi"], capture_output=True, text=True)
+
+        assert result.returncode == 0
+        assert result.stdout.strip() == "hi"


### PR DESCRIPTION
**When** a worktree is removed after a branch merge, **I want to** MCP cli tool calls to fall back gracefully instead of ENOENT, **so I can** continue using `mktmp` and other MCP tools in post-merge sessions without hitting "Current directory does not exist" errors.

---

[`e8d7ffa8`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/412/commits/e8d7ffa808a363e9a3fcca3debf17d43660e273d) ✨ GH-410 Enable MCP server to survive deleted bound worktrees
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/410

---