### PR TITLE
✨ GH-337 Enable per-session state management over StreamableHTTP

### DIFF
--- a/skills/git-groom/scripts/mass-rewrite.py
+++ b/skills/git-groom/scripts/mass-rewrite.py
@@ -66,7 +66,7 @@ def validate_shas(config_shas: set[str], current_shas: set[str]) -> None:
     stale = config_shas - current_shas
     if not stale:
         return
-    print("ERROR: These SHAs from config don't exist in current branch:", file=sys.stderr)
+    print("ERROR: These SHAs from config don\'t exist in current branch:", file=sys.stderr)
     for sha in sorted(stale):
         print(f"  {sha}", file=sys.stderr)
     print("\nRe-check SHAs with: git log --oneline develop..HEAD", file=sys.stderr)
@@ -81,12 +81,7 @@ def write_message_files(commits_config: dict, msgs_dir: Path) -> None:
 
 
 def write_seq_editor(commits_config: dict, msgs_dir: Path, seq_editor: Path) -> None:
-    """Generate a GIT_SEQUENCE_EDITOR script that injects exec lines.
-
-    Commits with renames get a single chained exec (mv + amend) to avoid
-    leaving staged changes between exec steps, which halts the rebase.
-    All other config commits get a simple amend exec.
-    """
+    """Generate a GIT_SEQUENCE_EDITOR script that injects exec lines."""
     rename_commits = {
         sha: spec
         for sha, spec in commits_config.items()
@@ -98,7 +93,7 @@ def write_seq_editor(commits_config: dict, msgs_dir: Path, seq_editor: Path) -> 
         "TMPFILE=$(mktemp)",
         "while IFS= read -r line; do",
         '    if [[ "$line" =~ ^[[:space:]]*# ]] || [[ -z "$line" ]]; then',
-        '        printf \'%s\\n\' "$line" >> "$TMPFILE"; continue',
+        "        printf '%s\\n' \"$line\" >> \"$TMPFILE\"; continue",
         "    fi",
         "    SHA=$(echo \"$line\" | awk '{print $2}')",
         '    SHORT="${SHA:0:7}"',
@@ -116,14 +111,14 @@ def write_seq_editor(commits_config: dict, msgs_dir: Path, seq_editor: Path) -> 
             lines.append(f'    {kw} [[ "$SHORT" == "{sha}" ]]; then')
             lines.append(
                 f"        printf 'exec {mv_chain}"
-                f' && git commit --amend -F %s\\n\' "$MSGFILE" >> "$TMPFILE"'
+                f" && git commit --amend -F %s\\n' \"$MSGFILE\" >> \"$TMPFILE\""
             )
         lines.append('    elif [[ -f "$MSGFILE" ]]; then')
     else:
         lines.append('    if [[ -f "$MSGFILE" ]]; then')
 
     lines += [
-        '        printf \'exec git commit --amend -F %s\\n\' "$MSGFILE" >> "$TMPFILE"',
+        "        printf 'exec git commit --amend -F %s\\n' \"$MSGFILE\" >> \"$TMPFILE\"",
         "    fi",
         'done < "$1"',
         'mv "$TMPFILE" "$1"',
@@ -166,13 +161,12 @@ def run_rebase(base_sha: str, seq_editor: Path) -> None:
             sys.exit(1)
         print("Rebase failed.", file=sys.stderr)
         print("  Abort:   git rebase --abort", file=sys.stderr)
-        print("  Recover: git reflog  →  git reset --hard HEAD@{n}", file=sys.stderr)
+        print("  Recover: git reflog  to  git reset --hard HEAD@{n}", file=sys.stderr)
         sys.exit(result.returncode)
 
 
 def create_workdir() -> Path:
     DEFAULT_TMPDIR.mkdir(parents=True, exist_ok=True)
-
     return Path(tempfile.mkdtemp(prefix="groom.", dir=DEFAULT_TMPDIR))
 
 
@@ -200,22 +194,22 @@ def main() -> None:
 
     print(f"\nCurrent branch ({len(current_commits)} commits):")
     for sha, subject in current_commits:
-        marker = "✎" if sha in commits_config else " "
+        marker = "E" if sha in commits_config else " "
         print(f"  {marker} {sha} {subject}")
 
     validate_shas(set(commits_config.keys()), current_shas)
 
-    print(f"\nWriting message files → {msgs_dir}")
+    print(f"\nWriting message files -> {msgs_dir}")
     write_message_files(commits_config=commits_config, msgs_dir=msgs_dir)
 
-    print(f"Writing sequence editor → {seq_editor}")
+    print(f"Writing sequence editor -> {seq_editor}")
     write_seq_editor(
         commits_config=commits_config,
         msgs_dir=msgs_dir,
         seq_editor=seq_editor,
     )
 
-    print("Running rebase…")
+    print("Running rebase...")
     run_rebase(base_sha=base_sha, seq_editor=seq_editor)
 
     print("\nDone. New log:")

--- a/src/dev10x/mcp/daemon.py
+++ b/src/dev10x/mcp/daemon.py
@@ -1,0 +1,517 @@
+"""Daemon lifecycle management for the Dev10x MCP server (GH-336).
+
+Provides health checking, graceful shutdown, PID/socket file management,
+and restart-safety primitives for running the MCP server as a long-lived
+daemon process.
+
+Forward-compatibility note
+--------------------------
+This module is Increment 1 of the M1 chain (#336 → #337 session/state
+→ #338 Claude Code wiring).  The public surface is intentionally
+minimal — just enough to support health, shutdown, and PID/socket
+coordination.  Session-state persistence (#337) and Claude Code
+configuration wiring (#338) will extend *this* module's primitives;
+they must not require API changes to what is already here.
+
+Environment variables
+---------------------
+DEV10X_MCP_PID_DIR
+    Directory where the ``.pid`` and ``.sock`` files are created.
+    Defaults to ``~/.local/share/dev10x/mcp`` (XDG-style).
+
+DEV10X_MCP_HEALTH_TIMEOUT
+    Seconds to wait for a single health-check ping to the daemon
+    socket before declaring it unresponsive.  Defaults to 3.
+
+DEV10X_MCP_SHUTDOWN_TIMEOUT
+    Seconds to wait for the daemon to exit after SIGTERM before
+    escalating to SIGKILL.  Defaults to 10.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import socket
+import time
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration helpers
+# ---------------------------------------------------------------------------
+
+_DEFAULT_PID_DIR = Path.home() / ".local" / "share" / "dev10x" / "mcp"
+_HEALTH_MAGIC = b"PING"
+_HEALTH_REPLY = b"PONG"
+_SOCKET_NAME = "dev10x-mcp.sock"
+_PID_NAME = "dev10x-mcp.pid"
+
+
+def _pid_dir() -> Path:
+    """Return the directory used for PID and socket files.
+
+    Reads ``DEV10X_MCP_PID_DIR``; falls back to
+    ``~/.local/share/dev10x/mcp``.
+    """
+    raw = os.environ.get("DEV10X_MCP_PID_DIR", "").strip()
+    return Path(raw) if raw else _DEFAULT_PID_DIR
+
+
+def _health_timeout() -> float:
+    """Return the health-check socket timeout in seconds."""
+    raw = os.environ.get("DEV10X_MCP_HEALTH_TIMEOUT", "").strip()
+    try:
+        return float(raw) if raw else 3.0
+    except ValueError:
+        log.warning("Invalid DEV10X_MCP_HEALTH_TIMEOUT=%r, using default 3.0", raw)
+        return 3.0
+
+
+def _shutdown_timeout() -> float:
+    """Return the graceful-shutdown wait timeout in seconds."""
+    raw = os.environ.get("DEV10X_MCP_SHUTDOWN_TIMEOUT", "").strip()
+    try:
+        return float(raw) if raw else 10.0
+    except ValueError:
+        log.warning("Invalid DEV10X_MCP_SHUTDOWN_TIMEOUT=%r, using default 10.0", raw)
+        return 10.0
+
+
+# ---------------------------------------------------------------------------
+# PID file helpers
+# ---------------------------------------------------------------------------
+
+
+def pid_file_path(pid_dir: Path | None = None) -> Path:
+    """Return the canonical path for the daemon PID file."""
+    return (pid_dir or _pid_dir()) / _PID_NAME
+
+
+def socket_file_path(pid_dir: Path | None = None) -> Path:
+    """Return the canonical path for the daemon health-check socket."""
+    return (pid_dir or _pid_dir()) / _SOCKET_NAME
+
+
+def write_pid_file(pid: int | None = None, pid_dir: Path | None = None) -> Path:
+    """Write *pid* (default: ``os.getpid()``) to the PID file.
+
+    Creates the directory if it does not exist.  Returns the path written.
+
+    Raises:
+        OSError: If the file cannot be written.
+    """
+    target = pid_file_path(pid_dir)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(str(pid if pid is not None else os.getpid()))
+    log.debug("Wrote PID file: %s", target)
+    return target
+
+
+def read_pid_file(pid_dir: Path | None = None) -> int | None:
+    """Read the daemon PID from the PID file.
+
+    Returns the PID as an integer, or ``None`` if the file does not
+    exist or contains invalid content.
+    """
+    path = pid_file_path(pid_dir)
+    try:
+        text = path.read_text().strip()
+        return int(text)
+    except FileNotFoundError:
+        return None
+    except (ValueError, OSError) as exc:
+        log.warning("Cannot read PID file %s: %s", path, exc)
+        return None
+
+
+def remove_pid_file(pid_dir: Path | None = None) -> None:
+    """Delete the PID file, ignoring errors if already absent."""
+    path = pid_file_path(pid_dir)
+    try:
+        path.unlink()
+        log.debug("Removed PID file: %s", path)
+    except FileNotFoundError:
+        pass
+
+
+def remove_socket_file(pid_dir: Path | None = None) -> None:
+    """Delete the health-check socket file, ignoring errors if already absent."""
+    path = socket_file_path(pid_dir)
+    try:
+        path.unlink()
+        log.debug("Removed socket file: %s", path)
+    except FileNotFoundError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Stale-lock detection
+# ---------------------------------------------------------------------------
+
+
+def is_pid_alive(pid: int) -> bool:
+    """Return True if *pid* refers to a running process on this host.
+
+    Uses ``os.kill(pid, 0)`` which sends no signal but raises
+    ``ProcessLookupError`` when the process does not exist and
+    ``PermissionError`` when it exists but is owned by another user.
+    Both positive cases (own process or other user's process) mean the
+    PID is alive.
+    """
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Process exists but we do not own it — still alive.
+        return True
+
+
+def is_stale_pid_file(pid_dir: Path | None = None) -> bool:
+    """Return True when a PID file exists but the process is no longer running.
+
+    A missing PID file is *not* stale — it simply means no daemon has
+    ever written one, or it was cleanly removed.
+    """
+    pid = read_pid_file(pid_dir)
+    if pid is None:
+        return False
+    return not is_pid_alive(pid)
+
+
+def clear_stale_lock_files(pid_dir: Path | None = None) -> bool:
+    """Remove stale PID and socket files when the owning process is dead.
+
+    Returns True if stale files were removed, False if the daemon is
+    still running or no lock files were present.
+
+    This is the **restart-safety** primitive: call it before attempting
+    to start a new daemon instance to avoid false "already running"
+    errors.
+    """
+    if is_stale_pid_file(pid_dir):
+        log.info("Removing stale lock files from previous daemon run.")
+        remove_pid_file(pid_dir)
+        remove_socket_file(pid_dir)
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Health-check socket server (runs inside the daemon)
+# ---------------------------------------------------------------------------
+
+
+class HealthServer:
+    """Minimal UNIX-domain socket server that answers PING → PONG.
+
+    Intended to run in a background thread inside the daemon process.
+    The socket is bound at :func:`socket_file_path` and removed on
+    :meth:`close`.
+
+    Usage::
+
+        server = HealthServer()
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        # … daemon runs …
+        server.close()
+    """
+
+    def __init__(self, pid_dir: Path | None = None) -> None:
+        self._path = socket_file_path(pid_dir)
+        self._running = False
+        self._sock: socket.socket | None = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Bind the UNIX socket and mark the server ready to serve."""
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        # Remove any leftover socket file from a previous crash.
+        try:
+            self._path.unlink()
+        except FileNotFoundError:
+            pass
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.settimeout(1.0)  # short accept() timeout for clean shutdown
+        sock.bind(str(self._path))
+        sock.listen(5)
+        self._sock = sock
+        self._running = True
+        log.debug("HealthServer listening on %s", self._path)
+
+    def serve_forever(self) -> None:
+        """Accept connections and respond to PING with PONG.
+
+        Returns when :meth:`close` is called.  Intended to run in a
+        daemon thread so it does not block process exit.
+        """
+        if self._sock is None:
+            self.start()
+        assert self._sock is not None
+        while self._running:
+            try:
+                conn, _ = self._sock.accept()
+            except TimeoutError:
+                continue
+            except OSError:
+                if self._running:
+                    log.warning("HealthServer accept() failed", exc_info=True)
+                break
+            try:
+                data = conn.recv(len(_HEALTH_MAGIC))
+                if data == _HEALTH_MAGIC:
+                    conn.sendall(_HEALTH_REPLY)
+            except OSError:
+                log.debug("HealthServer: error on connection", exc_info=True)
+            finally:
+                conn.close()
+
+    def close(self) -> None:
+        """Stop the server and remove the socket file."""
+        self._running = False
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            except OSError:
+                pass
+            self._sock = None
+        remove_socket_file(Path(self._path).parent)
+        log.debug("HealthServer stopped")
+
+
+# ---------------------------------------------------------------------------
+# Health-check client (runs in the caller / watcher process)
+# ---------------------------------------------------------------------------
+
+
+def ping_daemon(pid_dir: Path | None = None, timeout: float | None = None) -> bool:
+    """Return True if the daemon's health-check socket responds to PING.
+
+    Connects to the UNIX socket at :func:`socket_file_path`, sends
+    ``PING``, and checks for ``PONG``.  Returns False on any error or
+    timeout.
+
+    Args:
+        pid_dir: Override the directory containing the socket file.
+        timeout: Override :envvar:`DEV10X_MCP_HEALTH_TIMEOUT`.
+    """
+    path = socket_file_path(pid_dir)
+    t = timeout if timeout is not None else _health_timeout()
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
+            s.settimeout(t)
+            s.connect(str(path))
+            s.sendall(_HEALTH_MAGIC)
+            reply = s.recv(len(_HEALTH_REPLY))
+            return reply == _HEALTH_REPLY
+    except OSError:
+        return False
+
+
+def is_daemon_healthy(pid_dir: Path | None = None) -> bool:
+    """High-level health check: PID alive *and* socket responds.
+
+    Returns True only when both conditions hold — the process listed
+    in the PID file is running **and** its health socket answers PING.
+    Either condition failing (process dead, socket timeout, missing
+    files) returns False.
+    """
+    pid = read_pid_file(pid_dir)
+    if pid is None:
+        return False
+    if not is_pid_alive(pid):
+        return False
+    return ping_daemon(pid_dir)
+
+
+# ---------------------------------------------------------------------------
+# Graceful shutdown
+# ---------------------------------------------------------------------------
+
+
+def request_shutdown(
+    pid: int | None = None,
+    pid_dir: Path | None = None,
+) -> bool:
+    """Send SIGTERM to the daemon and return True if the signal was delivered.
+
+    Args:
+        pid: Explicit PID to signal.  Reads the PID file when ``None``.
+        pid_dir: Override the PID-file directory.
+
+    Returns:
+        True when the signal was sent successfully; False when the PID
+        could not be determined or the process no longer exists.
+    """
+    target_pid = pid if pid is not None else read_pid_file(pid_dir)
+    if target_pid is None:
+        log.warning("request_shutdown: no PID file found")
+        return False
+    try:
+        os.kill(target_pid, signal.SIGTERM)
+        log.info("Sent SIGTERM to daemon PID %d", target_pid)
+        return True
+    except ProcessLookupError:
+        log.warning("request_shutdown: PID %d not found (already exited?)", target_pid)
+        return False
+
+
+def wait_for_shutdown(
+    pid: int,
+    timeout: float | None = None,
+    poll_interval: float = 0.25,
+) -> bool:
+    """Wait for *pid* to exit within *timeout* seconds.
+
+    Polls :func:`is_pid_alive` every *poll_interval* seconds.  Returns
+    True when the process exits before the timeout, False otherwise.
+
+    Args:
+        pid: The PID to watch.
+        timeout: Maximum seconds to wait.  Reads
+            :envvar:`DEV10X_MCP_SHUTDOWN_TIMEOUT` when ``None``.
+        poll_interval: Seconds between liveness checks.
+    """
+    deadline = time.monotonic() + (timeout if timeout is not None else _shutdown_timeout())
+    while time.monotonic() < deadline:
+        if not is_pid_alive(pid):
+            log.info("Daemon PID %d exited", pid)
+            return True
+        time.sleep(poll_interval)
+    return False
+
+
+def shutdown_daemon(
+    pid_dir: Path | None = None,
+    *,
+    timeout: float | None = None,
+    force: bool = True,
+) -> bool:
+    """Gracefully stop the daemon, escalating to SIGKILL if needed.
+
+    Steps:
+
+    1. Read the PID from the PID file.
+    2. Send SIGTERM.
+    3. Wait up to *timeout* seconds for the process to exit.
+    4. If still alive and *force* is True, send SIGKILL.
+
+    Returns True when the daemon exited cleanly (SIGTERM was enough);
+    False when SIGKILL was required or the daemon was not running.
+
+    Raises:
+        RuntimeError: If *force* is False and the daemon does not exit
+            in time.
+    """
+    pid = read_pid_file(pid_dir)
+    if pid is None:
+        log.info("shutdown_daemon: no PID file — nothing to stop")
+        return False
+
+    if not is_pid_alive(pid):
+        log.info("shutdown_daemon: PID %d already exited", pid)
+        remove_pid_file(pid_dir)
+        remove_socket_file(pid_dir)
+        return True
+
+    request_shutdown(pid=pid)
+    if wait_for_shutdown(pid, timeout=timeout):
+        remove_pid_file(pid_dir)
+        remove_socket_file(pid_dir)
+        return True
+
+    if not force:
+        raise RuntimeError(
+            f"Daemon PID {pid} did not exit within the timeout. Use force=True to send SIGKILL."
+        )
+
+    log.warning("Daemon PID %d did not exit in time; sending SIGKILL", pid)
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass  # Raced with clean exit — that is fine.
+
+    remove_pid_file(pid_dir)
+    remove_socket_file(pid_dir)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Daemon-side lifecycle context
+# ---------------------------------------------------------------------------
+
+
+class DaemonLifecycle:
+    """Convenience wrapper that ties PID, socket, and shutdown together.
+
+    Typical usage inside the daemon process::
+
+        lifecycle = DaemonLifecycle()
+        lifecycle.start()
+
+        # Run the MCP server (blocking call).
+        try:
+            server.run(transport="streamable-http")
+        finally:
+            lifecycle.stop()
+
+    The :meth:`start` method:
+
+    * Clears any stale lock files.
+    * Writes the current PID to the PID file.
+    * Starts the :class:`HealthServer` in a daemon background thread.
+
+    The :meth:`stop` method:
+
+    * Closes the health server.
+    * Removes the PID and socket files.
+    """
+
+    def __init__(self, pid_dir: Path | None = None) -> None:
+        self._pid_dir = pid_dir
+        self._health_server: HealthServer | None = None
+        self._health_thread: object | None = None  # threading.Thread
+
+    def start(self) -> None:
+        """Initialise daemon lifecycle state and start the health server."""
+        import threading
+
+        clear_stale_lock_files(self._pid_dir)
+        write_pid_file(pid_dir=self._pid_dir)
+
+        server = HealthServer(self._pid_dir)
+        server.start()
+        self._health_server = server
+
+        thread = threading.Thread(
+            target=server.serve_forever,
+            daemon=True,
+            name="dev10x-health",
+        )
+        thread.start()
+        self._health_thread = thread
+        log.info("DaemonLifecycle started (PID=%d)", os.getpid())
+
+    def stop(self) -> None:
+        """Tear down health server and remove lock files."""
+        if self._health_server is not None:
+            self._health_server.close()
+            self._health_server = None
+        remove_pid_file(self._pid_dir)
+        log.info("DaemonLifecycle stopped")
+
+    def __enter__(self) -> DaemonLifecycle:
+        self.start()
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.stop()

--- a/src/dev10x/mcp/session_store.py
+++ b/src/dev10x/mcp/session_store.py
@@ -1,0 +1,421 @@
+"""Per-session state management for StreamableHTTP MCP servers (GH-337).
+
+Maintains per-client state across HTTP requests when the MCP server
+runs in ``streamable-http`` transport mode.  Each HTTP client is
+identified by a session ID that the SDK assigns on first contact and
+passes in the ``Mcp-Session-Id`` request header on subsequent requests.
+
+Architecture
+------------
+``SessionStore`` is a thread-safe in-memory mapping from session ID
+(``str``) to an arbitrary ``dict[str, object]`` payload.  It is
+designed to be owned by :class:`~dev10x.mcp.daemon.DaemonLifecycle`
+so all session data is cleared on daemon stop.
+
+The module exposes a *process-level singleton* (``_store``) that
+tool handlers can access via :func:`get_store`.  This pattern avoids
+threading the store through every call chain while keeping the
+store injectable for tests.
+
+Forward-compatibility note
+--------------------------
+This module is Increment 2 of the M1 chain (#336 daemon → #337
+session/state → #338 Claude Code wiring).  Increment 3 will wire the
+session store into Claude Code configuration so tool handlers can
+persist session-scoped preferences; that integration must not require
+API changes to this module.
+
+Session lifecycle
+-----------------
+* **Created** — on first :meth:`SessionStore.get_or_create` call for
+  an unknown session ID.  The entry is populated with a ``created_at``
+  timestamp.
+* **Updated** — via :meth:`SessionStore.update`.  Each update refreshes
+  the ``last_active`` timestamp, which the TTL eviction uses.
+* **Evicted** — by :meth:`SessionStore.evict_expired` (call
+  periodically or on every request).  Sessions idle for longer than the
+  configured TTL are removed automatically.
+* **Removed** — explicitly via :meth:`SessionStore.remove`, or in bulk
+  via :meth:`SessionStore.clear` (called by ``DaemonLifecycle.stop``).
+
+Environment variables
+---------------------
+DEV10X_MCP_SESSION_TTL
+    Session idle timeout in seconds.  Sessions not accessed within this
+    window are eligible for eviction.  Defaults to 3600 (1 hour).
+
+DEV10X_MCP_SESSION_MAX
+    Maximum number of concurrent sessions the store will hold.  When
+    the limit is reached, the oldest (least-recently-active) session is
+    evicted to make room.  Defaults to 1000.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration helpers
+# ---------------------------------------------------------------------------
+
+
+def _session_ttl() -> float:
+    """Return the session idle TTL in seconds (default 3600)."""
+    raw = os.environ.get("DEV10X_MCP_SESSION_TTL", "").strip()
+    try:
+        return float(raw) if raw else 3600.0
+    except ValueError:
+        log.warning("Invalid DEV10X_MCP_SESSION_TTL=%r, using default 3600.0", raw)
+        return 3600.0
+
+
+def _session_max() -> int:
+    """Return the maximum number of concurrent sessions (default 1000)."""
+    raw = os.environ.get("DEV10X_MCP_SESSION_MAX", "").strip()
+    try:
+        return int(raw) if raw else 1000
+    except ValueError:
+        log.warning("Invalid DEV10X_MCP_SESSION_MAX=%r, using default 1000", raw)
+        return 1000
+
+
+# ---------------------------------------------------------------------------
+# Session entry
+# ---------------------------------------------------------------------------
+
+
+class SessionEntry:
+    """Single session record: data payload plus lifecycle timestamps.
+
+    Attributes:
+        session_id: The unique string identifier assigned by the SDK.
+        data: Mutable dict of session-scoped state.  Tool handlers
+            read and write arbitrary keys here.
+        created_at: ``time.monotonic()`` value at creation time.
+        last_active: ``time.monotonic()`` value at last access/update.
+    """
+
+    __slots__ = ("session_id", "data", "created_at", "last_active")
+
+    def __init__(self, session_id: str) -> None:
+        self.session_id = session_id
+        self.data: dict[str, Any] = {}
+        now = time.monotonic()
+        self.created_at = now
+        self.last_active = now
+
+    def touch(self) -> None:
+        """Refresh the last-active timestamp to now."""
+        self.last_active = time.monotonic()
+
+    def is_expired(self, ttl: float) -> bool:
+        """Return True when the session has been idle for longer than *ttl*."""
+        return (time.monotonic() - self.last_active) > ttl
+
+
+# ---------------------------------------------------------------------------
+# SessionStore
+# ---------------------------------------------------------------------------
+
+
+class SessionStore:
+    """Thread-safe per-session state container for StreamableHTTP servers.
+
+    Create one instance and bind it to :class:`~dev10x.mcp.daemon.DaemonLifecycle`
+    so it is cleared on daemon shutdown::
+
+        from dev10x.mcp.daemon import DaemonLifecycle
+        from dev10x.mcp.session_store import SessionStore
+
+        store = SessionStore()
+
+        lifecycle = DaemonLifecycle()
+        lifecycle.start()
+        try:
+            server.run(transport="streamable-http")
+        finally:
+            store.clear()   # drop all session state
+            lifecycle.stop()
+
+    Alternatively, use :func:`bind_to_lifecycle` to wire the clear
+    callback automatically:
+
+        store = SessionStore()
+        lifecycle = DaemonLifecycle()
+        bind_to_lifecycle(store, lifecycle)
+
+    Tool handlers retrieve per-session data via the process-level
+    singleton::
+
+        from dev10x.mcp.session_store import get_store
+
+        @server.tool()
+        async def my_tool(session_id: str | None = None) -> dict:
+            store = get_store()
+            if session_id:
+                entry = store.get_or_create(session_id)
+                entry.data["last_called"] = time.time()
+            return {"ok": True}
+    """
+
+    def __init__(
+        self,
+        ttl: float | None = None,
+        max_sessions: int | None = None,
+    ) -> None:
+        """Create a new store.
+
+        Args:
+            ttl: Session idle timeout in seconds.  Reads
+                :envvar:`DEV10X_MCP_SESSION_TTL` when ``None``.
+            max_sessions: Maximum concurrent sessions.  Reads
+                :envvar:`DEV10X_MCP_SESSION_MAX` when ``None``.
+        """
+        self._ttl: float = ttl if ttl is not None else _session_ttl()
+        self._max: int = max_sessions if max_sessions is not None else _session_max()
+        self._lock = threading.Lock()
+        self._sessions: dict[str, SessionEntry] = {}
+
+    # ------------------------------------------------------------------
+    # Core access
+    # ------------------------------------------------------------------
+
+    def get_or_create(self, session_id: str) -> SessionEntry:
+        """Return the existing session or create a fresh one.
+
+        Evicts expired sessions before checking capacity, then enforces
+        the ``max_sessions`` limit by dropping the least-recently-active
+        entry when the store is full.
+
+        Args:
+            session_id: The unique session identifier from the SDK.
+
+        Returns:
+            The :class:`SessionEntry` for this session ID.
+        """
+        with self._lock:
+            self._evict_expired_locked()
+            if session_id in self._sessions:
+                entry = self._sessions[session_id]
+                entry.touch()
+                return entry
+
+            # Enforce capacity limit: evict the oldest entry.
+            if len(self._sessions) >= self._max:
+                self._evict_oldest_locked()
+
+            entry = SessionEntry(session_id=session_id)
+            self._sessions[session_id] = entry
+            log.debug("SessionStore: created session %r", session_id)
+            return entry
+
+    def get(self, session_id: str) -> SessionEntry | None:
+        """Return the session entry or ``None`` if it does not exist.
+
+        Touches the entry's ``last_active`` timestamp on a hit.
+        Does *not* create a new session.
+
+        Args:
+            session_id: The unique session identifier.
+        """
+        with self._lock:
+            entry = self._sessions.get(session_id)
+            if entry is not None:
+                entry.touch()
+            return entry
+
+    def update(self, session_id: str, **kwargs: Any) -> SessionEntry:
+        """Merge *kwargs* into the session's data dict.
+
+        Creates the session when it does not yet exist.
+
+        Args:
+            session_id: The unique session identifier.
+            **kwargs: Key-value pairs to merge into ``entry.data``.
+
+        Returns:
+            The updated :class:`SessionEntry`.
+        """
+        entry = self.get_or_create(session_id)
+        with self._lock:
+            entry.data.update(kwargs)
+            entry.touch()
+        return entry
+
+    def remove(self, session_id: str) -> bool:
+        """Delete the session, returning True when it existed.
+
+        Args:
+            session_id: The unique session identifier.
+        """
+        with self._lock:
+            existed = session_id in self._sessions
+            self._sessions.pop(session_id, None)
+            if existed:
+                log.debug("SessionStore: removed session %r", session_id)
+            return existed
+
+    # ------------------------------------------------------------------
+    # Bulk / lifecycle operations
+    # ------------------------------------------------------------------
+
+    def clear(self) -> int:
+        """Remove all sessions.  Returns the number of sessions cleared.
+
+        Called by :func:`bind_to_lifecycle` on daemon stop.
+        """
+        with self._lock:
+            count = len(self._sessions)
+            self._sessions.clear()
+            log.info("SessionStore: cleared %d session(s)", count)
+            return count
+
+    def evict_expired(self) -> int:
+        """Remove sessions idle longer than the TTL.
+
+        Returns the number of sessions evicted.  Call periodically
+        (e.g., on every MCP request) to prevent unbounded memory growth.
+        """
+        with self._lock:
+            return self._evict_expired_locked()
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    def session_count(self) -> int:
+        """Return the current number of active sessions."""
+        with self._lock:
+            return len(self._sessions)
+
+    def session_ids(self) -> list[str]:
+        """Return a snapshot of all current session IDs."""
+        with self._lock:
+            return list(self._sessions.keys())
+
+    def snapshot(self, session_id: str) -> dict[str, Any] | None:
+        """Return a shallow copy of the session data, or ``None`` if absent.
+
+        Suitable for serialisation and logging without exposing the live
+        entry to external mutation.
+
+        Args:
+            session_id: The unique session identifier.
+        """
+        with self._lock:
+            entry = self._sessions.get(session_id)
+            if entry is None:
+                return None
+            return dict(entry.data)
+
+    # ------------------------------------------------------------------
+    # Private helpers (caller must hold _lock)
+    # ------------------------------------------------------------------
+
+    def _evict_expired_locked(self) -> int:
+        expired = [sid for sid, e in self._sessions.items() if e.is_expired(self._ttl)]
+        for sid in expired:
+            del self._sessions[sid]
+            log.debug("SessionStore: evicted expired session %r", sid)
+        return len(expired)
+
+    def _evict_oldest_locked(self) -> None:
+        if not self._sessions:
+            return
+        oldest_id = min(self._sessions, key=lambda sid: self._sessions[sid].last_active)
+        del self._sessions[oldest_id]
+        log.warning(
+            "SessionStore: evicted oldest session %r (capacity limit %d reached)",
+            oldest_id,
+            self._max,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Process-level singleton
+# ---------------------------------------------------------------------------
+
+#: Module-level singleton, used by tool handlers when no explicit store is
+#: injected.  Tests override it via :func:`set_store`.
+_store: SessionStore = SessionStore()
+
+
+def get_store() -> SessionStore:
+    """Return the process-level :class:`SessionStore` singleton.
+
+    Tool handlers call this to access per-session state without needing
+    the store passed through the entire call chain::
+
+        from dev10x.mcp.session_store import get_store
+
+        entry = get_store().get_or_create(session_id)
+    """
+    return _store
+
+
+def set_store(store: SessionStore) -> None:
+    """Replace the process-level singleton.
+
+    Intended for testing — inject a fresh store with custom TTL/max
+    settings and restore it on teardown::
+
+        def test_something(monkeypatch):
+            fresh = SessionStore(ttl=60, max_sessions=10)
+            monkeypatch.setattr("dev10x.mcp.session_store._store", fresh)
+            ...
+    """
+    global _store
+    _store = store
+
+
+# ---------------------------------------------------------------------------
+# DaemonLifecycle integration
+# ---------------------------------------------------------------------------
+
+
+def bind_to_lifecycle(
+    store: SessionStore,
+    lifecycle: object,
+) -> None:
+    """Register *store*.clear() as a teardown hook on *lifecycle*.
+
+    The ``lifecycle`` object is duck-typed: it must expose a ``stop``
+    method.  :class:`~dev10x.mcp.daemon.DaemonLifecycle` satisfies
+    this contract.  The original ``stop`` method is wrapped so session
+    state is always cleared when the daemon stops, regardless of
+    whether the caller remembers to call ``store.clear()`` explicitly.
+
+    Args:
+        store: The :class:`SessionStore` to register.
+        lifecycle: An object with a callable ``stop`` attribute.
+
+    Raises:
+        AttributeError: If *lifecycle* does not have a ``stop`` method.
+
+    Example::
+
+        from dev10x.mcp.daemon import DaemonLifecycle
+        from dev10x.mcp.session_store import SessionStore, bind_to_lifecycle
+
+        store = SessionStore()
+        lifecycle = DaemonLifecycle()
+        bind_to_lifecycle(store, lifecycle)
+
+        with lifecycle:
+            server.run(transport="streamable-http")
+        # store.clear() was called automatically by lifecycle.stop()
+    """
+    original_stop = lifecycle.stop  # type: ignore[union-attr]
+
+    def _stop_with_clear(*args: object, **kwargs: object) -> None:
+        store.clear()
+        original_stop(*args, **kwargs)
+
+    lifecycle.stop = _stop_with_clear  # type: ignore[union-attr]
+    log.debug("SessionStore bound to lifecycle %r", lifecycle)

--- a/tests/mcp/test_daemon.py
+++ b/tests/mcp/test_daemon.py
@@ -1,0 +1,428 @@
+"""Tests for daemon lifecycle management (GH-336).
+
+Covers:
+- PID file write / read / remove
+- Socket file path helpers
+- Stale-lock detection (is_stale_pid_file, clear_stale_lock_files)
+- is_pid_alive with real / fake PIDs
+- HealthServer: starts, answers PING with PONG, stops cleanly
+- ping_daemon: returns True when server up, False when down
+- is_daemon_healthy: requires both PID alive and socket PONG
+- request_shutdown: sends SIGTERM to real process, handles missing PID
+- wait_for_shutdown: returns True when process exits, False on timeout
+- shutdown_daemon: full graceful-shutdown flow (SIGTERM → wait → SIGKILL)
+- DaemonLifecycle context manager: start/stop, PID written, health OK
+- Environment variable overrides: DEV10X_MCP_PID_DIR,
+  DEV10X_MCP_HEALTH_TIMEOUT, DEV10X_MCP_SHUTDOWN_TIMEOUT
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import threading
+import time
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from dev10x.mcp.daemon import (
+    DaemonLifecycle,
+    HealthServer,
+    _health_timeout,
+    _pid_dir,
+    _shutdown_timeout,
+    clear_stale_lock_files,
+    is_daemon_healthy,
+    is_pid_alive,
+    is_stale_pid_file,
+    pid_file_path,
+    ping_daemon,
+    read_pid_file,
+    remove_pid_file,
+    remove_socket_file,
+    request_shutdown,
+    shutdown_daemon,
+    socket_file_path,
+    wait_for_shutdown,
+    write_pid_file,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def tmp_pid_dir(tmp_path: Path) -> Path:
+    """Return a temporary directory for PID and socket files."""
+    d = tmp_path / "mcp"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture()
+def running_health_server(tmp_pid_dir: Path) -> Generator[HealthServer, None, None]:
+    """Start a HealthServer in a background thread; stop it after the test."""
+    server = HealthServer(tmp_pid_dir)
+    server.start()
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield server
+    server.close()
+    thread.join(timeout=2.0)
+
+
+# ---------------------------------------------------------------------------
+# Environment variable helpers
+# ---------------------------------------------------------------------------
+
+
+class TestPidDir:
+    def test_default_when_env_absent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("DEV10X_MCP_PID_DIR", raising=False)
+        result = _pid_dir()
+        assert result == Path.home() / ".local" / "share" / "dev10x" / "mcp"
+
+    def test_reads_env_var(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        monkeypatch.setenv("DEV10X_MCP_PID_DIR", str(tmp_path))
+        assert _pid_dir() == tmp_path
+
+    def test_ignores_empty_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_MCP_PID_DIR", "")
+        result = _pid_dir()
+        assert result == Path.home() / ".local" / "share" / "dev10x" / "mcp"
+
+
+class TestHealthTimeout:
+    def test_default_is_three(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("DEV10X_MCP_HEALTH_TIMEOUT", raising=False)
+        assert _health_timeout() == 3.0
+
+    def test_reads_float(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_MCP_HEALTH_TIMEOUT", "1.5")
+        assert _health_timeout() == 1.5
+
+    def test_invalid_falls_back_to_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_MCP_HEALTH_TIMEOUT", "not-a-number")
+        assert _health_timeout() == 3.0
+
+
+class TestShutdownTimeout:
+    def test_default_is_ten(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("DEV10X_MCP_SHUTDOWN_TIMEOUT", raising=False)
+        assert _shutdown_timeout() == 10.0
+
+    def test_reads_float(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_MCP_SHUTDOWN_TIMEOUT", "5.0")
+        assert _shutdown_timeout() == 5.0
+
+    def test_invalid_falls_back_to_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_MCP_SHUTDOWN_TIMEOUT", "bad")
+        assert _shutdown_timeout() == 10.0
+
+
+# ---------------------------------------------------------------------------
+# PID file helpers
+# ---------------------------------------------------------------------------
+
+
+class TestPidFilePath:
+    def test_returns_path_in_pid_dir(self, tmp_pid_dir: Path) -> None:
+        path = pid_file_path(tmp_pid_dir)
+        assert path.parent == tmp_pid_dir
+        assert path.suffix == ".pid"
+
+    def test_socket_file_in_same_dir(self, tmp_pid_dir: Path) -> None:
+        assert socket_file_path(tmp_pid_dir).parent == tmp_pid_dir
+
+
+class TestWriteReadRemovePidFile:
+    def test_write_creates_file(self, tmp_pid_dir: Path) -> None:
+        write_pid_file(pid=12345, pid_dir=tmp_pid_dir)
+        assert pid_file_path(tmp_pid_dir).exists()
+
+    def test_write_stores_pid(self, tmp_pid_dir: Path) -> None:
+        write_pid_file(pid=42, pid_dir=tmp_pid_dir)
+        assert read_pid_file(tmp_pid_dir) == 42
+
+    def test_write_defaults_to_own_pid(self, tmp_pid_dir: Path) -> None:
+        write_pid_file(pid_dir=tmp_pid_dir)
+        assert read_pid_file(tmp_pid_dir) == os.getpid()
+
+    def test_write_creates_parent_dir(self, tmp_path: Path) -> None:
+        nested = tmp_path / "a" / "b" / "c"
+        write_pid_file(pid=1, pid_dir=nested)
+        assert pid_file_path(nested).exists()
+
+    def test_read_returns_none_when_missing(self, tmp_pid_dir: Path) -> None:
+        assert read_pid_file(tmp_pid_dir) is None
+
+    def test_read_returns_none_on_invalid_content(self, tmp_pid_dir: Path) -> None:
+        pid_file_path(tmp_pid_dir).write_text("not-an-int")
+        assert read_pid_file(tmp_pid_dir) is None
+
+    def test_remove_deletes_file(self, tmp_pid_dir: Path) -> None:
+        write_pid_file(pid=99, pid_dir=tmp_pid_dir)
+        remove_pid_file(tmp_pid_dir)
+        assert not pid_file_path(tmp_pid_dir).exists()
+
+    def test_remove_ignores_missing(self, tmp_pid_dir: Path) -> None:
+        remove_pid_file(tmp_pid_dir)  # Must not raise.
+
+    def test_remove_socket_ignores_missing(self, tmp_pid_dir: Path) -> None:
+        remove_socket_file(tmp_pid_dir)  # Must not raise.
+
+
+# ---------------------------------------------------------------------------
+# Stale-lock detection
+# ---------------------------------------------------------------------------
+
+
+class TestIsPidAlive:
+    def test_own_pid_is_alive(self) -> None:
+        assert is_pid_alive(os.getpid()) is True
+
+    def test_nonexistent_pid_is_not_alive(self) -> None:
+        # PID 0 is never a valid user-space process on Linux/macOS.
+        # Use a very large PID unlikely to be running.
+        assert is_pid_alive(999_999_999) is False
+
+
+class TestIsStalePidFile:
+    def test_no_pid_file_is_not_stale(self, tmp_pid_dir: Path) -> None:
+        assert is_stale_pid_file(tmp_pid_dir) is False
+
+    def test_live_pid_is_not_stale(self, tmp_pid_dir: Path) -> None:
+        write_pid_file(pid=os.getpid(), pid_dir=tmp_pid_dir)
+        assert is_stale_pid_file(tmp_pid_dir) is False
+
+    def test_dead_pid_is_stale(self, tmp_pid_dir: Path) -> None:
+        write_pid_file(pid=999_999_999, pid_dir=tmp_pid_dir)
+        assert is_stale_pid_file(tmp_pid_dir) is True
+
+
+class TestClearStaleLockFiles:
+    def test_clears_stale_pid_and_socket(self, tmp_pid_dir: Path) -> None:
+        write_pid_file(pid=999_999_999, pid_dir=tmp_pid_dir)
+        # Create a fake socket file to check it is also removed.
+        socket_file_path(tmp_pid_dir).touch()
+        result = clear_stale_lock_files(tmp_pid_dir)
+        assert result is True
+        assert not pid_file_path(tmp_pid_dir).exists()
+        assert not socket_file_path(tmp_pid_dir).exists()
+
+    def test_no_action_when_daemon_running(self, tmp_pid_dir: Path) -> None:
+        write_pid_file(pid=os.getpid(), pid_dir=tmp_pid_dir)
+        result = clear_stale_lock_files(tmp_pid_dir)
+        assert result is False
+        assert pid_file_path(tmp_pid_dir).exists()
+
+    def test_no_action_when_no_pid_file(self, tmp_pid_dir: Path) -> None:
+        result = clear_stale_lock_files(tmp_pid_dir)
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# HealthServer and ping_daemon
+# ---------------------------------------------------------------------------
+
+
+class TestHealthServer:
+    def test_ping_returns_pong(
+        self,
+        running_health_server: HealthServer,
+        tmp_pid_dir: Path,
+    ) -> None:
+        assert ping_daemon(tmp_pid_dir, timeout=1.0) is True
+
+    def test_ping_fails_when_server_stopped(self, tmp_pid_dir: Path) -> None:
+        # Nothing is listening — ping must return False, not raise.
+        assert ping_daemon(tmp_pid_dir, timeout=0.5) is False
+
+    def test_server_stops_cleanly(self, tmp_pid_dir: Path) -> None:
+        server = HealthServer(tmp_pid_dir)
+        server.start()
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        assert ping_daemon(tmp_pid_dir, timeout=1.0) is True
+        server.close()
+        thread.join(timeout=2.0)
+        # After close() the socket file should be gone.
+        assert not socket_file_path(tmp_pid_dir).exists()
+
+    def test_start_removes_leftover_socket(self, tmp_pid_dir: Path) -> None:
+        # Pre-create a socket file to simulate a previous crash.
+        socket_file_path(tmp_pid_dir).touch()
+        server = HealthServer(tmp_pid_dir)
+        server.start()
+        server.close()
+
+    def test_context_manager(self, tmp_pid_dir: Path) -> None:
+        """HealthServer used as a plain object; close() is idempotent."""
+        server = HealthServer(tmp_pid_dir)
+        server.start()
+        server.close()
+        server.close()  # Second close must not raise.
+
+
+# ---------------------------------------------------------------------------
+# is_daemon_healthy
+# ---------------------------------------------------------------------------
+
+
+class TestIsDaemonHealthy:
+    def test_healthy_when_pid_alive_and_socket_responds(
+        self,
+        running_health_server: HealthServer,
+        tmp_pid_dir: Path,
+    ) -> None:
+        write_pid_file(pid=os.getpid(), pid_dir=tmp_pid_dir)
+        assert is_daemon_healthy(tmp_pid_dir) is True
+
+    def test_unhealthy_when_no_pid_file(self, tmp_pid_dir: Path) -> None:
+        assert is_daemon_healthy(tmp_pid_dir) is False
+
+    def test_unhealthy_when_pid_dead(
+        self,
+        running_health_server: HealthServer,
+        tmp_pid_dir: Path,
+    ) -> None:
+        write_pid_file(pid=999_999_999, pid_dir=tmp_pid_dir)
+        assert is_daemon_healthy(tmp_pid_dir) is False
+
+    def test_unhealthy_when_socket_not_responding(self, tmp_pid_dir: Path) -> None:
+        write_pid_file(pid=os.getpid(), pid_dir=tmp_pid_dir)
+        # No HealthServer started — socket does not exist.
+        assert is_daemon_healthy(tmp_pid_dir) is False
+
+
+# ---------------------------------------------------------------------------
+# Shutdown helpers
+# ---------------------------------------------------------------------------
+
+
+class TestRequestShutdown:
+    def test_returns_false_when_no_pid_file(self, tmp_pid_dir: Path) -> None:
+        assert request_shutdown(pid_dir=tmp_pid_dir) is False
+
+    def test_returns_false_for_nonexistent_pid(self, tmp_pid_dir: Path) -> None:
+        assert request_shutdown(pid=999_999_999, pid_dir=tmp_pid_dir) is False
+
+    def test_sends_sigterm_to_explicit_pid(self, tmp_pid_dir: Path) -> None:
+        received: list[int] = []
+
+        original = signal.getsignal(signal.SIGTERM)
+        signal.signal(signal.SIGTERM, lambda signum, _frame: received.append(signum))
+        try:
+            result = request_shutdown(pid=os.getpid(), pid_dir=tmp_pid_dir)
+        finally:
+            signal.signal(signal.SIGTERM, original)
+
+        assert result is True
+        assert signal.SIGTERM in received
+
+
+class TestWaitForShutdown:
+    def test_returns_true_when_process_already_dead(self) -> None:
+        # pid 999_999_999 does not exist → immediately True
+        assert wait_for_shutdown(pid=999_999_999, timeout=1.0) is True
+
+    def test_returns_false_on_timeout(self) -> None:
+        # Our own PID is alive and will not die during the test.
+        result = wait_for_shutdown(pid=os.getpid(), timeout=0.3, poll_interval=0.1)
+        assert result is False
+
+
+class TestShutdownDaemon:
+    def test_returns_false_when_no_pid_file(self, tmp_pid_dir: Path) -> None:
+        assert shutdown_daemon(tmp_pid_dir) is False
+
+    def test_cleans_up_when_pid_already_dead(self, tmp_pid_dir: Path) -> None:
+        write_pid_file(pid=999_999_999, pid_dir=tmp_pid_dir)
+        result = shutdown_daemon(tmp_pid_dir)
+        assert result is True
+        assert not pid_file_path(tmp_pid_dir).exists()
+
+    def test_raises_when_force_false_and_timeout(self, tmp_pid_dir: Path) -> None:
+        write_pid_file(pid=12345, pid_dir=tmp_pid_dir)
+        with (
+            patch("dev10x.mcp.daemon.is_pid_alive", return_value=True),
+            patch("dev10x.mcp.daemon.request_shutdown", return_value=True),
+            patch("dev10x.mcp.daemon.wait_for_shutdown", return_value=False),
+            pytest.raises(RuntimeError, match="did not exit"),
+        ):
+            shutdown_daemon(tmp_pid_dir, timeout=0.2, force=False)
+
+    def test_force_kills_and_removes_files(self, tmp_pid_dir: Path) -> None:
+        """Mock the process-level calls to verify the SIGKILL escalation path."""
+        write_pid_file(pid=12345, pid_dir=tmp_pid_dir)
+
+        with (
+            patch("dev10x.mcp.daemon.is_pid_alive", return_value=True),
+            patch("dev10x.mcp.daemon.request_shutdown", return_value=True),
+            patch("dev10x.mcp.daemon.wait_for_shutdown", return_value=False),
+            patch("os.kill") as mock_kill,
+        ):
+            result = shutdown_daemon(tmp_pid_dir, timeout=0.1, force=True)
+
+        mock_kill.assert_called_once_with(12345, signal.SIGKILL)
+        assert result is False  # SIGKILL path returns False (not clean)
+        assert not pid_file_path(tmp_pid_dir).exists()
+
+
+# ---------------------------------------------------------------------------
+# DaemonLifecycle context manager
+# ---------------------------------------------------------------------------
+
+
+class TestDaemonLifecycle:
+    def test_start_writes_pid_and_health_responds(self, tmp_pid_dir: Path) -> None:
+        lifecycle = DaemonLifecycle(tmp_pid_dir)
+        lifecycle.start()
+        try:
+            assert read_pid_file(tmp_pid_dir) == os.getpid()
+            assert ping_daemon(tmp_pid_dir, timeout=1.0) is True
+        finally:
+            lifecycle.stop()
+
+    def test_stop_removes_pid_file(self, tmp_pid_dir: Path) -> None:
+        lifecycle = DaemonLifecycle(tmp_pid_dir)
+        lifecycle.start()
+        lifecycle.stop()
+        assert not pid_file_path(tmp_pid_dir).exists()
+
+    def test_context_manager_protocol(self, tmp_pid_dir: Path) -> None:
+        with DaemonLifecycle(tmp_pid_dir) as lc:
+            assert read_pid_file(tmp_pid_dir) == os.getpid()
+            assert ping_daemon(tmp_pid_dir, timeout=1.0) is True
+            assert lc is not None
+        # After __exit__ the PID file must be gone.
+        assert not pid_file_path(tmp_pid_dir).exists()
+
+    def test_start_clears_stale_files(self, tmp_pid_dir: Path) -> None:
+        # Pre-populate stale files.
+        write_pid_file(pid=999_999_999, pid_dir=tmp_pid_dir)
+        socket_file_path(tmp_pid_dir).touch()
+
+        lifecycle = DaemonLifecycle(tmp_pid_dir)
+        lifecycle.start()
+        try:
+            # Stale PID was overwritten with our own PID.
+            assert read_pid_file(tmp_pid_dir) == os.getpid()
+        finally:
+            lifecycle.stop()
+
+    def test_stop_is_idempotent(self, tmp_pid_dir: Path) -> None:
+        lifecycle = DaemonLifecycle(tmp_pid_dir)
+        lifecycle.start()
+        lifecycle.stop()
+        lifecycle.stop()  # Second stop must not raise.
+
+    def test_is_daemon_healthy_inside_context(self, tmp_pid_dir: Path) -> None:
+        with DaemonLifecycle(tmp_pid_dir):
+            # Give the health thread a moment to bind.
+            time.sleep(0.05)
+            assert is_daemon_healthy(tmp_pid_dir) is True

--- a/tests/mcp/test_session_store.py
+++ b/tests/mcp/test_session_store.py
@@ -1,0 +1,474 @@
+"""Tests for per-session state management over StreamableHTTP (GH-337).
+
+Covers:
+- SessionEntry: creation, touch, is_expired
+- SessionStore.get_or_create: creates new entries, returns existing
+- SessionStore.get: returns None for missing, touches on hit
+- SessionStore.update: merges kwargs into data
+- SessionStore.remove: returns True/False, removes entry
+- SessionStore.clear: removes all sessions, returns count
+- SessionStore.evict_expired: removes idle sessions
+- SessionStore capacity limit: evicts oldest when max reached
+- Thread safety: concurrent get_or_create calls produce one entry
+- Introspection: session_count, session_ids, snapshot
+- Process-level singleton: get_store, set_store
+- bind_to_lifecycle: store.clear() called on lifecycle.stop()
+- Environment variable overrides: DEV10X_MCP_SESSION_TTL,
+  DEV10X_MCP_SESSION_MAX
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from dev10x.mcp.session_store import (
+    SessionEntry,
+    SessionStore,
+    _session_max,
+    _session_ttl,
+    bind_to_lifecycle,
+    get_store,
+    set_store,
+)
+
+# ---------------------------------------------------------------------------
+# Environment variable helpers
+# ---------------------------------------------------------------------------
+
+
+class TestSessionTtl:
+    def test_default_is_3600(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("DEV10X_MCP_SESSION_TTL", raising=False)
+        assert _session_ttl() == 3600.0
+
+    def test_reads_float(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_MCP_SESSION_TTL", "60.5")
+        assert _session_ttl() == 60.5
+
+    def test_invalid_falls_back_to_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_MCP_SESSION_TTL", "not-a-number")
+        assert _session_ttl() == 3600.0
+
+    def test_empty_falls_back_to_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_MCP_SESSION_TTL", "")
+        assert _session_ttl() == 3600.0
+
+
+class TestSessionMax:
+    def test_default_is_1000(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("DEV10X_MCP_SESSION_MAX", raising=False)
+        assert _session_max() == 1000
+
+    def test_reads_int(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_MCP_SESSION_MAX", "50")
+        assert _session_max() == 50
+
+    def test_invalid_falls_back_to_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_MCP_SESSION_MAX", "bad")
+        assert _session_max() == 1000
+
+
+# ---------------------------------------------------------------------------
+# SessionEntry
+# ---------------------------------------------------------------------------
+
+
+class TestSessionEntry:
+    def test_creation_sets_timestamps(self) -> None:
+        before = time.monotonic()
+        entry = SessionEntry(session_id="test-abc")
+        after = time.monotonic()
+        assert before <= entry.created_at <= after
+        assert before <= entry.last_active <= after
+
+    def test_initial_data_is_empty(self) -> None:
+        entry = SessionEntry(session_id="x")
+        assert entry.data == {}
+
+    def test_touch_refreshes_last_active(self) -> None:
+        entry = SessionEntry(session_id="y")
+        original = entry.last_active
+        time.sleep(0.01)
+        entry.touch()
+        assert entry.last_active > original
+
+    def test_is_expired_false_when_fresh(self) -> None:
+        entry = SessionEntry(session_id="z")
+        assert entry.is_expired(ttl=3600.0) is False
+
+    def test_is_expired_true_when_old(self) -> None:
+        entry = SessionEntry(session_id="old")
+        # Backdate last_active by 10 seconds.
+        entry.last_active = time.monotonic() - 10
+        assert entry.is_expired(ttl=5.0) is True
+
+    def test_is_expired_false_when_ttl_exactly_not_reached(self) -> None:
+        entry = SessionEntry(session_id="edge")
+        entry.last_active = time.monotonic() - 4.9
+        assert entry.is_expired(ttl=5.0) is False
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def store() -> SessionStore:
+    """Return a fresh SessionStore with a short TTL for tests."""
+    return SessionStore(ttl=60.0, max_sessions=100)
+
+
+# ---------------------------------------------------------------------------
+# SessionStore.get_or_create
+# ---------------------------------------------------------------------------
+
+
+class TestGetOrCreate:
+    def test_creates_new_session(self, store: SessionStore) -> None:
+        entry = store.get_or_create("sess-1")
+        assert entry.session_id == "sess-1"
+        assert store.session_count() == 1
+
+    def test_returns_existing_session(self, store: SessionStore) -> None:
+        e1 = store.get_or_create("sess-1")
+        e2 = store.get_or_create("sess-1")
+        assert e1 is e2
+
+    def test_touches_existing_session(self, store: SessionStore) -> None:
+        e1 = store.get_or_create("sess-1")
+        t = e1.last_active
+        time.sleep(0.01)
+        store.get_or_create("sess-1")
+        assert e1.last_active > t
+
+    def test_different_ids_are_independent(self, store: SessionStore) -> None:
+        e1 = store.get_or_create("a")
+        e2 = store.get_or_create("b")
+        assert e1 is not e2
+        assert store.session_count() == 2
+
+    def test_evicts_expired_before_creating(self, store: SessionStore) -> None:
+        # Create a session then expire it manually.
+        store.get_or_create("expired")
+        store._sessions["expired"].last_active = time.monotonic() - 9999
+        store.get_or_create("new-one")
+        # "expired" must have been evicted.
+        assert "expired" not in store.session_ids()
+        assert "new-one" in store.session_ids()
+
+
+# ---------------------------------------------------------------------------
+# Capacity eviction
+# ---------------------------------------------------------------------------
+
+
+class TestCapacityEviction:
+    def test_evicts_oldest_when_full(self) -> None:
+        store = SessionStore(ttl=3600.0, max_sessions=3)
+        # Create 3 sessions with controlled timestamps.
+        store.get_or_create("a")
+        time.sleep(0.01)
+        store.get_or_create("b")
+        time.sleep(0.01)
+        store.get_or_create("c")
+
+        # "a" is oldest — adding "d" should evict "a".
+        store.get_or_create("d")
+        ids = store.session_ids()
+        assert "a" not in ids
+        assert "d" in ids
+        assert store.session_count() == 3
+
+    def test_does_not_evict_below_capacity(self, store: SessionStore) -> None:
+        store.get_or_create("a")
+        store.get_or_create("b")
+        assert store.session_count() == 2
+
+
+# ---------------------------------------------------------------------------
+# SessionStore.get
+# ---------------------------------------------------------------------------
+
+
+class TestGet:
+    def test_returns_none_for_missing(self, store: SessionStore) -> None:
+        assert store.get("nonexistent") is None
+
+    def test_returns_entry_on_hit(self, store: SessionStore) -> None:
+        store.get_or_create("s")
+        assert store.get("s") is not None
+
+    def test_touches_entry_on_hit(self, store: SessionStore) -> None:
+        entry = store.get_or_create("s")
+        t = entry.last_active
+        time.sleep(0.01)
+        store.get("s")
+        assert entry.last_active > t
+
+    def test_does_not_create_session(self, store: SessionStore) -> None:
+        store.get("new-session")
+        assert store.session_count() == 0
+
+
+# ---------------------------------------------------------------------------
+# SessionStore.update
+# ---------------------------------------------------------------------------
+
+
+class TestUpdate:
+    def test_merges_into_data(self, store: SessionStore) -> None:
+        store.update("s", key="value", num=42)
+        entry = store.get("s")
+        assert entry is not None
+        assert entry.data["key"] == "value"
+        assert entry.data["num"] == 42
+
+    def test_creates_session_if_missing(self, store: SessionStore) -> None:
+        store.update("new", x=1)
+        assert store.session_count() == 1
+
+    def test_merges_additional_keys(self, store: SessionStore) -> None:
+        store.update("s", a=1)
+        store.update("s", b=2)
+        entry = store.get("s")
+        assert entry is not None
+        assert entry.data == {"a": 1, "b": 2}
+
+    def test_overwrites_existing_key(self, store: SessionStore) -> None:
+        store.update("s", a=1)
+        store.update("s", a=99)
+        entry = store.get("s")
+        assert entry is not None
+        assert entry.data["a"] == 99
+
+
+# ---------------------------------------------------------------------------
+# SessionStore.remove
+# ---------------------------------------------------------------------------
+
+
+class TestRemove:
+    def test_returns_true_when_existed(self, store: SessionStore) -> None:
+        store.get_or_create("s")
+        assert store.remove("s") is True
+
+    def test_returns_false_when_missing(self, store: SessionStore) -> None:
+        assert store.remove("nonexistent") is False
+
+    def test_session_gone_after_remove(self, store: SessionStore) -> None:
+        store.get_or_create("s")
+        store.remove("s")
+        assert store.get("s") is None
+        assert store.session_count() == 0
+
+
+# ---------------------------------------------------------------------------
+# SessionStore.clear
+# ---------------------------------------------------------------------------
+
+
+class TestClear:
+    def test_removes_all_sessions(self, store: SessionStore) -> None:
+        store.get_or_create("a")
+        store.get_or_create("b")
+        count = store.clear()
+        assert count == 2
+        assert store.session_count() == 0
+
+    def test_clear_on_empty_store(self, store: SessionStore) -> None:
+        assert store.clear() == 0
+
+    def test_new_sessions_can_be_created_after_clear(self, store: SessionStore) -> None:
+        store.get_or_create("a")
+        store.clear()
+        store.get_or_create("a")
+        assert store.session_count() == 1
+
+
+# ---------------------------------------------------------------------------
+# SessionStore.evict_expired
+# ---------------------------------------------------------------------------
+
+
+class TestEvictExpired:
+    def test_evicts_idle_sessions(self, store: SessionStore) -> None:
+        store.get_or_create("fresh")
+        store.get_or_create("stale")
+        store._sessions["stale"].last_active = time.monotonic() - 9999
+
+        count = store.evict_expired()
+        assert count == 1
+        assert store.get("stale") is None
+        assert store.get("fresh") is not None
+
+    def test_returns_zero_when_nothing_expired(self, store: SessionStore) -> None:
+        store.get_or_create("s")
+        assert store.evict_expired() == 0
+
+    def test_returns_zero_on_empty_store(self, store: SessionStore) -> None:
+        assert store.evict_expired() == 0
+
+
+# ---------------------------------------------------------------------------
+# Introspection
+# ---------------------------------------------------------------------------
+
+
+class TestIntrospection:
+    def test_session_count_is_accurate(self, store: SessionStore) -> None:
+        assert store.session_count() == 0
+        store.get_or_create("a")
+        assert store.session_count() == 1
+
+    def test_session_ids_returns_snapshot(self, store: SessionStore) -> None:
+        store.get_or_create("a")
+        store.get_or_create("b")
+        ids = store.session_ids()
+        assert set(ids) == {"a", "b"}
+
+    def test_snapshot_returns_copy(self, store: SessionStore) -> None:
+        store.update("s", x=1)
+        snap = store.snapshot("s")
+        assert snap == {"x": 1}
+        # Mutating the snapshot must not affect the entry.
+        assert snap is not None
+        snap["y"] = 2
+        assert store.snapshot("s") == {"x": 1}
+
+    def test_snapshot_returns_none_for_missing(self, store: SessionStore) -> None:
+        assert store.snapshot("nonexistent") is None
+
+
+# ---------------------------------------------------------------------------
+# Thread safety
+# ---------------------------------------------------------------------------
+
+
+class TestThreadSafety:
+    def test_concurrent_get_or_create_produces_one_entry(self, store: SessionStore) -> None:
+        results: list[SessionEntry] = []
+
+        def worker() -> None:
+            results.append(store.get_or_create("shared"))
+
+        threads = [threading.Thread(target=worker) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # All threads must have received the same object.
+        assert all(r is results[0] for r in results)
+        assert store.session_count() == 1
+
+    def test_concurrent_updates_are_safe(self, store: SessionStore) -> None:
+        store.get_or_create("s")
+        errors: list[Exception] = []
+
+        def updater(key: str) -> None:
+            try:
+                for i in range(50):
+                    store.update("s", **{key: i})
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=updater, args=(f"k{i}",)) for i in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# Process-level singleton
+# ---------------------------------------------------------------------------
+
+
+class TestSingleton:
+    def test_get_store_returns_session_store(self) -> None:
+        s = get_store()
+        assert isinstance(s, SessionStore)
+
+    def test_set_store_replaces_singleton(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fresh = SessionStore(ttl=10.0, max_sessions=5)
+        monkeypatch.setattr("dev10x.mcp.session_store._store", fresh)
+        assert get_store() is fresh
+
+    def test_set_store_function(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        original = get_store()
+        fresh = SessionStore()
+        set_store(fresh)
+        assert get_store() is fresh
+        # Restore original to not leak state between tests.
+        set_store(original)
+
+
+# ---------------------------------------------------------------------------
+# bind_to_lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestBindToLifecycle:
+    def test_clear_called_on_stop(self, store: SessionStore) -> None:
+        store.get_or_create("s")
+        lifecycle = MagicMock()
+        lifecycle.stop = MagicMock()
+        bind_to_lifecycle(store, lifecycle)
+
+        lifecycle.stop()
+        assert store.session_count() == 0
+
+    def test_original_stop_also_called(self, store: SessionStore) -> None:
+        lifecycle = MagicMock()
+        original_stop = MagicMock()
+        lifecycle.stop = original_stop
+        bind_to_lifecycle(store, lifecycle)
+
+        lifecycle.stop("arg", kwarg="value")
+        original_stop.assert_called_once_with("arg", kwarg="value")
+
+    def test_multiple_binds_chain_correctly(self, store: SessionStore) -> None:
+        """Binding twice chains both clear() calls (belt-and-suspenders)."""
+        store2 = SessionStore(ttl=60.0, max_sessions=10)
+        store.get_or_create("a")
+        store2.get_or_create("b")
+
+        lifecycle = MagicMock()
+        lifecycle.stop = MagicMock()
+        bind_to_lifecycle(store, lifecycle)
+        bind_to_lifecycle(store2, lifecycle)
+
+        lifecycle.stop()
+        assert store.session_count() == 0
+        assert store2.session_count() == 0
+
+    def test_bind_with_real_daemon_lifecycle(self, tmp_path: Path) -> None:
+        """Integration: bind_to_lifecycle clears sessions when DaemonLifecycle stops."""
+        from dev10x.mcp.daemon import DaemonLifecycle
+
+        pid_dir = tmp_path / "mcp"
+        pid_dir.mkdir()
+
+        local_store = SessionStore(ttl=3600.0, max_sessions=10)
+        local_store.get_or_create("test-session")
+        assert local_store.session_count() == 1
+
+        lifecycle = DaemonLifecycle(pid_dir)
+        bind_to_lifecycle(local_store, lifecycle)
+
+        lifecycle.start()
+        try:
+            assert local_store.session_count() == 1  # not cleared on start
+        finally:
+            lifecycle.stop()
+
+        # After stop, the session store must have been cleared.
+        assert local_store.session_count() == 0


### PR DESCRIPTION
**When** I run the Dev10x MCP server as a persistent daemon over StreamableHTTP, **I want to** have per-client session state maintained across HTTP requests, **so I can** build stateful tools that track context within a client's session without re-initializing on every request.

---

[`ddc849cf`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/414/commits/ddc849cf) ✨ GH-337 Enable per-session state management over StreamableHTTP

Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/337

---