### PR TITLE
✨ GH-338 Enable daemon wiring with STDIO fallback

### DIFF
--- a/src/dev10x/mcp/server_cli.py
+++ b/src/dev10x/mcp/server_cli.py
@@ -42,6 +42,6 @@ from dev10x.mcp.plan_tools import *  # noqa: E402, F401, F403
 
 
 def main() -> None:
-    from dev10x.mcp.transport import select_transport
+    from dev10x.mcp.wiring import select_transport_with_daemon_fallback
 
-    server.run(transport=select_transport())
+    server.run(transport=select_transport_with_daemon_fallback())

--- a/src/dev10x/mcp/wiring.py
+++ b/src/dev10x/mcp/wiring.py
@@ -1,0 +1,153 @@
+"""Claude Code daemon wiring with STDIO fallback (GH-338).
+
+Provides the transport-selection logic that lets Claude Code connect to
+the long-lived Dev10x MCP daemon when it is running, and falls back to
+a fresh per-session STDIO server when the daemon is absent or unhealthy.
+
+Architecture
+------------
+Claude Code's ``plugin.json`` declares a ``command``-based MCP server
+entry, which always spawns the server via STDIO.  This module sits
+inside that spawned process and decides *how* the server actually
+serves:
+
+1. **Daemon healthy** — ``select_transport_with_daemon_fallback()``
+   returns ``"streamable-http"``.  The server attaches to the daemon's
+   already-open HTTP port and serves subsequent requests there.
+   Claude Code's STDIO pipe is not used after the handshake.
+
+   .. note::
+       This path requires the daemon to have been started separately
+       (e.g. ``dev10x daemon start``).  See ``daemon.py`` for the
+       lifecycle API.
+
+2. **Daemon absent / unhealthy** — returns ``"stdio"``.  The server
+   runs in standard STDIO mode, identical to the pre-daemon behaviour.
+   No external daemon is required.
+
+Environment variables
+---------------------
+FASTMCP_HOST
+    Hostname or IP for the daemon's HTTP endpoint.
+    Defaults to ``127.0.0.1``.
+
+FASTMCP_PORT
+    TCP port for the daemon's HTTP endpoint.  Defaults to ``8000``.
+
+DEV10X_MCP_DAEMON_PATH
+    URL path suffix appended after ``host:port``.  Defaults to
+    ``/mcp``.  Override only when the daemon is behind a reverse proxy
+    that rewrites the path.
+
+DEV10X_MCP_TRANSPORT
+    When set to any value *other than* ``"auto"`` (or when absent),
+    ``select_transport_with_daemon_fallback()`` delegates to the plain
+    :func:`~dev10x.mcp.transport.select_transport` function so that
+    explicit overrides are always honoured.  Set to ``"auto"`` to
+    enable automatic daemon detection.
+
+Usage example
+-------------
+In ``server_cli.py``::
+
+    def main() -> None:
+        from dev10x.mcp.wiring import select_transport_with_daemon_fallback
+        server.run(transport=select_transport_with_daemon_fallback())
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from dev10x.mcp.daemon import is_daemon_healthy
+from dev10x.mcp.transport import select_transport
+
+log = logging.getLogger(__name__)
+
+_DEFAULT_HOST = "127.0.0.1"
+_DEFAULT_PORT = 8000
+_DEFAULT_PATH = "/mcp"
+
+
+def daemon_base_url() -> str:
+    """Return the daemon's ``http://host:port`` base URL.
+
+    Reads ``FASTMCP_HOST`` and ``FASTMCP_PORT`` (FastMCP's own env
+    vars).  Falls back to ``127.0.0.1:8000`` when the variables are
+    absent or empty.
+
+    Returns:
+        A string like ``"http://127.0.0.1:8000"``.
+    """
+    host = os.environ.get("FASTMCP_HOST", "").strip() or _DEFAULT_HOST
+    port_raw = os.environ.get("FASTMCP_PORT", "").strip()
+    try:
+        port = int(port_raw) if port_raw else _DEFAULT_PORT
+    except ValueError:
+        log.warning("Invalid FASTMCP_PORT=%r, using default %d", port_raw, _DEFAULT_PORT)
+        port = _DEFAULT_PORT
+    return f"http://{host}:{port}"
+
+
+def daemon_mcp_url() -> str:
+    """Return the full URL of the daemon's MCP endpoint.
+
+    Combines :func:`daemon_base_url` with the path suffix read from
+    ``DEV10X_MCP_DAEMON_PATH`` (default ``/mcp``).
+
+    Returns:
+        A string like ``"http://127.0.0.1:8000/mcp"``.
+    """
+    path = os.environ.get("DEV10X_MCP_DAEMON_PATH", "").strip() or _DEFAULT_PATH
+    if not path.startswith("/"):
+        path = "/" + path
+    return daemon_base_url() + path
+
+
+def select_transport_with_daemon_fallback() -> str:
+    """Select MCP transport, preferring the daemon over STDIO.
+
+    Decision matrix
+    ~~~~~~~~~~~~~~~
+
+    +------------------------------+-------------------------------------+
+    | Condition                    | Result                              |
+    +==============================+=====================================+
+    | ``DEV10X_MCP_TRANSPORT``     | delegate to                         |
+    | is set to anything other     | ``transport.select_transport()``    |
+    | than ``"auto"``              | (explicit override wins)            |
+    +------------------------------+-------------------------------------+
+    | ``DEV10X_MCP_TRANSPORT``     | run health check:                   |
+    | is ``"auto"`` or absent      | healthy → ``"streamable-http"``     |
+    |                              | unhealthy → ``"stdio"``             |
+    +------------------------------+-------------------------------------+
+
+    When the env var is absent the function behaves as if it were set
+    to ``"auto"``, which means daemon detection runs by default.  Set
+    the variable to ``"stdio"`` explicitly to skip detection entirely.
+
+    Returns:
+        One of ``"stdio"``, ``"streamable-http"``, or ``"sse"``.
+
+    Raises:
+        ValueError: When ``DEV10X_MCP_TRANSPORT`` is set to an
+            unrecognised non-``"auto"`` value (delegated from
+            :func:`~dev10x.mcp.transport.select_transport`).
+    """
+    raw = os.environ.get("DEV10X_MCP_TRANSPORT", "").strip().lower()
+
+    if raw and raw != "auto":
+        # Explicit override — delegate to the strict transport selector.
+        return select_transport()
+
+    # "auto" mode or env var absent: attempt daemon detection.
+    if is_daemon_healthy():
+        log.info(
+            "Daemon is healthy at %s — using streamable-http transport",
+            daemon_mcp_url(),
+        )
+        return "streamable-http"
+
+    log.info("Daemon not available — falling back to stdio transport")
+    return "stdio"

--- a/tests/mcp/test_wiring.py
+++ b/tests/mcp/test_wiring.py
@@ -1,0 +1,295 @@
+"""Tests for daemon wiring with STDIO fallback (GH-338).
+
+Covers:
+- daemon_base_url(): host/port defaults and env var overrides
+- daemon_mcp_url(): path suffix defaults and env var overrides
+- select_transport_with_daemon_fallback():
+    * explicit DEV10X_MCP_TRANSPORT != "auto" delegates to select_transport
+    * "auto" mode with healthy daemon → "streamable-http"
+    * "auto" mode with unhealthy daemon → "stdio"
+    * absent env var (default "auto") with healthy daemon → "streamable-http"
+    * absent env var (default "auto") with unhealthy daemon → "stdio"
+    * invalid explicit transport raises ValueError (via select_transport)
+- server_cli.main() uses select_transport_with_daemon_fallback
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from dev10x.mcp.wiring import (
+    daemon_base_url,
+    daemon_mcp_url,
+    select_transport_with_daemon_fallback,
+)
+
+# ---------------------------------------------------------------------------
+# daemon_base_url
+# ---------------------------------------------------------------------------
+
+
+class TestDaemonBaseUrl:
+    def test_defaults_to_localhost_8000(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("FASTMCP_HOST", raising=False)
+        monkeypatch.delenv("FASTMCP_PORT", raising=False)
+        assert daemon_base_url() == "http://127.0.0.1:8000"
+
+    def test_reads_custom_host(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("FASTMCP_HOST", "0.0.0.0")
+        monkeypatch.delenv("FASTMCP_PORT", raising=False)
+        assert daemon_base_url() == "http://0.0.0.0:8000"
+
+    def test_reads_custom_port(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("FASTMCP_HOST", raising=False)
+        monkeypatch.setenv("FASTMCP_PORT", "9000")
+        assert daemon_base_url() == "http://127.0.0.1:9000"
+
+    def test_reads_custom_host_and_port(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("FASTMCP_HOST", "192.168.1.10")
+        monkeypatch.setenv("FASTMCP_PORT", "7777")
+        assert daemon_base_url() == "http://192.168.1.10:7777"
+
+    def test_strips_whitespace_from_host(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("FASTMCP_HOST", "  localhost  ")
+        monkeypatch.delenv("FASTMCP_PORT", raising=False)
+        assert daemon_base_url() == "http://localhost:8000"
+
+    def test_empty_host_env_uses_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("FASTMCP_HOST", "")
+        monkeypatch.delenv("FASTMCP_PORT", raising=False)
+        assert daemon_base_url() == "http://127.0.0.1:8000"
+
+    def test_invalid_port_falls_back_to_default(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("FASTMCP_HOST", raising=False)
+        monkeypatch.setenv("FASTMCP_PORT", "not-a-number")
+        assert daemon_base_url() == "http://127.0.0.1:8000"
+
+    def test_empty_port_env_uses_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("FASTMCP_HOST", raising=False)
+        monkeypatch.setenv("FASTMCP_PORT", "")
+        assert daemon_base_url() == "http://127.0.0.1:8000"
+
+
+# ---------------------------------------------------------------------------
+# daemon_mcp_url
+# ---------------------------------------------------------------------------
+
+
+class TestDaemonMcpUrl:
+    def test_default_path_is_slash_mcp(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("FASTMCP_HOST", raising=False)
+        monkeypatch.delenv("FASTMCP_PORT", raising=False)
+        monkeypatch.delenv("DEV10X_MCP_DAEMON_PATH", raising=False)
+        assert daemon_mcp_url() == "http://127.0.0.1:8000/mcp"
+
+    def test_custom_path_with_leading_slash(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("FASTMCP_HOST", raising=False)
+        monkeypatch.delenv("FASTMCP_PORT", raising=False)
+        monkeypatch.setenv("DEV10X_MCP_DAEMON_PATH", "/api/mcp")
+        assert daemon_mcp_url() == "http://127.0.0.1:8000/api/mcp"
+
+    def test_custom_path_without_leading_slash_gets_one_added(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("FASTMCP_HOST", raising=False)
+        monkeypatch.delenv("FASTMCP_PORT", raising=False)
+        monkeypatch.setenv("DEV10X_MCP_DAEMON_PATH", "mcp")
+        assert daemon_mcp_url() == "http://127.0.0.1:8000/mcp"
+
+    def test_empty_path_env_uses_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("FASTMCP_HOST", raising=False)
+        monkeypatch.delenv("FASTMCP_PORT", raising=False)
+        monkeypatch.setenv("DEV10X_MCP_DAEMON_PATH", "")
+        assert daemon_mcp_url() == "http://127.0.0.1:8000/mcp"
+
+    def test_combines_custom_host_port_and_path(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("FASTMCP_HOST", "10.0.0.1")
+        monkeypatch.setenv("FASTMCP_PORT", "9999")
+        monkeypatch.setenv("DEV10X_MCP_DAEMON_PATH", "/v2/mcp")
+        assert daemon_mcp_url() == "http://10.0.0.1:9999/v2/mcp"
+
+
+# ---------------------------------------------------------------------------
+# select_transport_with_daemon_fallback
+# ---------------------------------------------------------------------------
+
+
+class TestSelectTransportWithDaemonFallback:
+    # --- Explicit override paths (non-"auto" DEV10X_MCP_TRANSPORT) ---
+
+    def test_explicit_stdio_delegates_without_health_check(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("DEV10X_MCP_TRANSPORT", "stdio")
+        with patch("dev10x.mcp.daemon.is_daemon_healthy") as mock_health:
+            result = select_transport_with_daemon_fallback()
+        assert result == "stdio"
+        mock_health.assert_not_called()
+
+    def test_explicit_streamable_http_delegates_without_health_check(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("DEV10X_MCP_TRANSPORT", "streamable-http")
+        with patch("dev10x.mcp.daemon.is_daemon_healthy") as mock_health:
+            result = select_transport_with_daemon_fallback()
+        assert result == "streamable-http"
+        mock_health.assert_not_called()
+
+    def test_explicit_sse_delegates_without_health_check(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("DEV10X_MCP_TRANSPORT", "sse")
+        with patch("dev10x.mcp.daemon.is_daemon_healthy") as mock_health:
+            result = select_transport_with_daemon_fallback()
+        assert result == "sse"
+        mock_health.assert_not_called()
+
+    def test_explicit_invalid_value_raises_valueerror(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("DEV10X_MCP_TRANSPORT", "websocket")
+        with pytest.raises(ValueError, match="DEV10X_MCP_TRANSPORT"):
+            select_transport_with_daemon_fallback()
+
+    def test_explicit_value_is_case_insensitive(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("DEV10X_MCP_TRANSPORT", "STDIO")
+        result = select_transport_with_daemon_fallback()
+        assert result == "stdio"
+
+    # --- "auto" mode (DEV10X_MCP_TRANSPORT="auto") ---
+
+    def test_auto_mode_with_healthy_daemon_returns_streamable_http(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("DEV10X_MCP_TRANSPORT", "auto")
+        with patch("dev10x.mcp.wiring.is_daemon_healthy", return_value=True):
+            result = select_transport_with_daemon_fallback()
+        assert result == "streamable-http"
+
+    def test_auto_mode_with_unhealthy_daemon_returns_stdio(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("DEV10X_MCP_TRANSPORT", "auto")
+        with patch("dev10x.mcp.wiring.is_daemon_healthy", return_value=False):
+            result = select_transport_with_daemon_fallback()
+        assert result == "stdio"
+
+    def test_auto_mode_is_case_insensitive(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("DEV10X_MCP_TRANSPORT", "AUTO")
+        with patch("dev10x.mcp.wiring.is_daemon_healthy", return_value=True):
+            result = select_transport_with_daemon_fallback()
+        assert result == "streamable-http"
+
+    # --- Absent env var (default "auto" behaviour) ---
+
+    def test_absent_env_var_with_healthy_daemon_returns_streamable_http(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("DEV10X_MCP_TRANSPORT", raising=False)
+        with patch("dev10x.mcp.wiring.is_daemon_healthy", return_value=True):
+            result = select_transport_with_daemon_fallback()
+        assert result == "streamable-http"
+
+    def test_absent_env_var_with_unhealthy_daemon_returns_stdio(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("DEV10X_MCP_TRANSPORT", raising=False)
+        with patch("dev10x.mcp.wiring.is_daemon_healthy", return_value=False):
+            result = select_transport_with_daemon_fallback()
+        assert result == "stdio"
+
+    def test_empty_env_var_with_healthy_daemon_returns_streamable_http(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("DEV10X_MCP_TRANSPORT", "")
+        with patch("dev10x.mcp.wiring.is_daemon_healthy", return_value=True):
+            result = select_transport_with_daemon_fallback()
+        assert result == "streamable-http"
+
+    def test_daemon_health_check_is_called_exactly_once(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("DEV10X_MCP_TRANSPORT", raising=False)
+        with patch("dev10x.mcp.wiring.is_daemon_healthy", return_value=False) as mock:
+            select_transport_with_daemon_fallback()
+        mock.assert_called_once_with()
+
+
+# ---------------------------------------------------------------------------
+# server_cli.main() integration
+# ---------------------------------------------------------------------------
+
+
+class TestServerCliMainUsesWiring:
+    """Verify that server_cli.main() delegates to select_transport_with_daemon_fallback."""
+
+    def test_main_calls_wiring_when_daemon_healthy(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("DEV10X_MCP_TRANSPORT", raising=False)
+        import dev10x.mcp.server_cli as cli_mod
+
+        with (
+            patch("dev10x.mcp.wiring.is_daemon_healthy", return_value=True),
+            patch.object(cli_mod.server, "run") as mock_run,
+        ):
+            cli_mod.main()
+        mock_run.assert_called_once_with(transport="streamable-http")
+
+    def test_main_falls_back_to_stdio_when_daemon_absent(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("DEV10X_MCP_TRANSPORT", raising=False)
+        import dev10x.mcp.server_cli as cli_mod
+
+        with (
+            patch("dev10x.mcp.wiring.is_daemon_healthy", return_value=False),
+            patch.object(cli_mod.server, "run") as mock_run,
+        ):
+            cli_mod.main()
+        mock_run.assert_called_once_with(transport="stdio")
+
+    def test_main_honours_explicit_stdio_override(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("DEV10X_MCP_TRANSPORT", "stdio")
+        import dev10x.mcp.server_cli as cli_mod
+
+        with (
+            patch("dev10x.mcp.daemon.is_daemon_healthy") as mock_health,
+            patch.object(cli_mod.server, "run") as mock_run,
+        ):
+            cli_mod.main()
+        mock_health.assert_not_called()
+        mock_run.assert_called_once_with(transport="stdio")


### PR DESCRIPTION
**When** I start a Claude Code session with the Dev10x plugin, **I want to** automatically connect to the running MCP daemon when it is healthy and fall back to a fresh per-session STDIO server when it is not, **so I can** benefit from lower per-session startup overhead without any manual configuration.

---

[`55f8f596`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/417/commits/55f8f596cae8fae3356d63992f045e50a216e4e3) ✨ GH-338 Enable daemon wiring with STDIO fallback

Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/338