### PR TITLE
🐛 GH-337 Correct type-ignore codes so mypy passes on develop

### DIFF
--- a/src/dev10x/mcp/session_store.py
+++ b/src/dev10x/mcp/session_store.py
@@ -411,11 +411,11 @@ def bind_to_lifecycle(
             server.run(transport="streamable-http")
         # store.clear() was called automatically by lifecycle.stop()
     """
-    original_stop = lifecycle.stop  # type: ignore[union-attr]
+    original_stop = lifecycle.stop  # type: ignore[attr-defined]
 
     def _stop_with_clear(*args: object, **kwargs: object) -> None:
         store.clear()
         original_stop(*args, **kwargs)
 
-    lifecycle.stop = _stop_with_clear  # type: ignore[union-attr]
+    lifecycle.stop = _stop_with_clear  # type: ignore[attr-defined]
     log.debug("SessionStore bound to lifecycle %r", lifecycle)


### PR DESCRIPTION
**When** a release is imminent and CI runs mypy, **I want to** have correct `type: ignore` codes in `session_store.py`, **so I can** trust that mypy passes without hidden suppressed errors masking real type issues.

---

[`2d525fa8`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/419/commits/2d525fa8b2f78a6d7154539f951ef6d2ce28c50a) 🐛 GH-337 Correct type-ignore codes so mypy passes on develop
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/337

---