### PR TITLE
✨ GH-407 Detect running-hook version drift at SessionStart

### DIFF
--- a/hooks/scripts/session-start.py
+++ b/hooks/scripts/session-start.py
@@ -149,6 +149,11 @@ def main() -> None:
             mode="build",
         ),
         SessionFeature(
+            name="session-hook-version-drift",
+            fn=s.build_hook_version_drift_context,
+            mode="build",
+        ),
+        SessionFeature(
             name="session-migrate-permissions",
             fn=s.session_migrate_permissions,
             mode="capture",

--- a/references/permission-architecture.md
+++ b/references/permission-architecture.md
@@ -211,6 +211,48 @@ not always inherited. Practical consequences:
 reason to remove a project rule. Run `dev10x permission investigate`
 or check `permission-auditor` findings instead.
 
+## Hook Load-Once Semantics (GH-407)
+
+Claude Code loads hooks **once at session start** from
+``$CLAUDE_PLUGIN_ROOT``. An on-disk ``claude plugin update``
+installs a newer version into the cache but does **not** hot-swap
+the running hooks — the session continues executing the pre-upgrade
+hooks until it is restarted.
+
+Practical implications:
+
+- A shipped bug-fix in a validator (e.g., DX012 `safe-expansion`
+  for single-quoted brace expressions) is dormant in sessions that
+  predated the upgrade. The fix tests green in CI but still produces
+  friction in those live sessions.
+- The stale hooks can inflate friction evidence: a false-positive that
+  a newer validator suppresses still fires in old sessions, making it
+  look like an unfixed regression.
+- The **settings-staleness** check (`build_install_check_context`) and
+  the **running-hook** check (`build_hook_version_drift_context`) are
+  distinct. Settings can be refreshed by upgrade-cleanup without
+  restarting the session; the running hooks remain stale until restart.
+
+The **hook version drift detector** (SessionStart feature
+`session-hook-version-drift`) addresses this:
+
+1. Reads the running version from ``$CLAUDE_PLUGIN_ROOT/plugin.json``
+   (set by Claude Code at session start).
+2. Scans ``~/.claude/plugins/cache/<publisher>/<slug>/`` for the
+   highest-installed version.
+3. On mismatch, emits:
+   *"Dev10x hooks running v0.72.0 but v0.76.0 is installed on disk.
+   Restart this session (or run `/Dev10x:upgrade-cleanup`) to activate
+   shipped friction fixes, validators, and catalog improvements."*
+4. Returns an empty string when running == latest or when either
+   version is unresolvable (``--plugin-dir`` dev installs bypass the
+   cache, so no drift signal is raised).
+
+**Regression note:** when a "shipped fix still fails" report arrives,
+check hook-version drift *before* assuming a logic regression. Confirm
+the session was started after the fix was installed by comparing the
+running-hook version against the fix's release tag.
+
 ## References
 
 - [ADR-0003](../docs/adr/0003-allow-rules-as-hook-enablers.md) — decision record

--- a/src/dev10x/domain/install_version.py
+++ b/src/dev10x/domain/install_version.py
@@ -85,6 +85,55 @@ def write_applied_version(
     return path
 
 
+def read_running_hook_version(*, plugin_root: Path | None = None) -> str | None:
+    """Return the version that is *currently executing* inside this session.
+
+    ``$CLAUDE_PLUGIN_ROOT`` is set by Claude Code to the plugin directory
+    that was resolved when the session started. Hooks loaded from that
+    directory run for the entire session lifetime — an on-disk upgrade
+    does not swap them out. Reading the version from this directory gives
+    us the *running* version, which may lag behind the latest installed
+    version when the user ran ``claude plugin update`` mid-session.
+
+    Returns ``None`` when the running root is unknown (e.g., local
+    ``--plugin-dir`` dev runs that do not carry a versioned cache path).
+    """
+    root = plugin_root or _default_plugin_root()
+    return read_plugin_version(plugin_root=root)
+
+
+def read_latest_installed_version(
+    *,
+    cache_dir: Path | None = None,
+    publisher: str = "Dev10x-Guru",
+    plugin_slug: str = "dev10x-claude",
+) -> str | None:
+    """Return the highest-version directory under the plugin cache.
+
+    Scans ``~/.claude/plugins/cache/<publisher>/<plugin_slug>/`` for
+    semver-named subdirectories and returns the latest. Returns ``None``
+    when the directory is absent or empty (e.g., ``--plugin-dir`` installs
+    that bypass the cache).
+    """
+    from dev10x.domain.claude_paths import ClaudeDir
+
+    root = cache_dir or (ClaudeDir.plugins_cache_dir() / publisher / plugin_slug)
+    if not root.is_dir():
+        return None
+    versions = sorted(
+        (d for d in root.iterdir() if d.is_dir()),
+        key=lambda p: _version_tuple(p.name),
+    )
+    return versions[-1].name if versions else None
+
+
+def _version_tuple(version: str) -> tuple[int, ...]:
+    try:
+        return tuple(int(x) for x in version.split("."))
+    except ValueError:
+        return (0,)
+
+
 def record_upgrade(*, version: str | None = None) -> Result[dict[str, Any]]:
     """Record the currently-installed plugin version as applied.
 
@@ -169,7 +218,9 @@ __all__ = [
     "InstallState",
     "install_state",
     "read_applied_version",
+    "read_latest_installed_version",
     "read_plugin_version",
+    "read_running_hook_version",
     "record_upgrade",
     "write_applied_version",
 ]

--- a/src/dev10x/hooks/session.py
+++ b/src/dev10x/hooks/session.py
@@ -26,6 +26,7 @@ from dev10x.domain.session_document import (
 from dev10x.hooks.session_dispatch import (
     build_autonomy_reassurance_context,  # noqa: F401 — re-exported via __all__
     build_guidance_context,  # noqa: F401 — re-exported via __all__
+    build_hook_version_drift_context,  # noqa: F401 — re-exported via __all__
     build_install_check_context,  # noqa: F401 — re-exported via __all__
     build_reload_context,  # noqa: F401 — re-exported via __all__
     context_compact,  # noqa: F401 — re-exported via __all__
@@ -73,6 +74,7 @@ def _format_decision_guidance(*, plan, friction_level):
 __all__ = [
     "build_autonomy_reassurance_context",
     "build_guidance_context",
+    "build_hook_version_drift_context",
     "build_install_check_context",
     "build_reload_context",
     "context_compact",

--- a/src/dev10x/hooks/session_dispatch.py
+++ b/src/dev10x/hooks/session_dispatch.py
@@ -139,6 +139,44 @@ def build_install_check_context() -> str:
     return ""
 
 
+def build_hook_version_drift_context() -> str:
+    """Warn when the running-hook version lags the latest installed version.
+
+    Claude Code loads hooks once at session start from ``$CLAUDE_PLUGIN_ROOT``.
+    An on-disk ``claude plugin update`` installs a newer version but does NOT
+    swap the running hooks — the session continues executing the pre-upgrade
+    hooks until it restarts. This means shipped friction fixes, new validators,
+    and catalog improvements are dormant in long-running sessions.
+
+    This check is **distinct** from :func:`build_install_check_context`, which
+    compares the installed version against the last-applied upgrade-cleanup
+    version. That check detects settings staleness; this one detects
+    running-hook staleness — they can diverge when settings were refreshed
+    but the session was not restarted.
+
+    Returns an empty string when no drift is detected or when either version
+    cannot be determined (``--plugin-dir`` dev installs, new users, etc.).
+    """
+    from dev10x.domain.install_version import (
+        read_latest_installed_version,
+        read_running_hook_version,
+    )
+
+    running = read_running_hook_version()
+    if running is None:
+        return ""
+    latest = read_latest_installed_version()
+    if latest is None:
+        return ""
+    if running == latest:
+        return ""
+    return (
+        f"Dev10x hooks running v{running} but v{latest} is installed on disk.\n"
+        "Restart this session (or run `/Dev10x:upgrade-cleanup`) to activate "
+        "shipped friction fixes, validators, and catalog improvements."
+    )
+
+
 def session_install_check() -> None:
     """Emit install-state guidance as additionalContext (SessionStart hook)."""
     content = build_install_check_context()
@@ -233,6 +271,7 @@ def session_goodbye(data: dict | None = None) -> None:
 
 
 __all__ = [
+    "build_hook_version_drift_context",
     "build_install_check_context",
     "build_reload_context",
     "build_autonomy_reassurance_context",

--- a/tests/domain/test_install_version.py
+++ b/tests/domain/test_install_version.py
@@ -14,7 +14,9 @@ from dev10x.domain.install_version import (
     InstallState,
     install_state,
     read_applied_version,
+    read_latest_installed_version,
     read_plugin_version,
+    read_running_hook_version,
     record_upgrade,
     write_applied_version,
 )
@@ -158,3 +160,65 @@ def test_record_upgrade_errors_when_unresolvable(
     result = record_upgrade()
     assert isinstance(result, ErrorResult)
     assert "could not resolve" in result.error.lower()
+
+
+class TestReadRunningHookVersion:
+    """GH-407: read_running_hook_version() reads from $CLAUDE_PLUGIN_ROOT."""
+
+    def test_returns_version_from_plugin_root(self, plugin_root: Path) -> None:
+        assert read_running_hook_version() == "0.72.0"
+
+    def test_returns_none_when_no_env_and_no_manifest(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
+        assert read_running_hook_version(plugin_root=tmp_path) is None
+
+    def test_accepts_explicit_plugin_root(self, plugin_root: Path) -> None:
+        assert read_running_hook_version(plugin_root=plugin_root) == "0.72.0"
+
+
+class TestReadLatestInstalledVersion:
+    """GH-407: read_latest_installed_version() scans the plugin cache."""
+
+    def test_returns_highest_semver_directory(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from dev10x.domain.claude_paths import CLAUDE_HOME_ENV_VAR, ClaudeDir
+
+        cache_base = tmp_path / "plugins" / "cache" / "Dev10x-Guru" / "dev10x-claude"
+        for ver in ("0.72.0", "0.76.0", "0.73.0"):
+            (cache_base / ver).mkdir(parents=True)
+        monkeypatch.setenv(CLAUDE_HOME_ENV_VAR, str(tmp_path))
+        ClaudeDir.reset_cache()
+
+        assert read_latest_installed_version() == "0.76.0"
+
+    def test_returns_none_when_cache_absent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from dev10x.domain.claude_paths import CLAUDE_HOME_ENV_VAR, ClaudeDir
+
+        monkeypatch.setenv(CLAUDE_HOME_ENV_VAR, str(tmp_path))
+        ClaudeDir.reset_cache()
+
+        assert read_latest_installed_version() is None
+
+    def test_returns_none_when_cache_empty(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from dev10x.domain.claude_paths import CLAUDE_HOME_ENV_VAR, ClaudeDir
+
+        cache_base = tmp_path / "plugins" / "cache" / "Dev10x-Guru" / "dev10x-claude"
+        cache_base.mkdir(parents=True)
+        monkeypatch.setenv(CLAUDE_HOME_ENV_VAR, str(tmp_path))
+        ClaudeDir.reset_cache()
+
+        assert read_latest_installed_version() is None
+
+    def test_accepts_explicit_cache_dir(self, tmp_path: Path) -> None:
+        cache_dir = tmp_path / "custom-cache"
+        for ver in ("0.10.0", "0.9.0"):
+            (cache_dir / ver).mkdir(parents=True)
+
+        assert read_latest_installed_version(cache_dir=cache_dir) == "0.10.0"

--- a/tests/hooks/test_session_start_hooks.py
+++ b/tests/hooks/test_session_start_hooks.py
@@ -255,6 +255,104 @@ class TestSessionInstallCheck:
         assert build_install_check_context() == ""
 
 
+class TestSessionHookVersionDrift:
+    """GH-407: Running-hook version drift detector."""
+
+    def test_silent_when_versions_match(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from dev10x.domain.claude_paths import CLAUDE_HOME_ENV_VAR, ClaudeDir
+        from dev10x.hooks.session_dispatch import build_hook_version_drift_context
+
+        plugin_root = tmp_path / "plugins" / "cache" / "Dev10x-Guru" / "dev10x-claude" / "0.76.0"
+        (plugin_root / ".claude-plugin").mkdir(parents=True)
+        (plugin_root / ".claude-plugin" / "plugin.json").write_text(
+            json.dumps({"version": "0.76.0"})
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+        monkeypatch.setenv(CLAUDE_HOME_ENV_VAR, str(tmp_path))
+        ClaudeDir.reset_cache()
+
+        cache_dir = tmp_path / "plugins" / "cache" / "Dev10x-Guru" / "dev10x-claude"
+        assert build_hook_version_drift_context() == ""
+
+    def test_warns_when_newer_version_installed(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from dev10x.domain.claude_paths import CLAUDE_HOME_ENV_VAR, ClaudeDir
+        from dev10x.hooks.session_dispatch import build_hook_version_drift_context
+
+        cache_base = tmp_path / "plugins" / "cache" / "Dev10x-Guru" / "dev10x-claude"
+        old_root = cache_base / "0.72.0"
+        new_root = cache_base / "0.76.0"
+        for root in (old_root, new_root):
+            (root / ".claude-plugin").mkdir(parents=True)
+            ver = root.name
+            (root / ".claude-plugin" / "plugin.json").write_text(json.dumps({"version": ver}))
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(old_root))
+        monkeypatch.setenv(CLAUDE_HOME_ENV_VAR, str(tmp_path))
+        ClaudeDir.reset_cache()
+
+        ctx = build_hook_version_drift_context()
+        assert "0.72.0" in ctx
+        assert "0.76.0" in ctx
+        assert "restart" in ctx.lower()
+        assert "/Dev10x:upgrade-cleanup" in ctx
+
+    def test_silent_when_running_version_unknown(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from dev10x.domain.claude_paths import CLAUDE_HOME_ENV_VAR, ClaudeDir
+        from dev10x.hooks.session_dispatch import build_hook_version_drift_context
+
+        monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
+        monkeypatch.setenv(CLAUDE_HOME_ENV_VAR, str(tmp_path))
+        ClaudeDir.reset_cache()
+
+        assert build_hook_version_drift_context() == ""
+
+    def test_silent_when_cache_absent(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from dev10x.domain.claude_paths import CLAUDE_HOME_ENV_VAR, ClaudeDir
+        from dev10x.hooks.session_dispatch import build_hook_version_drift_context
+
+        plugin_root = tmp_path / "plugin"
+        (plugin_root / ".claude-plugin").mkdir(parents=True)
+        (plugin_root / ".claude-plugin" / "plugin.json").write_text(
+            json.dumps({"version": "0.72.0"})
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+        monkeypatch.setenv(CLAUDE_HOME_ENV_VAR, str(tmp_path))
+        ClaudeDir.reset_cache()
+
+        assert build_hook_version_drift_context() == ""
+
+    def test_message_distinct_from_settings_staleness(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Drift message must not reference settings/upgrade state — only
+        running-hook vs installed-version mismatch."""
+        from dev10x.domain.claude_paths import CLAUDE_HOME_ENV_VAR, ClaudeDir
+        from dev10x.hooks.session_dispatch import build_hook_version_drift_context
+
+        cache_base = tmp_path / "plugins" / "cache" / "Dev10x-Guru" / "dev10x-claude"
+        old_root = cache_base / "0.72.0"
+        new_root = cache_base / "0.76.0"
+        for root in (old_root, new_root):
+            (root / ".claude-plugin").mkdir(parents=True)
+            ver = root.name
+            (root / ".claude-plugin" / "plugin.json").write_text(json.dumps({"version": ver}))
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(old_root))
+        monkeypatch.setenv(CLAUDE_HOME_ENV_VAR, str(tmp_path))
+        ClaudeDir.reset_cache()
+
+        ctx = build_hook_version_drift_context()
+        assert "hooks running" in ctx
+        assert "installed on disk" in ctx
+        assert "upgrade-cleanup was last run" not in ctx
+
+
 class TestSessionGitAliases:
     def test_outputs_alias_status(self, runner: CliRunner) -> None:
         result = runner.invoke(


### PR DESCRIPTION
**When** a `claude plugin update` installs a newer Dev10x version mid-session, **I want** the session to tell me my hooks are stale and recommend a restart, **so I can** activate shipped friction fixes, validators, and catalog improvements instead of running pre-upgrade hooks for hours.

---

[`9cf89ae9`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/422/commits/9cf89ae9e4e5a18636bfb8084b6c43be24649d3b) ✨ GH-407 Detect running-hook version drift at SessionStart
Closes #407
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/407

---