### PR TITLE
🚨 GH-407 Restore green develop by dropping unused test var

### DIFF
--- a/tests/hooks/test_session_start_hooks.py
+++ b/tests/hooks/test_session_start_hooks.py
@@ -273,7 +273,6 @@ class TestSessionHookVersionDrift:
         monkeypatch.setenv(CLAUDE_HOME_ENV_VAR, str(tmp_path))
         ClaudeDir.reset_cache()
 
-        cache_dir = tmp_path / "plugins" / "cache" / "Dev10x-Guru" / "dev10x-claude"
         assert build_hook_version_drift_context() == ""
 
     def test_warns_when_newer_version_installed(


### PR DESCRIPTION
**When** a new PR runs pre-PR checks (whole-repo ruff), **I want to** keep develop lint-clean, **so I can** open and merge PRs without an unrelated F841 from the version-drift test blocking every branch.

---

[`ec005900`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/423/commits/ec005900abe5178cd2fd32320e5fc553b07fe7fb) 🚨 GH-407 Restore green develop by dropping unused test var
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/407

---