### PR TITLE
✨ GH-339 Expose Dev10x knowledge as MCP resources

### DIFF
--- a/src/dev10x/mcp/knowledge_resources.py
+++ b/src/dev10x/mcp/knowledge_resources.py
@@ -1,0 +1,132 @@
+"""MCP resource registrations for Dev10x knowledge primitives (GH-339).
+
+Exposes playbooks, rules/INDEX.md + references/rules/*, and the skill
+index as addressable MCP resources so consumers can read them via URI
+instead of issuing Bash tool-calls or searching the filesystem.
+
+Resource URIs:
+    dev10x://skills/{skill_name}/playbook
+        - YAML playbook for the named skill
+        - 404-style error text when no playbook.yaml exists
+
+    dev10x://rules/index
+        - Contents of .claude/rules/INDEX.md
+
+    dev10x://rules/{rule_name}
+        - Contents of .claude/rules/{rule_name}.md
+
+    dev10x://references/{ref_name}
+        - Contents of references/{ref_name}.md
+
+    dev10x://skills/index
+        - Contents of SKILLS.md (generated skill index)
+
+All resources are served from the plugin root resolved at request time
+via ``get_plugin_root()`` so the live working-tree copy is used during
+development and the cached install is used in production.  See
+``subprocess_utils.get_plugin_root`` for the resolution logic.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dev10x.mcp._app import server
+from dev10x.subprocess_utils import get_plugin_root
+
+
+def _read_file(path: Path) -> str:
+    """Return file contents or a descriptive error string when missing."""
+    if not path.exists():
+        return f"# Not found\n\nNo file at `{path}`."
+    return path.read_text(encoding="utf-8")
+
+
+def _reject_traversal(name: str) -> str | None:
+    """Return an error string when *name* could escape its resource root.
+
+    The MCP framework constrains URI template segments, but resource
+    names are interpolated into filesystem paths, so reject traversal
+    sequences explicitly as defense-in-depth (GH-339 review).
+    """
+    if ".." in name or "/" in name or "\\" in name:
+        return f"# Invalid name\n\n`{name}` contains path-traversal characters."
+    return None
+
+
+# ── skill playbooks ────────────────────────────────────────────────
+
+
+@server.resource(
+    uri="dev10x://skills/{skill_name}/playbook",
+    name="skill-playbook",
+    description="YAML playbook for a named Dev10x skill",
+    mime_type="application/yaml",
+)
+def skill_playbook(skill_name: str) -> str:
+    """Return the playbook.yaml for *skill_name*, or an error string."""
+    if invalid := _reject_traversal(name=skill_name):
+        return invalid
+    path = get_plugin_root() / "skills" / skill_name / "references" / "playbook.yaml"
+    return _read_file(path)
+
+
+# ── rules ─────────────────────────────────────────────────────────
+
+
+@server.resource(
+    uri="dev10x://rules/index",
+    name="rules-index",
+    description="Dev10x .claude/rules/INDEX.md — agent routing and rule directory",
+    mime_type="text/markdown",
+)
+def rules_index() -> str:
+    """Return the contents of .claude/rules/INDEX.md."""
+    path = get_plugin_root() / ".claude" / "rules" / "INDEX.md"
+    return _read_file(path)
+
+
+@server.resource(
+    uri="dev10x://rules/{rule_name}",
+    name="rule-file",
+    description="A single Dev10x rule file from .claude/rules/",
+    mime_type="text/markdown",
+)
+def rule_file(rule_name: str) -> str:
+    """Return the contents of .claude/rules/{rule_name}.md."""
+    if invalid := _reject_traversal(name=rule_name):
+        return invalid
+    path = get_plugin_root() / ".claude" / "rules" / f"{rule_name}.md"
+    return _read_file(path)
+
+
+# ── shared references ──────────────────────────────────────────────
+
+
+@server.resource(
+    uri="dev10x://references/{ref_name}",
+    name="reference-file",
+    description="A Dev10x shared reference document from references/",
+    mime_type="text/markdown",
+)
+def reference_file(ref_name: str) -> str:
+    """Return the contents of references/{ref_name}.md."""
+    if invalid := _reject_traversal(name=ref_name):
+        return invalid
+    path = get_plugin_root() / "references" / f"{ref_name}.md"
+    return _read_file(path)
+
+
+# ── skill index ────────────────────────────────────────────────────
+
+
+@server.resource(
+    uri="dev10x://skills/index",
+    name="skills-index",
+    description="Dev10x SKILLS.md — the generated skill index",
+    mime_type="text/markdown",
+)
+def skills_index() -> str:
+    """Return the contents of SKILLS.md from the plugin root."""
+    path = get_plugin_root() / "SKILLS.md"
+    return _read_file(path)

--- a/src/dev10x/mcp/server_cli.py
+++ b/src/dev10x/mcp/server_cli.py
@@ -24,10 +24,13 @@ from __future__ import annotations
 # When `cwd` is None, behavior is unchanged from pre-GH-979 (subprocess
 # inherits the MCP server's startup CWD).
 # Importing the tool modules triggers @server.tool() registration.
+# Importing knowledge_resources triggers @server.resource() registration
+# (GH-339).
 from dev10x.mcp import (  # noqa: E402, F401
     audit_tools,
     git_tools,
     github_tools,
+    knowledge_resources,
     misc_tools,
     plan_tools,
 )

--- a/tests/mcp/test_knowledge_resources.py
+++ b/tests/mcp/test_knowledge_resources.py
@@ -1,0 +1,281 @@
+"""Tests for the Dev10x MCP knowledge resources (GH-339).
+
+Covers:
+- skill_playbook resource for an existing and missing playbook
+- rules_index resource
+- rule_file resource for an existing and missing rule
+- reference_file resource for an existing and missing reference
+- skills_index resource
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+knowledge_resources = pytest.importorskip(
+    "dev10x.mcp.knowledge_resources",
+    reason="mcp not installed",
+)
+
+
+# ── helpers ────────────────────────────────────────────────────────
+
+
+def _fake_root(tmp_path: Path) -> Path:
+    """Build a minimal plugin-root tree under *tmp_path*."""
+    # skills/<name>/references/playbook.yaml
+    playbook_dir = tmp_path / "skills" / "work-on" / "references"
+    playbook_dir.mkdir(parents=True)
+    (playbook_dir / "playbook.yaml").write_text("defaults:\n  single: []\n", encoding="utf-8")
+
+    # .claude/rules/INDEX.md and a named rule
+    rules_dir = tmp_path / ".claude" / "rules"
+    rules_dir.mkdir(parents=True)
+    (rules_dir / "INDEX.md").write_text("# Index\n", encoding="utf-8")
+    (rules_dir / "essentials.md").write_text("# Essentials\n", encoding="utf-8")
+
+    # references/<ref>.md
+    ref_dir = tmp_path / "references"
+    ref_dir.mkdir(parents=True)
+    (ref_dir / "git-commits.md").write_text("# Git commits\n", encoding="utf-8")
+
+    # SKILLS.md at root
+    (tmp_path / "SKILLS.md").write_text("# Skills\n", encoding="utf-8")
+
+    return tmp_path
+
+
+# ── skill_playbook ─────────────────────────────────────────────────
+
+
+class TestSkillPlaybook:
+    def test_returns_yaml_for_existing_skill(self, tmp_path: Path) -> None:
+        root = _fake_root(tmp_path)
+        with patch(
+            "dev10x.mcp.knowledge_resources.get_plugin_root",
+            return_value=root,
+        ):
+            result = knowledge_resources.skill_playbook(skill_name="work-on")
+
+        assert "defaults" in result
+        assert "single" in result
+
+    def test_returns_not_found_for_missing_skill(self, tmp_path: Path) -> None:
+        root = _fake_root(tmp_path)
+        with patch(
+            "dev10x.mcp.knowledge_resources.get_plugin_root",
+            return_value=root,
+        ):
+            result = knowledge_resources.skill_playbook(skill_name="nonexistent-skill")
+
+        assert "Not found" in result
+        assert "nonexistent-skill" in result
+
+    def test_returns_not_found_when_playbook_missing_from_existing_skill(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        root = _fake_root(tmp_path)
+        skill_dir = root / "skills" / "no-playbook-skill" / "references"
+        skill_dir.mkdir(parents=True)
+        # directory exists but no playbook.yaml
+        with patch(
+            "dev10x.mcp.knowledge_resources.get_plugin_root",
+            return_value=root,
+        ):
+            result = knowledge_resources.skill_playbook(skill_name="no-playbook-skill")
+
+        assert "Not found" in result
+
+
+# ── rules_index ────────────────────────────────────────────────────
+
+
+class TestRulesIndex:
+    def test_returns_index_content(self, tmp_path: Path) -> None:
+        root = _fake_root(tmp_path)
+        with patch(
+            "dev10x.mcp.knowledge_resources.get_plugin_root",
+            return_value=root,
+        ):
+            result = knowledge_resources.rules_index()
+
+        assert "# Index" in result
+
+    def test_returns_not_found_when_missing(self, tmp_path: Path) -> None:
+        root = _fake_root(tmp_path)
+        (root / ".claude" / "rules" / "INDEX.md").unlink()
+        with patch(
+            "dev10x.mcp.knowledge_resources.get_plugin_root",
+            return_value=root,
+        ):
+            result = knowledge_resources.rules_index()
+
+        assert "Not found" in result
+
+
+# ── rule_file ──────────────────────────────────────────────────────
+
+
+class TestRuleFile:
+    def test_returns_rule_content_for_existing_rule(self, tmp_path: Path) -> None:
+        root = _fake_root(tmp_path)
+        with patch(
+            "dev10x.mcp.knowledge_resources.get_plugin_root",
+            return_value=root,
+        ):
+            result = knowledge_resources.rule_file(rule_name="essentials")
+
+        assert "# Essentials" in result
+
+    def test_returns_not_found_for_missing_rule(self, tmp_path: Path) -> None:
+        root = _fake_root(tmp_path)
+        with patch(
+            "dev10x.mcp.knowledge_resources.get_plugin_root",
+            return_value=root,
+        ):
+            result = knowledge_resources.rule_file(rule_name="nonexistent-rule")
+
+        assert "Not found" in result
+        assert "nonexistent-rule" in result
+
+
+# ── reference_file ─────────────────────────────────────────────────
+
+
+class TestReferenceFile:
+    def test_returns_reference_content_for_existing_file(self, tmp_path: Path) -> None:
+        root = _fake_root(tmp_path)
+        with patch(
+            "dev10x.mcp.knowledge_resources.get_plugin_root",
+            return_value=root,
+        ):
+            result = knowledge_resources.reference_file(ref_name="git-commits")
+
+        assert "# Git commits" in result
+
+    def test_returns_not_found_for_missing_reference(self, tmp_path: Path) -> None:
+        root = _fake_root(tmp_path)
+        with patch(
+            "dev10x.mcp.knowledge_resources.get_plugin_root",
+            return_value=root,
+        ):
+            result = knowledge_resources.reference_file(ref_name="nonexistent-ref")
+
+        assert "Not found" in result
+        assert "nonexistent-ref" in result
+
+
+# ── skills_index ───────────────────────────────────────────────────
+
+
+class TestSkillsIndex:
+    def test_returns_skills_md_content(self, tmp_path: Path) -> None:
+        root = _fake_root(tmp_path)
+        with patch(
+            "dev10x.mcp.knowledge_resources.get_plugin_root",
+            return_value=root,
+        ):
+            result = knowledge_resources.skills_index()
+
+        assert "# Skills" in result
+
+    def test_returns_not_found_when_skills_md_missing(self, tmp_path: Path) -> None:
+        root = _fake_root(tmp_path)
+        (root / "SKILLS.md").unlink()
+        with patch(
+            "dev10x.mcp.knowledge_resources.get_plugin_root",
+            return_value=root,
+        ):
+            result = knowledge_resources.skills_index()
+
+        assert "Not found" in result
+
+
+# ── path-traversal rejection (GH-339 review) ───────────────────────
+
+
+class TestRejectsPathTraversal:
+    @pytest.mark.parametrize("malicious", ["../secrets", "a/b", "..\\win", ".."])
+    def test_skill_playbook_rejects_traversal(self, tmp_path: Path, malicious: str) -> None:
+        root = _fake_root(tmp_path)
+        with patch(
+            "dev10x.mcp.knowledge_resources.get_plugin_root",
+            return_value=root,
+        ):
+            result = knowledge_resources.skill_playbook(skill_name=malicious)
+
+        assert "Invalid name" in result
+
+    @pytest.mark.parametrize("malicious", ["../../etc/passwd", "nested/rule", ".."])
+    def test_rule_file_rejects_traversal(self, tmp_path: Path, malicious: str) -> None:
+        root = _fake_root(tmp_path)
+        with patch(
+            "dev10x.mcp.knowledge_resources.get_plugin_root",
+            return_value=root,
+        ):
+            result = knowledge_resources.rule_file(rule_name=malicious)
+
+        assert "Invalid name" in result
+
+    @pytest.mark.parametrize("malicious", ["../../../root", "a/b/c", "..\\.."])
+    def test_reference_file_rejects_traversal(self, tmp_path: Path, malicious: str) -> None:
+        root = _fake_root(tmp_path)
+        with patch(
+            "dev10x.mcp.knowledge_resources.get_plugin_root",
+            return_value=root,
+        ):
+            result = knowledge_resources.reference_file(ref_name=malicious)
+
+        assert "Invalid name" in result
+
+
+# ── registration smoke test ────────────────────────────────────────
+#
+# FastMCP.list_resources() / list_resource_templates() are async, but
+# the underlying _resource_manager exposes synchronous equivalents:
+#   _resource_manager.list_resources()  → list of Resource objects (.uri)
+#   _resource_manager.list_templates()  → list of ResourceTemplate objects (.uri_template)
+# We use those to inspect registration state without needing an event loop.
+
+
+class TestResourcesRegistered:
+    """Verify the resources are registered with the server."""
+
+    def test_skill_playbook_template_is_registered(self) -> None:
+        from dev10x.mcp._app import server
+
+        templates = server._resource_manager.list_templates()
+        uris = [t.uri_template for t in templates]
+        assert "dev10x://skills/{skill_name}/playbook" in uris
+
+    def test_rules_index_is_registered(self) -> None:
+        from dev10x.mcp._app import server
+
+        resources = server._resource_manager.list_resources()
+        uris = [str(r.uri) for r in resources]
+        assert "dev10x://rules/index" in uris
+
+    def test_rule_file_template_is_registered(self) -> None:
+        from dev10x.mcp._app import server
+
+        templates = server._resource_manager.list_templates()
+        uris = [t.uri_template for t in templates]
+        assert "dev10x://rules/{rule_name}" in uris
+
+    def test_reference_file_template_is_registered(self) -> None:
+        from dev10x.mcp._app import server
+
+        templates = server._resource_manager.list_templates()
+        uris = [t.uri_template for t in templates]
+        assert "dev10x://references/{ref_name}" in uris
+
+    def test_skills_index_is_registered(self) -> None:
+        from dev10x.mcp._app import server
+
+        resources = server._resource_manager.list_resources()
+        uris = [str(r.uri) for r in resources]
+        assert "dev10x://skills/index" in uris


### PR DESCRIPTION
**When** an MCP client needs Dev10x knowledge (playbooks, rules, references, skill index), **I want to** expose them as addressable `dev10x://` resource URIs, **so I can** read them directly instead of falling back to Bash tool-calls or filesystem searches.

---

[`91e4ae1a`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/425/commits/91e4ae1a3ac9c027c143fabeb4ce5760139fc280) ✨ GH-339 Expose Dev10x knowledge as MCP resources
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/339

---