### PR TITLE
✨ GH-345 Harvest closed PRs and review threads

### DIFF
--- a/src/dev10x/skills/harvest/__init__.py
+++ b/src/dev10x/skills/harvest/__init__.py
@@ -1,0 +1,7 @@
+"""Review-pattern harvesting — read-only MVP (M4 milestone).
+
+Provides functions to fetch merged/closed PRs and their review threads
+from GitHub repositories. The data structures here are consumed by
+downstream modules that cluster and score patterns (#346) and emit
+a candidate-rules report (#347).
+"""

--- a/src/dev10x/skills/harvest/closed_prs.py
+++ b/src/dev10x/skills/harvest/closed_prs.py
@@ -1,0 +1,150 @@
+"""Harvest closed/merged PRs from a GitHub repository.
+
+Reuses the project-audit Phase-1 ``gh pr list`` pattern to fetch PR
+metadata in bulk. Callers that want review threads should pass the
+returned PR numbers to ``review_threads.fetch_review_comments``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from dev10x.domain.common.result import ErrorResult, Result, err, ok
+from dev10x.subprocess_utils import async_run
+
+logger = logging.getLogger(__name__)
+
+#: Fields fetched per PR — chosen to minimise payload while providing
+#: everything downstream clustering needs.
+_PR_FIELDS = "number,title,body,mergedAt,closedAt,state,labels,author,baseRefName"
+
+#: Maximum PRs returned per ``gh pr list`` call (GitHub API cap is 1000,
+#: but we cap at 200 to match the project-audit Phase-1 heuristic and
+#: keep harvest latency reasonable for large repos).
+DEFAULT_LIMIT = 200
+
+
+@dataclass
+class ClosedPR:
+    """Lightweight representation of a closed or merged PR."""
+
+    number: int
+    title: str
+    body: str
+    state: str
+    merged_at: str | None
+    closed_at: str | None
+    base_ref: str
+    labels: list[str] = field(default_factory=list)
+    author: str = ""
+
+    @classmethod
+    def from_gh_json(cls, data: dict[str, Any]) -> ClosedPR:
+        labels = [
+            lbl.get("name", "") if isinstance(lbl, dict) else str(lbl)
+            for lbl in data.get("labels", [])
+        ]
+        author_obj = data.get("author") or {}
+        author_login = author_obj.get("login", "") if isinstance(author_obj, dict) else ""
+        return cls(
+            number=int(data.get("number", 0)),
+            title=data.get("title", ""),
+            body=data.get("body", "") or "",
+            state=data.get("state", ""),
+            merged_at=data.get("mergedAt"),
+            closed_at=data.get("closedAt"),
+            base_ref=data.get("baseRefName", ""),
+            labels=labels,
+            author=author_login,
+        )
+
+
+async def fetch_closed_prs(
+    *,
+    repo: str,
+    limit: int = DEFAULT_LIMIT,
+    state: str = "merged",
+) -> Result[list[ClosedPR]]:
+    """Fetch closed or merged PRs for *repo*.
+
+    Args:
+        repo: Repository in ``owner/name`` format.
+        limit: Maximum number of PRs to return.
+        state: ``"merged"`` (default) or ``"closed"`` or ``"all"``.
+            ``"all"`` returns both open and closed; callers that want
+            only closed-but-not-merged PRs should use ``"closed"``
+            and filter by ``merged_at is None``.
+
+    Returns:
+        ``ok([ClosedPR, ...])`` on success, ``err("...")`` on failure.
+    """
+    args = [
+        "gh",
+        "pr",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        state,
+        "--limit",
+        str(limit),
+        "--json",
+        _PR_FIELDS,
+    ]
+    result = await async_run(args=args, timeout=60)
+    if result.returncode != 0:
+        return err(result.stderr.strip() or f"gh pr list failed (exit {result.returncode})")
+
+    raw = result.stdout.strip()
+    if not raw:
+        return ok([])
+
+    try:
+        items: list[dict[str, Any]] = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return err(f"Failed to parse gh pr list output: {exc}")
+
+    prs = [ClosedPR.from_gh_json(item) for item in items]
+    logger.debug("Fetched %d PRs from %s (state=%s)", len(prs), repo, state)
+    return ok(prs)
+
+
+async def fetch_closed_prs_multi(
+    *,
+    repos: list[str],
+    limit: int = DEFAULT_LIMIT,
+    state: str = "merged",
+) -> Result[dict[str, list[ClosedPR]]]:
+    """Fetch closed PRs from multiple repositories.
+
+    Calls :func:`fetch_closed_prs` for each repo sequentially and
+    returns a mapping of repo → PR list.  On per-repo failure, the
+    error is logged and that repo is mapped to an empty list so
+    callers always receive a complete keyed dict.
+
+    Args:
+        repos: List of ``owner/name`` repository strings.
+        limit: Maximum PRs per repo.
+        state: State filter forwarded to :func:`fetch_closed_prs`.
+
+    Returns:
+        ``ok({"owner/name": [ClosedPR, ...]})`` on success.
+        Returns ``err(...)`` when ``repos`` is empty.
+        Per-repo failures appear as empty lists and are logged at WARNING.
+    """
+    if not repos:
+        return err("repos must be non-empty")
+
+    mapping: dict[str, list[ClosedPR]] = {}
+    for repo in repos:
+        result = await fetch_closed_prs(repo=repo, limit=limit, state=state)
+        if isinstance(result, ErrorResult):
+            logger.warning("Failed to harvest PRs from %s: %s", repo, result.error)
+            mapping[repo] = []
+        else:
+            mapping[repo] = result.value
+
+    return ok(mapping)

--- a/src/dev10x/skills/harvest/review_threads.py
+++ b/src/dev10x/skills/harvest/review_threads.py
@@ -1,0 +1,195 @@
+"""Harvest PR review comments (threads) from GitHub.
+
+Fetches inline review comments for a list of PR numbers via the GitHub
+REST API (``gh api``).  Returns a flat list of :class:`ReviewComment`
+objects that downstream consumers can cluster and score.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from dev10x.domain.common.result import ErrorResult, Result, err, ok
+from dev10x.subprocess_utils import async_run
+
+logger = logging.getLogger(__name__)
+
+#: REST fields fetched per review comment.  ``path`` + ``body`` are the
+#: core content; the rest provide grouping and deduplication keys for
+#: downstream clustering (#346).
+_COMMENT_FIELDS = (
+    "id,body,path,line,original_line,commit_id,created_at,"
+    "pull_request_review_id,in_reply_to_id,user"
+)
+
+#: GitHub REST API page size cap.
+_PAGE_SIZE = 100
+
+
+@dataclass
+class ReviewComment:
+    """A single inline PR review comment."""
+
+    pr_number: int
+    repo: str
+    comment_id: int
+    body: str
+    path: str
+    line: int | None
+    original_line: int | None
+    author: str
+    review_id: int | None
+    in_reply_to_id: int | None
+    created_at: str
+    commit_id: str
+
+    @classmethod
+    def from_gh_json(
+        cls,
+        data: dict[str, Any],
+        *,
+        pr_number: int,
+        repo: str,
+    ) -> ReviewComment:
+        user_obj = data.get("user") or {}
+        author = user_obj.get("login", "") if isinstance(user_obj, dict) else ""
+        return cls(
+            pr_number=pr_number,
+            repo=repo,
+            comment_id=int(data.get("id", 0)),
+            body=data.get("body", "") or "",
+            path=data.get("path", "") or "",
+            line=data.get("line"),
+            original_line=data.get("original_line"),
+            author=author,
+            review_id=data.get("pull_request_review_id"),
+            in_reply_to_id=data.get("in_reply_to_id"),
+            created_at=data.get("created_at", ""),
+            commit_id=data.get("commit_id", "") or "",
+        )
+
+    @property
+    def is_reply(self) -> bool:
+        """Return True when this comment is a reply in a thread."""
+        return self.in_reply_to_id is not None
+
+
+async def _fetch_pr_review_comments(
+    *,
+    repo: str,
+    pr_number: int,
+    page_size: int = _PAGE_SIZE,
+) -> Result[list[ReviewComment]]:
+    """Fetch all review comments for a single PR (handles pagination)."""
+    all_comments: list[ReviewComment] = []
+    page = 1
+
+    while True:
+        endpoint = f"repos/{repo}/pulls/{pr_number}/comments?per_page={page_size}&page={page}"
+        args = ["gh", "api", endpoint]
+        result = await async_run(args=args, timeout=30)
+
+        if result.returncode != 0:
+            return err(
+                result.stderr.strip()
+                or f"gh api failed for PR #{pr_number} (exit {result.returncode})"
+            )
+
+        raw = result.stdout.strip()
+        if not raw:
+            break
+
+        try:
+            items: list[dict[str, Any]] = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            return err(f"Failed to parse review comments for PR #{pr_number}: {exc}")
+
+        if not items:
+            break
+
+        for item in items:
+            all_comments.append(
+                ReviewComment.from_gh_json(
+                    item,
+                    pr_number=pr_number,
+                    repo=repo,
+                )
+            )
+
+        if len(items) < page_size:
+            break
+        page += 1
+
+    logger.debug("Fetched %d review comments for %s#%d", len(all_comments), repo, pr_number)
+    return ok(all_comments)
+
+
+async def fetch_review_comments(
+    *,
+    repo: str,
+    pr_numbers: list[int],
+) -> Result[list[ReviewComment]]:
+    """Fetch review comments for a list of PR numbers in *repo*.
+
+    Calls :func:`_fetch_pr_review_comments` for each PR sequentially.
+    Per-PR errors are logged at WARNING and that PR is skipped so the
+    caller receives a partial but valid dataset (fail-soft semantics
+    matching :func:`~closed_prs.fetch_closed_prs_multi`).
+
+    Args:
+        repo: Repository in ``owner/name`` format.
+        pr_numbers: List of PR numbers to harvest.
+
+    Returns:
+        ``ok([ReviewComment, ...])`` — the combined list across all PRs.
+        Never returns ``err``; per-PR failures appear in the log.
+    """
+    if not pr_numbers:
+        return ok([])
+
+    combined: list[ReviewComment] = []
+    for pr_num in pr_numbers:
+        result = await _fetch_pr_review_comments(repo=repo, pr_number=pr_num)
+        if isinstance(result, ErrorResult):
+            logger.warning(
+                "Failed to fetch review comments for %s#%d: %s",
+                repo,
+                pr_num,
+                result.error,
+            )
+        else:
+            combined.extend(result.value)
+
+    return ok(combined)
+
+
+async def fetch_review_comments_multi(
+    *,
+    repo_prs: dict[str, list[int]],
+) -> Result[dict[str, list[ReviewComment]]]:
+    """Fetch review comments across multiple repositories.
+
+    Args:
+        repo_prs: Mapping of ``repo`` → ``[pr_number, ...]``.
+
+    Returns:
+        ``ok({"owner/name": [ReviewComment, ...]})`` on success.
+        Returns ``err(...)`` when ``repo_prs`` is empty.
+        Per-repo failures appear as empty lists with a WARNING log entry.
+    """
+    if not repo_prs:
+        return err("repo_prs must be non-empty")
+
+    mapping: dict[str, list[ReviewComment]] = {}
+    for repo, pr_numbers in repo_prs.items():
+        result = await fetch_review_comments(repo=repo, pr_numbers=pr_numbers)
+        if isinstance(result, ErrorResult):
+            logger.warning("Failed to harvest review comments from %s: %s", repo, result.error)
+            mapping[repo] = []
+        else:
+            mapping[repo] = result.value
+
+    return ok(mapping)

--- a/tests/skills/harvest/test_closed_prs.py
+++ b/tests/skills/harvest/test_closed_prs.py
@@ -1,0 +1,192 @@
+"""Tests for dev10x.skills.harvest.closed_prs (GH-345)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dev10x.domain.common.result import ErrorResult, SuccessResult
+from dev10x.skills.harvest.closed_prs import (
+    DEFAULT_LIMIT,
+    ClosedPR,
+    fetch_closed_prs,
+    fetch_closed_prs_multi,
+)
+
+
+def _completed(
+    *,
+    returncode: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=[],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+_PR_FIXTURE: dict = {
+    "number": 42,
+    "title": "Enable review harvesting",
+    "body": (
+        "**When** a dev **wants to** analyse review patterns "
+        "**so** they **can** improve code quality."
+    ),
+    "mergedAt": "2026-05-01T12:00:00Z",
+    "closedAt": "2026-05-01T12:00:00Z",
+    "state": "MERGED",
+    "labels": [{"name": "enhancement"}],
+    "author": {"login": "wooyek"},
+    "baseRefName": "develop",
+}
+
+
+class TestClosedPRFromGhJson:
+    def test_parses_full_payload(self):
+        pr = ClosedPR.from_gh_json(_PR_FIXTURE)
+
+        assert pr.number == 42
+        assert pr.title == "Enable review harvesting"
+        assert pr.state == "MERGED"
+        assert pr.merged_at == "2026-05-01T12:00:00Z"
+        assert pr.base_ref == "develop"
+        assert pr.author == "wooyek"
+        assert pr.labels == ["enhancement"]
+
+    def test_missing_author_defaults_to_empty_string(self):
+        data = {**_PR_FIXTURE, "author": None}
+        pr = ClosedPR.from_gh_json(data)
+        assert pr.author == ""
+
+    def test_missing_labels_defaults_to_empty_list(self):
+        data = {**_PR_FIXTURE, "labels": []}
+        pr = ClosedPR.from_gh_json(data)
+        assert pr.labels == []
+
+    def test_plain_string_label_is_preserved(self):
+        data = {**_PR_FIXTURE, "labels": ["plain-string"]}
+        pr = ClosedPR.from_gh_json(data)
+        assert pr.labels == ["plain-string"]
+
+    def test_none_body_normalised_to_empty_string(self):
+        data = {**_PR_FIXTURE, "body": None}
+        pr = ClosedPR.from_gh_json(data)
+        assert pr.body == ""
+
+
+class TestFetchClosedPRs:
+    @pytest.mark.asyncio
+    @patch("dev10x.skills.harvest.closed_prs.async_run", new_callable=AsyncMock)
+    async def test_returns_parsed_prs_on_success(self, mock_run: AsyncMock):
+        mock_run.return_value = _completed(stdout=json.dumps([_PR_FIXTURE]))
+
+        result = await fetch_closed_prs(repo="owner/repo")
+
+        assert isinstance(result, SuccessResult)
+        assert len(result.value) == 1
+        assert result.value[0].number == 42
+
+    @pytest.mark.asyncio
+    @patch("dev10x.skills.harvest.closed_prs.async_run", new_callable=AsyncMock)
+    async def test_passes_correct_gh_args(self, mock_run: AsyncMock):
+        mock_run.return_value = _completed(stdout=json.dumps([_PR_FIXTURE]))
+
+        await fetch_closed_prs(repo="owner/repo", limit=50, state="closed")
+
+        args = mock_run.call_args.kwargs["args"]
+        assert "gh" in args
+        assert "pr" in args
+        assert "list" in args
+        assert "--repo" in args
+        assert "owner/repo" in args
+        assert "--state" in args
+        assert "closed" in args
+        assert "--limit" in args
+        assert "50" in args
+
+    @pytest.mark.asyncio
+    @patch("dev10x.skills.harvest.closed_prs.async_run", new_callable=AsyncMock)
+    async def test_returns_empty_list_on_empty_output(self, mock_run: AsyncMock):
+        mock_run.return_value = _completed(stdout="")
+
+        result = await fetch_closed_prs(repo="owner/repo")
+
+        assert isinstance(result, SuccessResult)
+        assert result.value == []
+
+    @pytest.mark.asyncio
+    @patch("dev10x.skills.harvest.closed_prs.async_run", new_callable=AsyncMock)
+    async def test_returns_error_on_nonzero_exit(self, mock_run: AsyncMock):
+        mock_run.return_value = _completed(returncode=1, stderr="gh: error: bad credentials")
+
+        result = await fetch_closed_prs(repo="owner/repo")
+
+        assert isinstance(result, ErrorResult)
+        assert "bad credentials" in result.error
+
+    @pytest.mark.asyncio
+    @patch("dev10x.skills.harvest.closed_prs.async_run", new_callable=AsyncMock)
+    async def test_returns_error_on_invalid_json(self, mock_run: AsyncMock):
+        mock_run.return_value = _completed(stdout="not-json{}")
+
+        result = await fetch_closed_prs(repo="owner/repo")
+
+        assert isinstance(result, ErrorResult)
+        assert "parse" in result.error.lower()
+
+    @pytest.mark.asyncio
+    @patch("dev10x.skills.harvest.closed_prs.async_run", new_callable=AsyncMock)
+    async def test_default_state_is_merged(self, mock_run: AsyncMock):
+        mock_run.return_value = _completed(stdout=json.dumps([]))
+
+        await fetch_closed_prs(repo="owner/repo")
+
+        args = mock_run.call_args.kwargs["args"]
+        state_idx = args.index("--state")
+        assert args[state_idx + 1] == "merged"
+
+    @pytest.mark.asyncio
+    @patch("dev10x.skills.harvest.closed_prs.async_run", new_callable=AsyncMock)
+    async def test_default_limit_is_applied(self, mock_run: AsyncMock):
+        mock_run.return_value = _completed(stdout=json.dumps([]))
+
+        await fetch_closed_prs(repo="owner/repo")
+
+        args = mock_run.call_args.kwargs["args"]
+        limit_idx = args.index("--limit")
+        assert args[limit_idx + 1] == str(DEFAULT_LIMIT)
+
+
+class TestFetchClosedPRsMulti:
+    @pytest.mark.asyncio
+    @patch("dev10x.skills.harvest.closed_prs.async_run", new_callable=AsyncMock)
+    async def test_returns_mapping_per_repo(self, mock_run: AsyncMock):
+        mock_run.return_value = _completed(stdout=json.dumps([_PR_FIXTURE]))
+
+        result = await fetch_closed_prs_multi(repos=["owner/repo-a", "owner/repo-b"])
+
+        assert isinstance(result, SuccessResult)
+        assert set(result.value.keys()) == {"owner/repo-a", "owner/repo-b"}
+        assert len(result.value["owner/repo-a"]) == 1
+
+    @pytest.mark.asyncio
+    @patch("dev10x.skills.harvest.closed_prs.async_run", new_callable=AsyncMock)
+    async def test_failed_repo_maps_to_empty_list(self, mock_run: AsyncMock):
+        mock_run.return_value = _completed(returncode=1, stderr="not found")
+
+        result = await fetch_closed_prs_multi(repos=["owner/missing"])
+
+        assert isinstance(result, SuccessResult)
+        assert result.value["owner/missing"] == []
+
+    @pytest.mark.asyncio
+    async def test_empty_repos_returns_error(self):
+        result = await fetch_closed_prs_multi(repos=[])
+
+        assert isinstance(result, ErrorResult)

--- a/tests/skills/harvest/test_review_threads.py
+++ b/tests/skills/harvest/test_review_threads.py
@@ -1,0 +1,202 @@
+"""Tests for dev10x.skills.harvest.review_threads (GH-345)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dev10x.domain.common.result import ErrorResult, SuccessResult
+from dev10x.skills.harvest.review_threads import (
+    ReviewComment,
+    _fetch_pr_review_comments,
+    fetch_review_comments,
+    fetch_review_comments_multi,
+)
+
+
+def _completed(
+    *,
+    returncode: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=[],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+_COMMENT_FIXTURE: dict = {
+    "id": 101,
+    "body": "This variable should be named `payment_method`, not `pm`.",
+    "path": "src/payments/models.py",
+    "line": 42,
+    "original_line": 42,
+    "commit_id": "abc123def456",
+    "created_at": "2026-05-01T10:00:00Z",
+    "pull_request_review_id": 999,
+    "in_reply_to_id": None,
+    "user": {"login": "reviewer1"},
+}
+
+_REPLY_FIXTURE: dict = {
+    **_COMMENT_FIXTURE,
+    "id": 102,
+    "body": "Agreed, will fix.",
+    "in_reply_to_id": 101,
+    "user": {"login": "author1"},
+}
+
+
+class TestReviewCommentFromGhJson:
+    def test_parses_full_payload(self):
+        comment = ReviewComment.from_gh_json(_COMMENT_FIXTURE, pr_number=42, repo="owner/repo")
+
+        assert comment.comment_id == 101
+        assert comment.body == "This variable should be named `payment_method`, not `pm`."
+        assert comment.path == "src/payments/models.py"
+        assert comment.line == 42
+        assert comment.author == "reviewer1"
+        assert comment.review_id == 999
+        assert comment.in_reply_to_id is None
+        assert comment.pr_number == 42
+        assert comment.repo == "owner/repo"
+
+    def test_is_reply_false_for_root_comment(self):
+        comment = ReviewComment.from_gh_json(_COMMENT_FIXTURE, pr_number=42, repo="owner/repo")
+        assert comment.is_reply is False
+
+    def test_is_reply_true_for_reply_comment(self):
+        comment = ReviewComment.from_gh_json(_REPLY_FIXTURE, pr_number=42, repo="owner/repo")
+        assert comment.is_reply is True
+
+    def test_missing_user_defaults_to_empty_string(self):
+        data = {**_COMMENT_FIXTURE, "user": None}
+        comment = ReviewComment.from_gh_json(data, pr_number=1, repo="owner/repo")
+        assert comment.author == ""
+
+    def test_none_body_normalised_to_empty_string(self):
+        data = {**_COMMENT_FIXTURE, "body": None}
+        comment = ReviewComment.from_gh_json(data, pr_number=1, repo="owner/repo")
+        assert comment.body == ""
+
+    def test_none_path_normalised_to_empty_string(self):
+        data = {**_COMMENT_FIXTURE, "path": None}
+        comment = ReviewComment.from_gh_json(data, pr_number=1, repo="owner/repo")
+        assert comment.path == ""
+
+
+class TestFetchReviewComments:
+    @pytest.mark.asyncio
+    @patch("dev10x.skills.harvest.review_threads.async_run", new_callable=AsyncMock)
+    async def test_returns_parsed_comments_single_page(self, mock_run: AsyncMock):
+        mock_run.side_effect = [
+            _completed(stdout=json.dumps([_COMMENT_FIXTURE])),
+            _completed(stdout=json.dumps([])),
+        ]
+
+        result = await fetch_review_comments(repo="owner/repo", pr_numbers=[42])
+
+        assert isinstance(result, SuccessResult)
+        assert len(result.value) == 1
+        assert result.value[0].comment_id == 101
+
+    @pytest.mark.asyncio
+    @patch("dev10x.skills.harvest.review_threads.async_run", new_callable=AsyncMock)
+    async def test_paginates_until_empty_page(self, mock_run: AsyncMock):
+        page1 = [_COMMENT_FIXTURE]
+        page2 = [{**_COMMENT_FIXTURE, "id": 200}]
+        mock_run.side_effect = [
+            _completed(stdout=json.dumps(page1)),
+            _completed(stdout=json.dumps(page2)),
+            _completed(stdout=json.dumps([])),
+        ]
+
+        result = await _fetch_pr_review_comments(repo="owner/repo", pr_number=42, page_size=1)
+
+        assert isinstance(result, SuccessResult)
+        assert len(result.value) == 2
+
+    @pytest.mark.asyncio
+    @patch("dev10x.skills.harvest.review_threads.async_run", new_callable=AsyncMock)
+    async def test_empty_pr_numbers_returns_empty_list(self, mock_run: AsyncMock):
+        result = await fetch_review_comments(repo="owner/repo", pr_numbers=[])
+
+        assert isinstance(result, SuccessResult)
+        assert result.value == []
+        mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("dev10x.skills.harvest.review_threads.async_run", new_callable=AsyncMock)
+    async def test_combines_comments_from_multiple_prs(self, mock_run: AsyncMock):
+        comment_pr1 = _COMMENT_FIXTURE
+        comment_pr2 = {**_COMMENT_FIXTURE, "id": 201}
+        # With the default page_size=100, a single-item page triggers early exit
+        # (len(items) < page_size), so each PR needs exactly one fetch call.
+        mock_run.side_effect = [
+            _completed(stdout=json.dumps([comment_pr1])),
+            _completed(stdout=json.dumps([comment_pr2])),
+        ]
+
+        result = await fetch_review_comments(repo="owner/repo", pr_numbers=[42, 43])
+
+        assert isinstance(result, SuccessResult)
+        assert len(result.value) == 2
+        pr_numbers = {c.pr_number for c in result.value}
+        assert pr_numbers == {42, 43}
+
+    @pytest.mark.asyncio
+    @patch("dev10x.skills.harvest.review_threads.async_run", new_callable=AsyncMock)
+    async def test_failed_pr_is_skipped_not_raised(self, mock_run: AsyncMock):
+        mock_run.side_effect = [
+            _completed(returncode=1, stderr="forbidden"),
+        ]
+
+        result = await fetch_review_comments(repo="owner/repo", pr_numbers=[42])
+
+        assert isinstance(result, SuccessResult)
+        assert result.value == []
+
+    @pytest.mark.asyncio
+    @patch("dev10x.skills.harvest.review_threads.async_run", new_callable=AsyncMock)
+    async def test_gh_api_endpoint_includes_repo_and_pr(self, mock_run: AsyncMock):
+        mock_run.return_value = _completed(stdout=json.dumps([]))
+
+        await fetch_review_comments(repo="owner/repo", pr_numbers=[99])
+
+        args = mock_run.call_args.kwargs["args"]
+        assert "gh" in args
+        assert "api" in args
+        endpoint = args[-1]
+        assert "repos/owner/repo/pulls/99/comments" in endpoint
+
+
+class TestFetchReviewCommentsMulti:
+    @pytest.mark.asyncio
+    @patch("dev10x.skills.harvest.review_threads.async_run", new_callable=AsyncMock)
+    async def test_returns_mapping_per_repo(self, mock_run: AsyncMock):
+        mock_run.side_effect = [
+            _completed(stdout=json.dumps([_COMMENT_FIXTURE])),
+            _completed(stdout=json.dumps([])),
+            _completed(stdout=json.dumps([])),
+        ]
+
+        result = await fetch_review_comments_multi(
+            repo_prs={"owner/repo-a": [42], "owner/repo-b": []}
+        )
+
+        assert isinstance(result, SuccessResult)
+        assert set(result.value.keys()) == {"owner/repo-a", "owner/repo-b"}
+        assert len(result.value["owner/repo-a"]) == 1
+        assert result.value["owner/repo-b"] == []
+
+    @pytest.mark.asyncio
+    async def test_empty_repo_prs_returns_error(self):
+        result = await fetch_review_comments_multi(repo_prs={})
+
+        assert isinstance(result, ErrorResult)


### PR DESCRIPTION
**When** the M4 learning loop needs raw material, **I want to** harvest merged PRs and their inline review threads as structured data, **so I can** feed downstream clustering and candidate-rule scoring without re-scraping GitHub each time.

---

[`cffe7c1a`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/426/commits/cffe7c1ad0c9271c60168882f878569ea5f1e004) ✨ GH-345 Harvest closed PRs and review threads
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/345

---