### PR TITLE
🐛 GH-420 Stop full-mode cleanup from reintroducing friction

### DIFF
--- a/skills/plugin-maintenance/SKILL.md
+++ b/skills/plugin-maintenance/SKILL.md
@@ -113,6 +113,13 @@ on the mode. Execute these `TaskCreate` calls at startup:
 13. `TaskCreate(subject="Run permission doctor", activeForm="Running doctor sweep")`
 14. `TaskCreate(subject="Diff user playbooks against defaults", activeForm="Diffing playbooks")`
 
+> ⚠ **#47 default-safety.** Step 12 (Clean) runs the safe default
+> only — it does NOT pass `--aggressive`, so global-duplicate
+> stripping is skipped (global→project merge is not guaranteed).
+> Step 13 (doctor) skips `canonicalize` by default (it emits
+> unreliable `**` wildcards). Both are opt-in; see §11–§12 for the
+> evidence gate and `clean --restore` recovery.
+
 Set sequential dependencies. Mark each step `in_progress` when
 starting and `completed` when done. Steps that produce no
 changes (dry-run shows no diff) should still be marked
@@ -553,9 +560,19 @@ fix proposals. Review and apply selectively.
 
 ### 11. Clean project files *(full only)*
 
-Strip redundant rules from project `settings.local.json` files
-that are now covered by global `~/.claude/settings.json`. Also
-flags rules containing leaked secrets.
+Strip redundant rules from project `settings.local.json` files.
+Also flags rules containing leaked secrets.
+
+> ⚠ **#47 — global→project merge is NOT guaranteed.** Empirical
+> evidence (#47, closed by #50) shows a project with its own
+> `settings.local.json` does **not** reliably inherit global
+> `~/.claude/settings.json` rules — the local file appears to win.
+> Removing a project rule *solely because it duplicates a global
+> rule* can therefore reintroduce per-invocation permission
+> prompts. For this reason **global-dedup is OFF by default**;
+> the default `clean` only removes rules that are safe regardless
+> of merge behavior (old version paths, shell fragments, env
+> noise, double-slash typos).
 
 1. Dry run (REQUIRED — show the user before applying):
 
@@ -569,19 +586,36 @@ For large cleanups prefer `--summary`:
 uvx dev10x permission clean --dry-run --summary
 ```
 
-2. Apply:
+2. Apply the safe default (no global-dedup):
 
 ```bash
 uvx dev10x permission clean
 ```
 
-**What gets cleaned:**
-- Exact duplicates of global rules
-- Rules covered by global wildcard patterns
+**What the default removes:**
 - Old plugin version paths (any version older than current)
 - Env-prefixed session noise (`GIT_SEQUENCE_EDITOR=*`, …)
 - Shell control flow fragments (`do`, `done`, `fi`, …)
 - Double-slash path typos (`Read(//work/...)`)
+
+**Opt-in global-dedup (`--aggressive`):** Removing exact
+duplicates of global rules and rules covered by global wildcards
+requires `--aggressive`, and only after
+`uvx dev10x permission investigate` confirms global→project
+inheritance holds for this environment (#47):
+
+```bash
+uvx dev10x permission clean --aggressive --dry-run
+uvx dev10x permission clean --aggressive
+```
+
+**Recovery (REQUIRED to document):** If an `--aggressive` run
+strips rules that were actually needed and prompts reappear,
+restore the pre-clean backup:
+
+```bash
+uvx dev10x permission clean --restore
+```
 
 **Leaked secret detection:** Rules containing plaintext
 credentials are flagged with warnings so users can rotate them.
@@ -605,7 +639,18 @@ of friction not covered by the other steps:
   the current project, or into the source repo when CWD is a worktree,
   are flagged so the user can remove them.
 
-1. Canonicalize pinned paths (idempotent, safe to re-run):
+1. Canonicalize pinned paths *(opt-in — do NOT run by default)*:
+
+> ⚠ **#47 — `**` wildcards are unreliable.** Canonicalize rewrites
+> a working version-pinned `~/` path into a `**`-wildcard path.
+> #47 found single `*` segments match but `**` and `*/**` were
+> unreliable — so canonicalize trades a path that works today (but
+> rots on upgrade) for one that may silently fail to match. Skip
+> this step in the default full-mode sweep. Only run it when the
+> user explicitly accepts the trade-off, or after
+> `uvx dev10x permission investigate` confirms `**` matches in this
+> environment. Recover with `clean --restore` (the pre-clean backup
+> predates canonicalize, so one restore undoes both).
 
 ```bash
 uvx dev10x permission doctor canonicalize --dry-run

--- a/src/dev10x/commands/permission.py
+++ b/src/dev10x/commands/permission.py
@@ -310,18 +310,42 @@ def init() -> None:
     default=False,
     help=(
         "Do not remove project rules that are exact duplicates of global rules. "
-        "Use this when global→project rule inheritance cannot be verified "
-        "(finding #47: local settings.local.json may not inherit global rules)."
+        "Retained for backward compatibility — global-dedup is now OFF by "
+        "default, so this flag is only meaningful alongside --aggressive."
+    ),
+)
+@click.option(
+    "--aggressive",
+    is_flag=True,
+    default=False,
+    help=(
+        "Also remove project rules that are exact duplicates of global rules. "
+        "OFF by default (finding #47): global→project rule inheritance is NOT "
+        "guaranteed when a project has its own settings.local.json, so stripping "
+        "the local copy can reintroduce permission prompts. Only enable after "
+        "`dev10x permission investigate` confirms inheritance holds for this "
+        "environment. Recover a bad run with `dev10x permission clean --restore`."
     ),
 )
 def clean(
-    *, dry_run: bool, verbose: bool, summary: bool, restore: bool, skip_global_dedup: bool
+    *,
+    dry_run: bool,
+    verbose: bool,
+    summary: bool,
+    restore: bool,
+    skip_global_dedup: bool,
+    aggressive: bool,
 ) -> None:
     """Clean redundant permissions from project settings files."""
     from dev10x.skills.permission import clean_project_files as mod
 
     if restore:
         sys.exit(mod._restore(config_path=mod.find_config()))
+
+    # Global-dedup is opt-in (finding #47). It runs only under --aggressive,
+    # and --skip-global-dedup always wins so the safe behavior cannot be
+    # accidentally re-enabled.
+    skip_global_dedup = skip_global_dedup or not aggressive
 
     config_path = mod.find_config()
     click.echo(f"Config: {config_path}")
@@ -407,9 +431,9 @@ def clean(
     if total_global_dedup > 0 and not skip_global_dedup:
         click.echo(
             f"\n⚠  WARNING: {total_global_dedup} rules removed as exact duplicates of global"
-            " rules. Global→project rule inheritance is NOT guaranteed when a project has its"
-            " own settings.local.json (finding #47). Re-run with --skip-global-dedup to"
-            " preserve project-local copies if you see new permission prompts."
+            " rules (--aggressive). Global→project rule inheritance is NOT guaranteed when a"
+            " project has its own settings.local.json (finding #47). If new permission prompts"
+            " appear, recover with `dev10x permission clean --restore`."
         )
 
     if total_secrets > 0:

--- a/tests/commands/test_permission_summary.py
+++ b/tests/commands/test_permission_summary.py
@@ -96,72 +96,118 @@ class TestUpdatePathsSummary:
         assert "0.10.0 -> 0.20.0" in result.output
 
 
+@pytest.fixture
+def project_with_clean_targets(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Path:
+    """Project whose settings.local.json duplicates two global rules."""
+    global_settings = tmp_path / ".claude" / "settings.json"
+    global_settings.parent.mkdir(parents=True, exist_ok=True)
+    global_settings.write_text(
+        json.dumps({"permissions": {"allow": ["Bash(git log:*)", "Bash(git status:*)"]}})
+    )
+
+    config_dir = tmp_path / ".claude" / "memory" / "Dev10x"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_path = config_dir / "projects.yaml"
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    config_path.write_text(
+        f"plugin_cache: {tmp_path}/.claude/plugins/cache/Dev10x-Guru/Dev10x\n"
+        f"roots: ['{project_root}']\n"
+        f"base_permissions: []\n"
+    )
+
+    proj_settings = project_root / ".claude" / "settings.local.json"
+    proj_settings.parent.mkdir()
+    proj_settings.write_text(
+        json.dumps(
+            {
+                "permissions": {
+                    "allow": [
+                        "Bash(git log:*)",  # duplicate of global
+                        "Bash(git status:*)",  # duplicate of global
+                        "Bash(make test:*)",  # kept
+                    ]
+                }
+            }
+        )
+    )
+
+    monkeypatch.setattr(
+        "dev10x.skills.permission.clean_project_files.find_config",
+        lambda: config_path,
+    )
+    monkeypatch.setattr(
+        "dev10x.skills.permission.clean_project_files.GLOBAL_SETTINGS",
+        global_settings,
+    )
+    monkeypatch.setattr(
+        "dev10x.skills.permission.clean_project_files.find_settings_files",
+        lambda **_kw: [proj_settings],
+    )
+    monkeypatch.setattr(
+        "dev10x.skills.permission.clean_project_files.detect_current_version",
+        lambda _cache: None,
+    )
+    return tmp_path
+
+
 class TestCleanSummary:
     """`clean --summary` prints one line per changed file."""
-
-    @pytest.fixture
-    def project_with_clean_targets(
-        self,
-        tmp_path: Path,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> Path:
-        global_settings = tmp_path / ".claude" / "settings.json"
-        global_settings.parent.mkdir(parents=True, exist_ok=True)
-        global_settings.write_text(
-            json.dumps({"permissions": {"allow": ["Bash(git log:*)", "Bash(git status:*)"]}})
-        )
-
-        config_dir = tmp_path / ".claude" / "memory" / "Dev10x"
-        config_dir.mkdir(parents=True, exist_ok=True)
-        config_path = config_dir / "projects.yaml"
-        project_root = tmp_path / "project"
-        project_root.mkdir()
-        config_path.write_text(
-            f"plugin_cache: {tmp_path}/.claude/plugins/cache/Dev10x-Guru/Dev10x\n"
-            f"roots: ['{project_root}']\n"
-            f"base_permissions: []\n"
-        )
-
-        proj_settings = project_root / ".claude" / "settings.local.json"
-        proj_settings.parent.mkdir()
-        proj_settings.write_text(
-            json.dumps(
-                {
-                    "permissions": {
-                        "allow": [
-                            "Bash(git log:*)",  # duplicate of global
-                            "Bash(git status:*)",  # duplicate of global
-                            "Bash(make test:*)",  # kept
-                        ]
-                    }
-                }
-            )
-        )
-
-        monkeypatch.setattr(
-            "dev10x.skills.permission.clean_project_files.find_config",
-            lambda: config_path,
-        )
-        monkeypatch.setattr(
-            "dev10x.skills.permission.clean_project_files.GLOBAL_SETTINGS",
-            global_settings,
-        )
-        monkeypatch.setattr(
-            "dev10x.skills.permission.clean_project_files.find_settings_files",
-            lambda **_kw: [proj_settings],
-        )
-        monkeypatch.setattr(
-            "dev10x.skills.permission.clean_project_files.detect_current_version",
-            lambda _cache: None,
-        )
-        return tmp_path
 
     def test_summary_prints_per_file_count(
         self,
         project_with_clean_targets: Path,
     ) -> None:
         runner = CliRunner()
-        result = runner.invoke(clean, ["--summary", "--dry-run"])
+        # Global-dedup is opt-in (#47): the two global duplicates are only
+        # stripped under --aggressive.
+        result = runner.invoke(clean, ["--summary", "--dry-run", "--aggressive"])
 
         assert result.exit_code == 0
         assert "settings.local.json: 2 removed" in result.output
+
+
+class TestCleanGlobalDedupOptIn:
+    """Global-dedup is OFF by default (#47, GH-420).
+
+    A project rule that exactly duplicates a global rule must NOT be
+    silently stripped under the default profile — only under --aggressive,
+    because global→project rule inheritance is not guaranteed.
+    """
+
+    def test_default_keeps_project_rules_duplicating_global(
+        self,
+        project_with_clean_targets: Path,
+    ) -> None:
+        runner = CliRunner()
+        result = runner.invoke(clean, ["--dry-run"])
+
+        assert result.exit_code == 0
+        # The two global duplicates (git log / git status) survive the default.
+        assert "All project files are clean." in result.output
+        assert "removed" not in result.output
+
+    def test_aggressive_removes_global_duplicates(
+        self,
+        project_with_clean_targets: Path,
+    ) -> None:
+        runner = CliRunner()
+        result = runner.invoke(clean, ["--dry-run", "--aggressive"])
+
+        assert result.exit_code == 0
+        assert "Would remove 2 rules" in result.output
+
+    def test_skip_global_dedup_overrides_aggressive(
+        self,
+        project_with_clean_targets: Path,
+    ) -> None:
+        runner = CliRunner()
+        result = runner.invoke(clean, ["--dry-run", "--aggressive", "--skip-global-dedup"])
+
+        assert result.exit_code == 0
+        # --skip-global-dedup always wins — the safe behavior cannot be
+        # accidentally re-enabled.
+        assert "All project files are clean." in result.output


### PR DESCRIPTION
**When** I run `Dev10x:plugin-maintenance` full mode to tidy permissions, **I want to** keep my working project-local rules and literal `~/` paths untouched by default, **so I can** avoid re-introducing the permission prompts the skill exists to remove (#47).

---

[`2222497c`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/428/commits/2222497ca18c28de1caeddee588c1302b1642f66) 🐛 GH-420 Stop full-mode cleanup from reintroducing friction
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/420

---