### PR TITLE
🐛 GH-427 Harden fanout swarm dispatch for worktree orchestrators

### DIFF
--- a/skills/fanout/instructions.md
+++ b/skills/fanout/instructions.md
@@ -288,6 +288,22 @@ skill targets.
 write-touching work item. Drop isolation only when the work
 is provably read-only (monitoring, fetching, reviewing).
 
+**Child worktree file-access allowlist (GH-424 F1):** A spawned
+agent's file access is limited to the session's project
+directories plus `/tmp`. A worktree created at a path *outside*
+that allowlist is not readable or writable by the child — it
+returns `BLOCKED` ("could not read/write files at the worktree
+path") or silently falls back to branching in the primary
+checkout (polluting the human's working copy). When a child must
+self-create a worktree, place it under an allowlisted path
+(e.g. `/tmp/<id>-<repo>-wt`), never a shared `.worktrees/` root
+that may sit outside the allowlist. Note that
+`isolation="worktree"` isolates only the orchestrator's own
+repo — for cross-repo (sibling-repo) items it does NOT create a
+worktree in the sibling repo, so those children must self-create
+one in an allowlisted location or they branch in the sibling's
+primary checkout.
+
 **Worktree Write-deny on path-scoped rule targets (GH-376,
 GH-399 F1):** Write allow-rules are keyed on the canonical
 worktree path (e.g. `/work/dx/.worktrees/<name>`). An agent
@@ -511,6 +527,12 @@ Etiquette (REQUIRED):
   resolve the conflict, pause, report via your result
   message, and do not push. The orchestrator will resolve.
 - Do not force-push and do not touch main/develop directly.
+- Branch upstream guard (GH-424 F2): if you self-create a
+  worktree with `git worktree add -b <new> <base>`, the new
+  branch tracks `<base>` — a bare `git push` would then advance
+  the base branch's PR. Immediately run `git branch
+  --unset-upstream`, and always push explicitly with
+  `git push -u origin HEAD` (never a bare `git push`).
 - Your worktree is ephemeral; assume it is destroyed if you
   make no changes.
 

--- a/skills/fanout/instructions.md
+++ b/skills/fanout/instructions.md
@@ -324,6 +324,64 @@ same repository root. Instead, use this recovery sequence:
 If `git worktree remove` fails (uncommitted changes), pass
 `--force` — the agent's ephemeral worktree is disposable.
 
+**Cross-repo salvage (GH-427).** When `worktree_orchestrator`
+is true (see Worktree-Orchestrator Precheck), steps 2–3 above do
+NOT work: the agent's worktree lives under a different repo root,
+`git worktree remove` from the orchestrator targets the wrong
+repo, and `git checkout <pr-branch>` cannot reach the branch. The
+object store IS shared, though, so the agent's commit is reachable
+via `git cat-file -e <sha>` from the orchestrator. Salvage by
+cherry-picking it onto a fresh orchestrator-side branch:
+1. Read the agent result for the commit SHA (or branch tip). If
+   the agent stopped before committing, its work lived only as
+   uncommitted files in an unreachable worktree — re-dispatch
+   from scratch instead.
+2. From the orchestrator worktree: create a branch from
+   `origin/<base>` via `Skill(Dev10x:ticket-branch)`, then
+   `git cherry-pick <agent-sha>` (the shared object store makes
+   the SHA reachable even though the branch ref is not).
+3. Resolve any conflicts, then ship the orchestrator-side branch
+   through the normal lifecycle.
+This is why the commit-early contract (ANTI-STALL CONTRACT) is
+mandatory: an uncommitted agent leaves nothing in the object
+store to cherry-pick.
+
+### Worktree-Orchestrator Precheck (GH-427)
+
+**Run this BEFORE the first Swarm Dispatch.** When the
+orchestrator session itself runs from a worktree whose physical
+root is *outside* the main repository tree (e.g. CWD is
+`/work/dx/.worktrees/<name>` while the repo lives at
+`/work/dx/<repo>`), `isolation="worktree"` agents land their
+ephemeral worktrees under `<repo>/.claude/worktrees/agent-<id>/`
+— a path the orchestrator cannot reach. `EnterWorktree(path=…)`
+rejects the switch ("not inside the repository at …") because
+the orchestrator's CWD is outside that repo root, so the GH-399
+F2 recovery sequence is unavailable and a mid-lifecycle agent
+(see ANTI-STALL CONTRACT) cannot be salvaged except by
+cherry-picking from the shared object store.
+
+**Detection (no subshell — two reads):**
+
+```
+git rev-parse --show-toplevel      # orchestrator worktree root
+git rev-parse --git-common-dir     # shared .git → the main repo root
+```
+
+If `--show-toplevel` is NOT a path prefix of the directory that
+holds `--git-common-dir`'s parent repo (i.e. the orchestrator is
+a sibling worktree, not the main checkout), set
+`worktree_orchestrator = true`.
+
+**When `worktree_orchestrator` is true, default to serial mode**
+(invoke `Skill(Dev10x:work-on)` inline, sequentially — see Serial
+fallback below) rather than dispatching a swarm that cannot be
+recovered. Announce the downgrade: "Orchestrator runs from a
+sibling worktree (cross-repo root); using serial mode per
+GH-427." The supervisor may override and force the swarm, but
+only with the cherry-pick salvage path (DONE_WITH_CONCERNS
+recovery, below) understood as the only recovery route.
+
 ### Swarm Dispatch (REQUIRED, GH-36)
 
 **Every work item MUST be delegated to a worktree-isolated
@@ -413,6 +471,13 @@ ANTI-STALL CONTRACT (highest priority — read before invoking work-on):
 - Do NOT stop after branch creation or after PR creation.
   Run straight through: branch → implement → commit → push →
   PR → CI monitor → merge. Every step is mandatory.
+- COMMIT EARLY (GH-427): reach a committed (ideally pushed)
+  state as soon as the change compiles — before deep test
+  polishing or refactoring. The commit is your durable
+  checkpoint: if your turn ends mid-lifecycle, the orchestrator
+  can salvage a committed SHA from the shared object store, but
+  uncommitted files in your ephemeral worktree are lost when the
+  worktree is reclaimed.
 - After work-on returns, if the PR is open but not merged,
   that is NOT done. Invoke Skill(Dev10x:gh-pr-monitor) and
   then Skill(Dev10x:gh-pr-merge) to complete.


### PR DESCRIPTION
**When** I run `Dev10x:fanout` from a sibling worktree or over items whose child worktrees fall outside the spawned-agent allowlist, **I want to** have the orchestrator detect the unsafe setup and keep child branches writable and base-safe, **so I can** trust the swarm to ship (or cleanly fall back to serial) instead of stranding agents and contaminating base PRs.

---

[`654982a3`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/429/commits/654982a325c7c54cbfe60369bf28a9c022c36043) 🐛 GH-427 Survive fanout dispatch from a sibling worktree
[`cf196869`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/429/commits/cf196869c617be8f8ad8c8991bbd159322ed9d80) 🐛 GH-424 Keep swarm child worktrees writable and base-safe
Closes #424
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/427

---