### PR TITLE
✨ GH-340 Serve review/commit/jtbd templates as MCP prompts

### DIFF
--- a/src/dev10x/mcp/knowledge_prompts.py
+++ b/src/dev10x/mcp/knowledge_prompts.py
@@ -1,0 +1,85 @@
+"""MCP prompt registrations for Dev10x workflow templates (GH-340).
+
+Exposes reusable, parametrized prompt templates as MCP prompts so
+clients can invoke them with argument autocomplete instead of
+re-deriving Dev10x conventions by hand. Each prompt mirrors the
+intent of its namesake skill (Dev10x:review, Dev10x:git-commit,
+Dev10x:jtbd) without re-implementing the skill's orchestration — the
+returned text is a ready-to-run instruction the client model acts on.
+
+Prompts:
+    review(target, focus)    — structured self-review instruction
+    commit(summary, ticket)  — Dev10x-formatted commit message
+    jtbd(context)            — JTBD Job Story draft
+
+Function parameters become the prompt's arguments (required when they
+have no default, optional otherwise), which clients surface as
+argument autocomplete. Registered on import via the FastMCP
+``@server.prompt()`` decorator; ``server_cli.py`` imports this module
+to trigger registration.
+"""
+
+from __future__ import annotations
+
+from dev10x.mcp._app import server
+
+
+@server.prompt(
+    name="review",
+    title="Dev10x self-review",
+    description="Review a branch or diff against Dev10x review guidelines",
+)
+def review(target: str = "the current branch", focus: str = "") -> str:
+    """Return a structured review instruction for *target*."""
+    focus_line = f"\nFocus especially on: {focus}." if focus.strip() else ""
+    return (
+        f"Review {target} against the project's code-review guidelines."
+        f"{focus_line}\n\n"
+        "Cover correctness, tests, architecture, and security. For each "
+        "finding, report severity (ERROR/WARNING/INFO), file:line, a short "
+        "description, and a suggested fix. Skip pure style preferences no "
+        "documented rule covers. End with a one-line verdict: ship, "
+        "fix-then-ship, or needs-discussion."
+    )
+
+
+@server.prompt(
+    name="commit",
+    title="Dev10x commit message",
+    description="Draft a gitmoji + ticket + JTBD-outcome commit message",
+)
+def commit(summary: str, ticket: str = "") -> str:
+    """Return commit-message drafting guidance for *summary*."""
+    ticket_line = (
+        f"Use ticket id `{ticket}` in the title and a `Fixes: {ticket}` footer."
+        if ticket.strip()
+        else "Extract the ticket id from the branch name; if none, omit the "
+        "ticket reference and the Fixes footer."
+    )
+    return (
+        f"Draft a commit message for this change: {summary}\n\n"
+        "Format:\n"
+        "- Title: `<gitmoji> <TICKET-ID> <outcome>` — describe what the change "
+        "ENABLES (e.g. 'Enable X'), not what was added. Max 72 characters.\n"
+        f"- {ticket_line}\n"
+        "- Body: one short paragraph on the problem, then a `Solution:` list "
+        "of bullet points.\n"
+        "- No Co-Authored-By footer."
+    )
+
+
+@server.prompt(
+    name="jtbd",
+    title="Dev10x Job Story",
+    description="Draft a JTBD Job Story for a ticket, PR, or feature",
+)
+def jtbd(context: str) -> str:
+    """Return a JTBD Job Story drafting instruction for *context*."""
+    return (
+        f"Draft a JTBD Job Story for: {context}\n\n"
+        "Use first-person, situation-driven voice in exactly this shape:\n"
+        "**When** <situation>, **I want to** <motivation>, **so I can** "
+        "<expected outcome>.\n\n"
+        "Name the actor and beneficiary explicitly. Describe the outcome, not "
+        "the implementation. Keep it to one or two sentences."
+    )

--- a/src/dev10x/mcp/server_cli.py
+++ b/src/dev10x/mcp/server_cli.py
@@ -25,11 +25,13 @@ from __future__ import annotations
 # inherits the MCP server's startup CWD).
 # Importing the tool modules triggers @server.tool() registration.
 # Importing knowledge_resources triggers @server.resource() registration
-# (GH-339).
+# (GH-339). Importing knowledge_prompts triggers @server.prompt()
+# registration (GH-340).
 from dev10x.mcp import (  # noqa: E402, F401
     audit_tools,
     git_tools,
     github_tools,
+    knowledge_prompts,
     knowledge_resources,
     misc_tools,
     plan_tools,

--- a/tests/mcp/test_knowledge_prompts.py
+++ b/tests/mcp/test_knowledge_prompts.py
@@ -1,0 +1,94 @@
+"""Tests for the Dev10x MCP knowledge prompts (GH-340).
+
+Covers:
+- review prompt with and without a focus argument
+- commit prompt with and without a ticket argument
+- jtbd prompt structure
+- registration smoke test (all three prompts registered)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+knowledge_prompts = pytest.importorskip(
+    "dev10x.mcp.knowledge_prompts",
+    reason="mcp not installed",
+)
+
+
+# ── review ─────────────────────────────────────────────────────────
+
+
+class TestReview:
+    def test_default_target_is_current_branch(self) -> None:
+        result = knowledge_prompts.review()
+
+        assert "Review the current branch" in result
+        assert "severity" in result
+
+    def test_named_target_is_interpolated(self) -> None:
+        result = knowledge_prompts.review(target="PR #42")
+
+        assert "Review PR #42" in result
+
+    def test_focus_line_appended_when_provided(self) -> None:
+        result = knowledge_prompts.review(focus="payment retries")
+
+        assert "Focus especially on: payment retries." in result
+
+    def test_focus_line_omitted_when_blank(self) -> None:
+        result = knowledge_prompts.review(focus="   ")
+
+        assert "Focus especially on" not in result
+
+
+# ── commit ─────────────────────────────────────────────────────────
+
+
+class TestCommit:
+    def test_summary_is_interpolated(self) -> None:
+        result = knowledge_prompts.commit(summary="add retry logic")
+
+        assert "add retry logic" in result
+        assert "Max 72 characters" in result
+
+    def test_ticket_drives_fixes_footer(self) -> None:
+        result = knowledge_prompts.commit(summary="fix timeout", ticket="GH-9")
+
+        assert "GH-9" in result
+        assert "Fixes: GH-9" in result
+
+    def test_no_ticket_falls_back_to_branch_extraction(self) -> None:
+        result = knowledge_prompts.commit(summary="fix timeout")
+
+        assert "Extract the ticket id from the branch name" in result
+        assert "Fixes:" not in result
+
+
+# ── jtbd ───────────────────────────────────────────────────────────
+
+
+class TestJtbd:
+    def test_returns_job_story_template(self) -> None:
+        result = knowledge_prompts.jtbd(context="GH-340 MCP prompts")
+
+        assert "GH-340 MCP prompts" in result
+        assert "**When**" in result
+        assert "**I want to**" in result
+        assert "**so I can**" in result
+
+
+# ── registration smoke test ────────────────────────────────────────
+
+
+class TestPromptsRegistered:
+    """Verify the prompts are registered with the server."""
+
+    @pytest.mark.parametrize("name", ["review", "commit", "jtbd"])
+    def test_prompt_is_registered(self, name: str) -> None:
+        from dev10x.mcp._app import server
+
+        prompts = server._prompt_manager.list_prompts()
+        names = [p.name for p in prompts]
+        assert name in names


### PR DESCRIPTION
**When** I drive Dev10x from an MCP client, **I want to** invoke the review, commit, and jtbd templates as first-class MCP prompts with argument autocomplete, **so I can** run Dev10x's workflow conventions without re-deriving them by hand each time.

---

[`9d8be912`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/431/commits/9d8be912e45385f7146145208f9ac3141b583907) ✨ GH-340 Serve review/commit/jtbd templates as MCP prompts
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/340

---