### PR TITLE
✨ GH-434 Enable spec-drift action gate for Edit|Write tools

### DIFF
--- a/src/dev10x/hooks/edit_validator.py
+++ b/src/dev10x/hooks/edit_validator.py
@@ -1,7 +1,14 @@
-"""Edit/Write tool validator — blocks sensitive file writes.
+"""Edit/Write tool validator — blocks sensitive file writes and spec drift.
 
-Loads rules from command-skill-map.yaml where matcher="Edit|Write",
-delegates evaluation to RuleEngine. First block wins.
+Two validation passes:
+
+1. YAML-rule pass: loads rules from command-skill-map.yaml where
+   matcher="Edit|Write", delegates evaluation to RuleEngine.
+   First block wins.
+
+2. Python-validator pass: runs active Edit|Write validators from the
+   shared ValidatorRegistry (e.g. SpecDriftValidator / DX015).
+   Only validators whose ``should_run()`` returns True participate.
 """
 
 from __future__ import annotations
@@ -10,7 +17,7 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from dev10x.domain.events.hook_input import HookResult
+from dev10x.domain.events.hook_input import HookInput, HookResult
 
 if TYPE_CHECKING:
     from dev10x.domain.rules.rule_engine import RuleEngine
@@ -24,6 +31,28 @@ def _build_engine(*, yaml_path: Path) -> RuleEngine:
 
     config = load_config(yaml_path=yaml_path)
     return RuleEngine.from_config(config=config)
+
+
+def _run_python_validators(*, data: dict[str, Any], debug: bool = False) -> None:
+    """Run Python validators that handle Edit|Write tool calls.
+
+    Mirrors the dispatch pattern in ``commands/hook.py:_validate_bash_body``
+    but filters to validators whose ``should_run`` returns True for the
+    given Edit|Write input.  YAML-rule blocks have already been handled
+    before this function is called.
+    """
+    from dev10x.validators import get_chain
+
+    inp = HookInput.from_dict(data=data)
+    for result in get_chain().run(inp=inp):
+        if debug:
+            import sys as _sys
+
+            print(
+                f"[DEBUG] Python validator blocked: {result}",
+                file=_sys.stderr,
+            )
+        result.emit()
 
 
 def validate_edit_write(
@@ -54,5 +83,7 @@ def validate_edit_write(
                 file=sys.stderr,
             )
         HookResult(message=match.message).emit()
+
+    _run_python_validators(data=data, debug=debug)
 
     sys.exit(0)

--- a/src/dev10x/validators/__init__.py
+++ b/src/dev10x/validators/__init__.py
@@ -125,6 +125,13 @@ _SPECS: list[ValidatorSpec] = [
         rule_id="DX014",
         profile=ProfileTier.STANDARD,
     ),
+    ValidatorSpec(
+        module_path="dev10x.validators.spec_drift",
+        class_name="SpecDriftValidator",
+        rule_id="DX015",
+        profile=ProfileTier.STANDARD,
+        experimental=True,
+    ),
 ]
 
 

--- a/src/dev10x/validators/spec_drift.py
+++ b/src/dev10x/validators/spec_drift.py
@@ -1,0 +1,185 @@
+"""Validator: block spec-governed edits when the spec is untouched (DX015).
+
+Implements the spec-first Golden Rule as action backpressure on
+``PreToolUse Edit|Write``: if the branch carries a ticket ID that
+maps to an active ``docs/specs/<TICKET-ID>.md``, and that spec file
+is **not** in the current git working set (staged or unstaged
+changes), warn before any source edit is applied.
+
+This moves the Golden Rule from "skill-if-invoked" (output
+backpressure via ``Dev10x:spec-update``) to "hook-always" (action
+backpressure that fires whenever the spec is untouched).
+
+Spawned from GH-430 recommendation P2. Full spec: GH-434.
+
+Design notes
+------------
+* ``should_run`` returns False for non-Edit/Write tools, for edits to
+  the spec file itself, and when no active spec can be found.
+* ``validate`` runs ``git diff --name-only HEAD`` to get the working
+  set, then checks whether the spec path is present.
+* Git failures (no repo, git not installed) silently pass — the hook
+  must not block CI runners or fresh checkouts.
+* The validator is ``experimental=True`` on first ship so users who
+  do not use SPDD can opt out with ``DEV10X_HOOK_EXPERIMENTAL=0``.
+  Once the adoption rate is confirmed, flip to ``experimental=False``.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import ClassVar
+
+from dev10x.domain import HookInput, HookResult
+from dev10x.domain.profile_tier import ProfileTier
+from dev10x.validators.base import ValidatorBase
+
+_TICKET_RE = re.compile(r"(?:^|/)([A-Z]+-\d+|GH-\d+)(?:/|$)", re.IGNORECASE)
+_SPECS_SUBDIR = "docs/specs"
+
+_WARN_MSG_TEMPLATE = """\
+⚠️  Spec-drift gate (DX015): spec exists but is untouched in the working set.
+
+Editing:   {file_path}
+Spec:      {spec_path}
+Ticket:    {ticket_id}
+
+The Golden Rule (ADR-0005) says: fix the prompt first, then regenerate.
+You are about to edit a source file while the canonical spec at
+``{spec_path}`` has not been touched in the current working set.
+
+Options:
+  1. Run ``Dev10x:spec-update`` first to update the spec, then regenerate.
+  2. Edit the spec file directly (``{spec_path}``) before this file.
+  3. Disable this check for the session: ``DEV10X_HOOK_DISABLE=DX015``.
+
+See ``.claude/rules/hook-patterns.md`` — DX015 / spec-drift — for details.
+"""
+
+
+def _branch_ticket_id(*, cwd: str) -> str | None:
+    """Return the first ticket-id found in the current branch name, or None."""
+    try:
+        branch = subprocess.check_output(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+            cwd=cwd or None,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return None
+    match = _TICKET_RE.search(branch)
+    if match:
+        return match.group(1).upper()
+    return None
+
+
+def _repo_toplevel(*, cwd: str) -> str | None:
+    """Return the git repository toplevel, or None if not a git repo."""
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+            cwd=cwd or None,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return None
+
+
+def _working_set_paths(*, cwd: str) -> set[str]:
+    """Return file paths present in staged + unstaged working set.
+
+    Uses ``git status --porcelain`` so the result includes both
+    index-staged (A/M) and working-tree-changed (??/M) entries.
+    Returns an empty set on any git error.
+    """
+    try:
+        output = subprocess.check_output(
+            ["git", "status", "--porcelain"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+            cwd=cwd or None,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return set()
+    paths: set[str] = set()
+    for line in output.splitlines():
+        # porcelain format: "XY filename" or "XY old -> new" for renames
+        if len(line) < 4:
+            continue
+        rest = line[3:].strip()
+        if " -> " in rest:
+            rest = rest.split(" -> ", 1)[1]
+        paths.add(rest.strip())
+    return paths
+
+
+@dataclass
+class SpecDriftValidator(ValidatorBase):
+    """Warn before editing a source file when the active spec is untouched.
+
+    Checks:
+    1. Tool is Edit or Write (skips Bash).
+    2. Branch carries a ticket ID (e.g. GH-434 in
+       ``janusz/GH-434/feature-name``).
+    3. A canonical spec ``docs/specs/<TICKET-ID>.md`` exists in the repo.
+    4. The spec file is NOT in the current git working set.
+
+    When all four conditions hold the validator emits a blocking
+    ``HookResult`` with remediation guidance.
+
+    Git errors (not a repo, git not installed, bare clone) are silently
+    swallowed so the hook never interferes with CI or non-git contexts.
+    """
+
+    name: ClassVar[str] = "spec-drift"
+    rule_id: ClassVar[str] = "DX015"
+    profile: ClassVar[ProfileTier] = ProfileTier.STANDARD
+    experimental: ClassVar[bool] = True
+
+    _cwd_override: str | None = field(default=None, repr=False)
+
+    def should_run(self, inp: HookInput) -> bool:
+        """Fast skip: only fires for Edit/Write, never for the spec file itself."""
+        if inp.tool_name not in ("Edit", "Write"):
+            return False
+        file_path = inp.raw.get("tool_input", {}).get("file_path", "")
+        if not file_path:
+            return False
+        if _SPECS_SUBDIR in file_path:
+            return False
+        return True
+
+    def validate(self, inp: HookInput) -> HookResult | None:
+        """Return a HookResult if the spec exists but is untouched."""
+        cwd = self._cwd_override or inp.cwd or ""
+        file_path: str = inp.raw.get("tool_input", {}).get("file_path", "")
+
+        ticket_id = _branch_ticket_id(cwd=cwd)
+        if not ticket_id:
+            return None
+
+        toplevel = _repo_toplevel(cwd=cwd)
+        if not toplevel:
+            return None
+
+        spec_rel = f"{_SPECS_SUBDIR}/{ticket_id}.md"
+        spec_path = Path(toplevel) / spec_rel
+        if not spec_path.exists():
+            return None
+
+        working_set = _working_set_paths(cwd=cwd)
+        if spec_rel in working_set:
+            return None
+
+        return HookResult(
+            message=_WARN_MSG_TEMPLATE.format(
+                file_path=file_path,
+                spec_path=spec_rel,
+                ticket_id=ticket_id,
+            )
+        )

--- a/tests/validators/test_spec_drift.py
+++ b/tests/validators/test_spec_drift.py
@@ -1,0 +1,468 @@
+"""Tests for SpecDriftValidator (DX015).
+
+Covers:
+- should_run() fast-skip for non-Edit/Write tools
+- should_run() skip when editing the spec file itself
+- validate() skips when no spec exists (no docs/specs/ in repo)
+- validate() skips when branch has no ticket ID
+- validate() skips when spec is already in working set
+- validate() returns HookResult when spec exists but untouched
+- Message format: references DX015, spec path, ticket ID, skill
+- Registry integration: DX015 in standard profile only with experimental flag
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from dev10x.domain import HookInput
+from dev10x.domain.profile_tier import ProfileTier
+from dev10x.validators import get_validators, reset_registry
+from dev10x.validators.spec_drift import (
+    SpecDriftValidator,
+    _branch_ticket_id,
+    _repo_toplevel,
+    _working_set_paths,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _edit_inp(
+    *,
+    file_path: str = "/work/repo/src/foo.py",
+    tool_name: str = "Edit",
+    cwd: str = "/work/repo",
+) -> HookInput:
+    raw: dict[str, Any] = {
+        "tool_name": tool_name,
+        "tool_input": {
+            "file_path": file_path,
+            "old_string": "before",
+            "new_string": "after",
+        },
+    }
+    return HookInput(
+        tool_name=tool_name,
+        command="",
+        raw=raw,
+        cwd=cwd,
+    )
+
+
+@pytest.fixture()
+def validator() -> SpecDriftValidator:
+    return SpecDriftValidator()
+
+
+# ---------------------------------------------------------------------------
+# should_run
+# ---------------------------------------------------------------------------
+
+
+class TestShouldRun:
+    def test_bash_tool_skipped(self, validator: SpecDriftValidator) -> None:
+        inp = HookInput(
+            tool_name="Bash",
+            command="ls -la",
+            raw={"tool_name": "Bash", "tool_input": {"command": "ls -la"}},
+        )
+        assert validator.should_run(inp=inp) is False
+
+    def test_read_tool_skipped(self, validator: SpecDriftValidator) -> None:
+        inp = _edit_inp(tool_name="Read")
+        assert validator.should_run(inp=inp) is False
+
+    def test_edit_tool_runs(self, validator: SpecDriftValidator) -> None:
+        inp = _edit_inp(tool_name="Edit")
+        assert validator.should_run(inp=inp) is True
+
+    def test_write_tool_runs(self, validator: SpecDriftValidator) -> None:
+        inp = _edit_inp(tool_name="Write", file_path="/work/repo/src/new_module.py")
+        assert validator.should_run(inp=inp) is True
+
+    def test_editing_spec_file_skipped(self, validator: SpecDriftValidator) -> None:
+        inp = _edit_inp(file_path="/work/repo/docs/specs/GH-434.md")
+        assert validator.should_run(inp=inp) is False
+
+    def test_empty_file_path_skipped(self, validator: SpecDriftValidator) -> None:
+        inp = _edit_inp(file_path="")
+        assert validator.should_run(inp=inp) is False
+
+    def test_spec_subdir_in_path_skipped(self, validator: SpecDriftValidator) -> None:
+        inp = _edit_inp(file_path="/work/repo/docs/specs/FEAT-123.md")
+        assert validator.should_run(inp=inp) is False
+
+
+# ---------------------------------------------------------------------------
+# _branch_ticket_id
+# ---------------------------------------------------------------------------
+
+
+class TestBranchTicketId:
+    def test_extracts_gh_ticket(self) -> None:
+        with patch("subprocess.check_output", return_value="janusz/GH-434/feature\n"):
+            result = _branch_ticket_id(cwd="/work/repo")
+        assert result == "GH-434"
+
+    def test_extracts_feat_ticket(self) -> None:
+        with patch("subprocess.check_output", return_value="user/FEAT-123/something\n"):
+            result = _branch_ticket_id(cwd="/work/repo")
+        assert result == "FEAT-123"
+
+    def test_returns_none_for_no_ticket(self) -> None:
+        with patch("subprocess.check_output", return_value="main\n"):
+            result = _branch_ticket_id(cwd="/work/repo")
+        assert result is None
+
+    def test_returns_none_on_git_error(self) -> None:
+        with patch(
+            "subprocess.check_output",
+            side_effect=subprocess.CalledProcessError(128, "git"),
+        ):
+            result = _branch_ticket_id(cwd="/work/repo")
+        assert result is None
+
+    def test_returns_none_when_git_missing(self) -> None:
+        with patch("subprocess.check_output", side_effect=FileNotFoundError()):
+            result = _branch_ticket_id(cwd="/work/repo")
+        assert result is None
+
+    def test_uppercases_ticket_id(self) -> None:
+        with patch("subprocess.check_output", return_value="user/gh-434/feature\n"):
+            result = _branch_ticket_id(cwd="/work/repo")
+        assert result == "GH-434"
+
+
+# ---------------------------------------------------------------------------
+# _repo_toplevel
+# ---------------------------------------------------------------------------
+
+
+class TestRepoToplevel:
+    def test_returns_toplevel(self) -> None:
+        with patch("subprocess.check_output", return_value="/work/repo\n"):
+            result = _repo_toplevel(cwd="/work/repo")
+        assert result == "/work/repo"
+
+    def test_returns_none_on_error(self) -> None:
+        with patch(
+            "subprocess.check_output",
+            side_effect=subprocess.CalledProcessError(128, "git"),
+        ):
+            result = _repo_toplevel(cwd="/some/path")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _working_set_paths
+# ---------------------------------------------------------------------------
+
+
+class TestWorkingSetPaths:
+    def test_parses_modified_file(self) -> None:
+        with patch("subprocess.check_output", return_value=" M docs/specs/GH-434.md\n"):
+            paths = _working_set_paths(cwd="/work/repo")
+        assert "docs/specs/GH-434.md" in paths
+
+    def test_parses_added_file(self) -> None:
+        with patch("subprocess.check_output", return_value="A  docs/specs/NEW-1.md\n"):
+            paths = _working_set_paths(cwd="/work/repo")
+        assert "docs/specs/NEW-1.md" in paths
+
+    def test_parses_rename(self) -> None:
+        with patch(
+            "subprocess.check_output",
+            return_value="R  old/path.md -> new/path.md\n",
+        ):
+            paths = _working_set_paths(cwd="/work/repo")
+        assert "new/path.md" in paths
+
+    def test_returns_empty_on_git_error(self) -> None:
+        with patch(
+            "subprocess.check_output",
+            side_effect=subprocess.CalledProcessError(128, "git"),
+        ):
+            paths = _working_set_paths(cwd="/work/repo")
+        assert paths == set()
+
+    def test_returns_empty_when_git_missing(self) -> None:
+        with patch("subprocess.check_output", side_effect=FileNotFoundError()):
+            paths = _working_set_paths(cwd="/work/repo")
+        assert paths == set()
+
+
+# ---------------------------------------------------------------------------
+# validate() — full integration with mocks
+# ---------------------------------------------------------------------------
+
+
+class TestValidate:
+    def test_returns_none_when_no_ticket_id(self, validator: SpecDriftValidator) -> None:
+        inp = _edit_inp()
+        with patch(
+            "dev10x.validators.spec_drift._branch_ticket_id",
+            return_value=None,
+        ):
+            result = validator.validate(inp=inp)
+        assert result is None
+
+    def test_returns_none_when_no_repo_toplevel(self, validator: SpecDriftValidator) -> None:
+        inp = _edit_inp()
+        with (
+            patch(
+                "dev10x.validators.spec_drift._branch_ticket_id",
+                return_value="GH-434",
+            ),
+            patch(
+                "dev10x.validators.spec_drift._repo_toplevel",
+                return_value=None,
+            ),
+        ):
+            result = validator.validate(inp=inp)
+        assert result is None
+
+    def test_returns_none_when_spec_missing(
+        self, validator: SpecDriftValidator, tmp_path: Path
+    ) -> None:
+        inp = _edit_inp(cwd=str(tmp_path))
+        with (
+            patch(
+                "dev10x.validators.spec_drift._branch_ticket_id",
+                return_value="GH-434",
+            ),
+            patch(
+                "dev10x.validators.spec_drift._repo_toplevel",
+                return_value=str(tmp_path),
+            ),
+            patch(
+                "dev10x.validators.spec_drift._working_set_paths",
+                return_value=set(),
+            ),
+        ):
+            result = validator.validate(inp=inp)
+        assert result is None
+
+    def test_returns_none_when_spec_in_working_set(
+        self, validator: SpecDriftValidator, tmp_path: Path
+    ) -> None:
+        spec_dir = tmp_path / "docs" / "specs"
+        spec_dir.mkdir(parents=True)
+        (spec_dir / "GH-434.md").write_text("# GH-434 spec")
+        inp = _edit_inp(cwd=str(tmp_path))
+        with (
+            patch(
+                "dev10x.validators.spec_drift._branch_ticket_id",
+                return_value="GH-434",
+            ),
+            patch(
+                "dev10x.validators.spec_drift._repo_toplevel",
+                return_value=str(tmp_path),
+            ),
+            patch(
+                "dev10x.validators.spec_drift._working_set_paths",
+                return_value={"docs/specs/GH-434.md"},
+            ),
+        ):
+            result = validator.validate(inp=inp)
+        assert result is None
+
+    def test_blocks_when_spec_exists_and_untouched(
+        self, validator: SpecDriftValidator, tmp_path: Path
+    ) -> None:
+        spec_dir = tmp_path / "docs" / "specs"
+        spec_dir.mkdir(parents=True)
+        (spec_dir / "GH-434.md").write_text("# GH-434 spec")
+        inp = _edit_inp(file_path="/work/repo/src/validators/spec_drift.py", cwd=str(tmp_path))
+        with (
+            patch(
+                "dev10x.validators.spec_drift._branch_ticket_id",
+                return_value="GH-434",
+            ),
+            patch(
+                "dev10x.validators.spec_drift._repo_toplevel",
+                return_value=str(tmp_path),
+            ),
+            patch(
+                "dev10x.validators.spec_drift._working_set_paths",
+                return_value={"src/validators/spec_drift.py"},
+            ),
+        ):
+            result = validator.validate(inp=inp)
+        assert result is not None
+
+    def test_write_tool_also_blocked(self, validator: SpecDriftValidator, tmp_path: Path) -> None:
+        spec_dir = tmp_path / "docs" / "specs"
+        spec_dir.mkdir(parents=True)
+        (spec_dir / "FEAT-999.md").write_text("# FEAT-999 spec")
+        inp = _edit_inp(
+            file_path="/work/repo/src/new_module.py",
+            tool_name="Write",
+            cwd=str(tmp_path),
+        )
+        with (
+            patch(
+                "dev10x.validators.spec_drift._branch_ticket_id",
+                return_value="FEAT-999",
+            ),
+            patch(
+                "dev10x.validators.spec_drift._repo_toplevel",
+                return_value=str(tmp_path),
+            ),
+            patch(
+                "dev10x.validators.spec_drift._working_set_paths",
+                return_value=set(),
+            ),
+        ):
+            result = validator.validate(inp=inp)
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# Message format
+# ---------------------------------------------------------------------------
+
+
+class TestMessageFormat:
+    def _blocked_result(
+        self,
+        validator: SpecDriftValidator,
+        tmp_path: Path,
+        ticket_id: str = "GH-434",
+    ):
+        spec_dir = tmp_path / "docs" / "specs"
+        spec_dir.mkdir(parents=True, exist_ok=True)
+        (spec_dir / f"{ticket_id}.md").write_text(f"# {ticket_id} spec")
+        inp = _edit_inp(file_path="/work/repo/src/foo.py", cwd=str(tmp_path))
+        with (
+            patch(
+                "dev10x.validators.spec_drift._branch_ticket_id",
+                return_value=ticket_id,
+            ),
+            patch(
+                "dev10x.validators.spec_drift._repo_toplevel",
+                return_value=str(tmp_path),
+            ),
+            patch(
+                "dev10x.validators.spec_drift._working_set_paths",
+                return_value=set(),
+            ),
+        ):
+            return validator.validate(inp=inp)
+
+    def test_message_contains_rule_id(self, validator: SpecDriftValidator, tmp_path: Path) -> None:
+        result = self._blocked_result(validator, tmp_path)
+        assert result is not None
+        assert "DX015" in result.message
+
+    def test_message_contains_ticket_id(
+        self, validator: SpecDriftValidator, tmp_path: Path
+    ) -> None:
+        result = self._blocked_result(validator, tmp_path)
+        assert result is not None
+        assert "GH-434" in result.message
+
+    def test_message_contains_spec_path(
+        self, validator: SpecDriftValidator, tmp_path: Path
+    ) -> None:
+        result = self._blocked_result(validator, tmp_path)
+        assert result is not None
+        assert "docs/specs/GH-434.md" in result.message
+
+    def test_message_references_spec_update_skill(
+        self, validator: SpecDriftValidator, tmp_path: Path
+    ) -> None:
+        result = self._blocked_result(validator, tmp_path)
+        assert result is not None
+        assert "spec-update" in result.message
+
+    def test_message_references_hook_patterns(
+        self, validator: SpecDriftValidator, tmp_path: Path
+    ) -> None:
+        result = self._blocked_result(validator, tmp_path)
+        assert result is not None
+        assert "hook-patterns.md" in result.message
+
+    def test_message_contains_edited_file_path(
+        self, validator: SpecDriftValidator, tmp_path: Path
+    ) -> None:
+        result = self._blocked_result(validator, tmp_path)
+        assert result is not None
+        assert "/work/repo/src/foo.py" in result.message
+
+
+# ---------------------------------------------------------------------------
+# Registry integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    reset_registry()
+    yield
+    reset_registry()
+
+
+class TestRegistryIntegration:
+    def test_dx015_absent_in_standard_without_experimental(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("DEV10X_HOOK_PROFILE", raising=False)
+        monkeypatch.delenv("DEV10X_HOOK_EXPERIMENTAL", raising=False)
+        validators = get_validators()
+        rule_ids = {v.rule_id for v in validators}
+        assert "DX015" not in rule_ids
+
+    def test_dx015_present_in_standard_with_experimental(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("DEV10X_HOOK_PROFILE", raising=False)
+        monkeypatch.setenv("DEV10X_HOOK_EXPERIMENTAL", "1")
+        validators = get_validators()
+        rule_ids = {v.rule_id for v in validators}
+        assert "DX015" in rule_ids
+
+    def test_dx015_absent_in_minimal_even_with_experimental(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DEV10X_HOOK_PROFILE", "minimal")
+        monkeypatch.setenv("DEV10X_HOOK_EXPERIMENTAL", "1")
+        validators = get_validators()
+        rule_ids = {v.rule_id for v in validators}
+        assert "DX015" not in rule_ids
+
+    def test_dx015_can_be_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_HOOK_EXPERIMENTAL", "1")
+        monkeypatch.setenv("DEV10X_HOOK_DISABLE", "DX015")
+        validators = get_validators()
+        rule_ids = {v.rule_id for v in validators}
+        assert "DX015" not in rule_ids
+
+    def test_validator_instance_is_spec_drift(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_HOOK_EXPERIMENTAL", "1")
+        validators = get_validators()
+        spec_drift_validators = [v for v in validators if v.rule_id == "DX015"]
+        assert len(spec_drift_validators) == 1
+        assert isinstance(spec_drift_validators[0], SpecDriftValidator)
+
+    def test_validator_profile_is_standard(self) -> None:
+        v = SpecDriftValidator()
+        assert v.profile is ProfileTier.STANDARD
+
+    def test_validator_is_experimental(self) -> None:
+        v = SpecDriftValidator()
+        assert v.experimental is True
+
+    def test_rule_ids_remain_unique(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_HOOK_PROFILE", "strict")
+        monkeypatch.setenv("DEV10X_HOOK_EXPERIMENTAL", "1")
+        validators = get_validators()
+        rule_ids = [v.rule_id for v in validators]
+        assert len(rule_ids) == len(set(rule_ids)), f"Duplicate rule_ids: {rule_ids}"


### PR DESCRIPTION
When I edit source files on a ticket branch that has an active canonical spec, I want the hook to warn me before the edit lands so I can update the spec first and keep the Golden Rule enforced automatically.

---

[`7709a5f4`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/438/commits/7709a5f4dff69431483c7ee68810f698886fb2c6) ✨ GH-434 Enable spec-drift action gate for Edit|Write tools
Fixes: https://github.com/Dev10x-Guru/dev10x-claude/issues/434

---