### PR TITLE
✨ GH-433 Enable CI-enforced coverage threshold on hook tests

### DIFF
--- a/.coveragerc-hooks
+++ b/.coveragerc-hooks
@@ -1,0 +1,8 @@
+[run]
+omit =
+    src/dev10x/hooks/scripts/*
+
+[report]
+exclude_lines =
+    if __name__
+    pragma: no cover

--- a/.github/workflows/pytest-hooks.yml
+++ b/.github/workflows/pytest-hooks.yml
@@ -34,5 +34,11 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
 
-      - name: Run hook tests
-        run: uv run --extra dev pytest tests/hooks/ -v --tb=short -o 'addopts='
+      - name: Run hook tests with coverage
+        run: |
+          uv run --extra dev pytest tests/hooks/ \
+            -v --tb=short \
+            -o 'addopts=' \
+            --cov=src/dev10x/hooks \
+            --cov-config=.coveragerc-hooks \
+            --cov-report=term-missing --cov-fail-under=70

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Dev10x"
-version = "0.77.0"
+version = "0.78.0.dev0"
 description = "Claude Code plugin providing reusable skills, hooks, and commands"
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -63,7 +63,7 @@ addopts = "--cov=src/dev10x --cov-report=term-missing"
 source = ["src/dev10x"]
 
 [tool.coverage.report]
-fail_under = 38
+fail_under = 75
 show_missing = true
 exclude_lines = ["if __name__", "pragma: no cover"]
 


### PR DESCRIPTION
**When** a PR modifies hook code, **I want** CI to automatically verify coverage does not regress below the established threshold, **so** coverage discipline is machine-enforced rather than agent-dependent.

---

[`c00a639d`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/440/commits/c00a639de2ce3fbcf15df41fd832c41255a794c7) ✨ GH-433 Enable CI-enforced coverage threshold on hook tests
Fixes: https://github.com/Dev10x-Guru/dev10x-claude/issues/433

---