### PR TITLE
✨ GH-432 Enable CI-gated performance-regression detection

### DIFF
--- a/.github/workflows/pytest-bench.yml
+++ b/.github/workflows/pytest-bench.yml
@@ -38,11 +38,9 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
 
-      - name: Install package
-        run: uv pip install --system -e ".[dev]"
-
       - name: Restore benchmark baseline
-        uses: actions/cache@v4
+        id: cache-benchmarks
+        uses: actions/cache/restore@v4
         with:
           path: .benchmarks
           key: benchmarks-${{ github.base_ref || github.ref_name }}-${{ github.sha }}
@@ -50,7 +48,16 @@ jobs:
             benchmarks-${{ github.base_ref || github.ref_name }}-
             benchmarks-develop-
 
-      - name: Run benchmark gate tests
+      - name: Run benchmarks (first run — save baseline)
+        if: steps.cache-benchmarks.outputs.cache-hit != 'true'
+        run: |
+          uv run --extra dev pytest tests/benchmarks/ \
+            --benchmark-only \
+            --benchmark-autosave \
+            -v --tb=short -o 'addopts='
+
+      - name: Run benchmarks (compare against baseline)
+        if: steps.cache-benchmarks.outputs.cache-hit == 'true'
         run: |
           uv run --extra dev pytest tests/benchmarks/ \
             --benchmark-only \
@@ -58,8 +65,6 @@ jobs:
             --benchmark-compare \
             --benchmark-compare-fail=mean:20% \
             -v --tb=short -o 'addopts='
-        env:
-          BENCHMARK_STORAGE: .benchmarks
 
       - name: Save benchmark results
         if: github.ref == 'refs/heads/develop'

--- a/.github/workflows/pytest-bench.yml
+++ b/.github/workflows/pytest-bench.yml
@@ -1,0 +1,69 @@
+name: Benchmark Gate
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - "hooks/**"
+      - "src/dev10x/**"
+      - "tests/benchmarks/**"
+      - "tests/fixtures/startup_baseline.json"
+      - "pyproject.toml"
+      - ".github/workflows/pytest-bench.yml"
+  pull_request:
+    branches: [develop]
+    paths:
+      - "hooks/**"
+      - "src/dev10x/**"
+      - "tests/benchmarks/**"
+      - "tests/fixtures/startup_baseline.json"
+      - "pyproject.toml"
+      - ".github/workflows/pytest-bench.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install package
+        run: uv pip install --system -e ".[dev]"
+
+      - name: Restore benchmark baseline
+        uses: actions/cache@v4
+        with:
+          path: .benchmarks
+          key: benchmarks-${{ github.base_ref || github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            benchmarks-${{ github.base_ref || github.ref_name }}-
+            benchmarks-develop-
+
+      - name: Run benchmark gate tests
+        run: |
+          uv run --extra dev pytest tests/benchmarks/ \
+            --benchmark-only \
+            --benchmark-autosave \
+            --benchmark-compare \
+            --benchmark-compare-fail=mean:20% \
+            -v --tb=short -o 'addopts='
+        env:
+          BENCHMARK_STORAGE: .benchmarks
+
+      - name: Save benchmark results
+        if: github.ref == 'refs/heads/develop'
+        uses: actions/cache/save@v4
+        with:
+          path: .benchmarks
+          key: benchmarks-develop-${{ github.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ __pycache__/
 build/
 dist/
 
+# Benchmark run artefacts (CI caches these; local runs produce them)
+.benchmarks/
+
 # Claude Code local settings
 .claude/settings.local.json
 .claude/settings.local.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,5 +74,15 @@ src = ["src"]
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP"]
 
+[tool.pytest_benchmark]
+# Store baselines in .benchmarks/ (gitignored per-run, cached by CI)
+storage = "file"
+# Fail on mean regression > 20% vs stored baseline
+compare_fail = ["mean:20%"]
+# Minimum rounds so outliers don't skew results
+min_rounds = 5
+timer = "perf_counter"
+disable_gc = true
+
 [tool.mypy]
 mypy_path = "src"


### PR DESCRIPTION
**When** I push changes that affect hook latency or startup time, **I want to** see the benchmark run against a stored baseline automatically, **so I can** catch performance regressions before they merge to develop.

---

[`c523ac00`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/441/commits/c523ac00b2690fbba88fdcad49ae4ea37e428bb5) ✨ GH-432 Enable CI-gated performance-regression detection
[`89433aba`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/441/commits/89433aba74fa1d6a9d634c51667c2b02e52426b8) 🐛 GH-432 Fix benchmark workflow install and first-run

Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/432