### PR TITLE
📝 Document DX014/DX015 rules, backpressure ref, perf CI gate

### DIFF
--- a/.claude/rules/INDEX.md
+++ b/.claude/rules/INDEX.md
@@ -92,6 +92,7 @@ Always apply `references/review-checks-common.md`.
 | `testing-patterns.md` | Pytest fixture composition, async handlers, parametrized tests | Code reviews, test authoring | Referenced, not auto-loaded |
 | `pr-backlog-deferral.md` | Deferring non-blocking review findings to a backlog | `Dev10x:gh-pr-review` skill, code review CI | Referenced, not auto-loaded |
 | `milestone-naming.md` | Milestone naming convention, initiative prefixes (AUD-Mn vs MCP-Mn) | `Dev10x:project-scope`, `Dev10x:work-on` milestone steps | Referenced, not auto-loaded |
+| `backpressure.md` | Two-direction backpressure architecture (action gating + friction tuning + output gates) | Review & architecture docs, code review CI | Referenced, not auto-loaded |
 
 ## Agent Specs (`.claude/agents/`)
 

--- a/.claude/rules/hook-patterns.md
+++ b/.claude/rules/hook-patterns.md
@@ -170,6 +170,8 @@ higher tiers — `minimal` rules are always active.
 | DX011 | pipeline-allow | standard |
 | DX012 | safe-expansion | minimal |
 | DX013 | mcp-prefix | standard |
+| DX014 | sensitivity-target | standard |
+| DX015 | spec-drift | standard (experimental) |
 
 ### Configuration
 

--- a/.claude/rules/performance.md
+++ b/.claude/rules/performance.md
@@ -26,6 +26,20 @@ These are click framework and Python stdlib — not optimizable
 without replacing the framework. Current lazy loading covers
 all dev10x subcommands.
 
+## CI Gate (GH-432)
+
+The benchmark suite is wired into CI as a backpressure gate.
+`.github/workflows/pytest-bench.yml` runs `tests/benchmarks/` with
+`pytest-benchmark` on every PR, comparing each run against a cached
+baseline. The job **fails on a mean regression greater than 20%**
+via `--benchmark-compare-fail=mean:20%`, so a perf regression in
+hook latency or CLI startup blocks merge rather than shipping
+undetected.
+
+Per-run artefacts under `.benchmarks/` are git-ignored. To inspect
+a regression locally, run the benchmark tests and compare against
+the stored baseline before pushing.
+
 ## Monitoring
 
 Run `time uv run dev10x --help` after dependency changes.


### PR DESCRIPTION
**When** fanout ships PRs from isolated worktrees, **I want to** apply the `.claude/rules/**` index rows for new validators, references, and CI gates in the canonical worktree, **so I can** keep the rule index consistent even when GH-376 blocks path-scoped edits in ephemeral worktrees.

---

[`70295a55`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/443/commits/70295a5541514c44ef353b23b21a6a0d93e0c47f) 📝 Document DX014/DX015 rules, backpressure ref, perf CI gate

---