### PR TITLE
📝 GH-444 Correct duplicate placeholder in investigate Common Mistakes

### DIFF
--- a/skills/investigate/SKILL.md
+++ b/skills/investigate/SKILL.md
@@ -173,4 +173,4 @@ ${CLAUDE_PLUGIN_ROOT}/skills/investigate/scripts/reply.sh "$channel_id" "$thread
 | Skipping user approval before posting | Message goes out with errors you can't take back |
 | Creating a ticket for a one-liner fix | Ticket noise, distracts the team |
 | Not reading thread replies | Duplicating investigation someone already did |
-| Using this skill for a Sentry URL with a domain-specific error | This skill is for Slack threads. If the Sentry error is about Square Terminal or payments, use `app-debug-payments` or `app-debug-payments` instead — they have pre-built SQL, decision trees, and scripts for those errors |
+| Using this skill for a Sentry URL with a domain-specific error | This skill is for Slack threads. If the Sentry error is about Square Terminal or payments, use `app-debug-terminal` or `app-debug-payments` instead — they have pre-built SQL, decision trees, and scripts for those errors |


### PR DESCRIPTION
**When** I follow the `investigate` skill's routing guidance for domain-specific Sentry errors, **I want to** see two distinct skill names in the Common Mistakes table, **so I can** route Square Terminal errors to the right debug skill instead of guessing.

---

[`935390a8`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/449/commits/935390a882e7204e9a49f6d9d95eb57cece502b9) 📝 GH-444 Correct duplicate placeholder in investigate Common Mistakes

Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/444