### PR TITLE
📝 GH-445 Enable global playbook overrides at ~/.claude/Dev10x/

### DIFF
--- a/references/execution-modes.md
+++ b/references/execution-modes.md
@@ -61,7 +61,7 @@ active_modes: [solo-maintainer]
 ### Project-level (persistent across sessions)
 
 ```yaml
-# ~/.claude/Dev10x/playbooks/work-on.yaml (global, preferred)
+# ~/.config/Dev10x/playbooks/work-on.yaml (global, preferred)
 # or .claude/Dev10x/playbooks/work-on.yaml (project-local)
 active_modes: [solo-maintainer]
 
@@ -76,7 +76,7 @@ mode_extensions:
 ### Resolution order
 
 1. Session override (`.claude/Dev10x/session.yaml`)
-2. Project override (`~/.claude/Dev10x/playbooks/<skill>.yaml`)
+2. Project override (`~/.config/Dev10x/playbooks/<skill>.yaml`)
 3. Default (no modes active)
 
 ## Per-Step Mode Mappings

--- a/references/execution-modes.md
+++ b/references/execution-modes.md
@@ -61,7 +61,7 @@ active_modes: [solo-maintainer]
 ### Project-level (persistent across sessions)
 
 ```yaml
-# ~/.claude/memory/Dev10x/playbooks/work-on.yaml (global, preferred)
+# ~/.claude/Dev10x/playbooks/work-on.yaml (global, preferred)
 # or .claude/Dev10x/playbooks/work-on.yaml (project-local)
 active_modes: [solo-maintainer]
 
@@ -76,7 +76,7 @@ mode_extensions:
 ### Resolution order
 
 1. Session override (`.claude/Dev10x/session.yaml`)
-2. Project override (`memory/playbooks/<skill>.yaml`)
+2. Project override (`~/.claude/Dev10x/playbooks/<skill>.yaml`)
 3. Default (no modes active)
 
 ## Per-Step Mode Mappings

--- a/references/skill-pipelines.md
+++ b/references/skill-pipelines.md
@@ -230,7 +230,7 @@ the matching pipeline automatically:
 The playbook system (`Dev10x:playbook`) defines each pipeline as a
 play with named steps. User overrides follow the 3-tier resolution
 in `references/config-resolution.md` (global preferred:
-`~/.claude/Dev10x/playbooks/work-on.yaml`).
+`~/.config/Dev10x/playbooks/work-on.yaml`).
 
 See `references/task-orchestration.md` for orchestration patterns
 and `.claude/rules/model-selection.md` for model assignments per step.

--- a/references/skill-pipelines.md
+++ b/references/skill-pipelines.md
@@ -230,7 +230,7 @@ the matching pipeline automatically:
 The playbook system (`Dev10x:playbook`) defines each pipeline as a
 play with named steps. User overrides follow the 3-tier resolution
 in `references/config-resolution.md` (global preferred:
-`~/.claude/memory/Dev10x/playbooks/work-on.yaml`).
+`~/.claude/Dev10x/playbooks/work-on.yaml`).
 
 See `references/task-orchestration.md` for orchestration patterns
 and `.claude/rules/model-selection.md` for model assignments per step.

--- a/skills/gh-pr-respond/instructions.md
+++ b/skills/gh-pr-respond/instructions.md
@@ -53,9 +53,9 @@ This skill is playbook-powered. The workflow steps are defined in
 
 **Loading order** (see `references/config-resolution.md`):
 1. `.claude/Dev10x/playbooks/gh-pr-respond.yaml` (project-local)
-2. `~/.claude/Dev10x/playbooks/gh-pr-respond.yaml` (global + repo match);
+2. `~/.config/Dev10x/playbooks/gh-pr-respond.yaml` (global + repo match);
    fall back to `~/.claude/memory/Dev10x/playbooks/gh-pr-respond.yaml`
-   for backwards compatibility when the new path is absent.
+   for backwards compatibility when the XDG path is absent.
 3. `${CLAUDE_PLUGIN_ROOT}/skills/gh-pr-respond/references/playbook.yaml`
 
 Customize with `/Dev10x:playbook edit gh-pr-respond <play>`.

--- a/skills/gh-pr-respond/instructions.md
+++ b/skills/gh-pr-respond/instructions.md
@@ -53,7 +53,9 @@ This skill is playbook-powered. The workflow steps are defined in
 
 **Loading order** (see `references/config-resolution.md`):
 1. `.claude/Dev10x/playbooks/gh-pr-respond.yaml` (project-local)
-2. `~/.claude/memory/Dev10x/playbooks/gh-pr-respond.yaml` (global + repo match)
+2. `~/.claude/Dev10x/playbooks/gh-pr-respond.yaml` (global + repo match);
+   fall back to `~/.claude/memory/Dev10x/playbooks/gh-pr-respond.yaml`
+   for backwards compatibility when the new path is absent.
 3. `${CLAUDE_PLUGIN_ROOT}/skills/gh-pr-respond/references/playbook.yaml`
 
 Customize with `/Dev10x:playbook edit gh-pr-respond <play>`.

--- a/skills/gh-pr-respond/references/playbook.yaml
+++ b/skills/gh-pr-respond/references/playbook.yaml
@@ -2,7 +2,7 @@
 # Default location: ${CLAUDE_PLUGIN_ROOT}/skills/gh-pr-respond/references/playbook.yaml
 # User overrides (see references/config-resolution.md):
 #   1. .claude/Dev10x/playbooks/gh-pr-respond.yaml (project-local)
-#   2. ~/.claude/Dev10x/playbooks/gh-pr-respond.yaml (global + repo match)
+#   2. ~/.config/Dev10x/playbooks/gh-pr-respond.yaml (global + repo match)
 #      → fallback: ~/.claude/memory/Dev10x/playbooks/gh-pr-respond.yaml
 # Managed by Dev10x:playbook skill.
 #

--- a/skills/gh-pr-respond/references/playbook.yaml
+++ b/skills/gh-pr-respond/references/playbook.yaml
@@ -2,7 +2,8 @@
 # Default location: ${CLAUDE_PLUGIN_ROOT}/skills/gh-pr-respond/references/playbook.yaml
 # User overrides (see references/config-resolution.md):
 #   1. .claude/Dev10x/playbooks/gh-pr-respond.yaml (project-local)
-#   2. ~/.claude/memory/Dev10x/playbooks/gh-pr-respond.yaml (global + repo match)
+#   2. ~/.claude/Dev10x/playbooks/gh-pr-respond.yaml (global + repo match)
+#      → fallback: ~/.claude/memory/Dev10x/playbooks/gh-pr-respond.yaml
 # Managed by Dev10x:playbook skill.
 #
 # Play names match the mode detection in SKILL.md:

--- a/skills/investigate/references/playbook.yaml
+++ b/skills/investigate/references/playbook.yaml
@@ -2,7 +2,8 @@
 # Default location: ${CLAUDE_PLUGIN_ROOT}/skills/investigate/references/playbook.yaml
 # User overrides (see references/config-resolution.md):
 #   1. .claude/Dev10x/playbooks/investigate.yaml (project-local)
-#   2. ~/.claude/memory/Dev10x/playbooks/investigate.yaml (global + repo match)
+#   2. ~/.claude/Dev10x/playbooks/investigate.yaml (global + repo match)
+#      → fallback: ~/.claude/memory/Dev10x/playbooks/investigate.yaml
 # Managed by Dev10x:playbook skill.
 #
 # Play names match mode detection in SKILL.md:

--- a/skills/investigate/references/playbook.yaml
+++ b/skills/investigate/references/playbook.yaml
@@ -2,7 +2,7 @@
 # Default location: ${CLAUDE_PLUGIN_ROOT}/skills/investigate/references/playbook.yaml
 # User overrides (see references/config-resolution.md):
 #   1. .claude/Dev10x/playbooks/investigate.yaml (project-local)
-#   2. ~/.claude/Dev10x/playbooks/investigate.yaml (global + repo match)
+#   2. ~/.config/Dev10x/playbooks/investigate.yaml (global + repo match)
 #      → fallback: ~/.claude/memory/Dev10x/playbooks/investigate.yaml
 # Managed by Dev10x:playbook skill.
 #

--- a/skills/playbook-maintenance/SKILL.md
+++ b/skills/playbook-maintenance/SKILL.md
@@ -55,7 +55,8 @@ Scan for all playbook-powered skills and their user overrides.
 2. Glob for user override files (all tiers per
    `references/config-resolution.md`):
    - `.claude/Dev10x/playbooks/*.yaml` (project-local)
-   - `~/.claude/memory/Dev10x/playbooks/*.yaml` (global)
+   - `~/.claude/Dev10x/playbooks/*.yaml` (global)
+   - `~/.claude/memory/Dev10x/playbooks/*.yaml` (global legacy, backwards compat)
 3. Match override files to default playbooks by filename
    (e.g., `work-on.yaml` matches `skills/work-on/references/playbook.yaml`)
 4. Report skills with overrides vs. skills without

--- a/skills/playbook-maintenance/SKILL.md
+++ b/skills/playbook-maintenance/SKILL.md
@@ -55,7 +55,7 @@ Scan for all playbook-powered skills and their user overrides.
 2. Glob for user override files (all tiers per
    `references/config-resolution.md`):
    - `.claude/Dev10x/playbooks/*.yaml` (project-local)
-   - `~/.claude/Dev10x/playbooks/*.yaml` (global)
+   - `~/.config/Dev10x/playbooks/*.yaml` (global)
    - `~/.claude/memory/Dev10x/playbooks/*.yaml` (global legacy, backwards compat)
 3. Match override files to default playbooks by filename
    (e.g., `work-on.yaml` matches `skills/work-on/references/playbook.yaml`)

--- a/skills/playbook/SKILL.md
+++ b/skills/playbook/SKILL.md
@@ -12,10 +12,10 @@ user-invocable: true
 invocation-name: Dev10x:playbook
 allowed-tools:
   - Read(.claude/Dev10x/playbooks/*.yaml)
-  - Read(~/.claude/Dev10x/playbooks/*.yaml)
+  - Read(~/.config/Dev10x/playbooks/*.yaml)
   - Read(~/.claude/memory/Dev10x/playbooks/*.yaml)
   - Write(.claude/Dev10x/playbooks/*.yaml)
-  - Write(~/.claude/Dev10x/playbooks/*.yaml)
+  - Write(~/.config/Dev10x/playbooks/*.yaml)
   - AskUserQuestion
   - TaskCreate
   - TaskUpdate

--- a/skills/playbook/SKILL.md
+++ b/skills/playbook/SKILL.md
@@ -12,9 +12,10 @@ user-invocable: true
 invocation-name: Dev10x:playbook
 allowed-tools:
   - Read(.claude/Dev10x/playbooks/*.yaml)
+  - Read(~/.claude/Dev10x/playbooks/*.yaml)
   - Read(~/.claude/memory/Dev10x/playbooks/*.yaml)
   - Write(.claude/Dev10x/playbooks/*.yaml)
-  - Write(~/.claude/memory/Dev10x/playbooks/*.yaml)
+  - Write(~/.claude/Dev10x/playbooks/*.yaml)
   - AskUserQuestion
   - TaskCreate
   - TaskUpdate

--- a/skills/playbook/instructions.md
+++ b/skills/playbook/instructions.md
@@ -27,7 +27,7 @@ User overrides follow the resolution order in
 | Tier | Path | Scope |
 |------|------|-------|
 | 1 | `.claude/Dev10x/playbooks/<key>.yaml` | Project-local |
-| 2 | `~/.claude/Dev10x/playbooks/<key>.yaml` | Global with repo mapping |
+| 2 | `~/.config/Dev10x/playbooks/<key>.yaml` | Global with repo mapping |
 
 Where `<key>` is the skill directory name (e.g., `work-on`,
 `release-notes`).
@@ -40,9 +40,9 @@ for the YAML format.
 
 When loading a play, resolve in this order:
 1. Project-local (`.claude/Dev10x/playbooks/<key>.yaml`)
-2. Global with repo matching (`~/.claude/Dev10x/playbooks/<key>.yaml`);
+2. Global with repo matching (`~/.config/Dev10x/playbooks/<key>.yaml`);
    fall back to `~/.claude/memory/Dev10x/playbooks/<key>.yaml` for
-   backwards compatibility when the new path is absent.
+   backwards compatibility when the XDG path is absent.
 3. Defaults from the skill's `references/playbook.yaml`
 
 Within the resolved file, apply overrides in this order:
@@ -190,7 +190,7 @@ language rather than editing YAML.
    - Read the user's playbook file for this skill (create if absent)
    - Add/update the override entry for this play
    - Set `persist: true` and `added: <today's date>`
-   - Write to `~/.claude/Dev10x/playbooks/<skill-key>.yaml`
+   - Write to `~/.config/Dev10x/playbooks/<skill-key>.yaml`
      (global — preferred) or `.claude/Dev10x/playbooks/<skill-key>.yaml`
      (project-local). See `references/config-resolution.md`.
 
@@ -292,7 +292,7 @@ and `references/friction-levels.md` for friction behavior.
 
 **Project activation** (global playbook with repo mapping):
 ```yaml
-# ~/.claude/Dev10x/playbooks/work-on.yaml
+# ~/.config/Dev10x/playbooks/work-on.yaml
 projects:
   - match: "example-org/*"
     active_modes: [solo-maintainer]
@@ -347,7 +347,7 @@ with all 5 plays as a reference implementation.
    the 3-tier resolution in `references/config-resolution.md`:
    ```
    1. .claude/Dev10x/playbooks/<key>.yaml (project-local)
-   2. ~/.claude/Dev10x/playbooks/<key>.yaml (global + repo match)
+   2. ~/.config/Dev10x/playbooks/<key>.yaml (global + repo match)
       → fallback: ~/.claude/memory/Dev10x/playbooks/<key>.yaml
    3. ${CLAUDE_PLUGIN_ROOT}/skills/<skill>/references/playbook.yaml
    ```
@@ -356,7 +356,7 @@ with all 5 plays as a reference implementation.
 **Loading pattern for orchestration skills:**
 ```
 Read(.claude/Dev10x/playbooks/<key>.yaml)
-  → if absent, Read(~/.claude/Dev10x/playbooks/<key>.yaml) + repo match
+  → if absent, Read(~/.config/Dev10x/playbooks/<key>.yaml) + repo match
     → if absent (backwards compat), Read(~/.claude/memory/Dev10x/playbooks/<key>.yaml)
   → if absent, Read(${CLAUDE_PLUGIN_ROOT}/skills/<skill>/references/playbook.yaml)
   → resolve: overrides first, then defaults
@@ -417,7 +417,7 @@ and skill delegations in a readable tree format.
 4. Skill creates the step with `skills: [tt:e2e-debug]`
 5. Shows preview with 11 steps
 6. User selects "Save"
-7. Writes override to `~/.claude/Dev10x/playbooks/work-on.yaml`
+7. Writes override to `~/.config/Dev10x/playbooks/work-on.yaml`
 
 ### Example 5: Future — e2e-debug with a playbook
 

--- a/skills/playbook/instructions.md
+++ b/skills/playbook/instructions.md
@@ -27,7 +27,7 @@ User overrides follow the resolution order in
 | Tier | Path | Scope |
 |------|------|-------|
 | 1 | `.claude/Dev10x/playbooks/<key>.yaml` | Project-local |
-| 2 | `~/.claude/memory/Dev10x/playbooks/<key>.yaml` | Global with repo mapping |
+| 2 | `~/.claude/Dev10x/playbooks/<key>.yaml` | Global with repo mapping |
 
 Where `<key>` is the skill directory name (e.g., `work-on`,
 `release-notes`).
@@ -40,7 +40,9 @@ for the YAML format.
 
 When loading a play, resolve in this order:
 1. Project-local (`.claude/Dev10x/playbooks/<key>.yaml`)
-2. Global with repo matching (`~/.claude/memory/Dev10x/playbooks/<key>.yaml`)
+2. Global with repo matching (`~/.claude/Dev10x/playbooks/<key>.yaml`);
+   fall back to `~/.claude/memory/Dev10x/playbooks/<key>.yaml` for
+   backwards compatibility when the new path is absent.
 3. Defaults from the skill's `references/playbook.yaml`
 
 Within the resolved file, apply overrides in this order:
@@ -188,7 +190,7 @@ language rather than editing YAML.
    - Read the user's playbook file for this skill (create if absent)
    - Add/update the override entry for this play
    - Set `persist: true` and `added: <today's date>`
-   - Write to `~/.claude/memory/Dev10x/playbooks/<skill-key>.yaml`
+   - Write to `~/.claude/Dev10x/playbooks/<skill-key>.yaml`
      (global — preferred) or `.claude/Dev10x/playbooks/<skill-key>.yaml`
      (project-local). See `references/config-resolution.md`.
 
@@ -290,7 +292,7 @@ and `references/friction-levels.md` for friction behavior.
 
 **Project activation** (global playbook with repo mapping):
 ```yaml
-# ~/.claude/memory/Dev10x/playbooks/work-on.yaml
+# ~/.claude/Dev10x/playbooks/work-on.yaml
 projects:
   - match: "example-org/*"
     active_modes: [solo-maintainer]
@@ -345,7 +347,8 @@ with all 5 plays as a reference implementation.
    the 3-tier resolution in `references/config-resolution.md`:
    ```
    1. .claude/Dev10x/playbooks/<key>.yaml (project-local)
-   2. ~/.claude/memory/Dev10x/playbooks/<key>.yaml (global + repo match)
+   2. ~/.claude/Dev10x/playbooks/<key>.yaml (global + repo match)
+      → fallback: ~/.claude/memory/Dev10x/playbooks/<key>.yaml
    3. ${CLAUDE_PLUGIN_ROOT}/skills/<skill>/references/playbook.yaml
    ```
 4. The `Dev10x:playbook` skill automatically discovers your skill
@@ -353,7 +356,8 @@ with all 5 plays as a reference implementation.
 **Loading pattern for orchestration skills:**
 ```
 Read(.claude/Dev10x/playbooks/<key>.yaml)
-  → if absent, Read(~/.claude/memory/Dev10x/playbooks/<key>.yaml) + repo match
+  → if absent, Read(~/.claude/Dev10x/playbooks/<key>.yaml) + repo match
+    → if absent (backwards compat), Read(~/.claude/memory/Dev10x/playbooks/<key>.yaml)
   → if absent, Read(${CLAUDE_PLUGIN_ROOT}/skills/<skill>/references/playbook.yaml)
   → resolve: overrides first, then defaults
   → validate version (warn on mismatch)
@@ -413,7 +417,7 @@ and skill delegations in a readable tree format.
 4. Skill creates the step with `skills: [tt:e2e-debug]`
 5. Shows preview with 11 steps
 6. User selects "Save"
-7. Writes override to `~/.claude/memory/Dev10x/playbooks/work-on.yaml`
+7. Writes override to `~/.claude/Dev10x/playbooks/work-on.yaml`
 
 ### Example 5: Future — e2e-debug with a playbook
 

--- a/skills/playbook/references/playbook.yaml
+++ b/skills/playbook/references/playbook.yaml
@@ -4,7 +4,7 @@ version: "0.78.0.dev0"
 # Default location: ${CLAUDE_PLUGIN_ROOT}/skills/playbook/references/playbook.yaml
 # User overrides (resolution order — see references/config-resolution.md):
 #   1. .claude/Dev10x/playbooks/<skill-key>.yaml (project-local)
-#   2. ~/.claude/Dev10x/playbooks/<skill-key>.yaml (global + repo match)
+#   2. ~/.config/Dev10x/playbooks/<skill-key>.yaml (global + repo match)
 #      → fallback: ~/.claude/memory/Dev10x/playbooks/<skill-key>.yaml
 # Managed by Dev10x:playbook skill.
 #

--- a/skills/playbook/references/playbook.yaml
+++ b/skills/playbook/references/playbook.yaml
@@ -4,7 +4,8 @@ version: "0.78.0.dev0"
 # Default location: ${CLAUDE_PLUGIN_ROOT}/skills/playbook/references/playbook.yaml
 # User overrides (resolution order — see references/config-resolution.md):
 #   1. .claude/Dev10x/playbooks/<skill-key>.yaml (project-local)
-#   2. ~/.claude/memory/Dev10x/playbooks/<skill-key>.yaml (global + repo match)
+#   2. ~/.claude/Dev10x/playbooks/<skill-key>.yaml (global + repo match)
+#      → fallback: ~/.claude/memory/Dev10x/playbooks/<skill-key>.yaml
 # Managed by Dev10x:playbook skill.
 #
 # Structure:

--- a/skills/plugin-maintenance/SKILL.md
+++ b/skills/plugin-maintenance/SKILL.md
@@ -690,7 +690,7 @@ uvx dev10x permission doctor enable-group kubernetes-readonly
 ### 13. Diff user playbooks against plugin defaults *(full only)* (GH-192)
 
 User playbook overrides under `.claude/Dev10x/playbooks/` and
-`~/.claude/memory/Dev10x/playbooks/` drift from the plugin defaults as
+`~/.claude/Dev10x/playbooks/` drift from the plugin defaults as
 new versions ship new steps, fragments, or field changes. This step
 surfaces those upstream changes without overwriting user customizations.
 

--- a/skills/plugin-maintenance/SKILL.md
+++ b/skills/plugin-maintenance/SKILL.md
@@ -690,7 +690,7 @@ uvx dev10x permission doctor enable-group kubernetes-readonly
 ### 13. Diff user playbooks against plugin defaults *(full only)* (GH-192)
 
 User playbook overrides under `.claude/Dev10x/playbooks/` and
-`~/.claude/Dev10x/playbooks/` drift from the plugin defaults as
+`~/.config/Dev10x/playbooks/` drift from the plugin defaults as
 new versions ship new steps, fragments, or field changes. This step
 surfaces those upstream changes without overwriting user customizations.
 

--- a/skills/release-notes/SKILL.md
+++ b/skills/release-notes/SKILL.md
@@ -49,7 +49,7 @@ This skill is driven by playbook configuration. The default playbook
 lives at `${CLAUDE_PLUGIN_ROOT}/skills/release-notes/references/playbook.yaml`.
 Projects can override via the 4-tier resolution in
 `references/config-resolution.md` (global preferred:
-`~/.claude/memory/Dev10x/playbooks/release-notes.yaml`).
+`~/.claude/Dev10x/playbooks/release-notes.yaml`).
 
 ### Plays
 

--- a/skills/release-notes/SKILL.md
+++ b/skills/release-notes/SKILL.md
@@ -49,7 +49,7 @@ This skill is driven by playbook configuration. The default playbook
 lives at `${CLAUDE_PLUGIN_ROOT}/skills/release-notes/references/playbook.yaml`.
 Projects can override via the 4-tier resolution in
 `references/config-resolution.md` (global preferred:
-`~/.claude/Dev10x/playbooks/release-notes.yaml`).
+`~/.config/Dev10x/playbooks/release-notes.yaml`).
 
 ### Plays
 

--- a/skills/release-notes/references/playbook.yaml
+++ b/skills/release-notes/references/playbook.yaml
@@ -2,7 +2,7 @@
 # Default location: ${CLAUDE_PLUGIN_ROOT}/skills/release-notes/references/playbook.yaml
 # User overrides (see references/config-resolution.md):
 #   1. .claude/Dev10x/playbooks/release-notes.yaml (project-local)
-#   2. ~/.claude/Dev10x/playbooks/release-notes.yaml (global + repo match)
+#   2. ~/.config/Dev10x/playbooks/release-notes.yaml (global + repo match)
 #      → fallback: ~/.claude/memory/Dev10x/playbooks/release-notes.yaml
 # Managed by Dev10x:playbook skill.
 #

--- a/skills/release-notes/references/playbook.yaml
+++ b/skills/release-notes/references/playbook.yaml
@@ -2,7 +2,8 @@
 # Default location: ${CLAUDE_PLUGIN_ROOT}/skills/release-notes/references/playbook.yaml
 # User overrides (see references/config-resolution.md):
 #   1. .claude/Dev10x/playbooks/release-notes.yaml (project-local)
-#   2. ~/.claude/memory/Dev10x/playbooks/release-notes.yaml (global + repo match)
+#   2. ~/.claude/Dev10x/playbooks/release-notes.yaml (global + repo match)
+#      → fallback: ~/.claude/memory/Dev10x/playbooks/release-notes.yaml
 # Managed by Dev10x:playbook skill.
 #
 # Play-level `config` block holds structured settings that the

--- a/skills/work-on/SKILL.md
+++ b/skills/work-on/SKILL.md
@@ -14,6 +14,7 @@ invocation-name: Dev10x:work-on
 allowed-tools:
   - mcp__plugin_Dev10x_cli__*
   - Read(.claude/Dev10x/playbooks/work-on.yaml)
+  - Read(~/.claude/Dev10x/playbooks/work-on.yaml)
   - Read(~/.claude/memory/Dev10x/playbooks/work-on.yaml)
   - Read(${CLAUDE_PLUGIN_ROOT}/skills/playbook/references/playbook.yaml)
   - Write(.claude/Dev10x/**)

--- a/skills/work-on/SKILL.md
+++ b/skills/work-on/SKILL.md
@@ -14,7 +14,7 @@ invocation-name: Dev10x:work-on
 allowed-tools:
   - mcp__plugin_Dev10x_cli__*
   - Read(.claude/Dev10x/playbooks/work-on.yaml)
-  - Read(~/.claude/Dev10x/playbooks/work-on.yaml)
+  - Read(~/.config/Dev10x/playbooks/work-on.yaml)
   - Read(~/.claude/memory/Dev10x/playbooks/work-on.yaml)
   - Read(${CLAUDE_PLUGIN_ROOT}/skills/playbook/references/playbook.yaml)
   - Write(.claude/Dev10x/**)

--- a/skills/work-on/instructions.md
+++ b/skills/work-on/instructions.md
@@ -538,11 +538,11 @@ that can be overridden per project.
 
 **Play source** (resolved in order — see `references/config-resolution.md`):
 1. `.claude/Dev10x/playbooks/work-on.yaml` — project-local override
-2. `~/.claude/Dev10x/playbooks/work-on.yaml` — global with repo
+2. `~/.config/Dev10x/playbooks/work-on.yaml` — global with repo
    matching (get repo via `git remote get-url origin`, walk
    `projects[].match` globs, use first hit's `overrides`/`fragments`);
    fall back to `~/.claude/memory/Dev10x/playbooks/work-on.yaml` for
-   backwards compatibility when the new path is absent.
+   backwards compatibility when the XDG path is absent.
 3. `${CLAUDE_PLUGIN_ROOT}/skills/playbook/references/playbook.yaml`
 
 **Playbook schema:** See the `Dev10x:playbook` skill's
@@ -578,11 +578,11 @@ play definitions. If you cannot confirm this, STOP.
 ```bash
 # ❌ FORBIDDEN — chained probes shift the allow-rule prefix
 ls /work/.../playbooks 2>/dev/null; ls ~/.claude/memory/...
-cat ~/.claude/Dev10x/playbooks/work-on.yaml
+cat ~/.config/Dev10x/playbooks/work-on.yaml
 
 # ✅ REQUIRED — use Read with absolute paths, one call per tier
 Read(file_path="/abs/path/.claude/Dev10x/playbooks/work-on.yaml")
-Read(file_path="/home/<user>/.claude/Dev10x/playbooks/work-on.yaml")
+Read(file_path="/home/<user>/.config/Dev10x/playbooks/work-on.yaml")
 Read(file_path="${CLAUDE_PLUGIN_ROOT}/skills/playbook/references/playbook.yaml")
 ```
 
@@ -596,7 +596,7 @@ resolution algorithm needs.
 1. Determine the `work_type` from gathered context (see table below)
 2. Resolve the playbook using the 3-tier resolution order above:
    a. Try `.claude/Dev10x/playbooks/work-on.yaml` (project-local)
-   b. Try `~/.claude/Dev10x/playbooks/work-on.yaml` (global); if
+   b. Try `~/.config/Dev10x/playbooks/work-on.yaml` (global); if
       absent, fall back to `~/.claude/memory/Dev10x/playbooks/work-on.yaml`
       for backwards compatibility — if found (either path), get repo
       via `git remote get-url origin`, walk `projects[].match` globs;

--- a/skills/work-on/instructions.md
+++ b/skills/work-on/instructions.md
@@ -538,9 +538,11 @@ that can be overridden per project.
 
 **Play source** (resolved in order — see `references/config-resolution.md`):
 1. `.claude/Dev10x/playbooks/work-on.yaml` — project-local override
-2. `~/.claude/memory/Dev10x/playbooks/work-on.yaml` — global with
-   repo matching (get repo via `git remote get-url origin`, walk
-   `projects[].match` globs, use first hit's `overrides`/`fragments`)
+2. `~/.claude/Dev10x/playbooks/work-on.yaml` — global with repo
+   matching (get repo via `git remote get-url origin`, walk
+   `projects[].match` globs, use first hit's `overrides`/`fragments`);
+   fall back to `~/.claude/memory/Dev10x/playbooks/work-on.yaml` for
+   backwards compatibility when the new path is absent.
 3. `${CLAUDE_PLUGIN_ROOT}/skills/playbook/references/playbook.yaml`
 
 **Playbook schema:** See the `Dev10x:playbook` skill's
@@ -576,11 +578,11 @@ play definitions. If you cannot confirm this, STOP.
 ```bash
 # ❌ FORBIDDEN — chained probes shift the allow-rule prefix
 ls /work/.../playbooks 2>/dev/null; ls ~/.claude/memory/...
-cat ~/.claude/memory/Dev10x/playbooks/work-on.yaml
+cat ~/.claude/Dev10x/playbooks/work-on.yaml
 
 # ✅ REQUIRED — use Read with absolute paths, one call per tier
 Read(file_path="/abs/path/.claude/Dev10x/playbooks/work-on.yaml")
-Read(file_path="/home/<user>/.claude/memory/Dev10x/playbooks/work-on.yaml")
+Read(file_path="/home/<user>/.claude/Dev10x/playbooks/work-on.yaml")
 Read(file_path="${CLAUDE_PLUGIN_ROOT}/skills/playbook/references/playbook.yaml")
 ```
 
@@ -594,9 +596,11 @@ resolution algorithm needs.
 1. Determine the `work_type` from gathered context (see table below)
 2. Resolve the playbook using the 3-tier resolution order above:
    a. Try `.claude/Dev10x/playbooks/work-on.yaml` (project-local)
-   b. Try `~/.claude/memory/Dev10x/playbooks/work-on.yaml` (global)
-      — if found, get repo via `git remote get-url origin`, walk
-      `projects[].match` globs; use first matching entry's config.
+   b. Try `~/.claude/Dev10x/playbooks/work-on.yaml` (global); if
+      absent, fall back to `~/.claude/memory/Dev10x/playbooks/work-on.yaml`
+      for backwards compatibility — if found (either path), get repo
+      via `git remote get-url origin`, walk `projects[].match` globs;
+      use first matching entry's config.
       Top-level `fragments` are shared across all matched projects.
    c. Fall back to `${CLAUDE_PLUGIN_ROOT}/skills/playbook/references/playbook.yaml`
 3. **VERIFY: Confirm the playbook loaded successfully.** Check that


### PR DESCRIPTION
**When** I configure global playbook overrides, **I want to** store them at `~/.claude/Dev10x/playbooks/` instead of `~/.claude/memory/Dev10x/playbooks/`, **so I can** keep plugin config out of Claude Code's auto-memory directory where it may be pruned.

---

[`c3148484`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/450/commits/c314848496640bf8a7e7a7ffde86ac9813192984) 📝 GH-445 Enable global playbook overrides at ~/.claude/Dev10x/

Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/445