### PR TITLE
✨ GH-448 Enable XDG config path for databases.yaml discovery

### DIFF
--- a/references/config-resolution.md
+++ b/references/config-resolution.md
@@ -220,9 +220,28 @@ is migrated lazily on first read.
 
 ### Database Connections
 
-| Tier | Path |
-|------|------|
-| 2 | `~/.config/Dev10x/databases.yaml` |
+`databases.yaml` stores named database entries for `Dev10x:db-psql`.
+The script resolves config from multiple locations so project plugins
+(e.g., `tt:db`) are discovered automatically without symlinks.
+
+| Priority | Path | Notes |
+|----------|------|-------|
+| 1 | `$DB_CONFIG` | Explicit override; skips all other locations |
+| 2 | `${CLAUDE_PLUGIN_ROOT}/skills/db-psql/databases.yaml` | Plugin-shipped defaults |
+| 3 | `~/.config/Dev10x/databases.yaml` | **Preferred** user-global location (XDG) |
+| 4 | `~/.claude/memory/Dev10x/databases.yaml` | Deprecated fallback (kept for backward compat) |
+| 5 | `skills/*/databases.yaml` | Sibling skills in the same plugin |
+| 6 | `~/.claude/skills/*/databases.yaml` | User-installed standalone skills |
+| 7 | `~/.claude/plugins/marketplaces/*/skills/*/databases.yaml` | Other marketplace plugins |
+
+**Recommended setup**: place your user-level `databases.yaml` at
+`~/.config/Dev10x/databases.yaml` (priority 3). The legacy
+`~/.claude/memory/Dev10x/databases.yaml` path still works but is
+deprecated; migrate to the XDG location when convenient.
+
+`$DB_CONFIG` env-var override is not recommended in Claude Code
+sessions — prefixing a `DB_CONFIG=...` env var shifts the effective
+command prefix and breaks allow-rule matching (see GH-448).
 
 ## Skills That Reference These Paths
 

--- a/skills/db-psql/SKILL.md
+++ b/skills/db-psql/SKILL.md
@@ -84,9 +84,11 @@ db.sh script searches for config files in this order:
 
 1. `$DB_CONFIG` environment variable (explicit path)
 2. Own skill directory (`skills/db-psql/databases.yaml`)
-3. `~/.claude/memory/Dev10x/databases.yaml` (global, user-level)
-4. Sibling plugin skill directories (`skills/*/databases.yaml`)
-5. User skill directories (`~/.claude/skills/*/databases.yaml`)
+3. `~/.config/Dev10x/databases.yaml` (XDG; preferred global location)
+4. `~/.claude/memory/Dev10x/databases.yaml` (deprecated fallback)
+5. Sibling plugin skill directories (`skills/*/databases.yaml`)
+6. User skill directories (`~/.claude/skills/*/databases.yaml`)
+7. Marketplace plugins (`~/.claude/plugins/marketplaces/*/skills/*/databases.yaml`)
 
 Example YAML with both backends:
 

--- a/skills/db-psql/scripts/db.sh
+++ b/skills/db-psql/scripts/db.sh
@@ -62,6 +62,10 @@ discover_configs() {
 
   load_config "$SKILL_DIR/databases.yaml"
 
+  # XDG user-level config (preferred global location — GH-448)
+  load_config "${XDG_CONFIG_HOME:-$HOME/.config}/Dev10x/databases.yaml"
+
+  # Deprecated fallback: legacy memory path (kept for backward compat)
   load_config "$HOME/.claude/memory/Dev10x/databases.yaml"
 
   for cfg in "$SKILLS_DIR"/*/databases.yaml; do
@@ -74,13 +78,19 @@ discover_configs() {
     [[ -f "$cfg" ]] || continue
     load_config "$cfg"
   done
+
+  # Marketplace plugins (other installed plugin collections)
+  for cfg in "$HOME/.claude/plugins/marketplaces"/*/skills/*/databases.yaml; do
+    [[ -f "$cfg" ]] || continue
+    load_config "$cfg"
+  done
 }
 
 discover_configs
 
 if [[ ${#DB_BACKEND[@]} -eq 0 ]]; then
   echo "ERROR: No databases configured." >&2
-  echo "Create databases.yaml in ~/.claude/memory/ or a skill directory." >&2
+  echo "Create databases.yaml at ~/.config/Dev10x/databases.yaml or a skill directory." >&2
   echo "See: $SKILL_DIR/databases.yaml.example" >&2
   exit 1
 fi

--- a/skills/db/SKILL.md
+++ b/skills/db/SKILL.md
@@ -56,9 +56,11 @@ search order. Key locations:
 
 1. `$DB_CONFIG` environment variable (explicit override)
 2. Plugin skill directory (`skills/db-psql/databases.yaml`)
-3. `~/.claude/memory/Dev10x/databases.yaml` — global, user-level config
-4. Sibling plugin skills (`skills/*/databases.yaml`)
-5. User skill directories (`~/.claude/skills/*/databases.yaml`)
+3. `~/.config/Dev10x/databases.yaml` — XDG; preferred global location
+4. `~/.claude/memory/Dev10x/databases.yaml` — deprecated fallback
+5. Sibling plugin skills (`skills/*/databases.yaml`)
+6. User skill directories (`~/.claude/skills/*/databases.yaml`)
+7. Marketplace plugins (`~/.claude/plugins/marketplaces/*/skills/*/databases.yaml`)
 
 ### Additional context
 


### PR DESCRIPTION
**When** I configure databases for Dev10x db skills, **I want to** place my `databases.yaml` at the standard XDG config location (`~/.config/Dev10x/databases.yaml`), **so** db.sh finds it automatically without symlinks or `DB_CONFIG` env-var prefixes that break Claude Code allow-rule matching.

---

[`ab0c7475`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/451/commits/ab0c747568eee0399d785f816c7b1fef85580a90) ✨ GH-448 Enable XDG config path for databases.yaml discovery
Closes #448
Fixes: https://github.com/Dev10x-Guru/dev10x-claude/issues/448

---