### PR TITLE
🐛 GH-442 Enable uvx dev10x skill notify slack-send

### DIFF
--- a/src/dev10x/commands/skill.py
+++ b/src/dev10x/commands/skill.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import subprocess
 import sys
 from pathlib import Path
 
@@ -21,14 +20,6 @@ def notify() -> None:
     `Dev10x:slack-review-request` and `Dev10x:slack` skills do not need
     to embed plugin-cache paths in their documented invocations.
     """
-
-
-def _plugin_root() -> Path:
-    """Resolve the plugin root containing the skills/ directory.
-
-    `src/dev10x/commands/skill.py` -> parents[3] = plugin root.
-    """
-    return Path(__file__).resolve().parents[3]
 
 
 @notify.command(name="slack-review-prepare")
@@ -69,37 +60,36 @@ def slack_send(
     thread_ts: str | None,
     workspace: str | None,
 ) -> None:
-    """Send a Slack message via the plugin's slack-notify.py script.
+    """Send a Slack message via the importable slack_notify module (GH-442).
 
-    Delegates to `skills/slack/slack-notify.py` while exposing a
-    version-stable CLI surface. The underlying script handles token
-    resolution, user-group mention expansion, and bot identity.
+    Delegates to `dev10x.skills.notifications.slack_notify` so the command
+    works when dev10x is installed via ``uvx`` — where ``skills/`` data files
+    are not shipped as part of the wheel and cannot be reached by filesystem
+    traversal from the installed package location.
     """
     if not message and not message_file:
         raise click.UsageError("Provide --message or --message-file.")
 
-    slack_notify = _plugin_root() / "skills" / "slack" / "slack-notify.py"
-    if not slack_notify.exists():
-        click.echo(f"slack-notify.py not found at {slack_notify}", err=True)
-        sys.exit(1)
+    from dev10x.skills.notifications import slack_notify
 
-    cmd: list[str] = [str(slack_notify), "--channel", channel]
-    if message_file is not None:
-        cmd.extend(["--message-file", str(message_file)])
-    if message is not None:
-        cmd.extend(["--message", message])
-    if thread_ts is not None:
-        cmd.extend(["--thread-ts", thread_ts])
     if workspace is not None:
-        cmd.extend(["--workspace", workspace])
+        slack_notify.set_workspace(workspace)
 
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
-    if result.stdout:
-        click.echo(result.stdout.rstrip())
-    if result.returncode != 0:
-        if result.stderr:
-            click.echo(result.stderr.rstrip(), err=True)
-        sys.exit(result.returncode)
+    msg: str
+    if message_file is not None:
+        msg = message_file.read_text()
+    else:
+        msg = message  # type: ignore[assignment]  # validated above
+
+    ts = slack_notify.send_slack_message(
+        channel=channel,
+        message=msg,
+        thread_ts=thread_ts,
+    )
+    if ts:
+        click.echo(f"✅ Slack message sent successfully! ts={ts}")
+    else:
+        sys.exit(1)
 
 
 @skill.command(name="count-instructions")

--- a/src/dev10x/skills/monitor/pr_notify.py
+++ b/src/dev10x/skills/monitor/pr_notify.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import subprocess
 import sys
 from datetime import datetime
@@ -361,35 +360,17 @@ def cmd_send(args: argparse.Namespace) -> None:
         if args.message_file:
             message = Path(args.message_file).read_text()
 
-        # Post via Slack notification script if available, otherwise
-        # print the message for the user to post manually.
-        slack_notify = Path(__file__).parents[4] / "skills" / "slack" / "slack-notify.py"
-        if slack_notify.exists() and args.channel:
-            notify_args = [
-                "run",
-                "--script",
-                str(slack_notify),
-                "--channel",
-                args.channel,
-                "--message",
-                message,
-            ]
-            result = subprocess.run(
-                ["uv", *notify_args],
-                capture_output=True,
-                text=True,
-                timeout=30,
-            )
-            if result.returncode != 0:
-                print(
-                    f"❌ Slack notification failed: {result.stderr.strip()}",
-                    file=sys.stderr,
-                )
+        # Post via importable slack_notify module (GH-442). Works in both
+        # plugin-checkout and uvx-installed contexts.
+        if args.channel:
+            from dev10x.skills.notifications import slack_notify as _slack
+
+            ts = _slack.send_slack_message(channel=args.channel, message=message)
+            if ts is None:
+                print("❌ Slack notification failed", file=sys.stderr)
                 sys.exit(1)
-            print(result.stdout.strip())
-            ts_match = re.search(r"ts=(\S+)", result.stdout)
-            if ts_match:
-                slack_ts = ts_match.group(1)
+            print(f"✅ Slack message sent successfully! ts={ts}")
+            slack_ts = ts
         else:
             print(f"📋 Notification message (post manually):\n{message}")
 

--- a/src/dev10x/skills/notifications/slack_notify.py
+++ b/src/dev10x/skills/notifications/slack_notify.py
@@ -1,0 +1,312 @@
+"""Importable Slack notification helpers (GH-442).
+
+Extracted from ``skills/slack/slack-notify.py`` so the logic is available
+when dev10x is installed via ``uvx`` — where the ``skills/`` data files are
+not part of the wheel and cannot be located via filesystem traversal.
+
+The standalone ``skills/slack/slack-notify.py`` uv-script remains the entry
+point for direct plugin-checkout invocations; this module powers the
+``dev10x skill notify slack-send`` CLI command and any in-process callers.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from slack_sdk import WebClient
+
+CONFIG_PATH = pathlib.Path.home() / ".claude" / "memory" / "slack-config.yaml"
+
+_active_workspace: str | None = None
+_config: dict | None = None
+
+
+def _load_config() -> dict:
+    if CONFIG_PATH.exists():
+        import yaml
+
+        return yaml.safe_load(CONFIG_PATH.read_text()) or {}
+    return {}
+
+
+def _get_config() -> dict:
+    global _config
+    if _config is None:
+        _config = _load_config()
+    return _config
+
+
+def _workspace_config() -> dict:
+    if _active_workspace is None:
+        return {}
+    workspaces = _get_config().get("workspaces", {}) or {}
+    return workspaces.get(_active_workspace, {}) or {}
+
+
+def set_workspace(name: str | None) -> None:
+    """Select an active workspace. Affects keyring service and per-workspace config."""
+    global _active_workspace
+    _active_workspace = name
+
+
+def _resolve(key: str, default: str = "") -> str:
+    """Read a config key, preferring the active workspace's override."""
+    ws = _workspace_config()
+    if key in ws:
+        return ws[key] or default
+    return _get_config().get(key, default) or default
+
+
+def _self_user_id() -> str:
+    return os.environ.get("SLACK_SELF_USER_ID") or _resolve("self_user_id", "")
+
+
+def _bot_username() -> str:
+    return _resolve("bot_username", "Claude AI")
+
+
+def _user_groups() -> dict[str, str]:
+    ws = _workspace_config()
+    if "user_groups" in ws:
+        return ws.get("user_groups") or {}
+    return _get_config().get("user_groups", {}) or {}
+
+
+def resolve_mentions(message: str) -> str:
+    for mention, group_id in _user_groups().items():
+        message = message.replace(mention, group_id)
+    return message
+
+
+def _keyring_lookup(*, service: str, key: str) -> str | None:
+    if sys.platform == "darwin":
+        cmd = ["security", "find-generic-password", "-s", service, "-a", key, "-w"]
+    else:
+        cmd = ["secret-tool", "lookup", "service", service, "key", key]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        return result.stdout.strip() or None
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def _keyring_service() -> str:
+    """Resolve keyring service name for the active workspace.
+
+    Honors ``keyring_service:`` override in the workspace config; otherwise
+    falls back to ``slack-<workspace>``.
+    """
+    if _active_workspace is None:
+        return "slack"
+    ws = _workspace_config()
+    override = ws.get("keyring_service")
+    if override:
+        return override
+    return f"slack-{_active_workspace}"
+
+
+def get_token() -> str:
+    """Resolve the Slack bot token.
+
+    Resolution order:
+      1. If --workspace was set: keyring at the workspace's service name.
+         Raise if missing — workspace was explicitly requested.
+      2. SLACK_TOKEN environment variable.
+      3. Default keyring at service=slack.
+    """
+    if _active_workspace is not None:
+        service = _keyring_service()
+        token = _keyring_lookup(service=service, key="bot_token")
+        if token:
+            return token
+        raise RuntimeError(
+            f"No Slack token found in keyring for workspace "
+            f"'{_active_workspace}' (service={service})"
+        )
+    env_token = os.environ.get("SLACK_TOKEN")
+    if env_token:
+        return env_token
+    token = _keyring_lookup(service="slack", key="bot_token")
+    if token:
+        return token
+    raise RuntimeError(
+        "No Slack token found. Set SLACK_TOKEN env, configure the default "
+        "keyring (service=slack, key=bot_token), or pass --workspace NAME."
+    )
+
+
+def send_slack_message(
+    channel: str,
+    message: str,
+    thread_ts: str | None = None,
+    broadcast: bool = False,
+    reactions: list[str] | None = None,
+    unfurl: bool = False,
+) -> str | None:
+    try:
+        from slack_sdk import WebClient
+
+        resolved_message = resolve_mentions(message)
+        token = get_token()
+        is_user_token = token.startswith("xoxp-")
+        client = WebClient(token=token)
+        result = client.chat_postMessage(
+            channel=channel,
+            text=resolved_message,
+            username=None if is_user_token else _bot_username(),
+            thread_ts=thread_ts,
+            reply_broadcast=broadcast if thread_ts else None,
+            unfurl_links=unfurl,
+            unfurl_media=unfurl,
+        )
+        ts = result["ts"]
+        if reactions:
+            for emoji in reactions:
+                client.reactions_add(channel=channel, timestamp=ts, name=emoji)
+        return ts
+    except Exception as ex:
+        print(f"❌ Failed to send Slack message: {ex}", file=sys.stderr)
+        return None
+
+
+def upload_slack_files(
+    channel: str,
+    file_paths: list[str],
+    message: str | None = None,
+    thread_ts: str | None = None,
+) -> str | None:
+    from slack_sdk import WebClient
+    from slack_sdk.errors import SlackApiError
+
+    token = get_token()
+    client = WebClient(token=token)
+    resolved_message = resolve_mentions(message) if message else None
+
+    file_uploads = []
+    for path in file_paths:
+        if not os.path.exists(path):
+            print(f"❌ File not found: {path}", file=sys.stderr)
+            return None
+        file_uploads.append({"file": path, "title": os.path.basename(path)})
+
+    try:
+        result = _files_upload_v2(
+            client=client,
+            file_uploads=file_uploads,
+            channel=channel,
+            initial_comment=resolved_message,
+            thread_ts=thread_ts,
+        )
+        files = result.get("files", [])
+        print(f"✅ Uploaded {len(file_uploads)} file(s): {[f.get('id') for f in files]}")
+        return files[0].get("id") if files else None
+    except SlackApiError as ex:
+        if ex.response.get("error") == "missing_scope":
+            needed = ex.response.get("needed", "files:write")
+            print(
+                f"❌ Bot token missing '{needed}' scope. "
+                f"Add it at https://api.slack.com/apps → OAuth & Permissions.",
+                file=sys.stderr,
+            )
+            raise SystemExit(1) from ex
+        raise
+
+
+def _files_upload_v2(
+    client: WebClient,
+    file_uploads: list[dict],
+    channel: str,
+    initial_comment: str | None,
+    thread_ts: str | None,
+) -> dict:
+    from slack_sdk.errors import SlackApiError
+
+    kwargs = dict(
+        file_uploads=file_uploads,
+        channel=channel,
+        initial_comment=initial_comment,
+        thread_ts=thread_ts,
+    )
+    try:
+        return client.files_upload_v2(**kwargs)
+    except SlackApiError as ex:
+        if ex.response.get("error") == "not_in_channel":
+            try:
+                print("Bot not in channel, joining…", file=sys.stderr)
+                client.conversations_join(channel=channel)
+                return client.files_upload_v2(**kwargs)
+            except SlackApiError:
+                print(
+                    f"❌ Bot is not a member of channel {channel} and cannot auto-join. "
+                    f"Invite the bot via channel settings → Integrations.",
+                    file=sys.stderr,
+                )
+                raise SystemExit(1) from ex
+        raise
+
+
+def send_reminder(message: str) -> str | None:
+    self_user_id = _self_user_id()
+    if not self_user_id:
+        print(
+            "❌ self_user_id not configured. Set it in "
+            f"{CONFIG_PATH} or SLACK_SELF_USER_ID env var.",
+            file=sys.stderr,
+        )
+        return None
+    try:
+        from slack_sdk import WebClient
+
+        token = get_token()
+        client = WebClient(token=token)
+        dm = client.conversations_open(users=self_user_id)
+        channel = dm["channel"]["id"]
+        return send_slack_message(channel=channel, message=message)
+    except Exception as ex:
+        print(f"❌ Failed to send reminder: {ex}", file=sys.stderr)
+        return None
+
+
+def update_slack_message(channel: str, ts: str, message: str) -> bool:
+    try:
+        from slack_sdk import WebClient
+
+        resolved_message = resolve_mentions(message)
+        token = get_token()
+        client = WebClient(token=token)
+        client.chat_update(channel=channel, ts=ts, text=resolved_message)
+        return True
+    except Exception as ex:
+        print(f"❌ Failed to update Slack message: {ex}", file=sys.stderr)
+        return False
+
+
+def delete_slack_message(channel: str, ts: str) -> bool:
+    try:
+        from slack_sdk import WebClient
+
+        token = get_token()
+        client = WebClient(token=token)
+        client.chat_delete(channel=channel, ts=ts)
+        return True
+    except Exception as ex:
+        print(f"❌ Failed to delete Slack message: {ex}", file=sys.stderr)
+        return False
+
+
+def delete_slack_file(file_id: str) -> bool:
+    try:
+        from slack_sdk import WebClient
+
+        token = get_token()
+        client = WebClient(token=token)
+        client.files_delete(file=file_id)
+        return True
+    except Exception as ex:
+        print(f"❌ Failed to delete Slack file: {ex}", file=sys.stderr)
+        return False

--- a/tests/commands/test_skill_notify.py
+++ b/tests/commands/test_skill_notify.py
@@ -1,8 +1,7 @@
-"""Tests for `dev10x skill notify` subcommands (GH-313)."""
+"""Tests for `dev10x skill notify` subcommands (GH-313, GH-442)."""
 
 from __future__ import annotations
 
-import subprocess
 from pathlib import Path
 
 import pytest
@@ -14,16 +13,6 @@ from dev10x.cli import cli
 @pytest.fixture()
 def runner() -> CliRunner:
     return CliRunner()
-
-
-class TestPluginRoot:
-    def test_plugin_root_resolves_to_repo_root(self) -> None:
-        from dev10x.commands.skill import _plugin_root
-
-        root = _plugin_root()
-
-        assert (root / "skills").is_dir(), f"skills/ not under {root}"
-        assert (root / "src" / "dev10x" / "commands" / "skill.py").is_file()
 
 
 class TestNotifyGroupRegistration:
@@ -90,38 +79,29 @@ class TestSlackSend:
         assert result.exit_code != 0
         assert "Provide --message or --message-file" in result.output
 
-    def test_invokes_slack_notify_script(
+    def test_calls_send_slack_message(
         self,
         runner: CliRunner,
         monkeypatch: pytest.MonkeyPatch,
-        tmp_path: Path,
     ) -> None:
-        fake_script = tmp_path / "slack-notify.py"
-        fake_script.write_text("#!/usr/bin/env python\n")
+        """GH-442: slack-send must call send_slack_message, not subprocess the script."""
+        captured: dict[str, object] = {}
 
-        from dev10x.commands import skill as skill_module
+        def fake_send(
+            channel: str,
+            message: str,
+            thread_ts: str | None = None,
+            **kwargs: object,
+        ) -> str:
+            captured["channel"] = channel
+            captured["message"] = message
+            captured["thread_ts"] = thread_ts
+            return "1234567890.123456"
 
-        monkeypatch.setattr(
-            skill_module,
-            "_plugin_root",
-            lambda: tmp_path.parent,
-        )
-        (tmp_path.parent / "skills" / "slack").mkdir(parents=True, exist_ok=True)
-        real_script = tmp_path.parent / "skills" / "slack" / "slack-notify.py"
-        real_script.write_text("#!/usr/bin/env python\n")
+        from dev10x.skills.notifications import slack_notify
 
-        captured_cmd: list[list[str]] = []
-
-        def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess:
-            captured_cmd.append(cmd)
-            return subprocess.CompletedProcess(
-                args=cmd,
-                returncode=0,
-                stdout="✅ Slack message sent",
-                stderr="",
-            )
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(slack_notify, "send_slack_message", fake_send)
+        monkeypatch.setattr(slack_notify, "set_workspace", lambda name: None)
 
         result = runner.invoke(
             cli,
@@ -141,38 +121,29 @@ class TestSlackSend:
         )
 
         assert result.exit_code == 0, result.output
+        assert captured["channel"] == "C123"
+        assert captured["message"] == "hello"
+        assert captured["thread_ts"] == "1.2"
         assert "Slack message sent" in result.output
-        assert captured_cmd, "subprocess.run was not invoked"
-        cmd = captured_cmd[0]
-        assert cmd[0] == str(real_script)
-        assert "--channel" in cmd and "C123" in cmd
-        assert "--message" in cmd and "hello" in cmd
-        assert "--thread-ts" in cmd and "1.2" in cmd
-        assert "--workspace" in cmd and "aperture" in cmd
 
-    def test_passes_message_file_through(
+    def test_reads_message_from_file(
         self,
         runner: CliRunner,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
     ) -> None:
-        from dev10x.commands import skill as skill_module
+        captured: dict[str, object] = {}
 
-        monkeypatch.setattr(skill_module, "_plugin_root", lambda: tmp_path)
-        slack_dir = tmp_path / "skills" / "slack"
-        slack_dir.mkdir(parents=True, exist_ok=True)
-        (slack_dir / "slack-notify.py").write_text("#!/usr/bin/env python\n")
+        def fake_send(channel: str, message: str, **kwargs: object) -> str:
+            captured["message"] = message
+            return "ts"
+
+        from dev10x.skills.notifications import slack_notify
+
+        monkeypatch.setattr(slack_notify, "send_slack_message", fake_send)
 
         msg_file = tmp_path / "msg.txt"
         msg_file.write_text("hello from file")
-
-        captured_cmd: list[list[str]] = []
-
-        def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess:
-            captured_cmd.append(cmd)
-            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
 
         result = runner.invoke(
             cli,
@@ -188,48 +159,16 @@ class TestSlackSend:
         )
 
         assert result.exit_code == 0, result.output
-        assert "--message-file" in captured_cmd[0]
-        assert str(msg_file) in captured_cmd[0]
+        assert captured["message"] == "hello from file"
 
-    def test_propagates_nonzero_exit_code(
+    def test_exits_nonzero_on_send_failure(
         self,
         runner: CliRunner,
         monkeypatch: pytest.MonkeyPatch,
-        tmp_path: Path,
     ) -> None:
-        from dev10x.commands import skill as skill_module
+        from dev10x.skills.notifications import slack_notify
 
-        monkeypatch.setattr(skill_module, "_plugin_root", lambda: tmp_path.parent)
-        slack_dir = tmp_path.parent / "skills" / "slack"
-        slack_dir.mkdir(parents=True, exist_ok=True)
-        (slack_dir / "slack-notify.py").write_text("#!/usr/bin/env python\n")
-
-        def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess:
-            return subprocess.CompletedProcess(
-                args=cmd,
-                returncode=2,
-                stdout="",
-                stderr="missing_scope",
-            )
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
-
-        result = runner.invoke(
-            cli,
-            ["skill", "notify", "slack-send", "--channel", "C123", "--message", "x"],
-        )
-
-        assert result.exit_code == 2
-
-    def test_missing_slack_notify_script(
-        self,
-        runner: CliRunner,
-        monkeypatch: pytest.MonkeyPatch,
-        tmp_path: Path,
-    ) -> None:
-        from dev10x.commands import skill as skill_module
-
-        monkeypatch.setattr(skill_module, "_plugin_root", lambda: tmp_path / "missing")
+        monkeypatch.setattr(slack_notify, "send_slack_message", lambda **kw: None)
 
         result = runner.invoke(
             cli,
@@ -237,4 +176,26 @@ class TestSlackSend:
         )
 
         assert result.exit_code == 1
-        assert "slack-notify.py not found" in result.output
+
+    def test_works_without_skills_directory(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """GH-442: command must succeed even when skills/ dir is absent (uvx install)."""
+        from dev10x.skills.notifications import slack_notify
+
+        monkeypatch.setattr(
+            slack_notify,
+            "send_slack_message",
+            lambda **kw: "ts.ok",
+        )
+
+        result = runner.invoke(
+            cli,
+            ["skill", "notify", "slack-send", "--channel", "C999", "--message", "hi"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Slack message sent" in result.output

--- a/tests/skills/slack/test_slack_notify_module.py
+++ b/tests/skills/slack/test_slack_notify_module.py
@@ -1,0 +1,178 @@
+"""Tests for the importable slack_notify module (GH-442).
+
+Mirrors the standalone-script test suite in test_slack_notify.py
+to confirm the importable package module has identical behaviour.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev10x.skills.notifications import slack_notify as mod
+
+
+@pytest.fixture(autouse=True)
+def reset_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reset module-level state so tests are isolated."""
+    monkeypatch.setattr(mod, "_config", {})
+    monkeypatch.setattr(mod, "_active_workspace", None)
+    monkeypatch.delenv("SLACK_TOKEN", raising=False)
+    monkeypatch.delenv("SLACK_SELF_USER_ID", raising=False)
+
+
+class TestGetToken:
+    def test_default_keyring_used_when_no_env_and_no_workspace(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        calls: list[dict] = []
+
+        def fake_lookup(*, service: str, key: str) -> str | None:
+            calls.append({"service": service, "key": key})
+            return "xoxb-from-default-keyring"
+
+        monkeypatch.setattr(mod, "_keyring_lookup", fake_lookup)
+        assert mod.get_token() == "xoxb-from-default-keyring"
+        assert calls == [{"service": "slack", "key": "bot_token"}]
+
+    def test_env_var_wins_over_default_keyring(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("SLACK_TOKEN", "xoxb-from-env")
+        monkeypatch.setattr(
+            mod,
+            "_keyring_lookup",
+            lambda *, service, key: "xoxb-from-default-keyring",
+        )
+        assert mod.get_token() == "xoxb-from-env"
+
+    def test_workspace_uses_namespaced_keyring(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        looked_up: list[str] = []
+
+        def fake_lookup(*, service: str, key: str) -> str | None:
+            looked_up.append(service)
+            return "xoxb-aperture" if service == "slack-aperture" else None
+
+        monkeypatch.setattr(mod, "_keyring_lookup", fake_lookup)
+        mod.set_workspace("aperture")
+        assert mod.get_token() == "xoxb-aperture"
+        assert looked_up == ["slack-aperture"]
+
+    def test_workspace_missing_token_raises(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(mod, "_keyring_lookup", lambda *, service, key: None)
+        mod.set_workspace("aperture")
+        with pytest.raises(RuntimeError, match="aperture"):
+            mod.get_token()
+
+    def test_no_sources_raises(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(mod, "_keyring_lookup", lambda *, service, key: None)
+        with pytest.raises(RuntimeError, match="No Slack token found"):
+            mod.get_token()
+
+    def test_workspace_keyring_service_override(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            mod,
+            "_config",
+            {"workspaces": {"aperture": {"keyring_service": "custom-aperture"}}},
+        )
+        looked_up: list[str] = []
+
+        def fake_lookup(*, service: str, key: str) -> str | None:
+            looked_up.append(service)
+            return "xoxb-aperture"
+
+        monkeypatch.setattr(mod, "_keyring_lookup", fake_lookup)
+        mod.set_workspace("aperture")
+        assert mod.get_token() == "xoxb-aperture"
+        assert looked_up == ["custom-aperture"]
+
+
+class TestWorkspaceConfigResolution:
+    @pytest.fixture()
+    def config(self) -> dict:
+        return {
+            "self_user_id": "U_DEFAULT",
+            "bot_username": "Default Bot",
+            "user_groups": {"@default-team": "<!subteam^S_DEFAULT>"},
+            "workspaces": {
+                "aperture": {
+                    "self_user_id": "U_APERTURE",
+                    "bot_username": "Aperture Bot",
+                    "user_groups": {"@aperture-team": "<!subteam^S_APERTURE>"},
+                },
+            },
+        }
+
+    def test_defaults_when_no_workspace(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        config: dict,
+    ) -> None:
+        monkeypatch.setattr(mod, "_config", config)
+        assert mod._self_user_id() == "U_DEFAULT"
+        assert mod._bot_username() == "Default Bot"
+        assert mod._user_groups() == {"@default-team": "<!subteam^S_DEFAULT>"}
+
+    def test_workspace_overrides_defaults(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        config: dict,
+    ) -> None:
+        monkeypatch.setattr(mod, "_config", config)
+        mod.set_workspace("aperture")
+        assert mod._self_user_id() == "U_APERTURE"
+        assert mod._bot_username() == "Aperture Bot"
+        assert mod._user_groups() == {"@aperture-team": "<!subteam^S_APERTURE>"}
+
+    def test_unknown_workspace_falls_back_to_defaults(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        config: dict,
+    ) -> None:
+        monkeypatch.setattr(mod, "_config", config)
+        mod.set_workspace("ghost")
+        assert mod._bot_username() == "Default Bot"
+        assert mod._self_user_id() == "U_DEFAULT"
+
+    def test_self_user_id_env_overrides_all(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        config: dict,
+    ) -> None:
+        monkeypatch.setattr(mod, "_config", config)
+        monkeypatch.setenv("SLACK_SELF_USER_ID", "U_FROM_ENV")
+        mod.set_workspace("aperture")
+        assert mod._self_user_id() == "U_FROM_ENV"
+
+
+class TestResolveMentions:
+    def test_uses_active_workspace_user_groups(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            mod,
+            "_config",
+            {
+                "user_groups": {"@default": "<!subteam^S_DEF>"},
+                "workspaces": {
+                    "aperture": {"user_groups": {"@aperture": "<!subteam^S_APE>"}},
+                },
+            },
+        )
+        mod.set_workspace("aperture")
+        assert mod.resolve_mentions("ping @aperture") == "ping <!subteam^S_APE>"
+        assert mod.resolve_mentions("ping @default") == "ping @default"


### PR DESCRIPTION
When I install dev10x via `uvx` and run `dev10x skill notify slack-send`, I want the command to call Slack directly without resolving filesystem paths to the `skills/` directory, so I can send Slack messages reliably from any install context including uvx where `skills/` is not packaged in the wheel.

---

[`3e19b77f`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/452/commits/3e19b77fbfd924d9961ab9f3333b786907fecddb) 🐛 GH-442 Enable uvx dev10x skill notify slack-send
Fixes: https://github.com/Dev10x-Guru/dev10x-claude/issues/442

---