### PR TITLE
♻️ GH-249 Enable declarative friction-level dispatch (F4)

### DIFF
--- a/src/dev10x/domain/friction_level.py
+++ b/src/dev10x/domain/friction_level.py
@@ -54,5 +54,48 @@ class FrictionLevel(StrEnum):
                 return member
         return cls.default()
 
+    def pending_decisions_guidance(self) -> str:
+        """Return the session-resume instruction for pending-decision state.
+
+        Called by ``DecisionGuidanceRule`` when the plan has one or more
+        unresolved decision tasks.  Each member encodes its own pacing
+        rule, eliminating the if/elif dispatch from the rule body.
+
+        Returns:
+            A non-empty instruction string for every recognised member.
+        """
+        if self is FrictionLevel.ADAPTIVE:
+            return (
+                "Session resumed with pending decisions. Friction level is adaptive — "
+                "auto-select recommended options for all queued decisions and continue "
+                "advancing through the task list without calling AskUserQuestion."
+            )
+        return (
+            "Session resumed with pending decisions. "
+            "Re-ask each pending decision using AskUserQuestion — "
+            "invoke Dev10x:ask before advancing."
+        )
+
+    def fallback_guidance(self, *, fallback: str) -> str:
+        """Return a friction-level-specific fallback clause for block messages.
+
+        In GUIDED mode the agent is shown a concrete fallback path (skill
+        guardrails to apply manually, or an MCP-unavailability escape).
+        In STRICT and ADAPTIVE modes the block is unadorned — the fallback
+        text is omitted so the message stays concise.
+
+        Args:
+            fallback: The fallback snippet to surface in GUIDED mode.
+                      May be an MCP-server fallback description, a manual-
+                      guardrail list, or any other escape-hatch hint.
+
+        Returns:
+            The fallback clause (including a leading newline) when GUIDED,
+            or an empty string for other levels.
+        """
+        if self is FrictionLevel.GUIDED:
+            return fallback
+        return ""
+
 
 __all__ = ["FrictionLevel"]

--- a/src/dev10x/domain/session_rules.py
+++ b/src/dev10x/domain/session_rules.py
@@ -69,26 +69,12 @@ class DecisionGuidanceRule(PolicyRule[str]):
             raise UnknownFrictionLevelError(f"Unknown friction level: {self.friction_level!r}")
 
         summary = PlanSummary.from_dict(data=self.plan)
-        decisions = summary.pending_decisions
-        if not decisions:
-            has_remaining = bool(summary.pending_tasks)
-            if has_remaining:
+        if not summary.pending_decisions:
+            if summary.pending_tasks:
                 return "Session resumed with tasks remaining. Auto-advance through the task list."
             return ""
 
-        if self.friction_level is FrictionLevel.ADAPTIVE:
-            return (
-                "Session resumed with pending decisions. Friction level is adaptive — "
-                "auto-select recommended options for all queued decisions and continue "
-                "advancing through the task list without calling AskUserQuestion."
-            )
-        if self.friction_level in (FrictionLevel.STRICT, FrictionLevel.GUIDED):
-            return (
-                "Session resumed with pending decisions. "
-                "Re-ask each pending decision using AskUserQuestion — "
-                "invoke Dev10x:ask before advancing."
-            )
-        raise UnknownFrictionLevelError(f"Unhandled friction level: {self.friction_level!r}")
+        return self.friction_level.pending_decisions_guidance()
 
 
 __all__ = [

--- a/src/dev10x/validators/skill_redirect.py
+++ b/src/dev10x/validators/skill_redirect.py
@@ -184,40 +184,39 @@ def _format_skill_msg(
         else ""
     )
     if comp.type == "use-tool":
-        if friction_level is FrictionLevel.GUIDED and comp.description:
-            return (
-                f"\u26d4  `{label}` blocked — use the MCP tool instead.\n\n"
-                f"  Tool: `{comp.tool}`\n\n"
-                f"Why: Raw CLI bypasses structured responses and causes\n"
-                f"permission friction ({comp.guardrails}).\n\n"
-                f"If the MCP server is unavailable, fall back to:\n"
-                f"{comp.description}"
-                f"{MCP_UNAVAILABLE_HINT}"
-                f"{file_issue_hint}{OVERRIDE_HINT}"
+        mcp_fallback = friction_level.fallback_guidance(
+            fallback=(
+                f"If the MCP server is unavailable, fall back to:\n{comp.description}"
+                if comp.description
+                else ""
             )
+        )
+        sep = "\n\n" if mcp_fallback else ""
         return (
             f"\u26d4  `{label}` blocked — use the MCP tool instead.\n\n"
             f"  Tool: `{comp.tool}`\n\n"
             f"Why: Raw CLI bypasses structured responses and causes\n"
             f"permission friction ({comp.guardrails})."
+            f"{sep}{mcp_fallback}"
             f"{MCP_UNAVAILABLE_HINT}"
             f"{file_issue_hint}{OVERRIDE_HINT}"
         )
 
-    if friction_level is FrictionLevel.GUIDED and comp.fallback:
-        return (
-            f"\u26d4  `{label}` blocked — use the skill instead.\n\n"
-            f"  Skill: `Skill({comp.skill})`\n\n"
-            f"Why: Raw CLI bypasses guardrails that the skill enforces\n"
-            f"({comp.guardrails}).\n\n"
-            f"If the skill fails, apply these guardrails manually:\n"
-            f"{comp.fallback}{file_issue_hint}{OVERRIDE_HINT}"
+    skill_fallback = friction_level.fallback_guidance(
+        fallback=(
+            f"If the skill fails, apply these guardrails manually:\n{comp.fallback}"
+            if comp.fallback
+            else ""
         )
+    )
+    sep = "\n\n" if skill_fallback else ""
     return (
         f"\u26d4  `{label}` blocked — use the skill instead.\n\n"
         f"  Skill: `Skill({comp.skill})`\n\n"
         f"Why: Raw CLI bypasses guardrails that the skill enforces\n"
-        f"({comp.guardrails}).{file_issue_hint}{OVERRIDE_HINT}"
+        f"({comp.guardrails})."
+        f"{sep}{skill_fallback}"
+        f"{file_issue_hint}{OVERRIDE_HINT}"
     )
 
 

--- a/tests/domain/test_friction_level.py
+++ b/tests/domain/test_friction_level.py
@@ -39,3 +39,42 @@ def test_member_values_are_lowercase() -> None:
 def test_str_enum_round_trips_through_yaml() -> None:
     assert FrictionLevel.ADAPTIVE == "adaptive"
     assert "adaptive" == FrictionLevel.ADAPTIVE.value
+
+
+class TestPendingDecisionsGuidance:
+    def test_adaptive_auto_selects(self) -> None:
+        result = FrictionLevel.ADAPTIVE.pending_decisions_guidance()
+        assert "auto-select" in result
+        assert "without calling AskUserQuestion" in result
+
+    def test_guided_asks_user(self) -> None:
+        result = FrictionLevel.GUIDED.pending_decisions_guidance()
+        assert "AskUserQuestion" in result
+        assert "auto-select" not in result
+
+    def test_strict_asks_user(self) -> None:
+        result = FrictionLevel.STRICT.pending_decisions_guidance()
+        assert "AskUserQuestion" in result
+        assert "auto-select" not in result
+
+    def test_all_members_return_non_empty(self) -> None:
+        for member in FrictionLevel:
+            assert member.pending_decisions_guidance()
+
+
+class TestFallbackGuidance:
+    def test_guided_returns_fallback(self) -> None:
+        result = FrictionLevel.GUIDED.fallback_guidance(fallback="try this instead")
+        assert result == "try this instead"
+
+    def test_strict_returns_empty(self) -> None:
+        result = FrictionLevel.STRICT.fallback_guidance(fallback="try this instead")
+        assert result == ""
+
+    def test_adaptive_returns_empty(self) -> None:
+        result = FrictionLevel.ADAPTIVE.fallback_guidance(fallback="try this instead")
+        assert result == ""
+
+    def test_guided_with_empty_fallback_returns_empty(self) -> None:
+        result = FrictionLevel.GUIDED.fallback_guidance(fallback="")
+        assert result == ""


### PR DESCRIPTION
**When** I resume a session with pending decisions, **I want** the friction level's pacing rule to be encoded on the `FrictionLevel` enum itself **so I can** extend or audit per-level behaviour without scanning dispersed if/elif chains across two modules.

---

[`e5c32c39`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/453/commits/e5c32c39209d4a1901a7687fdf5e304cba397f63) ♻️ GH-249 Enable declarative friction-level dispatch (F4)

**Changes:**
- `FrictionLevel.pending_decisions_guidance()` — per-member resume instruction, removes if/elif from `DecisionGuidanceRule.apply()`
- `FrictionLevel.fallback_guidance(*, fallback)` — GUIDED-only fallback clause, consolidates four-branch if/elif in `_format_skill_msg()`
- `DecisionGuidanceRule.apply()` simplified to a single delegation call
- 8 new tests covering both methods across all members

Refs: #249
Fixes: none — self-motivated