### PR TITLE
📝 GH-447 Enable automatic playbook migration on upgrade

### DIFF
--- a/skills/plugin-maintenance/SKILL.md
+++ b/skills/plugin-maintenance/SKILL.md
@@ -354,6 +354,33 @@ For each file:
 4. `mv` source to destination
 5. Report what moved
 
+**Playbook overrides (GH-447) — full mode only:**
+
+Migrate global playbook overrides from the old
+`~/.claude/memory/Dev10x/playbooks/` path to the XDG-canonical
+`~/.config/Dev10x/playbooks/` path (established by GH-445).
+
+For each `*.yaml` in `~/.claude/memory/Dev10x/playbooks/`:
+
+| Entry type | Action |
+|------------|--------|
+| Regular file | Move to `~/.config/Dev10x/playbooks/<filename>`, refusing to overwrite an existing destination — surface the conflict instead |
+| Symlink pointing into `~/.config/Dev10x/playbooks/` | Delete (pre-migration artefact — the target already exists at the new location) |
+| Symlink pointing elsewhere | Leave in place and warn — manual inspection required |
+
+After processing all entries:
+- Report each migrated file (source → destination)
+- Report each skipped conflict (both paths exist)
+- If `~/.claude/memory/Dev10x/playbooks/` is now empty, remove it
+
+Playbook migration steps:
+1. Check if `~/.claude/memory/Dev10x/playbooks/` exists (skip entire
+   sub-step if not — users who never had overrides skip cleanly)
+2. Ensure `~/.config/Dev10x/playbooks/` exists (create if missing)
+3. For each entry: apply the action table above
+4. Remove the source directory when empty
+5. Report a summary of what moved, what was skipped, and why
+
 ### 3. Ensure workspace directories **[bootstrap]** (GH-40)
 
 Register paths outside the project root (e.g. `/tmp/Dev10x`) under

--- a/skills/upgrade-cleanup/SKILL.md
+++ b/skills/upgrade-cleanup/SKILL.md
@@ -3,7 +3,9 @@ name: Dev10x:upgrade-cleanup
 description: >
   Post-upgrade cleanup entry point — delegates to
   `Dev10x:plugin-maintenance` in `full` mode. Updates plugin
-  version paths, ensures base permissions, migrates config files,
+  version paths, ensures base permissions, migrates config files
+  (including global playbook overrides from
+  ~/.claude/memory/Dev10x/playbooks/ to ~/.config/Dev10x/playbooks/),
   generalizes session-specific args, enumerates MCP tool globs,
   refreshes script coverage, merges worktree rules, audits for
   friction-causing patterns, and cleans redundant rules from
@@ -60,10 +62,17 @@ Skill(skill="Dev10x:plugin-maintenance", args="full")
 ```
 
 The maintenance skill creates its own task list and runs
-steps 1–9 sequentially (update paths → migrate configs →
-ensure base perms → generalize → enumerate MCP → script
-coverage → worktree merge → permission audit → clean project
-files).
+steps 1–14 sequentially (update paths → migrate configs
+including playbook overrides → ensure base perms → generalize →
+enumerate MCP → script coverage → worktree merge → permission
+audit → clean project files → diff playbooks).
+
+The "Migrate config files" step (step 3) includes migrating global
+playbook overrides from `~/.claude/memory/Dev10x/playbooks/` to
+`~/.config/Dev10x/playbooks/` (GH-447). Regular files are moved;
+symlinks pointing into the new location are deleted; conflicts
+(destination already exists) are surfaced rather than overwritten.
+The old directory is removed once empty.
 
 After the maintenance pass succeeds, record the plugin version
 so the SessionStart install-check stays silent until the next


### PR DESCRIPTION
**When** I upgrade Dev10x after GH-445 changed the tier-2 playbook path, **I want to** have my existing global playbook overrides automatically migrated to `~/.config/Dev10x/playbooks/`, **so I can** continue using my customizations without manually moving files after every upgrade.

---

[`97751716`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/454/commits/9775171634b8ff817734bfca9a7c8d9fa08ecb93) 📝 GH-447 Enable automatic playbook migration on upgrade

Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/447