### PR TITLE
✨ GH-341 Enable MCP resource update notifications

### DIFF
--- a/src/dev10x/mcp/_app.py
+++ b/src/dev10x/mcp/_app.py
@@ -2,10 +2,60 @@
 
 Split out of server_cli.py (GH-243/A6) so per-domain tool modules
 register against one server without a circular import.
+
+GH-341: A lifespan context manager starts the knowledge-resource file
+watcher and wires it to the active MCP session so that
+``notifications/resources/list_changed`` and
+``notifications/resources/updated`` are emitted to clients whenever the
+underlying files change.
 """
 
 from __future__ import annotations
 
+import asyncio
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
 from mcp.server.fastmcp import FastMCP
 
-server = FastMCP(name="Dev10x-cli")
+from dev10x.mcp.resource_watcher import KnowledgeResourceWatcher, wire_watcher_to_server
+from dev10x.subprocess_utils import get_plugin_root
+
+log = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def _knowledge_watcher_lifespan(app: FastMCP) -> AsyncIterator[None]:
+    """Lifespan that runs the knowledge-resource file watcher (GH-341).
+
+    On server start:
+    1. Creates a :class:`~dev10x.mcp.resource_watcher.KnowledgeResourceWatcher`
+       rooted at the plugin install directory.
+    2. Registers an ``InitializedNotification`` handler on the low-level
+       server so the watcher receives the active session as soon as the
+       MCP client completes its handshake.
+    3. Starts the poll loop as a background asyncio task.
+
+    On server shutdown (lifespan exit) the background task is cancelled.
+    """
+    plugin_root = get_plugin_root()
+    watcher = KnowledgeResourceWatcher(plugin_root=plugin_root)
+
+    wire_watcher_to_server(server=app._mcp_server, watcher=watcher)
+
+    task = asyncio.create_task(watcher.run(), name="dev10x-resource-watcher")
+    log.debug("Resource watcher task started for root: %s", plugin_root)
+
+    try:
+        yield
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        log.debug("Resource watcher task stopped")
+
+
+server = FastMCP(name="Dev10x-cli", lifespan=_knowledge_watcher_lifespan)

--- a/src/dev10x/mcp/resource_watcher.py
+++ b/src/dev10x/mcp/resource_watcher.py
@@ -1,0 +1,413 @@
+"""MCP resource update notifications for Dev10x knowledge resources (GH-341).
+
+Watches the on-disk files that back the knowledge resources registered in
+``knowledge_resources.py`` and emits ``notifications/resources/list_changed``
+(when a file is added or removed) or ``notifications/resources/updated``
+(when an existing file's content changes) to connected MCP clients.
+
+Architecture
+------------
+``KnowledgeResourceWatcher`` polls file modification-times on a configurable
+interval (default 5 s).  Polling avoids the need for ``watchfiles`` or OS
+inotify libraries — no extra dependencies are required.
+
+Session wiring
+--------------
+MCP resource notifications must be sent through an active ``ServerSession``.
+The watcher receives a session reference via :meth:`set_session`, which is
+called by the ``InitializedNotification`` handler registered on the low-level
+server in :func:`wire_watcher_to_server`.
+
+Calling :meth:`set_session` with ``None`` (the default) disables notification
+dispatch so that the same watcher instance can be used in unit tests without
+needing a live server connection.
+
+Watched paths
+-------------
+The watcher tracks four roots that correspond to the five resource handlers
+in ``knowledge_resources.py``:
+
+* ``skills/*/references/playbook.yaml``  →  ``dev10x://skills/{name}/playbook``
+* ``.claude/rules/*.md``                 →  ``dev10x://rules/{name}``
+* ``references/*.md``                    →  ``dev10x://references/{name}``
+* ``SKILLS.md``                          →  ``dev10x://skills/index``
+
+Changes to these files trigger ``resources/updated``; a file appearing or
+disappearing triggers ``resources/list_changed`` (because the set of
+enumerable template results changes).
+
+Environment variables
+---------------------
+DEV10X_RESOURCE_WATCH_INTERVAL
+    Poll interval in seconds.  Defaults to 5.  Set to 0 to disable polling
+    entirely (e.g. in integration tests).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from mcp.server.session import ServerSession
+
+log = logging.getLogger(__name__)
+
+
+def _poll_interval() -> float:
+    """Return the file-watch poll interval in seconds.
+
+    Reads ``DEV10X_RESOURCE_WATCH_INTERVAL``; defaults to 5.0.
+    A value of 0 disables polling entirely.
+    """
+    raw = os.environ.get("DEV10X_RESOURCE_WATCH_INTERVAL", "").strip()
+    try:
+        return float(raw) if raw else 5.0
+    except ValueError:
+        log.warning(
+            "Invalid DEV10X_RESOURCE_WATCH_INTERVAL=%r, using default 5.0",
+            raw,
+        )
+        return 5.0
+
+
+# ── per-file snapshot ──────────────────────────────────────────────
+
+
+@dataclass
+class _FileState:
+    """Last-seen mtime and existence state for one watched path."""
+
+    exists: bool
+    mtime: float
+
+
+# ── change events ──────────────────────────────────────────────────
+
+
+@dataclass
+class ResourceChanged:
+    """A single resource change event.
+
+    Attributes:
+        uri: The ``dev10x://`` URI of the changed resource.
+        list_changed: True when the *list* of resources changed (file added
+            or removed).  False when only the content of an existing file
+            changed.
+    """
+
+    uri: str
+    list_changed: bool = False
+
+
+# ── watcher ───────────────────────────────────────────────────────
+
+
+class KnowledgeResourceWatcher:
+    """Poll Dev10x knowledge files and emit MCP resource notifications.
+
+    Typical lifecycle::
+
+        watcher = KnowledgeResourceWatcher(plugin_root=get_plugin_root())
+        # (wire_watcher_to_server will call watcher.set_session(...) when the
+        # MCP client sends its InitializedNotification)
+        await watcher.run()  # blocks until cancelled
+
+    The watcher is safe to create before the MCP session is established;
+    file scanning still runs and changes are accumulated, but notifications
+    are only sent after :meth:`set_session` is called.
+
+    Args:
+        plugin_root: Root of the Dev10x plugin tree.  All watched paths are
+            relative to this directory.
+        poll_interval: Seconds between scans.  ``None`` uses the value of
+            ``DEV10X_RESOURCE_WATCH_INTERVAL``.
+    """
+
+    def __init__(
+        self,
+        plugin_root: Path,
+        poll_interval: float | None = None,
+    ) -> None:
+        self._root = plugin_root
+        self._interval: float = poll_interval if poll_interval is not None else _poll_interval()
+        self._session: ServerSession | None = None
+        self._snapshot: dict[Path, _FileState] = {}
+
+    # ── session wiring ────────────────────────────────────────────
+
+    def set_session(self, session: ServerSession | None) -> None:
+        """Attach (or detach) the active MCP session.
+
+        Called by the ``InitializedNotification`` handler to give the watcher
+        a live session through which it can send notifications.  Pass ``None``
+        to detach (e.g. on disconnect).
+
+        Args:
+            session: The active :class:`~mcp.server.session.ServerSession`,
+                or ``None`` to disable notification dispatch.
+        """
+        self._session = session
+        if session is not None:
+            log.debug("Resource watcher: session attached")
+        else:
+            log.debug("Resource watcher: session detached")
+
+    # ── path helpers ──────────────────────────────────────────────
+
+    def _watched_files(self) -> dict[Path, str]:
+        """Return a mapping of absolute path → resource URI for all watchable files.
+
+        The map is rebuilt on every scan so that newly-created skill directories
+        are picked up automatically.
+        """
+        mapping: dict[Path, str] = {}
+        root = self._root
+
+        # SKILLS.md → dev10x://skills/index
+        skills_index = root / "SKILLS.md"
+        mapping[skills_index] = "dev10x://skills/index"
+
+        # .claude/rules/INDEX.md → dev10x://rules/index
+        rules_index = root / ".claude" / "rules" / "INDEX.md"
+        mapping[rules_index] = "dev10x://rules/index"
+
+        # .claude/rules/*.md → dev10x://rules/{stem}
+        rules_dir = root / ".claude" / "rules"
+        if rules_dir.is_dir():
+            for md in rules_dir.glob("*.md"):
+                if md.name != "INDEX.md":
+                    mapping[md] = f"dev10x://rules/{md.stem}"
+
+        # references/*.md → dev10x://references/{stem}
+        references_dir = root / "references"
+        if references_dir.is_dir():
+            for md in references_dir.glob("*.md"):
+                mapping[md] = f"dev10x://references/{md.stem}"
+
+        # skills/*/references/playbook.yaml → dev10x://skills/{name}/playbook
+        skills_dir = root / "skills"
+        if skills_dir.is_dir():
+            for playbook in skills_dir.glob("*/references/playbook.yaml"):
+                skill_name = playbook.parent.parent.name
+                mapping[playbook] = f"dev10x://skills/{skill_name}/playbook"
+
+        return mapping
+
+    # ── scan logic ────────────────────────────────────────────────
+
+    def _take_snapshot(
+        self,
+        watched: dict[Path, str],
+    ) -> dict[Path, _FileState]:
+        """Return a fresh snapshot of file states for *watched*."""
+        snapshot: dict[Path, _FileState] = {}
+        for path in watched:
+            exists = path.exists()
+            mtime = path.stat().st_mtime if exists else 0.0
+            snapshot[path] = _FileState(exists=exists, mtime=mtime)
+        return snapshot
+
+    def scan_changes(self) -> list[ResourceChanged]:
+        """Scan watched files and return a list of change events.
+
+        Compares the current on-disk state against the stored snapshot and
+        updates the snapshot in-place.  Returns an empty list when nothing
+        has changed.
+
+        This method is synchronous and safe to call from tests without an
+        event loop.  The :meth:`run` async loop calls it on every tick.
+
+        Returns:
+            List of :class:`ResourceChanged` events, one per changed URI.
+            URIs are deduplicated — only the first event per URI per scan
+            is returned.
+        """
+        watched = self._watched_files()
+        current = self._take_snapshot(watched=watched)
+
+        events: dict[str, ResourceChanged] = {}
+
+        # Check every currently-watched path.
+        for path, uri in watched.items():
+            prev = self._snapshot.get(path)
+            cur = current[path]
+
+            if prev is None:
+                # Previously unknown path — treat as potential addition.
+                if cur.exists:
+                    log.debug("Resource watcher: new file %s → %s", path, uri)
+                    events[uri] = ResourceChanged(uri=uri, list_changed=True)
+            elif not prev.exists and cur.exists:
+                # File appeared.
+                log.debug("Resource watcher: appeared %s → %s", path, uri)
+                events[uri] = ResourceChanged(uri=uri, list_changed=True)
+            elif prev.exists and not cur.exists:
+                # File disappeared.
+                log.debug("Resource watcher: disappeared %s → %s", path, uri)
+                events[uri] = ResourceChanged(uri=uri, list_changed=True)
+            elif prev.exists and cur.exists and prev.mtime != cur.mtime:
+                # Content changed.
+                log.debug("Resource watcher: modified %s → %s", path, uri)
+                if uri not in events:
+                    events[uri] = ResourceChanged(uri=uri, list_changed=False)
+
+        # Check previously-watched paths no longer in watched (directory removed).
+        for path, state in self._snapshot.items():
+            if path not in watched and state.exists:
+                removed_uri = self._snapshot_uri(path=path)
+                if removed_uri and removed_uri not in events:
+                    log.debug("Resource watcher: removed from watch %s → %s", path, removed_uri)
+                    events[removed_uri] = ResourceChanged(uri=removed_uri, list_changed=True)
+
+        self._snapshot = current
+        return list(events.values())
+
+    def _snapshot_uri(self, path: Path) -> str | None:
+        """Return the URI for *path* from the previous snapshot's watch map, if known."""
+        # Re-derive from the path's relationship to the root.
+        root = self._root
+        try:
+            rel = path.relative_to(root)
+        except ValueError:
+            return None
+        parts = rel.parts
+        if len(parts) == 1 and parts[0] == "SKILLS.md":
+            return "dev10x://skills/index"
+        if len(parts) >= 3 and parts[0] == ".claude" and parts[1] == "rules":
+            stem = Path(parts[2]).stem
+            return "dev10x://rules/index" if parts[2] == "INDEX.md" else f"dev10x://rules/{stem}"
+        if len(parts) == 2 and parts[0] == "references":
+            return f"dev10x://references/{Path(parts[1]).stem}"
+        if (
+            len(parts) == 4
+            and parts[0] == "skills"
+            and parts[2] == "references"
+            and parts[3] == "playbook.yaml"
+        ):
+            return f"dev10x://skills/{parts[1]}/playbook"
+        return None
+
+    # ── notification dispatch ─────────────────────────────────────
+
+    async def _notify(self, events: list[ResourceChanged]) -> None:
+        """Send MCP notifications for *events*.
+
+        Skips silently when no session is attached.
+
+        Args:
+            events: Change events returned by :meth:`scan_changes`.
+        """
+        session = self._session
+        if session is None or not events:
+            return
+
+        any_list_changed = any(e.list_changed for e in events)
+
+        try:
+            if any_list_changed:
+                await session.send_resource_list_changed()
+                log.debug("Resource watcher: sent resources/list_changed")
+
+            for event in events:
+                if not event.list_changed:
+                    from pydantic import AnyUrl
+
+                    await session.send_resource_updated(AnyUrl(event.uri))
+                    log.debug("Resource watcher: sent resources/updated for %s", event.uri)
+        except Exception:
+            log.debug(
+                "Resource watcher: notification send failed (session may have closed)",
+                exc_info=True,
+            )
+            self._session = None
+
+    # ── main loop ─────────────────────────────────────────────────
+
+    async def run(self) -> None:
+        """Poll for file changes and emit MCP notifications in a loop.
+
+        Runs until cancelled (e.g. via task group cancellation at server
+        shutdown).  When ``poll_interval`` is 0, this coroutine returns
+        immediately (useful in tests to disable background polling).
+        """
+        if self._interval <= 0:
+            log.debug("Resource watcher: disabled (interval=0)")
+            return
+
+        log.info("Resource watcher: starting, interval=%.1fs", self._interval)
+
+        # Seed the snapshot on first run so we do not emit spurious changes
+        # for files that already existed before the server started.
+        watched = self._watched_files()
+        self._snapshot = self._take_snapshot(watched=watched)
+
+        while True:
+            await asyncio.sleep(self._interval)
+            try:
+                changes = self.scan_changes()
+                if changes:
+                    await self._notify(events=changes)
+            except Exception:
+                log.debug("Resource watcher: scan error", exc_info=True)
+
+
+# ── server wiring ─────────────────────────────────────────────────
+
+
+@dataclass
+class _WatcherRegistry:
+    """Module-level singleton holding the active watcher instance.
+
+    This indirection lets tests replace the watcher without modifying the
+    FastMCP server object.
+    """
+
+    watcher: KnowledgeResourceWatcher | None = field(default=None)
+
+
+_registry: _WatcherRegistry = _WatcherRegistry()
+
+
+def get_watcher() -> KnowledgeResourceWatcher | None:
+    """Return the currently registered :class:`KnowledgeResourceWatcher`, or ``None``."""
+    return _registry.watcher
+
+
+def wire_watcher_to_server(
+    server: object,
+    watcher: KnowledgeResourceWatcher,
+) -> None:
+    """Register *watcher* with the MCP low-level *server*'s notification handlers.
+
+    Installs an ``InitializedNotification`` handler on the low-level server
+    object so that the watcher receives the active session as soon as the MCP
+    client completes its handshake.
+
+    This function is intentionally low-coupling: it accepts any object with a
+    ``notification_handlers`` dict and a ``request_context`` property, which
+    matches both the real ``mcp.server.lowlevel.server.Server`` and test stubs.
+
+    Args:
+        server: The low-level MCP ``Server`` instance (e.g.
+            ``fastmcp_instance._mcp_server``).
+        watcher: The watcher to attach.
+    """
+    import mcp.types as mcp_types
+
+    _registry.watcher = watcher
+
+    async def _on_initialized(notification: mcp_types.InitializedNotification) -> None:
+        try:
+            session = server.request_context.session  # type: ignore[attr-defined]
+            watcher.set_session(session=session)
+            log.debug("Resource watcher: session wired via InitializedNotification")
+        except Exception:
+            log.debug("Resource watcher: could not acquire session on initialized", exc_info=True)
+
+    server.notification_handlers[mcp_types.InitializedNotification] = _on_initialized  # type: ignore[attr-defined]
+    log.debug("Resource watcher: InitializedNotification handler registered")

--- a/tests/mcp/test_resource_watcher.py
+++ b/tests/mcp/test_resource_watcher.py
@@ -1,0 +1,640 @@
+"""Tests for the Dev10x MCP resource update notifications (GH-341).
+
+Covers:
+- KnowledgeResourceWatcher.scan_changes detects added, removed, and modified files
+- Notification dispatch to a session on content changes vs list changes
+- Polling loop disabled when interval=0
+- wire_watcher_to_server registers the InitializedNotification handler
+- get_watcher returns the registered watcher
+- _app.py lifespan creates and cancels the watcher task
+- _poll_interval reads the env var with correct fallback
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+resource_watcher = pytest.importorskip(
+    "dev10x.mcp.resource_watcher",
+    reason="mcp not installed",
+)
+
+KnowledgeResourceWatcher = resource_watcher.KnowledgeResourceWatcher
+ResourceChanged = resource_watcher.ResourceChanged
+wire_watcher_to_server = resource_watcher.wire_watcher_to_server
+get_watcher = resource_watcher.get_watcher
+_poll_interval = resource_watcher._poll_interval
+
+
+# ── helpers ────────────────────────────────────────────────────────
+
+
+def _make_root(tmp_path: Path) -> Path:
+    """Create a minimal plugin-root layout under *tmp_path*."""
+    # skills/work-on/references/playbook.yaml
+    playbook_dir = tmp_path / "skills" / "work-on" / "references"
+    playbook_dir.mkdir(parents=True)
+    (playbook_dir / "playbook.yaml").write_text("defaults:\n  single: []\n")
+
+    # .claude/rules/INDEX.md and one rule
+    rules_dir = tmp_path / ".claude" / "rules"
+    rules_dir.mkdir(parents=True)
+    (rules_dir / "INDEX.md").write_text("# Index\n")
+    (rules_dir / "essentials.md").write_text("# Essentials\n")
+
+    # references/git-commits.md
+    ref_dir = tmp_path / "references"
+    ref_dir.mkdir(parents=True)
+    (ref_dir / "git-commits.md").write_text("# Git commits\n")
+
+    # SKILLS.md
+    (tmp_path / "SKILLS.md").write_text("# Skills\n")
+
+    return tmp_path
+
+
+def _make_watcher(tmp_path: Path, interval: float = 0.0) -> KnowledgeResourceWatcher:
+    root = _make_root(tmp_path)
+    return KnowledgeResourceWatcher(plugin_root=root, poll_interval=interval)
+
+
+# ── _poll_interval ─────────────────────────────────────────────────
+
+
+class TestPollInterval:
+    def test_default_is_five(self) -> None:
+        with patch.dict("os.environ", {}, clear=True):
+            result = _poll_interval()
+
+        assert result == 5.0
+
+    def test_reads_env_var(self) -> None:
+        with patch.dict("os.environ", {"DEV10X_RESOURCE_WATCH_INTERVAL": "10"}):
+            result = _poll_interval()
+
+        assert result == 10.0
+
+    def test_invalid_env_var_falls_back_to_default(self) -> None:
+        with patch.dict("os.environ", {"DEV10X_RESOURCE_WATCH_INTERVAL": "notanumber"}):
+            result = _poll_interval()
+
+        assert result == 5.0
+
+    def test_zero_is_accepted(self) -> None:
+        with patch.dict("os.environ", {"DEV10X_RESOURCE_WATCH_INTERVAL": "0"}):
+            result = _poll_interval()
+
+        assert result == 0.0
+
+
+# ── scan_changes — initial seed ────────────────────────────────────
+
+
+class TestScanChangesInitialSeed:
+    def test_no_changes_reported_on_first_scan_after_run_seeds(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        watcher = _make_watcher(tmp_path)
+        # Seed snapshot directly as run() would do
+        watched = watcher._watched_files()
+        watcher._snapshot = watcher._take_snapshot(watched=watched)
+
+        changes = watcher.scan_changes()
+
+        assert changes == []
+
+    def test_empty_snapshot_reports_existing_files_as_added(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        watcher = _make_watcher(tmp_path)
+        # Don't seed — simulate first scan without pre-seeding
+
+        changes = watcher.scan_changes()
+
+        uris = {c.uri for c in changes}
+        assert "dev10x://skills/index" in uris
+        assert all(c.list_changed for c in changes)
+
+
+# ── scan_changes — content modified ───────────────────────────────
+
+
+class TestScanChangesModified:
+    def test_detects_modified_file_as_content_change(self, tmp_path: Path) -> None:
+        watcher = _make_watcher(tmp_path)
+        watched = watcher._watched_files()
+        watcher._snapshot = watcher._take_snapshot(watched=watched)
+
+        skills_md = tmp_path / "SKILLS.md"
+        # Force a different mtime by writing new content
+        skills_md.write_text("# Updated Skills\n")
+        # Manipulate snapshot mtime to guarantee difference
+        watcher._snapshot[skills_md].mtime -= 1.0
+
+        changes = watcher.scan_changes()
+
+        uris = {c.uri for c in changes}
+        assert "dev10x://skills/index" in uris
+        matching = [c for c in changes if c.uri == "dev10x://skills/index"]
+        assert matching[0].list_changed is False
+
+    def test_detects_modified_rule_file(self, tmp_path: Path) -> None:
+        watcher = _make_watcher(tmp_path)
+        watched = watcher._watched_files()
+        watcher._snapshot = watcher._take_snapshot(watched=watched)
+
+        essentials = tmp_path / ".claude" / "rules" / "essentials.md"
+        essentials.write_text("# Updated Essentials\n")
+        watcher._snapshot[essentials].mtime -= 1.0
+
+        changes = watcher.scan_changes()
+
+        uris = {c.uri for c in changes}
+        assert "dev10x://rules/essentials" in uris
+
+
+# ── scan_changes — file appeared/disappeared (branch coverage) ────
+
+
+class TestScanChangesAppearedDisappeared:
+    def test_detects_appeared_file_in_snapshot_as_list_changed(self, tmp_path: Path) -> None:
+        watcher = _make_watcher(tmp_path)
+        watched = watcher._watched_files()
+        watcher._snapshot = watcher._take_snapshot(watched=watched)
+
+        # SKILLS.md is in snapshot as existing; mark it as not-existing
+        # to simulate a file that was gone and came back
+        skills_md = tmp_path / "SKILLS.md"
+        watcher._snapshot[skills_md].exists = False
+        watcher._snapshot[skills_md].mtime = 0.0
+
+        changes = watcher.scan_changes()
+
+        uris = {c.uri for c in changes}
+        assert "dev10x://skills/index" in uris
+        matching = [c for c in changes if c.uri == "dev10x://skills/index"]
+        assert matching[0].list_changed is True
+
+    def test_detects_disappeared_file_in_fixed_watched_as_list_changed(
+        self, tmp_path: Path
+    ) -> None:
+        watcher = _make_watcher(tmp_path)
+        watched = watcher._watched_files()
+        watcher._snapshot = watcher._take_snapshot(watched=watched)
+
+        # Mark SKILLS.md as existing in snapshot, but make the file not exist
+        skills_md = tmp_path / "SKILLS.md"
+        watcher._snapshot[skills_md].exists = True
+        skills_md.unlink()
+
+        # Because SKILLS.md is a fixed path (not dynamic glob), it stays in watched
+        # even when it doesn't exist, so the disappeared branch fires
+        changes = watcher.scan_changes()
+
+        uris = {c.uri for c in changes}
+        assert "dev10x://skills/index" in uris
+        matching = [c for c in changes if c.uri == "dev10x://skills/index"]
+        assert matching[0].list_changed is True
+
+
+# ── scan_changes — file added/removed ─────────────────────────────
+
+
+class TestScanChangesListChanged:
+    def test_detects_new_playbook_as_list_changed(self, tmp_path: Path) -> None:
+        watcher = _make_watcher(tmp_path)
+        watched = watcher._watched_files()
+        watcher._snapshot = watcher._take_snapshot(watched=watched)
+
+        # Add a new skill playbook
+        new_skill_dir = tmp_path / "skills" / "new-skill" / "references"
+        new_skill_dir.mkdir(parents=True)
+        (new_skill_dir / "playbook.yaml").write_text("defaults:\n  single: []\n")
+
+        changes = watcher.scan_changes()
+
+        uris = {c.uri for c in changes}
+        assert "dev10x://skills/new-skill/playbook" in uris
+        matching = [c for c in changes if c.uri == "dev10x://skills/new-skill/playbook"]
+        assert matching[0].list_changed is True
+
+    def test_detects_removed_rule_as_list_changed(self, tmp_path: Path) -> None:
+        watcher = _make_watcher(tmp_path)
+        watched = watcher._watched_files()
+        watcher._snapshot = watcher._take_snapshot(watched=watched)
+
+        essentials = tmp_path / ".claude" / "rules" / "essentials.md"
+        essentials.unlink()
+
+        changes = watcher.scan_changes()
+
+        uris = {c.uri for c in changes}
+        assert "dev10x://rules/essentials" in uris
+        matching = [c for c in changes if c.uri == "dev10x://rules/essentials"]
+        assert matching[0].list_changed is True
+
+    def test_detects_new_reference_file(self, tmp_path: Path) -> None:
+        watcher = _make_watcher(tmp_path)
+        watched = watcher._watched_files()
+        watcher._snapshot = watcher._take_snapshot(watched=watched)
+
+        new_ref = tmp_path / "references" / "new-guide.md"
+        new_ref.write_text("# New Guide\n")
+
+        changes = watcher.scan_changes()
+
+        uris = {c.uri for c in changes}
+        assert "dev10x://references/new-guide" in uris
+
+
+# ── scan_changes — deduplication ──────────────────────────────────
+
+
+class TestScanChangesDeduplication:
+    def test_same_uri_reported_once_per_scan(self, tmp_path: Path) -> None:
+        watcher = _make_watcher(tmp_path)
+        # Empty snapshot → all files appear as additions
+        changes = watcher.scan_changes()
+
+        uris = [c.uri for c in changes]
+        assert len(uris) == len(set(uris)), "duplicate URIs in scan results"
+
+
+# ── set_session ────────────────────────────────────────────────────
+
+
+class TestSetSession:
+    def test_set_session_attaches_session(self, tmp_path: Path) -> None:
+        watcher = _make_watcher(tmp_path)
+        mock_session = MagicMock()
+
+        watcher.set_session(session=mock_session)
+
+        assert watcher._session is mock_session
+
+    def test_set_session_none_detaches(self, tmp_path: Path) -> None:
+        watcher = _make_watcher(tmp_path)
+        watcher.set_session(session=MagicMock())
+
+        watcher.set_session(session=None)
+
+        assert watcher._session is None
+
+
+# ── _notify ────────────────────────────────────────────────────────
+
+
+class TestNotify:
+    @pytest.mark.asyncio
+    async def test_no_op_when_session_is_none(self, tmp_path: Path) -> None:
+        watcher = _make_watcher(tmp_path)
+        # session not set — should not raise
+
+        await watcher._notify(events=[ResourceChanged(uri="dev10x://rules/index")])
+
+    @pytest.mark.asyncio
+    async def test_no_op_when_events_empty(self, tmp_path: Path) -> None:
+        watcher = _make_watcher(tmp_path)
+        session = AsyncMock()
+        watcher.set_session(session=session)
+
+        await watcher._notify(events=[])
+
+        session.send_resource_list_changed.assert_not_called()
+        session.send_resource_updated.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sends_list_changed_for_list_change_event(self, tmp_path: Path) -> None:
+        watcher = _make_watcher(tmp_path)
+        session = AsyncMock()
+        watcher.set_session(session=session)
+
+        await watcher._notify(
+            events=[ResourceChanged(uri="dev10x://rules/essentials", list_changed=True)]
+        )
+
+        session.send_resource_list_changed.assert_called_once()
+        session.send_resource_updated.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sends_resource_updated_for_content_change(self, tmp_path: Path) -> None:
+        watcher = _make_watcher(tmp_path)
+        session = AsyncMock()
+        watcher.set_session(session=session)
+
+        await watcher._notify(
+            events=[ResourceChanged(uri="dev10x://skills/index", list_changed=False)]
+        )
+
+        session.send_resource_updated.assert_called_once()
+        session.send_resource_list_changed.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sends_both_for_mixed_events(self, tmp_path: Path) -> None:
+        watcher = _make_watcher(tmp_path)
+        session = AsyncMock()
+        watcher.set_session(session=session)
+
+        await watcher._notify(
+            events=[
+                ResourceChanged(uri="dev10x://rules/new-rule", list_changed=True),
+                ResourceChanged(uri="dev10x://skills/index", list_changed=False),
+            ]
+        )
+
+        session.send_resource_list_changed.assert_called_once()
+        session.send_resource_updated.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_detaches_session_on_send_failure(self, tmp_path: Path) -> None:
+        watcher = _make_watcher(tmp_path)
+        session = AsyncMock()
+        session.send_resource_list_changed.side_effect = Exception("connection lost")
+        watcher.set_session(session=session)
+
+        await watcher._notify(
+            events=[ResourceChanged(uri="dev10x://rules/index", list_changed=True)]
+        )
+
+        assert watcher._session is None
+
+
+# ── run loop ───────────────────────────────────────────────────────
+
+
+class TestRunLoop:
+    @pytest.mark.asyncio
+    async def test_returns_immediately_when_interval_is_zero(self, tmp_path: Path) -> None:
+        watcher = KnowledgeResourceWatcher(plugin_root=_make_root(tmp_path), poll_interval=0.0)
+
+        # Should return without blocking
+        await asyncio.wait_for(watcher.run(), timeout=1.0)
+
+    @pytest.mark.asyncio
+    async def test_seeds_snapshot_and_cancels_cleanly(self, tmp_path: Path) -> None:
+        watcher = KnowledgeResourceWatcher(plugin_root=_make_root(tmp_path), poll_interval=0.05)
+        task = asyncio.create_task(watcher.run())
+        await asyncio.sleep(0.01)  # let it seed
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        # Snapshot was seeded — no spurious changes on next manual scan
+        changes = watcher.scan_changes()
+        assert changes == []
+
+    @pytest.mark.asyncio
+    async def test_loop_body_notifies_on_detected_change(self, tmp_path: Path) -> None:
+        """Verify the loop calls _notify when scan_changes returns events."""
+        watcher = KnowledgeResourceWatcher(plugin_root=_make_root(tmp_path), poll_interval=0.02)
+        session = AsyncMock()
+        watcher.set_session(session=session)
+
+        task = asyncio.create_task(watcher.run())
+        await asyncio.sleep(0.01)  # let it seed snapshot
+
+        # Create a new file so the next tick detects a list change
+        new_ref = tmp_path / "references" / "loop-added.md"
+        new_ref.write_text("# Loop Added\n")
+
+        # Wait long enough for a tick to scan and notify
+        await asyncio.sleep(0.06)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        session.send_resource_list_changed.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_loop_swallows_scan_exception(self, tmp_path: Path) -> None:
+        """Verify a scan_changes exception inside the loop is caught, not fatal."""
+        watcher = KnowledgeResourceWatcher(plugin_root=_make_root(tmp_path), poll_interval=0.02)
+
+        call_count = {"n": 0}
+
+        def _boom() -> list:
+            call_count["n"] += 1
+            raise RuntimeError("scan blew up")
+
+        # Seed first, then swap in the raising scan so the loop hits the except branch
+        task = asyncio.create_task(watcher.run())
+        await asyncio.sleep(0.01)  # let it seed
+        watcher.scan_changes = _boom  # type: ignore[method-assign]
+
+        await asyncio.sleep(0.06)  # at least one tick raises and is swallowed
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        assert call_count["n"] >= 1, "the raising scan was never invoked by the loop"
+
+
+# ── _snapshot_uri ─────────────────────────────────────────────────
+
+
+class TestSnapshotUri:
+    """Direct unit tests for the _snapshot_uri path-derivation helper."""
+
+    def test_returns_none_for_path_outside_root(self, tmp_path: Path) -> None:
+        watcher = _make_watcher(tmp_path)
+        outside = Path("/completely/unrelated/path.md")
+
+        result = watcher._snapshot_uri(path=outside)
+
+        assert result is None
+
+    def test_returns_skills_index_for_skills_md(self, tmp_path: Path) -> None:
+        watcher = _make_watcher(tmp_path)
+        skills_md = tmp_path / "SKILLS.md"
+
+        result = watcher._snapshot_uri(path=skills_md)
+
+        assert result == "dev10x://skills/index"
+
+    def test_returns_reference_uri_for_references_md(self, tmp_path: Path) -> None:
+        watcher = _make_watcher(tmp_path)
+        ref_file = tmp_path / "references" / "git-commits.md"
+
+        result = watcher._snapshot_uri(path=ref_file)
+
+        assert result == "dev10x://references/git-commits"
+
+    def test_returns_playbook_uri_for_skill_playbook_yaml(self, tmp_path: Path) -> None:
+        watcher = _make_watcher(tmp_path)
+        playbook = tmp_path / "skills" / "my-skill" / "references" / "playbook.yaml"
+
+        result = watcher._snapshot_uri(path=playbook)
+
+        assert result == "dev10x://skills/my-skill/playbook"
+
+    def test_returns_none_for_unrecognized_path_inside_root(self, tmp_path: Path) -> None:
+        watcher = _make_watcher(tmp_path)
+        unrecognized = tmp_path / "some" / "other" / "file.txt"
+
+        result = watcher._snapshot_uri(path=unrecognized)
+
+        assert result is None
+
+    def test_snapshot_uri_used_when_dir_removed_from_watched(self, tmp_path: Path) -> None:
+        """Verify _snapshot_uri covers removed-from-watch path in scan_changes."""
+        watcher = _make_watcher(tmp_path)
+        watched = watcher._watched_files()
+        watcher._snapshot = watcher._take_snapshot(watched=watched)
+
+        # Simulate a path that was previously watched but is no longer watched
+        # by injecting it into the snapshot directly (won't be in next _watched_files)
+        phantom = tmp_path / "references" / "phantom.md"
+        watcher._snapshot[phantom] = resource_watcher._FileState(exists=True, mtime=1.0)
+
+        changes = watcher.scan_changes()
+
+        uris = {c.uri for c in changes}
+        assert "dev10x://references/phantom" in uris
+        matching = [c for c in changes if c.uri == "dev10x://references/phantom"]
+        assert matching[0].list_changed is True
+
+
+# ── wire_watcher_to_server ─────────────────────────────────────────
+
+
+class TestWireWatcherToServer:
+    @pytest.mark.asyncio
+    async def test_registers_initialized_notification_handler(self, tmp_path: Path) -> None:
+        import mcp.types as mcp_types
+
+        stub_server = MagicMock()
+        stub_server.notification_handlers = {}
+
+        watcher = _make_watcher(tmp_path)
+        wire_watcher_to_server(server=stub_server, watcher=watcher)
+
+        assert mcp_types.InitializedNotification in stub_server.notification_handlers
+
+    @pytest.mark.asyncio
+    async def test_handler_sets_session_from_request_context(self, tmp_path: Path) -> None:
+        import mcp.types as mcp_types
+
+        mock_session = MagicMock()
+        stub_server = MagicMock()
+        stub_server.notification_handlers = {}
+        stub_server.request_context.session = mock_session
+
+        watcher = _make_watcher(tmp_path)
+        wire_watcher_to_server(server=stub_server, watcher=watcher)
+
+        handler = stub_server.notification_handlers[mcp_types.InitializedNotification]
+        await handler(mcp_types.InitializedNotification())
+
+        assert watcher._session is mock_session
+
+    @pytest.mark.asyncio
+    async def test_handler_tolerates_missing_request_context(self, tmp_path: Path) -> None:
+        import mcp.types as mcp_types
+
+        stub_server = MagicMock()
+        stub_server.notification_handlers = {}
+        stub_server.request_context.session = None
+        type(stub_server).request_context = property(
+            lambda self: (_ for _ in ()).throw(LookupError("no context"))
+        )
+
+        watcher = _make_watcher(tmp_path)
+        wire_watcher_to_server(server=stub_server, watcher=watcher)
+
+        handler = stub_server.notification_handlers[mcp_types.InitializedNotification]
+        # Should not raise even when request_context is unavailable
+        await handler(mcp_types.InitializedNotification())
+
+        # Session not wired — watcher still detached
+        assert watcher._session is None
+
+    def test_registers_watcher_in_global_registry(self, tmp_path: Path) -> None:
+        stub_server = MagicMock()
+        stub_server.notification_handlers = {}
+
+        watcher = _make_watcher(tmp_path)
+        wire_watcher_to_server(server=stub_server, watcher=watcher)
+
+        assert get_watcher() is watcher
+
+
+# ── get_watcher ────────────────────────────────────────────────────
+
+
+class TestGetWatcher:
+    def test_returns_none_before_registration(self) -> None:
+        resource_watcher._registry.watcher = None
+
+        result = get_watcher()
+
+        assert result is None
+
+
+# ── lifespan integration ───────────────────────────────────────────
+
+
+class TestLifespanIntegration:
+    @pytest.mark.asyncio
+    async def test_lifespan_starts_and_cancels_watcher_task(self) -> None:
+        from dev10x.mcp._app import _knowledge_watcher_lifespan
+
+        mock_app = MagicMock()
+        mock_app._mcp_server.notification_handlers = {}
+
+        # Patch at the module where the name is bound (module-level imports in _app.py)
+        with patch("dev10x.mcp._app.get_plugin_root", return_value=Path("/nonexistent")):
+            with patch("dev10x.mcp._app.KnowledgeResourceWatcher") as MockWatcher:
+                mock_watcher_instance = MagicMock()
+
+                async def _fake_run() -> None:
+                    try:
+                        await asyncio.sleep(999)
+                    except asyncio.CancelledError:
+                        pass
+
+                mock_watcher_instance.run = _fake_run
+                MockWatcher.return_value = mock_watcher_instance
+
+                async with _knowledge_watcher_lifespan(mock_app):
+                    # Lifespan is active — watcher should be running
+                    pass
+                # After exit — task should be cancelled (no exception raised)
+
+    @pytest.mark.asyncio
+    async def test_lifespan_wires_watcher_to_server(self) -> None:
+        from dev10x.mcp._app import _knowledge_watcher_lifespan
+
+        mock_app = MagicMock()
+        mock_app._mcp_server.notification_handlers = {}
+
+        # Patch at the module where the name is bound (module-level imports in _app.py)
+        with patch("dev10x.mcp._app.get_plugin_root", return_value=Path("/nonexistent")):
+            with patch("dev10x.mcp._app.KnowledgeResourceWatcher") as MockWatcher:
+                mock_watcher_instance = MagicMock()
+
+                async def _fake_run() -> None:
+                    await asyncio.sleep(0)
+
+                mock_watcher_instance.run = _fake_run
+                MockWatcher.return_value = mock_watcher_instance
+
+                with patch("dev10x.mcp._app.wire_watcher_to_server") as mock_wire:
+                    async with _knowledge_watcher_lifespan(mock_app):
+                        pass
+
+                mock_wire.assert_called_once_with(
+                    server=mock_app._mcp_server,
+                    watcher=mock_watcher_instance,
+                )


### PR DESCRIPTION
**When** a Dev10x knowledge resource file (rule, playbook, references doc, or the skill/rules index) changes on disk, **I want to** have connected MCP clients notified immediately, **so I can** keep client resource caches fresh instead of serving stale content.

---

[`a94cd450`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/455/commits/a94cd450ad29bafa4665f6f9d280e82ee5f56ad8) ✨ GH-341 Enable MCP resource update notifications
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/341

---