### PR TITLE
📝 GH-446 Enable databases.yaml migration on upgrade

### DIFF
--- a/skills/plugin-maintenance/SKILL.md
+++ b/skills/plugin-maintenance/SKILL.md
@@ -381,6 +381,48 @@ Playbook migration steps:
 4. Remove the source directory when empty
 5. Report a summary of what moved, what was skipped, and why
 
+**databases.yaml from legacy/backup skill directories (GH-446) — full mode only:**
+
+Skill consolidation and upgrades may move user-installed skills into
+hidden backup directories (e.g.,
+`~/.claude/skills/.20260601-1100-backup/<skill>/`). The `glob *`
+used by `db.sh`'s discover_configs skips dotted directory names, so
+`databases.yaml` files in those backup dirs are silently not found —
+even though `~/.config/Dev10x/databases.yaml` (priority 3 since
+GH-448) is now the preferred global location.
+
+Scan for stray `databases.yaml` files using `find` (which reaches
+dotted dirs, unlike glob `*`):
+
+```
+find ~/.claude/skills -name databases.yaml
+```
+
+Also check `~/.claude/memory/Dev10x/databases.yaml` explicitly
+(already covered by the table above, but include in this report).
+
+For each located `databases.yaml` whose resolved path differs from
+`~/.config/Dev10x/databases.yaml`:
+
+| Entry type | Action |
+|------------|--------|
+| Regular file, destination absent | Move to `~/.config/Dev10x/databases.yaml`, report migration |
+| Regular file, destination present | Leave in place — surface the conflict (show both paths); do NOT overwrite |
+| Symlink pointing to `~/.config/Dev10x/databases.yaml` | Delete (pre-migration artefact; target is already canonical) |
+| Symlink pointing elsewhere | Leave in place and warn — manual inspection required |
+
+databases.yaml migration steps:
+1. Run `find ~/.claude/skills -name databases.yaml` to locate all
+   candidates (including dotted backup dirs)
+2. Also check `~/.claude/memory/Dev10x/databases.yaml` explicitly
+3. Skip candidates that are already at, or are a symlink to,
+   `~/.config/Dev10x/databases.yaml` — migration not needed
+4. Ensure `~/.config/Dev10x/` exists before any write
+5. For each remaining candidate: apply the action table above
+6. Report a summary: files moved, conflicts surfaced, symlinks
+   cleaned, or "no stray databases.yaml found" when the scan
+   comes up empty
+
 ### 3. Ensure workspace directories **[bootstrap]** (GH-40)
 
 Register paths outside the project root (e.g. `/tmp/Dev10x`) under

--- a/skills/upgrade-cleanup/SKILL.md
+++ b/skills/upgrade-cleanup/SKILL.md
@@ -5,7 +5,9 @@ description: >
   `Dev10x:plugin-maintenance` in `full` mode. Updates plugin
   version paths, ensures base permissions, migrates config files
   (including global playbook overrides from
-  ~/.claude/memory/Dev10x/playbooks/ to ~/.config/Dev10x/playbooks/),
+  ~/.claude/memory/Dev10x/playbooks/ to ~/.config/Dev10x/playbooks/,
+  and databases.yaml from legacy/backup skill directories to
+  ~/.config/Dev10x/databases.yaml),
   generalizes session-specific args, enumerates MCP tool globs,
   refreshes script coverage, merges worktree rules, audits for
   friction-causing patterns, and cleans redundant rules from
@@ -67,12 +69,22 @@ including playbook overrides → ensure base perms → generalize →
 enumerate MCP → script coverage → worktree merge → permission
 audit → clean project files → diff playbooks).
 
-The "Migrate config files" step (step 3) includes migrating global
-playbook overrides from `~/.claude/memory/Dev10x/playbooks/` to
-`~/.config/Dev10x/playbooks/` (GH-447). Regular files are moved;
-symlinks pointing into the new location are deleted; conflicts
-(destination already exists) are surfaced rather than overwritten.
-The old directory is removed once empty.
+The "Migrate config files" step (step 3) includes two sub-migrations:
+
+1. **Playbook overrides (GH-447):** global playbook overrides from
+   `~/.claude/memory/Dev10x/playbooks/` to
+   `~/.config/Dev10x/playbooks/`. Regular files are moved; symlinks
+   pointing into the new location are deleted; conflicts (destination
+   already exists) are surfaced rather than overwritten. The old
+   directory is removed once empty.
+
+2. **databases.yaml (GH-446):** stray `databases.yaml` files found in
+   legacy or hidden backup skill directories (e.g.,
+   `~/.claude/skills/.20260601-1100-backup/*/`) are migrated to
+   `~/.config/Dev10x/databases.yaml` — the preferred global location
+   since GH-448. The scan uses `find` (not glob `*`) to reach dotted
+   directories. Conflicts (destination already exists) are surfaced
+   rather than overwritten.
 
 After the maintenance pass succeeds, record the plugin version
 so the SessionStart install-check stays silent until the next


### PR DESCRIPTION
**When** I upgrade Dev10x and my databases.yaml was in a user-installed skill that got moved into a hidden backup directory (e.g. `~/.claude/skills/.20260601-1100-backup/<skill>/`), **I want** Dev10x:upgrade-cleanup to detect and migrate it to `~/.config/Dev10x/databases.yaml` during the "Migrate config files" step, **so I can** avoid the silent "No databases configured" error caused by glob `*` skipping dotted directory names.

---

[`7fa14077`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/456/commits/7fa1407775c401e4c06aaa86c1c5062db9bb1d46) 📝 GH-446 Enable databases.yaml migration on upgrade
Fixes: https://github.com/Dev10x-Guru/dev10x-claude/issues/446

---