### PR TITLE
📝 GH-445 Align rules doc with XDG playbook path

### DIFF
--- a/.claude/rules/playbook-pattern.md
+++ b/.claude/rules/playbook-pattern.md
@@ -59,16 +59,18 @@ Users can override playbooks using the 3-tier resolution order
 | Tier | Path | Scope |
 |------|------|-------|
 | 1 | `.claude/Dev10x/playbooks/<skill-name>.yaml` | Project-local |
-| 2 | `~/.claude/memory/Dev10x/playbooks/<skill-name>.yaml` | Global + repo mapping |
+| 2 | `~/.config/Dev10x/playbooks/<skill-name>.yaml` | Global + repo mapping |
 | 3 | `${CLAUDE_PLUGIN_ROOT}/skills/<name>/references/playbook.yaml` | Plugin defaults |
 
 Tier 2 (global) is preferred — one file serves multiple repos via
 `projects[].match` globs. The skill loads this file at invocation,
 allowing users to customize behavior without editing the plugin.
 
-> **Note (GH-941):** The old `~/.claude/projects/<key>/memory/`
-> path is removed. All tier 2 config lives under
-> `~/.claude/memory/Dev10x/`.
+> **Note (GH-445):** Tier 2 moved to the XDG-canonical
+> `~/.config/Dev10x/playbooks/`. The old
+> `~/.claude/memory/Dev10x/playbooks/` path remains a deprecated
+> read-only fallback, and the GH-941-era
+> `~/.claude/projects/<key>/memory/` path is removed.
 
 ## Reviewer Expectations
 


### PR DESCRIPTION
**When** I review a playbook skill after PR #450 moved global overrides to `~/.config/Dev10x/playbooks/`, **I want to** see the same tier-2 path in `.claude/rules/playbook-pattern.md`, **so I can** apply reviewer expectations without chasing a stale path.

---

[`5094fb4b`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/457/commits/5094fb4b12a0a2978d57105984148ca1b646f5b4) 📝 GH-445 Align rules doc with XDG playbook path
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/445

---