### PR TITLE
✨ GH-342 Enable progress streaming for long-running MCP tools

### DIFF
--- a/src/dev10x/mcp/git_tools.py
+++ b/src/dev10x/mcp/git_tools.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+# Context is required at runtime: FastMCP evaluates tool annotations with
+# eval_str=True to detect the injected context parameter (GH-342). The
+# noqa keeps ruff from stripping it as a type-only import under
+# `from __future__ import annotations`.
+from mcp.server.fastmcp import Context  # noqa: F401
+
 from dev10x.mcp._app import server
 
 
@@ -42,13 +48,19 @@ async def push_safe(
 
 
 @server.tool()
-async def rebase_groom(seq_path: str, base_ref: str, cwd: str | None = None) -> dict:
+async def rebase_groom(
+    seq_path: str,
+    base_ref: str,
+    cwd: str | None = None,
+    ctx: Context | None = None,
+) -> dict:
     """Rebase and groom commits using an interactive sequence file.
 
     Args:
         seq_path: Path to git rebase sequence file
         base_ref: Base ref to rebase onto (e.g., develop, main)
         cwd: Effective working directory (GH-979).
+        ctx: FastMCP context injected automatically — do not pass (GH-342).
 
     Returns:
         Dictionary with keys: success (bool), commits_rewritten (int)
@@ -56,8 +68,31 @@ async def rebase_groom(seq_path: str, base_ref: str, cwd: str | None = None) -> 
     from dev10x import git as git_tools
     from dev10x.subprocess_utils import use_cwd
 
+    if ctx is not None:
+        await ctx.report_progress(
+            progress=0, total=100, message=f"Starting rebase-groom onto {base_ref}"
+        )
+        await ctx.info(f"rebase_groom: rebasing onto {base_ref} using {seq_path}")
+
     with use_cwd(cwd):
-        return (await git_tools.rebase_groom(seq_path=seq_path, base_ref=base_ref)).to_dict()
+        result = (await git_tools.rebase_groom(seq_path=seq_path, base_ref=base_ref)).to_dict()
+
+    if ctx is not None:
+        if "error" in result:
+            await ctx.report_progress(
+                progress=100, total=100, message=f"rebase-groom failed: {result['error']}"
+            )
+            await ctx.log(level="error", message=f"rebase_groom: {result['error']}")
+        else:
+            rewritten = result.get("commits_rewritten", "?")
+            await ctx.report_progress(
+                progress=100,
+                total=100,
+                message=f"rebase-groom done: {rewritten} commits rewritten",
+            )
+            await ctx.info(f"rebase_groom: complete — {rewritten} commits rewritten")
+
+    return result
 
 
 @server.tool()
@@ -87,12 +122,17 @@ async def create_worktree(
 
 
 @server.tool()
-async def mass_rewrite(config_path: str, cwd: str | None = None) -> dict:
+async def mass_rewrite(
+    config_path: str,
+    cwd: str | None = None,
+    ctx: Context | None = None,
+) -> dict:
     """Rewrite multiple commit messages in one unattended rebase pass.
 
     Args:
         config_path: Path to JSON config file with rewrite instructions.
         cwd: Effective working directory (GH-979).
+        ctx: FastMCP context injected automatically — do not pass (GH-342).
 
     Returns:
         Dictionary with keys: success (bool), output (str), error (str if failed)
@@ -100,8 +140,24 @@ async def mass_rewrite(config_path: str, cwd: str | None = None) -> dict:
     from dev10x import git as git_tools
     from dev10x.subprocess_utils import use_cwd
 
+    if ctx is not None:
+        await ctx.report_progress(progress=0, total=100, message="Starting mass-rewrite")
+        await ctx.info(f"mass_rewrite: running unattended rebase from {config_path}")
+
     with use_cwd(cwd):
-        return (await git_tools.mass_rewrite(config_path=config_path)).to_dict()
+        result = (await git_tools.mass_rewrite(config_path=config_path)).to_dict()
+
+    if ctx is not None:
+        if "error" in result:
+            await ctx.report_progress(
+                progress=100, total=100, message=f"mass-rewrite failed: {result['error']}"
+            )
+            await ctx.log(level="error", message=f"mass_rewrite: {result['error']}")
+        else:
+            await ctx.report_progress(progress=100, total=100, message="mass-rewrite complete")
+            await ctx.info("mass_rewrite: all commits rewritten successfully")
+
+    return result
 
 
 @server.tool()

--- a/src/dev10x/mcp/github_tools.py
+++ b/src/dev10x/mcp/github_tools.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+# Context is required at runtime: FastMCP evaluates tool annotations with
+# eval_str=True to detect the injected context parameter (GH-342). The
+# noqa keeps ruff from stripping it as a type-only import under
+# `from __future__ import annotations`.
+from mcp.server.fastmcp import Context  # noqa: F401
+
 from dev10x.mcp._app import server
 
 
@@ -447,6 +453,7 @@ async def create_pr(
     closes: list[int] | None = None,
     draft: bool = True,
     cwd: str | None = None,
+    ctx: Context | None = None,
 ) -> dict:
     """Create a PR with two-pass body generation.
 
@@ -465,6 +472,7 @@ async def create_pr(
         cwd: Effective working directory (GH-979). Pass the worktree
             path after EnterWorktree so the PR is created from the
             worktree's branch, not the main repo's.
+        ctx: FastMCP context injected automatically — do not pass (GH-342).
 
     Returns:
         Dictionary with keys: pr_number (int), url (str)
@@ -472,8 +480,12 @@ async def create_pr(
     from dev10x import github as gh
     from dev10x.subprocess_utils import use_cwd
 
+    if ctx is not None:
+        await ctx.report_progress(progress=0, total=100, message=f"Creating PR: {title}")
+        await ctx.info(f"create_pr: opening PR for {issue_id} (draft={draft})")
+
     with use_cwd(cwd):
-        return (
+        result = (
             await gh.create_pr(
                 title=title,
                 job_story=job_story,
@@ -484,6 +496,19 @@ async def create_pr(
                 draft=draft,
             )
         ).to_dict()
+
+    if ctx is not None:
+        if "error" in result:
+            await ctx.report_progress(
+                progress=100, total=100, message=f"PR creation failed: {result['error']}"
+            )
+            await ctx.log(level="error", message=f"create_pr: {result['error']}")
+        else:
+            url = result.get("url", "")
+            await ctx.report_progress(progress=100, total=100, message=f"PR created: {url}")
+            await ctx.info(f"create_pr: PR #{result.get('pr_number')} ready at {url}")
+
+    return result
 
 
 @server.tool()

--- a/src/dev10x/mcp/misc_tools.py
+++ b/src/dev10x/mcp/misc_tools.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+# Context is required at runtime: FastMCP evaluates tool annotations with
+# eval_str=True to detect the injected context parameter (GH-342). The
+# noqa keeps ruff from stripping it as a type-only import under
+# `from __future__ import annotations`.
+from mcp.server.fastmcp import Context  # noqa: F401
+
 from dev10x.mcp._app import server
 
 
@@ -177,6 +183,7 @@ async def run_tests(
     coverage: bool = True,
     timeout: int = 600,
     cwd: str | None = None,
+    ctx: Context | None = None,
 ) -> dict:
     """Run pytest with coverage via ``uv run`` (GH-238).
 
@@ -194,6 +201,7 @@ async def run_tests(
             ``--cov --cov-report=term-missing``.
         timeout: Subprocess timeout in seconds (default 600).
         cwd: Effective working directory (GH-979).
+        ctx: FastMCP context injected automatically — do not pass (GH-342).
 
     Returns:
         Dictionary with keys: returncode (int), summary (str),
@@ -206,5 +214,19 @@ async def run_tests(
     from dev10x import runner
     from dev10x.subprocess_utils import use_cwd
 
+    extra_desc = " ".join(args) if args else "full suite"
+    if ctx is not None:
+        await ctx.report_progress(progress=0, total=100, message=f"Starting pytest: {extra_desc}")
+        await ctx.info(f"run_tests: launching pytest ({extra_desc})")
+
     with use_cwd(cwd):
-        return (await runner.run_tests(args=args, coverage=coverage, timeout=timeout)).to_dict()
+        result = (await runner.run_tests(args=args, coverage=coverage, timeout=timeout)).to_dict()
+
+    if ctx is not None:
+        summary = result.get("summary", "")
+        failed = result.get("failed", 0)
+        await ctx.report_progress(progress=100, total=100, message=f"pytest done: {summary}")
+        level = "warning" if failed else "info"
+        await ctx.log(level=level, message=f"run_tests: {summary or 'complete'}")
+
+    return result

--- a/tests/mcp/test_progress_notifications.py
+++ b/tests/mcp/test_progress_notifications.py
@@ -1,0 +1,257 @@
+"""Progress & log notifications for long-running MCP tools (GH-342).
+
+The four long-running tools — ``run_tests``, ``mass_rewrite``,
+``rebase_groom``, ``create_pr`` — accept an optional FastMCP ``Context``
+that FastMCP injects automatically. When present, each tool emits a
+start ``report_progress(0, 100)`` + ``info`` notification before the
+subprocess and a terminal ``report_progress(100, 100)`` + ``info``/
+``log`` notification after it. When ``ctx`` is ``None`` (the default in
+unit tests and for clients that do not send a progress token), the tool
+behaves exactly as before — no notifications, same return payload.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+cli_server = pytest.importorskip("dev10x.mcp.server_cli", reason="mcp not installed")
+
+
+def _completed(
+    *,
+    returncode: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=[],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+@pytest.fixture
+def ctx() -> AsyncMock:
+    """A stand-in FastMCP Context with awaitable notification methods."""
+    fake = AsyncMock()
+    fake.report_progress = AsyncMock()
+    fake.info = AsyncMock()
+    fake.log = AsyncMock()
+    return fake
+
+
+class TestRunTestsNotifications:
+    @pytest.mark.asyncio
+    @patch("dev10x.runner.async_run", new_callable=AsyncMock)
+    async def test_emits_start_and_done_progress(
+        self,
+        mock_run: AsyncMock,
+        ctx: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(stdout="==== 5 passed in 0.1s ====")
+
+        result = await cli_server.run_tests(ctx=ctx)
+
+        assert result["passed"] == 5
+        assert ctx.report_progress.await_count == 2
+        first = ctx.report_progress.await_args_list[0].kwargs
+        last = ctx.report_progress.await_args_list[1].kwargs
+        assert first["progress"] == 0
+        assert first["total"] == 100
+        assert last["progress"] == 100
+        assert last["total"] == 100
+        ctx.info.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch("dev10x.runner.async_run", new_callable=AsyncMock)
+    async def test_failed_run_logs_warning(
+        self,
+        mock_run: AsyncMock,
+        ctx: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(
+            returncode=1,
+            stdout="==== 1 failed, 2 passed in 0.1s ====",
+        )
+
+        await cli_server.run_tests(ctx=ctx)
+
+        assert ctx.log.await_args.kwargs["level"] == "warning"
+
+    @pytest.mark.asyncio
+    @patch("dev10x.runner.async_run", new_callable=AsyncMock)
+    async def test_args_summarised_in_start_message(
+        self,
+        mock_run: AsyncMock,
+        ctx: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(stdout="==== 1 passed in 0.1s ====")
+
+        await cli_server.run_tests(args=["-k", "foo"], ctx=ctx)
+
+        assert "-k foo" in ctx.report_progress.await_args_list[0].kwargs["message"]
+
+    @pytest.mark.asyncio
+    @patch("dev10x.runner.async_run", new_callable=AsyncMock)
+    async def test_no_notifications_without_ctx(
+        self,
+        mock_run: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(stdout="==== 1 passed in 0.1s ====")
+
+        result = await cli_server.run_tests()
+
+        assert result["passed"] == 1
+
+
+class TestRebaseGroomNotifications:
+    @pytest.mark.asyncio
+    @patch("dev10x.git.async_run_script", new_callable=AsyncMock)
+    async def test_success_emits_progress_and_info(
+        self,
+        mock_run: AsyncMock,
+        ctx: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(stdout="SUCCESS=true\nCOMMITS_REWRITTEN=5")
+
+        result = await cli_server.rebase_groom(
+            seq_path="/tmp/seq",
+            base_ref="develop",
+            ctx=ctx,
+        )
+
+        assert "error" not in result
+        assert ctx.report_progress.await_count == 2
+        assert ctx.report_progress.await_args_list[1].kwargs["progress"] == 100
+        assert ctx.info.await_count == 2
+
+    @pytest.mark.asyncio
+    @patch("dev10x.git.async_run_script", new_callable=AsyncMock)
+    async def test_failure_logs_error(
+        self,
+        mock_run: AsyncMock,
+        ctx: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(returncode=1, stderr="rebase blew up")
+
+        result = await cli_server.rebase_groom(
+            seq_path="/tmp/seq",
+            base_ref="develop",
+            ctx=ctx,
+        )
+
+        assert "error" in result
+        assert ctx.log.await_args.kwargs["level"] == "error"
+
+    @pytest.mark.asyncio
+    @patch("dev10x.git.async_run_script", new_callable=AsyncMock)
+    async def test_no_notifications_without_ctx(
+        self,
+        mock_run: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(stdout="SUCCESS=true\nCOMMITS_REWRITTEN=1")
+
+        result = await cli_server.rebase_groom(seq_path="/tmp/seq", base_ref="develop")
+
+        assert isinstance(result, dict)
+
+
+class TestMassRewriteNotifications:
+    @pytest.mark.asyncio
+    @patch("dev10x.git.async_run_script", new_callable=AsyncMock)
+    async def test_success_emits_progress_and_info(
+        self,
+        mock_run: AsyncMock,
+        ctx: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(stdout="ok")
+
+        result = await cli_server.mass_rewrite(config_path="/tmp/r.json", ctx=ctx)
+
+        assert "error" not in result
+        assert ctx.report_progress.await_count == 2
+        assert ctx.info.await_count == 2
+
+    @pytest.mark.asyncio
+    @patch("dev10x.git.async_run_script", new_callable=AsyncMock)
+    async def test_failure_logs_error(
+        self,
+        mock_run: AsyncMock,
+        ctx: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(returncode=1, stderr="bad config")
+
+        result = await cli_server.mass_rewrite(config_path="/tmp/x.json", ctx=ctx)
+
+        assert "error" in result
+        assert ctx.log.await_args.kwargs["level"] == "error"
+
+    @pytest.mark.asyncio
+    @patch("dev10x.git.async_run_script", new_callable=AsyncMock)
+    async def test_no_notifications_without_ctx(
+        self,
+        mock_run: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(stdout="ok")
+
+        result = await cli_server.mass_rewrite(config_path="/tmp/r.json")
+
+        assert isinstance(result, dict)
+
+
+class TestCreatePrNotifications:
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run_script", new_callable=AsyncMock)
+    async def test_success_emits_progress_and_info(
+        self,
+        mock_run: AsyncMock,
+        ctx: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(stdout="https://github.com/o/r/pull/7\n7")
+
+        result = await cli_server.create_pr(
+            title="t",
+            job_story="js",
+            issue_id="GH-1",
+            ctx=ctx,
+        )
+
+        assert result["pr_number"] == 7
+        assert ctx.report_progress.await_count == 2
+        assert "github.com" in ctx.report_progress.await_args_list[1].kwargs["message"]
+        assert ctx.info.await_count == 2
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run_script", new_callable=AsyncMock)
+    async def test_failure_logs_error(
+        self,
+        mock_run: AsyncMock,
+        ctx: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(returncode=1, stderr="no branch")
+
+        result = await cli_server.create_pr(
+            title="t",
+            job_story="js",
+            issue_id="GH-1",
+            ctx=ctx,
+        )
+
+        assert "error" in result
+        assert ctx.log.await_args.kwargs["level"] == "error"
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run_script", new_callable=AsyncMock)
+    async def test_no_notifications_without_ctx(
+        self,
+        mock_run: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(stdout="https://github.com/o/r/pull/9\n9")
+
+        result = await cli_server.create_pr(title="t", job_story="js", issue_id="GH-1")
+
+        assert result["pr_number"] == 9


### PR DESCRIPTION
**When** I run a long-running MCP tool — run_tests, mass_rewrite, rebase_groom, or create_pr — **I want to** have progress and log notifications streamed to my client **so** I **can** see the operation is alive and learn its outcome instead of staring at a silent stall.

---

[`70816cb9`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/458/commits/70816cb965c7cd8e8c0f4483dbc96a3083aa642b) ✨ GH-342 Enable progress streaming for long-running MCP tools
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/342

---