### PR TITLE
✨ GH-344 Enable client-declared directory roots scoping

### DIFF
--- a/src/dev10x/mcp/_app.py
+++ b/src/dev10x/mcp/_app.py
@@ -8,6 +8,13 @@ watcher and wires it to the active MCP session so that
 ``notifications/resources/list_changed`` and
 ``notifications/resources/updated`` are emitted to clients whenever the
 underlying files change.
+
+GH-344: The same lifespan also creates a :class:`ClientRootsManager`
+that fetches and caches the client-declared directory roots via
+``roots/list`` on session initialisation and refreshes the cache on
+``notifications/roots/list_changed``.  The roots are used to scope
+CWD/worktree operations, complementing the GH-979 effective-CWD
+discipline.
 """
 
 from __future__ import annotations
@@ -20,29 +27,37 @@ from contextlib import asynccontextmanager
 from mcp.server.fastmcp import FastMCP
 
 from dev10x.mcp.resource_watcher import KnowledgeResourceWatcher, wire_watcher_to_server
+from dev10x.mcp.roots_manager import ClientRootsManager, wire_roots_to_server
 from dev10x.subprocess_utils import get_plugin_root
 
 log = logging.getLogger(__name__)
 
 
 @asynccontextmanager
-async def _knowledge_watcher_lifespan(app: FastMCP) -> AsyncIterator[None]:
-    """Lifespan that runs the knowledge-resource file watcher (GH-341).
+async def _server_lifespan(app: FastMCP) -> AsyncIterator[None]:
+    """Lifespan that wires the knowledge-resource watcher and roots manager.
 
     On server start:
+
     1. Creates a :class:`~dev10x.mcp.resource_watcher.KnowledgeResourceWatcher`
-       rooted at the plugin install directory.
-    2. Registers an ``InitializedNotification`` handler on the low-level
-       server so the watcher receives the active session as soon as the
-       MCP client completes its handshake.
-    3. Starts the poll loop as a background asyncio task.
+       rooted at the plugin install directory and registers its
+       ``InitializedNotification`` handler (GH-341).
+    2. Creates a :class:`~dev10x.mcp.roots_manager.ClientRootsManager` and
+       registers its ``InitializedNotification`` handler (chained after the
+       watcher's) plus a ``RootsListChangedNotification`` handler (GH-344).
+    3. Starts the resource-watcher poll loop as a background asyncio task.
 
     On server shutdown (lifespan exit) the background task is cancelled.
     """
     plugin_root = get_plugin_root()
     watcher = KnowledgeResourceWatcher(plugin_root=plugin_root)
 
+    # GH-341: resource watcher registers the first InitializedNotification handler.
     wire_watcher_to_server(server=app._mcp_server, watcher=watcher)
+
+    # GH-344: roots manager chains its handler after the watcher's.
+    roots_manager = ClientRootsManager()
+    wire_roots_to_server(server=app._mcp_server, manager=roots_manager)
 
     task = asyncio.create_task(watcher.run(), name="dev10x-resource-watcher")
     log.debug("Resource watcher task started for root: %s", plugin_root)
@@ -58,4 +73,4 @@ async def _knowledge_watcher_lifespan(app: FastMCP) -> AsyncIterator[None]:
         log.debug("Resource watcher task stopped")
 
 
-server = FastMCP(name="Dev10x-cli", lifespan=_knowledge_watcher_lifespan)
+server = FastMCP(name="Dev10x-cli", lifespan=_server_lifespan)

--- a/src/dev10x/mcp/roots_manager.py
+++ b/src/dev10x/mcp/roots_manager.py
@@ -1,0 +1,272 @@
+"""MCP client-roots awareness for Dev10x (GH-344).
+
+Fetches the client-declared directory roots via ``roots/list`` and
+listens for ``notifications/roots/list_changed`` so the cached set
+stays fresh.  The roots scope CWD/worktree operations: when the client
+declares roots, callers can validate that an effective CWD is under one
+of those roots, complementing the existing GH-979 effective-CWD
+discipline and permission hooks.
+
+Architecture
+------------
+``ClientRootsManager`` is a lightweight stateful object that holds the
+current root set.  It is created once per server lifespan in ``_app.py``
+and wired to the low-level MCP server the same way
+``KnowledgeResourceWatcher`` is: an ``InitializedNotification`` handler
+calls :meth:`set_session` so the manager can issue its first
+``roots/list`` request as soon as the handshake completes.
+
+Subsequent ``RootsListChangedNotification`` events trigger a refresh call
+automatically.
+
+``ClientRootsManager`` exposes a synchronous :attr:`roots` property that
+callers can read at any time.  The value is ``None`` before the first
+successful fetch and an empty list ``[]`` when the client declares no
+roots.
+
+Environment variables
+---------------------
+DEV10X_ROOTS_ENABLED
+    Set to ``0`` to disable roots integration entirely.  Defaults to
+    ``1`` (enabled).  Useful in tests or environments where the client
+    does not implement the roots capability.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from mcp.server.session import ServerSession
+
+log = logging.getLogger(__name__)
+
+
+def _roots_enabled() -> bool:
+    """Return True when roots integration is enabled.
+
+    Reads ``DEV10X_ROOTS_ENABLED``; defaults to ``True``.
+    Set to ``0`` to disable.
+    """
+    raw = os.environ.get("DEV10X_ROOTS_ENABLED", "").strip()
+    return raw not in ("0", "false", "no")
+
+
+# ── Root value object ──────────────────────────────────────────────
+
+
+class ClientRoot:
+    """A single client-declared root directory.
+
+    Args:
+        uri: The ``file://`` URI declared by the client.
+        name: Human-readable label (may be ``None``).
+    """
+
+    def __init__(self, uri: str, name: str | None = None) -> None:
+        self.uri = uri
+        self.name = name
+        if uri.startswith("file://"):
+            self._path: Path | None = Path(uri[7:]).resolve()
+        else:
+            self._path = None
+
+    @property
+    def path(self) -> Path | None:
+        """Resolved filesystem path, or ``None`` for non-file URIs."""
+        return self._path
+
+    def contains(self, candidate: str | Path) -> bool:
+        """Return ``True`` when *candidate* is inside this root.
+
+        Args:
+            candidate: Filesystem path to test.
+        """
+        if self._path is None:
+            return False
+        try:
+            Path(candidate).resolve().relative_to(self._path)
+            return True
+        except ValueError:
+            return False
+
+    def to_dict(self) -> dict[str, str | None]:
+        return {"uri": self.uri, "name": self.name}
+
+    def __repr__(self) -> str:
+        return f"ClientRoot(uri={self.uri!r}, name={self.name!r})"
+
+
+# ── Manager ────────────────────────────────────────────────────────
+
+
+class ClientRootsManager:
+    """Fetch and cache the set of client-declared MCP roots (GH-344).
+
+    Lifecycle::
+
+        manager = ClientRootsManager()
+        wire_roots_to_server(server=app._mcp_server, manager=manager)
+        # (set_session called automatically on InitializedNotification)
+        # tools may read manager.roots at any time
+
+    Args:
+        enabled: When ``False``, skip all network calls (useful in tests).
+            ``None`` (default) reads ``DEV10X_ROOTS_ENABLED``.
+    """
+
+    def __init__(self, enabled: bool | None = None) -> None:
+        self._enabled: bool = enabled if enabled is not None else _roots_enabled()
+        self._session: ServerSession | None = None
+        self._roots: list[ClientRoot] | None = None
+
+    @property
+    def roots(self) -> list[ClientRoot] | None:
+        """Current root set, or ``None`` if not yet fetched.
+
+        An empty list means the client declared roots capability but no
+        roots.  ``None`` means no successful fetch has completed yet.
+        """
+        return self._roots
+
+    def is_within_roots(self, cwd: str | Path) -> bool:
+        """Return ``True`` when *cwd* is inside at least one declared root.
+
+        When no roots are declared (``self.roots`` is ``None`` or empty),
+        every CWD is considered valid (no restriction applies).
+
+        Args:
+            cwd: Filesystem path to validate.
+        """
+        roots = self._roots
+        if not roots:
+            return True
+        return any(r.contains(candidate=cwd) for r in roots)
+
+    def set_session(self, session: ServerSession | None) -> None:
+        """Attach (or detach) the active MCP session.
+
+        Called by the ``InitializedNotification`` handler.  When *session*
+        is ``None`` the cached roots are cleared.
+
+        Args:
+            session: Active ``ServerSession``, or ``None`` to detach.
+        """
+        self._session = session
+        if session is not None:
+            log.debug("ClientRootsManager: session attached")
+        else:
+            log.debug("ClientRootsManager: session detached")
+            self._roots = None
+
+    async def refresh(self) -> None:
+        """Fetch the current roots from the client via ``roots/list``.
+
+        No-op when disabled or when no session is attached.  Logs and
+        suppresses all exceptions so that a non-roots-capable client does
+        not break server startup.
+        """
+        if not self._enabled:
+            log.debug("ClientRootsManager: disabled — skipping roots/list")
+            return
+        session = self._session
+        if session is None:
+            log.debug("ClientRootsManager: no session — skipping roots/list")
+            return
+        try:
+            result = await session.list_roots()
+            self._roots = [
+                ClientRoot(uri=str(r.uri), name=getattr(r, "name", None)) for r in result.roots
+            ]
+            log.debug(
+                "ClientRootsManager: fetched %d root(s): %s",
+                len(self._roots),
+                [r.uri for r in self._roots],
+            )
+        except Exception:
+            log.debug(
+                "ClientRootsManager: roots/list failed (client may not support roots capability)",
+                exc_info=True,
+            )
+
+
+# ── module-level registry ──────────────────────────────────────────
+
+_manager: ClientRootsManager | None = None
+
+
+def get_manager() -> ClientRootsManager | None:
+    """Return the currently registered :class:`ClientRootsManager`, or ``None``."""
+    return _manager
+
+
+def wire_roots_to_server(
+    server: object,
+    manager: ClientRootsManager,
+) -> None:
+    """Register *manager* with the MCP low-level *server*'s handlers.
+
+    Installs:
+
+    * An ``InitializedNotification`` handler — wires the session and
+      triggers the first ``roots/list`` fetch.  When the resource watcher
+      already registered an ``InitializedNotification`` handler, the two
+      are chained so both fire in sequence.
+    * A ``RootsListChangedNotification`` handler — refreshes the cached
+      roots whenever the client signals a change.
+
+    Args:
+        server: The low-level MCP ``Server`` instance
+            (e.g. ``fastmcp_instance._mcp_server``).
+        manager: The roots manager to attach.
+    """
+    import asyncio
+
+    import mcp.types as mcp_types
+
+    global _manager
+    _manager = manager
+
+    async def _on_initialized(notification: mcp_types.InitializedNotification) -> None:
+        try:
+            session = server.request_context.session  # type: ignore[attr-defined]
+            manager.set_session(session=session)
+            await manager.refresh()
+        except Exception:
+            log.debug(
+                "ClientRootsManager: could not wire session on initialized",
+                exc_info=True,
+            )
+
+    async def _on_roots_changed(
+        notification: mcp_types.RootsListChangedNotification,
+    ) -> None:
+        log.debug("ClientRootsManager: roots/list_changed received — refreshing")
+        asyncio.create_task(manager.refresh(), name="dev10x-roots-refresh")
+
+    # Chain with the existing InitializedNotification handler (GH-341 resource
+    # watcher registers one first).
+    existing_init = server.notification_handlers.get(  # type: ignore[attr-defined]
+        mcp_types.InitializedNotification
+    )
+
+    if existing_init is not None:
+
+        async def _chained_init(notification: mcp_types.InitializedNotification) -> None:
+            await existing_init(notification)
+            await _on_initialized(notification)
+
+        server.notification_handlers[mcp_types.InitializedNotification] = _chained_init  # type: ignore[attr-defined]
+    else:
+        server.notification_handlers[mcp_types.InitializedNotification] = _on_initialized  # type: ignore[attr-defined]
+
+    server.notification_handlers[mcp_types.RootsListChangedNotification] = _on_roots_changed  # type: ignore[attr-defined]
+
+    log.debug(
+        "ClientRootsManager: handlers registered "
+        "(InitializedNotification chained=%s, RootsListChangedNotification)",
+        existing_init is not None,
+    )

--- a/src/dev10x/mcp/roots_tools.py
+++ b/src/dev10x/mcp/roots_tools.py
@@ -1,0 +1,41 @@
+"""MCP tool registrations for client-roots awareness (GH-344)."""
+
+from __future__ import annotations
+
+from dev10x.mcp._app import server
+
+
+@server.tool()
+async def list_client_roots() -> dict:
+    """Return the client-declared MCP directory roots (GH-344).
+
+    MCP clients (e.g. Claude Code after ``EnterWorktree``) may declare one
+    or more filesystem roots via the ``roots`` capability.  Dev10x fetches
+    this list on session initialisation and refreshes it whenever the
+    client sends ``notifications/roots/list_changed``.
+
+    The roots complement the existing GH-979 effective-CWD discipline: a
+    skill that passes ``cwd=`` to an MCP tool can call this tool first to
+    confirm the target directory is inside a declared root and fail early
+    with a clear message if it is not.
+
+    Returns:
+        Dictionary with keys:
+
+        * ``roots`` — list of ``{"uri": str, "name": str | null}`` objects,
+          one per client-declared root.  Empty list when the client
+          declares no roots.  ``null`` when no session has been established
+          yet (e.g. the tool is called before the MCP handshake).
+        * ``enabled`` — ``bool``, False when ``DEV10X_ROOTS_ENABLED=0``.
+    """
+    from dev10x.mcp.roots_manager import get_manager
+
+    manager = get_manager()
+    if manager is None:
+        return {"roots": None, "enabled": False}
+
+    roots = manager.roots
+    return {
+        "roots": [r.to_dict() for r in roots] if roots is not None else None,
+        "enabled": manager._enabled,
+    }

--- a/src/dev10x/mcp/server_cli.py
+++ b/src/dev10x/mcp/server_cli.py
@@ -6,6 +6,7 @@ Tool handlers now live in per-domain modules under `src/dev10x/mcp/`:
   - plan_tools.py    — plan-sync handlers
   - audit_tools.py   — session audit and hook-log handlers
   - misc_tools.py    — mktmp, slack, permission, skill-index, upgrade handlers
+  - roots_tools.py   — client-roots awareness (GH-344)
 
 This module imports all of them (triggering @server.tool() registration)
 and re-exports their names for backward-compatible attribute access.
@@ -27,6 +28,7 @@ from __future__ import annotations
 # Importing knowledge_resources triggers @server.resource() registration
 # (GH-339). Importing knowledge_prompts triggers @server.prompt()
 # registration (GH-340).
+# Importing roots_tools registers the list_client_roots tool (GH-344).
 from dev10x.mcp import (  # noqa: E402, F401
     audit_tools,
     git_tools,
@@ -35,6 +37,7 @@ from dev10x.mcp import (  # noqa: E402, F401
     knowledge_resources,
     misc_tools,
     plan_tools,
+    roots_tools,
 )
 from dev10x.mcp._app import (
     server,  # noqa: F401  (re-exported for callers importing server from server_cli)
@@ -44,6 +47,7 @@ from dev10x.mcp.git_tools import *  # noqa: E402, F401, F403
 from dev10x.mcp.github_tools import *  # noqa: E402, F401, F403
 from dev10x.mcp.misc_tools import *  # noqa: E402, F401, F403
 from dev10x.mcp.plan_tools import *  # noqa: E402, F401, F403
+from dev10x.mcp.roots_tools import *  # noqa: E402, F401, F403
 
 
 def main() -> None:

--- a/tests/mcp/test_resource_watcher.py
+++ b/tests/mcp/test_resource_watcher.py
@@ -588,7 +588,7 @@ class TestGetWatcher:
 class TestLifespanIntegration:
     @pytest.mark.asyncio
     async def test_lifespan_starts_and_cancels_watcher_task(self) -> None:
-        from dev10x.mcp._app import _knowledge_watcher_lifespan
+        from dev10x.mcp._app import _server_lifespan
 
         mock_app = MagicMock()
         mock_app._mcp_server.notification_handlers = {}
@@ -607,14 +607,15 @@ class TestLifespanIntegration:
                 mock_watcher_instance.run = _fake_run
                 MockWatcher.return_value = mock_watcher_instance
 
-                async with _knowledge_watcher_lifespan(mock_app):
-                    # Lifespan is active — watcher should be running
-                    pass
+                with patch("dev10x.mcp._app.wire_roots_to_server"):
+                    async with _server_lifespan(mock_app):
+                        # Lifespan is active — watcher should be running
+                        pass
                 # After exit — task should be cancelled (no exception raised)
 
     @pytest.mark.asyncio
     async def test_lifespan_wires_watcher_to_server(self) -> None:
-        from dev10x.mcp._app import _knowledge_watcher_lifespan
+        from dev10x.mcp._app import _server_lifespan
 
         mock_app = MagicMock()
         mock_app._mcp_server.notification_handlers = {}
@@ -631,8 +632,9 @@ class TestLifespanIntegration:
                 MockWatcher.return_value = mock_watcher_instance
 
                 with patch("dev10x.mcp._app.wire_watcher_to_server") as mock_wire:
-                    async with _knowledge_watcher_lifespan(mock_app):
-                        pass
+                    with patch("dev10x.mcp._app.wire_roots_to_server"):
+                        async with _server_lifespan(mock_app):
+                            pass
 
                 mock_wire.assert_called_once_with(
                     server=mock_app._mcp_server,

--- a/tests/mcp/test_roots.py
+++ b/tests/mcp/test_roots.py
@@ -1,0 +1,354 @@
+"""Tests for client-roots awareness (GH-344).
+
+Covers:
+- ClientRoot.contains correctly identifies paths inside/outside a root
+- ClientRoot.path resolves file:// URIs and returns None for non-file URIs
+- ClientRoot.to_dict returns the expected shape
+- ClientRootsManager.roots starts as None
+- ClientRootsManager.is_within_roots returns True when roots is None/empty
+- ClientRootsManager.refresh fetches roots from session and caches them
+- ClientRootsManager.refresh is a no-op when disabled
+- ClientRootsManager.refresh is a no-op when no session is attached
+- ClientRootsManager.refresh suppresses exceptions from list_roots
+- ClientRootsManager.set_session(None) clears cached roots
+- wire_roots_to_server registers InitializedNotification handler
+- wire_roots_to_server chains with existing InitializedNotification handler
+- wire_roots_to_server registers RootsListChangedNotification handler
+- get_manager returns the registered manager
+- _roots_enabled reads the env var correctly
+- list_client_roots MCP tool returns None roots before session
+- list_client_roots MCP tool returns populated roots after refresh
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+roots_mod = pytest.importorskip(
+    "dev10x.mcp.roots_manager",
+    reason="mcp not installed",
+)
+
+ClientRoot = roots_mod.ClientRoot
+ClientRootsManager = roots_mod.ClientRootsManager
+get_manager = roots_mod.get_manager
+wire_roots_to_server = roots_mod.wire_roots_to_server
+_roots_enabled = roots_mod._roots_enabled
+
+
+# ── helpers ────────────────────────────────────────────────────────
+
+
+def _make_list_roots_result(uris: list[str]) -> Any:
+    """Build a mock ListRootsResult with the given URIs."""
+    roots = []
+    for uri in uris:
+        r = MagicMock()
+        r.uri = uri
+        r.name = None
+        roots.append(r)
+    result = MagicMock()
+    result.roots = roots
+    return result
+
+
+def _make_server_stub(existing_init_handler: Any = None) -> MagicMock:
+    """Build a minimal low-level server stub."""
+    stub = MagicMock()
+    handlers: dict[type, Any] = {}
+    if existing_init_handler is not None:
+        import mcp.types as mcp_types
+
+        handlers[mcp_types.InitializedNotification] = existing_init_handler
+    stub.notification_handlers = handlers
+    return stub
+
+
+# ── ClientRoot ─────────────────────────────────────────────────────
+
+
+class TestClientRoot:
+    def test_path_resolves_file_uri(self, tmp_path: Path) -> None:
+        root = ClientRoot(uri=f"file://{tmp_path}")
+        assert root.path == tmp_path.resolve()
+
+    def test_path_is_none_for_non_file_uri(self) -> None:
+        root = ClientRoot(uri="https://example.com/root")
+        assert root.path is None
+
+    def test_contains_child_path(self, tmp_path: Path) -> None:
+        root = ClientRoot(uri=f"file://{tmp_path}")
+        child = tmp_path / "subdir" / "file.txt"
+        assert root.contains(candidate=child) is True
+
+    def test_contains_returns_false_for_sibling(self, tmp_path: Path) -> None:
+        sibling = tmp_path.parent / "other"
+        root = ClientRoot(uri=f"file://{tmp_path}")
+        assert root.contains(candidate=sibling) is False
+
+    def test_contains_returns_false_for_non_file_uri(self, tmp_path: Path) -> None:
+        root = ClientRoot(uri="https://example.com/root")
+        assert root.contains(candidate=tmp_path) is False
+
+    def test_to_dict_returns_uri_and_name(self) -> None:
+        root = ClientRoot(uri="file:///tmp/x", name="MyRoot")
+        assert root.to_dict() == {"uri": "file:///tmp/x", "name": "MyRoot"}
+
+    def test_to_dict_name_is_none_when_unset(self) -> None:
+        root = ClientRoot(uri="file:///tmp/x")
+        assert root.to_dict()["name"] is None
+
+    def test_repr_includes_uri(self) -> None:
+        root = ClientRoot(uri="file:///tmp/x")
+        assert "file:///tmp/x" in repr(root)
+
+
+# ── ClientRootsManager ─────────────────────────────────────────────
+
+
+class TestClientRootsManager:
+    def test_roots_starts_as_none(self) -> None:
+        mgr = ClientRootsManager()
+        assert mgr.roots is None
+
+    def test_is_within_roots_true_when_no_roots(self, tmp_path: Path) -> None:
+        mgr = ClientRootsManager()
+        assert mgr.is_within_roots(cwd=tmp_path) is True
+
+    def test_is_within_roots_true_when_empty_roots(self, tmp_path: Path) -> None:
+        mgr = ClientRootsManager()
+        mgr._roots = []
+        assert mgr.is_within_roots(cwd=tmp_path) is True
+
+    def test_is_within_roots_true_when_inside_declared_root(self, tmp_path: Path) -> None:
+        mgr = ClientRootsManager()
+        mgr._roots = [ClientRoot(uri=f"file://{tmp_path}")]
+        child = tmp_path / "sub"
+        assert mgr.is_within_roots(cwd=child) is True
+
+    def test_is_within_roots_false_when_outside_declared_root(self, tmp_path: Path) -> None:
+        mgr = ClientRootsManager()
+        sub = tmp_path / "allowed"
+        mgr._roots = [ClientRoot(uri=f"file://{sub}")]
+        other = tmp_path / "forbidden"
+        assert mgr.is_within_roots(cwd=other) is False
+
+    def test_set_session_none_clears_roots(self) -> None:
+        mgr = ClientRootsManager()
+        mgr._roots = [ClientRoot(uri="file:///tmp/x")]
+        mgr.set_session(session=None)
+        assert mgr.roots is None
+
+    @pytest.mark.asyncio
+    async def test_refresh_fetches_roots_from_session(self, tmp_path: Path) -> None:
+        mgr = ClientRootsManager(enabled=True)
+        session = AsyncMock()
+        session.list_roots = AsyncMock(
+            return_value=_make_list_roots_result([f"file://{tmp_path}"])
+        )
+        mgr.set_session(session=session)
+
+        await mgr.refresh()
+
+        assert mgr.roots is not None
+        assert len(mgr.roots) == 1
+        assert mgr.roots[0].uri == f"file://{tmp_path}"
+
+    @pytest.mark.asyncio
+    async def test_refresh_noop_when_disabled(self) -> None:
+        mgr = ClientRootsManager(enabled=False)
+        session = AsyncMock()
+        mgr.set_session(session=session)
+
+        await mgr.refresh()
+
+        session.list_roots.assert_not_awaited()
+        assert mgr.roots is None
+
+    @pytest.mark.asyncio
+    async def test_refresh_noop_without_session(self) -> None:
+        mgr = ClientRootsManager(enabled=True)
+        # No session attached.
+        await mgr.refresh()
+        assert mgr.roots is None
+
+    @pytest.mark.asyncio
+    async def test_refresh_suppresses_list_roots_exception(self) -> None:
+        mgr = ClientRootsManager(enabled=True)
+        session = AsyncMock()
+        session.list_roots = AsyncMock(side_effect=RuntimeError("not supported"))
+        mgr.set_session(session=session)
+
+        await mgr.refresh()  # Must not raise.
+
+        assert mgr.roots is None
+
+
+# ── wire_roots_to_server ───────────────────────────────────────────
+
+
+class TestWireRootsToServer:
+    def test_registers_roots_changed_handler(self) -> None:
+        import mcp.types as mcp_types
+
+        stub = _make_server_stub()
+        mgr = ClientRootsManager()
+        wire_roots_to_server(server=stub, manager=mgr)
+        assert mcp_types.RootsListChangedNotification in stub.notification_handlers
+
+    def test_registers_initialized_handler_when_none_exists(self) -> None:
+        import mcp.types as mcp_types
+
+        stub = _make_server_stub()
+        mgr = ClientRootsManager()
+        wire_roots_to_server(server=stub, manager=mgr)
+        assert mcp_types.InitializedNotification in stub.notification_handlers
+
+    @pytest.mark.asyncio
+    async def test_chains_existing_initialized_handler(self) -> None:
+        import mcp.types as mcp_types
+
+        call_log: list[str] = []
+
+        async def existing(n: mcp_types.InitializedNotification) -> None:
+            call_log.append("existing")
+
+        stub = _make_server_stub(existing_init_handler=existing)
+        stub.request_context = MagicMock()
+        stub.request_context.session = AsyncMock()
+        stub.request_context.session.list_roots = AsyncMock(
+            return_value=_make_list_roots_result([])
+        )
+
+        mgr = ClientRootsManager(enabled=True)
+        wire_roots_to_server(server=stub, manager=mgr)
+
+        handler = stub.notification_handlers[mcp_types.InitializedNotification]
+        notification = MagicMock(spec=mcp_types.InitializedNotification)
+        await handler(notification)
+
+        assert "existing" in call_log
+
+    @pytest.mark.asyncio
+    async def test_initialized_handler_calls_refresh(self) -> None:
+        import mcp.types as mcp_types
+
+        stub = _make_server_stub()
+        stub.request_context = MagicMock()
+        stub.request_context.session = AsyncMock()
+        stub.request_context.session.list_roots = AsyncMock(
+            return_value=_make_list_roots_result(["file:///tmp/test"])
+        )
+
+        mgr = ClientRootsManager(enabled=True)
+        wire_roots_to_server(server=stub, manager=mgr)
+
+        handler = stub.notification_handlers[mcp_types.InitializedNotification]
+        await handler(MagicMock(spec=mcp_types.InitializedNotification))
+
+        assert mgr.roots is not None
+        assert len(mgr.roots) == 1
+
+    @pytest.mark.asyncio
+    async def test_roots_changed_handler_schedules_refresh(self) -> None:
+        import mcp.types as mcp_types
+
+        stub = _make_server_stub()
+        mgr = ClientRootsManager(enabled=False)
+        wire_roots_to_server(server=stub, manager=mgr)
+
+        handler = stub.notification_handlers[mcp_types.RootsListChangedNotification]
+        with patch.object(asyncio, "create_task") as mock_create_task:
+            await handler(MagicMock(spec=mcp_types.RootsListChangedNotification))
+            mock_create_task.assert_called_once()
+
+    def test_get_manager_returns_registered_manager(self) -> None:
+        stub = _make_server_stub()
+        mgr = ClientRootsManager()
+        wire_roots_to_server(server=stub, manager=mgr)
+        assert get_manager() is mgr
+
+    @pytest.mark.asyncio
+    async def test_initialized_handler_suppresses_session_access_error(self) -> None:
+        import mcp.types as mcp_types
+
+        stub = _make_server_stub()
+        # Raise when the handler tries to access request_context.session.
+        stub.request_context = MagicMock()
+        type(stub.request_context).session = property(
+            lambda self: (_ for _ in ()).throw(RuntimeError("no session"))
+        )
+
+        mgr = ClientRootsManager(enabled=True)
+        wire_roots_to_server(server=stub, manager=mgr)
+
+        handler = stub.notification_handlers[mcp_types.InitializedNotification]
+        await handler(MagicMock(spec=mcp_types.InitializedNotification))  # Must not raise.
+
+        assert mgr.roots is None
+
+
+# ── _roots_enabled ─────────────────────────────────────────────────
+
+
+class TestRootsEnabled:
+    def test_enabled_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("DEV10X_ROOTS_ENABLED", raising=False)
+        assert _roots_enabled() is True
+
+    def test_disabled_by_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_ROOTS_ENABLED", "0")
+        assert _roots_enabled() is False
+
+    def test_disabled_by_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_ROOTS_ENABLED", "false")
+        assert _roots_enabled() is False
+
+    def test_enabled_by_one(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_ROOTS_ENABLED", "1")
+        assert _roots_enabled() is True
+
+
+# ── list_client_roots MCP tool ─────────────────────────────────────
+
+
+class TestListClientRootsTool:
+    @pytest.mark.asyncio
+    async def test_returns_none_roots_when_no_manager(self) -> None:
+        cli_server = pytest.importorskip("dev10x.mcp.server_cli", reason="mcp not installed")
+        with patch("dev10x.mcp.roots_manager.get_manager", return_value=None):
+            result = await cli_server.list_client_roots()
+        assert result == {"roots": None, "enabled": False}
+
+    @pytest.mark.asyncio
+    async def test_returns_none_roots_before_refresh(self) -> None:
+        cli_server = pytest.importorskip("dev10x.mcp.server_cli", reason="mcp not installed")
+        mgr = ClientRootsManager(enabled=True)
+        with patch("dev10x.mcp.roots_manager.get_manager", return_value=mgr):
+            result = await cli_server.list_client_roots()
+        assert result["roots"] is None
+        assert result["enabled"] is True
+
+    @pytest.mark.asyncio
+    async def test_returns_populated_roots_after_refresh(self, tmp_path: Path) -> None:
+        cli_server = pytest.importorskip("dev10x.mcp.server_cli", reason="mcp not installed")
+        mgr = ClientRootsManager(enabled=True)
+        mgr._roots = [ClientRoot(uri=f"file://{tmp_path}", name="Work")]
+        with patch("dev10x.mcp.roots_manager.get_manager", return_value=mgr):
+            result = await cli_server.list_client_roots()
+        assert result["roots"] == [{"uri": f"file://{tmp_path}", "name": "Work"}]
+        assert result["enabled"] is True
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_when_no_roots_declared(self) -> None:
+        cli_server = pytest.importorskip("dev10x.mcp.server_cli", reason="mcp not installed")
+        mgr = ClientRootsManager(enabled=True)
+        mgr._roots = []
+        with patch("dev10x.mcp.roots_manager.get_manager", return_value=mgr):
+            result = await cli_server.list_client_roots()
+        assert result["roots"] == []


### PR DESCRIPTION
**When** Claude Code declares filesystem roots after `EnterWorktree`, **I want** the MCP server to fetch and cache those roots via `roots/list` and refresh on `notifications/roots/list_changed`, **so** CWD/worktree operations can be validated against client-declared scope, complementing the GH-979 effective-CWD discipline.

---

[`452b2e26`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/459/commits/452b2e26cf6d99ef51daff90b83adaa50de1b1d8) ✨ GH-344 Enable client-declared directory roots scoping
Closes #344
Fixes: https://github.com/Dev10x-Guru/dev10x-claude/issues/344

---