### PR TITLE
♻️ GH-344 Improve roots manager encapsulation

### DIFF
--- a/src/dev10x/mcp/roots_manager.py
+++ b/src/dev10x/mcp/roots_manager.py
@@ -132,6 +132,11 @@ class ClientRootsManager:
         """
         return self._roots
 
+    @property
+    def enabled(self) -> bool:
+        """Return whether roots integration is enabled."""
+        return self._enabled
+
     def is_within_roots(self, cwd: str | Path) -> bool:
         """Return ``True`` when *cwd* is inside at least one declared root.
 

--- a/src/dev10x/mcp/roots_tools.py
+++ b/src/dev10x/mcp/roots_tools.py
@@ -37,5 +37,5 @@ async def list_client_roots() -> dict:
     roots = manager.roots
     return {
         "roots": [r.to_dict() for r in roots] if roots is not None else None,
-        "enabled": manager._enabled,
+        "enabled": manager.enabled,
     }

--- a/tests/mcp/test_roots.py
+++ b/tests/mcp/test_roots.py
@@ -116,6 +116,10 @@ class TestClientRootsManager:
         mgr = ClientRootsManager()
         assert mgr.roots is None
 
+    def test_enabled_property_reflects_constructor_flag(self) -> None:
+        assert ClientRootsManager(enabled=True).enabled is True
+        assert ClientRootsManager(enabled=False).enabled is False
+
     def test_is_within_roots_true_when_no_roots(self, tmp_path: Path) -> None:
         mgr = ClientRootsManager()
         assert mgr.is_within_roots(cwd=tmp_path) is True


### PR DESCRIPTION
**When** the merged PR #459 left a claude-review finding open about `list_client_roots` reading the private `_enabled` member, **I want to** expose a public `enabled` property and use it at the tool layer, **so I can** keep the manager's public API clean and the review thread answerable with a shipped commit.

---

[`c3ae8c40`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/460/commits/c3ae8c40b444afca877720bad5ca38af34fa084e) ♻️ GH-344 Improve roots manager encapsulation
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/344

---