### PR TITLE
🐛 GH-462 Fix audit findings: resume, CWD guard, merge race, drift gate

### DIFF
--- a/references/orchestration/subagent-status-protocol.md
+++ b/references/orchestration/subagent-status-protocol.md
@@ -82,8 +82,18 @@ else:
 a swarm agent hits a context limit, permission wall, or turn
 budget before finishing the PR lifecycle, it may terminate
 with free-form prose as its last line. This is NOT `DONE`.
-Orchestrators MUST treat it as `NEEDS_CONTEXT` and re-dispatch.
-The re-dispatch prompt should include:
+Orchestrators MUST treat it as `NEEDS_CONTEXT`.
+
+**Resume-first recovery (GH-462 F1):** Before re-dispatching a
+fresh agent, attempt a **SendMessage resume** of the same agent —
+send a short continuation prompt (e.g., "Please continue and
+finish through to PR merge"). This preserves the agent's full
+in-context state (PR branch, CI results, diff history) and
+typically completes the lifecycle at lower cost. Re-dispatch a
+fresh agent only when the agent is no longer resumable (turn
+expired, session ended, or the original agent returned BLOCKED).
+
+When a fresh re-dispatch is needed, the prompt should include:
 - The last known PR URL (if visible in the result)
 - The last known branch name
 - A directive to continue from the current PR state rather

--- a/skills/fanout/instructions.md
+++ b/skills/fanout/instructions.md
@@ -471,7 +471,14 @@ Swarm context:
 - lock_wait_timeout: 30s
 
 Bootstrap (REQUIRED first, before Skill invocation):
-1. Write .claude/Dev10x/session.yaml inside your isolated
+1. Verify `git rev-parse --show-toplevel` equals YOUR
+   ephemeral isolated worktree path before any branch
+   checkout or git mutation. If a git/MCP call ever reports
+   the orchestrator's canonical worktree as its toplevel,
+   pass explicit cwd= pointing at your worktree — never
+   check out branches in the canonical worktree (GH-462 F2,
+   stale-CWD class GH-410).
+2. Write .claude/Dev10x/session.yaml inside your isolated
    worktree with:
        friction_level: adaptive
        active_modes: [solo-maintainer, swarm-child]
@@ -774,15 +781,23 @@ Phase 4's job is therefore **collection**, not orchestration:
    **Missing status line (GH-368 F2, GH-385 F1):** If the
    agent's trailing line does not match any of the four
    status tokens, treat it as `NEEDS_CONTEXT: agent
-   terminated without a status line`. Re-dispatch the item
-   with the last known PR URL inlined so the new agent can
-   resume from the PR rather than restarting from scratch.
+   terminated without a status line`.
+   **Resume strategy (GH-462 F1):** Before re-dispatching a
+   fresh agent, **prefer SendMessage resume** — send a
+   continuation prompt to the SAME agent via SendMessage
+   (e.g., "Please continue from where you left off and
+   finish through to PR merge"). SendMessage preserves the
+   agent's in-context PR state, branch, and CI history,
+   completing the lifecycle at lower cost than a fresh
+   dispatch. Use re-dispatch (new agent with PR URL inlined)
+   only when the agent is no longer resumable (turn expired,
+   session ended, or agent returned BLOCKED).
    **"PR created but not merged" (GH-368 F1):** If the
    agent result contains a PR URL and the trailing line is
    `DONE` but the PR state (via `mcp__plugin_Dev10x_cli__pr_get`)
    shows the PR is still OPEN, downgrade the status to
-   `NEEDS_CONTEXT: PR open, merge incomplete` and re-dispatch
-   to finish the monitor → merge lifecycle.
+   `NEEDS_CONTEXT: PR open, merge incomplete`. Apply the
+   same resume-first strategy before re-dispatching.
 2. Mark the matching Phase 3 subtask `completed` only when
    the PR is confirmed MERGED. Mark `pending` again if the
    agent reported `NEEDS_CONTEXT` or if the PR is open.
@@ -1080,6 +1095,15 @@ with more context, or escalate to the user via
 `AskUserQuestion`. A `BLOCKED:` status replaces today's
 heuristic agent-failure detection — the agent self-reports the
 failure, no guesswork.
+
+**NEEDS_CONTEXT recovery — prefer SendMessage resume (GH-462 F1):**
+When an agent returns `NEEDS_CONTEXT` (or terminates without a
+status token), the orchestrator SHOULD attempt a SendMessage
+resume before re-dispatching a fresh agent. SendMessage preserves
+the agent's full in-context state (PR branch, CI results, diff)
+and typically completes the lifecycle on the first resume.
+Re-dispatch a fresh agent only when the agent is no longer
+resumable (expired turn, session ended, or `BLOCKED`).
 
 See [`references/orchestration/subagent-status-protocol.md`](
 ../../references/orchestration/subagent-status-protocol.md)

--- a/skills/gh-pr-merge/instructions.md
+++ b/skills/gh-pr-merge/instructions.md
@@ -342,11 +342,23 @@ defaults (`strategy: rebase`, `delete_branch: true`,
 
 ### Step 3: Run all 8 validation checks
 
-Run checks in parallel where possible (checks 1-4 use `gh`
-commands, check 5-6 use `git` commands). Collect all results
-before reporting. **Check 1b MUST be run as a separate step
-after Check 1** — it calls `check-top-level-comments.sh` and
-is NOT part of the GraphQL batch (GH-728).
+**Comment-check ordering (GH-462 F3):** Checks 1, 1b, and
+1c fetch comment state that is time-sensitive — automated
+review bots continue posting comments during the CI window,
+so comment state read before CI settles is stale. Run
+Checks 2–7 first (CI, draft, mergeable, working copy,
+fixup, approval). Only after Check 2 confirms CI is green
+(all checks `pass`) re-fetch and run Checks 1, 1b, and 1c
+as a final gate immediately before Step 5 merge. This
+eliminates the race where a bot posts a REQUIRED finding
+after the comment check but before the merge.
+
+Run non-comment checks in parallel where possible (checks 2-7
+use `gh`/`git` commands). **Check 1b MUST be run as a
+separate step after Check 1** — it calls
+`check-top-level-comments.sh` and is NOT part of the
+GraphQL batch (GH-728). Collect all results before
+reporting.
 
 ### Step 4: Report validation results
 

--- a/skills/git-commit/SKILL.md
+++ b/skills/git-commit/SKILL.md
@@ -14,6 +14,7 @@ allowed-tools:
   - AskUserQuestion
   - mcp__plugin_Dev10x_cli__mktmp
   - mcp__plugin_Dev10x_cli__plan_sync_json_summary
+  - mcp__plugin_Dev10x_cli__plan_sync_archive
   - Bash(/tmp/Dev10x/bin/mktmp.sh:*)
   - Write(/tmp/Dev10x/git/**)
 ---

--- a/skills/git-commit/instructions.md
+++ b/skills/git-commit/instructions.md
@@ -287,6 +287,25 @@ Substitute the placeholders in the call spec:
   ticket ID; fall back to `<user>/<expected-ticket>/...` if no
   reflog entry matches
 
+**Verify expected branch exists before offering the switch option
+(GH-462 F5):** Before constructing the gate options, run:
+
+```bash
+git rev-parse --verify <expected-branch>
+```
+
+- If the command exits **0** (branch exists locally or as a
+  remote ref), include the "Switch back to expected branch"
+  option as documented.
+- If the command exits **non-zero** (branch no longer exists —
+  e.g., deleted after merge), the switch option would fail with
+  `pathspec did not match`. Instead, replace it with:
+  - **Archive stale plan** — call `plan_sync_archive()` to
+    clear the obsolete `in_progress` plan, then continue on
+    the current branch. Present this as the recommended option
+    with description "The expected branch was deleted (likely
+    merged). Archive the stale plan and commit here."
+
 **Handling the user's choice:**
 
 - **Switch back to expected branch** — run `git checkout
@@ -294,6 +313,9 @@ Substitute the placeholders in the call spec:
   user) re-invokes `Dev10x:git-commit` after the checkout. Do
   NOT auto-resume — the working tree state on the expected
   branch may differ and Step 1's status check must re-run.
+- **Archive stale plan** (shown instead of switch when branch
+  is gone) — call `mcp__plugin_Dev10x_cli__plan_sync_archive()`
+  and proceed to Step 2 on the current branch.
 - **Continue on current branch** — proceed to Step 2. The
   ticket ID extracted in Step 2 will reflect the actual branch,
   not the expected one. This is the intentional-switch path.

--- a/skills/git-commit/tool-calls/ask-branch-drift.md
+++ b/skills/git-commit/tool-calls/ask-branch-drift.md
@@ -1,5 +1,8 @@
 # Decision Gate: Branch Drift Detected
 
+**Branch-exists variant** (use when `git rev-parse --verify <expected-branch>`
+exits 0 — the expected branch exists):
+
 ```
 AskUserQuestion(questions=[{
     question: "HEAD is on `<actual-branch>` but this session's plan expects ticket `<expected-ticket>` (last branched as `<expected-branch>`). Continue committing here, or switch back?",
@@ -11,6 +14,26 @@ AskUserQuestion(questions=[{
          description: "Commit on `<actual-branch>` anyway. Use when the drift is intentional (e.g., you switched tasks mid-session)."},
         {label: "Abort",
          description: "Cancel commit without switching. Investigate manually."}
+    ],
+    multiSelect: false
+}])
+```
+
+**Branch-gone variant** (use when `git rev-parse --verify <expected-branch>`
+exits non-zero — the expected branch was deleted, e.g., after merge).
+Replace the "Switch back" option with "Archive stale plan":
+
+```
+AskUserQuestion(questions=[{
+    question: "HEAD is on `<actual-branch>` but this session's plan expects ticket `<expected-ticket>`. The expected branch `<expected-branch>` no longer exists (likely merged and deleted). Archive the stale plan and commit here?",
+    header: "Branch drift — stale plan",
+    options: [
+        {label: "Archive stale plan (Recommended)",
+         description: "Call plan_sync_archive() to clear the obsolete in_progress plan, then commit on `<actual-branch>`."},
+        {label: "Continue on current branch",
+         description: "Commit on `<actual-branch>` without archiving. Plan sync will remain in a stale state."},
+        {label: "Abort",
+         description: "Cancel commit without changes. Investigate manually."}
     ],
     multiSelect: false
 }])
@@ -35,3 +58,17 @@ drift the gate is designed to catch.
   `checkout: moving to <branch>` line whose target contains the
   expected ticket ID; fall back to `"<user>/<expected-ticket>/..."`
   if no reflog entry matches.
+
+## Branch existence check (GH-462 F5)
+
+Before presenting the gate, run:
+```bash
+git rev-parse --verify <expected-branch>
+```
+
+- Exit 0 → use the **branch-exists** variant above
+- Non-zero → use the **branch-gone** variant above
+
+This prevents offering "Switch back to expected branch" for a
+branch that no longer exists, which would fail with
+`error: pathspec did not match any file(s) known to git`.


### PR DESCRIPTION
**When** a fanout swarm agent turn ends mid-implementation, **I want to** resume the same agent via SendMessage before re-dispatching, **so I can** complete the PR lifecycle at lower cost without losing context. Also: swarm children verify their worktree CWD before checkout; gh-pr-merge re-fetches comments after CI settles; git-commit drift gate verifies branch exists before offering switch.

---

[`362177bc`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/467/commits/362177bc2f3c58c78c674992b25d05bb85f62c8b) 🐛 GH-462 Prefer SendMessage resume over re-dispatch on turn death
[`744c2025`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/467/commits/744c2025c77ac17d2bbff6a77e341321d09658ec) 🐛 GH-462 Run comment checks after CI-green to close bot-post race
[`b676fc1d`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/467/commits/b676fc1d078c398a627364321ed9854dd78bae30) 🐛 GH-462 Guard drift gate against offering switch to deleted branch
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/462

---