### PR TITLE
🐛 GH-471 Enable plugin scripts to run without re-prompting

### DIFF
--- a/skills/upgrade-cleanup/projects.yaml
+++ b/skills/upgrade-cleanup/projects.yaml
@@ -55,75 +55,20 @@ base_permissions:
   - "Bash(~/.claude/tools/*.sh:*)"
   - "Bash(/home/*/.claude/tools/*:*)"
 
-  # --- Plugin scripts: bin/ ---
-  - "Bash(~/.claude/plugins/cache/**/bin/release.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/bin/require-tool.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/bin/statusline.sh:*)"
+  # --- Plugin scripts (GH-471) ---
+  # Per-script Bash rules are NO LONGER listed here. They previously used
+  # `cache/**/` globs, which Claude Code's Bash matcher treats literally —
+  # the literal `**` never appears in a real command string, so the rules
+  # never matched and every plugin script prompted. `update-paths` cannot
+  # re-version a `**` rule either (no literal X.Y.Z segment to bump).
+  #
+  # Concrete, version-pinned rules
+  # (`.../<version>/{bin,hooks,skills}/.../foo.{sh,py}:*`) are emitted by
+  # `permission ensure-scripts` (from scan_plugin_scripts) and re-bumped by
+  # `permission update-paths` on every upgrade. ensure-scripts also purges
+  # any surviving dead `**` script rules from user settings, replacing them
+  # with the concrete forms. See update_paths.is_dead_glob_script_rule.
 
-  # --- Plugin scripts: hooks/ ---
-  - "Bash(~/.claude/plugins/cache/**/hooks/scripts/permission-denied.py:*)"
-  - "Bash(~/.claude/plugins/cache/**/hooks/scripts/precompact-context.py:*)"
-  # Manual-invocation hook: dev10x.hooks.session.session_reload can be
-  # called directly to refresh session state without restart. Not
-  # registered in hooks.json because it's on-demand, not automatic.
-  # The audit may flag this as "unused" — keep it; the auditor lacks
-  # context that it serves manual reloads.
-  - "Bash(~/.claude/plugins/cache/**/hooks/scripts/session-start-reload.py:*)"
-  - "Bash(~/.claude/plugins/cache/**/hooks/scripts/task-plan-sync.py:*)"
-  - "Bash(~/.claude/plugins/cache/**/hooks/scripts/validate-bash-command.py:*)"
-  - "Bash(~/.claude/plugins/cache/**/hooks/scripts/validate-edit-write.py:*)"
-
-  # --- Plugin scripts: skills/ ---
-  - "Bash(~/.claude/plugins/cache/**/skills/db-psql/scripts/db.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/db-psql/scripts/dsn-resolve.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/db-psql/scripts/parse-databases.py:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/gh-context/scripts/detect-tracker.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/gh-context/scripts/gh-issue-comments.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/gh-context/scripts/gh-issue-create.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/gh-context/scripts/gh-issue-get.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/gh-context/scripts/gh-pr-detect.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/gh-pr-create/scripts/create-pr.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/gh-pr-create/scripts/detect-base-branch.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/gh-pr-create/scripts/generate-commit-list.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/gh-pr-create/scripts/post-summary-comment.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/gh-pr-create/scripts/pre-pr-checks.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/gh-pr-create/scripts/verify-state.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/gh-pr-doctor/scripts/gh-audit-check.py:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/gh-pr-doctor/scripts/gh-audit-comment.py:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/gh-pr-doctor/scripts/gh-unresolved-threads.py:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/gh-pr-merge/scripts/check-top-level-comments.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/gh-pr-monitor/scripts/ci-check-status.py:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/gh-pr-monitor/scripts/pr-notify.py:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/git-alias-setup/scripts/git-alias-setup.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/git-commit-split/scripts/start-split-rebase.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/git-groom/scripts/mass-rewrite.py:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/git/scripts/git-push-safe.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/git/scripts/git-rebase-groom.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/git/scripts/git-seq-editor.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/git/scripts/protected-branches.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/git-worktree/scripts/create-worktree.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/git-worktree/scripts/next-worktree-name.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/git-worktree/scripts/session-end-cleanup.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/git-worktree/scripts/setup-session-end-hook.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/investigate/scripts/parse-slack-url.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/investigate/scripts/reply.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/playwright/scripts/run-playwright.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/py-uv/scripts/check-uv.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/qa-self/scripts/convert-evidence.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/qa-self/scripts/upload-screenshots.py:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/release-notes/scripts/collect-prs.py:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/skill-audit/scripts/analyze-actions.py:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/skill-audit/scripts/analyze-actions.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/skill-audit/scripts/analyze-permissions.py:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/skill-audit/scripts/analyze-permissions.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/skill-audit/scripts/extract-session.py:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/skill-audit/scripts/extract-session.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/skill-create/scripts/scaffold.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/skill-index/scripts/generate-all.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/skill-index/scripts/generate-motd.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/skill-index/scripts/generate-skills-menu.sh:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/slack-review-request/scripts/slack-review-request.py:*)"
-  - "Bash(~/.claude/plugins/cache/**/skills/ticket-create/scripts/create-github-issue.sh:*)"
   # GH-269: upgrade-cleanup/scripts/*.py shims were retired in favour
   # of the version-stable `uvx dev10x permission …` CLI. The
   # replacement allow-rules live below under "Dev10x CLI". The

--- a/src/dev10x/skills/permission/update_paths.py
+++ b/src/dev10x/skills/permission/update_paths.py
@@ -349,6 +349,58 @@ def build_script_allow_rules(
     return rules
 
 
+def is_dead_glob_script_rule(entry: str) -> bool:
+    """True for a Bash plugin-cache rule that uses a ``**`` glob (GH-471).
+
+    Claude Code's Bash permission matcher treats ``**`` literally — the
+    literal characters never appear in a real command string — so these
+    rules never match. ``update-paths`` cannot repair them either, since
+    its version regex only rewrites rules containing a literal ``X.Y.Z``.
+    They are dead weight and must be purged in favour of concrete
+    version-pinned rules emitted by :func:`build_script_allow_rules`.
+
+    Scoped to ``Bash(`` cache rules so unversioned ``Read(... /**)``
+    marketplaces rules (which are functional) are never touched.
+    """
+    return entry.startswith("Bash(") and "plugins/cache/" in entry and "**" in entry
+
+
+def purge_dead_glob_script_rules(
+    path: Path,
+    *,
+    dry_run: bool = False,
+) -> tuple[int, list[str]]:
+    """Remove dead ``**`` cache-glob Bash rules from a settings file.
+
+    Returns ``(count_removed, messages)``. Idempotent — a file with no
+    dead globs returns ``(0, [])``.
+    """
+    try:
+        content = path.read_text()
+        data = json.loads(content)
+    except (OSError, json.JSONDecodeError) as exc:
+        return 0, [f"  SKIP (unreadable JSON): {exc}"]
+
+    allow_list: list[str] = data.get("permissions", {}).get("allow", [])
+    dead = [r for r in allow_list if is_dead_glob_script_rule(r)]
+    if not dead:
+        return 0, []
+
+    if not dry_run:
+        from dev10x.skills.permission.backup import create_backup
+        from dev10x.skills.permission.file_lock import locked_json_update
+
+        create_backup(path)
+        with locked_json_update(path=path) as live_data:
+            allow = live_data.get("permissions", {}).get("allow", [])
+            live_data["permissions"]["allow"] = [
+                r for r in allow if not is_dead_glob_script_rule(r)
+            ]
+
+    messages = [f"  - {r}  (dead ** cache glob removed)" for r in dead]
+    return len(dead), messages
+
+
 def verify_script_coverage(
     settings_path: Path,
     expected_rules: list[str],
@@ -370,7 +422,13 @@ def verify_script_coverage(
             continue
         script_name = Path(match.group(1)).name
         pattern = re.compile(rf"Bash\(.*/{re.escape(script_name)}:\*\)")
-        if rule in allow_list or any(pattern.search(entry) for entry in allow_list):
+        # GH-471: a ** cache glob never matches in Claude Code's Bash
+        # matcher and update-paths cannot re-version it (no literal X.Y.Z
+        # segment), so it is NOT real coverage. Skip dead globs here so a
+        # concrete version-pinned rule is emitted instead.
+        if rule in allow_list or any(
+            pattern.search(entry) for entry in allow_list if not is_dead_glob_script_rule(entry)
+        ):
             covered.append(rule)
         else:
             missing.append(rule)
@@ -1042,33 +1100,45 @@ def ensure_scripts(
             messages.append("(dry run — no files will be modified)\n")
 
     total_added = 0
+    total_purged = 0
     files_changed = 0
 
     for path in sorted(settings_files):
+        # GH-471: purge dead ** cache globs first so verify_script_coverage
+        # reports the concrete version-pinned rules as missing and they get
+        # added — replacing the non-functional globs rather than coexisting.
+        purged, purge_messages = purge_dead_glob_script_rules(path, dry_run=dry_run)
+
         _covered, missing = verify_script_coverage(
             settings_path=path,
             expected_rules=expected_rules,
         )
-        if not missing:
-            continue
+        count = 0
+        file_messages: list[str] = []
+        if missing:
+            count, file_messages = ensure_script_rules(
+                settings_path=path,
+                missing_rules=missing,
+                dry_run=dry_run,
+            )
 
-        count, file_messages = ensure_script_rules(
-            settings_path=path,
-            missing_rules=missing,
-            dry_run=dry_run,
-        )
-        if count > 0:
+        if purged > 0 or count > 0:
             if not quiet:
                 messages.append(f"\n{path}")
+                messages.extend(purge_messages)
                 messages.extend(file_messages)
             total_added += count
+            total_purged += purged
             files_changed += 1
 
-    if total_added == 0:
+    if total_added == 0 and total_purged == 0:
         messages.append("All settings files have complete script coverage.")
     else:
-        verb = "Would add" if dry_run else "Added"
-        messages.append(f"{verb} {total_added} script rules across {files_changed} files.")
+        verb = "Would update" if dry_run else "Updated"
+        messages.append(
+            f"{verb} {files_changed} files "
+            f"(+{total_added} concrete rules, -{total_purged} dead ** globs)."
+        )
 
     return _result(
         exit_code=0,

--- a/tests/skills/upgrade-cleanup/test_ensure_scripts.py
+++ b/tests/skills/upgrade-cleanup/test_ensure_scripts.py
@@ -107,6 +107,38 @@ class TestVerifyScriptCoverage:
 
         assert len(covered) == 1
 
+    def test_glob_star_entry_is_not_coverage(self, settings_file: Path) -> None:
+        # GH-471: a ** cache glob is non-functional in Claude Code's Bash
+        # matcher and update-paths cannot re-version it (no literal X.Y.Z
+        # segment). It must NOT count as coverage, so ensure-scripts emits
+        # the concrete version-pinned rule instead of silently skipping it.
+        dead_glob = "Bash(~/.claude/plugins/cache/Dev10x-Guru/Dev10x/**/bin/mktmp.sh:*)"
+        settings_file.write_text(json.dumps({"permissions": {"allow": [dead_glob]}}))
+        concrete = "Bash(/home/u/.claude/plugins/cache/Dev10x-Guru/Dev10x/0.78.0/bin/mktmp.sh:*)"
+
+        _covered, missing = update_paths.verify_script_coverage(
+            settings_path=settings_file,
+            expected_rules=[concrete],
+        )
+
+        assert missing == [concrete]
+
+    def test_concrete_versioned_entry_at_other_path_is_coverage(self, settings_file: Path) -> None:
+        # The version-bump case still counts as covered: a concrete path at
+        # an older version is re-versioned by update-paths, so ensure-scripts
+        # must not duplicate it.
+        older = "Bash(/home/u/.claude/plugins/cache/Dev10x-Guru/Dev10x/0.77.0/bin/mktmp.sh:*)"
+        settings_file.write_text(json.dumps({"permissions": {"allow": [older]}}))
+        newer = "Bash(/home/u/.claude/plugins/cache/Dev10x-Guru/Dev10x/0.78.0/bin/mktmp.sh:*)"
+
+        covered, missing = update_paths.verify_script_coverage(
+            settings_path=settings_file,
+            expected_rules=[newer],
+        )
+
+        assert covered == [newer]
+        assert missing == []
+
     def test_no_false_positive_on_substring_match(self, settings_file: Path) -> None:
         settings_file.write_text(
             json.dumps({"permissions": {"allow": ["Bash(/path/test-utils.sh:*)"]}})
@@ -181,3 +213,207 @@ class TestEnsureScriptRules:
 
         assert count == 0
         assert messages == []
+
+
+class TestIsDeadGlobScriptRule:
+    def test_bash_cache_glob_is_dead(self) -> None:
+        rule = "Bash(~/.claude/plugins/cache/Dev10x-Guru/Dev10x/**/bin/mktmp.sh:*)"
+        assert update_paths.is_dead_glob_script_rule(rule) is True
+
+    def test_concrete_versioned_bash_rule_is_not_dead(self) -> None:
+        rule = "Bash(~/.claude/plugins/cache/Dev10x-Guru/Dev10x/0.78.0/bin/mktmp.sh:*)"
+        assert update_paths.is_dead_glob_script_rule(rule) is False
+
+    def test_read_marketplaces_glob_is_not_dead(self) -> None:
+        # Read rules are functional with ** and must never be purged.
+        rule = "Read(~/.claude/plugins/marketplaces/Dev10x-Guru/**)"
+        assert update_paths.is_dead_glob_script_rule(rule) is False
+
+    def test_non_cache_bash_glob_is_not_dead(self) -> None:
+        rule = "Bash(/tmp/Dev10x/**/*.py:*)"
+        assert update_paths.is_dead_glob_script_rule(rule) is False
+
+
+class TestPurgeDeadGlobScriptRules:
+    @pytest.fixture()
+    def settings_file(self, tmp_path: Path) -> Path:
+        return tmp_path / "settings.local.json"
+
+    def test_removes_dead_glob_keeps_others(self, settings_file: Path) -> None:
+        dead = "Bash(~/.claude/plugins/cache/Dev10x-Guru/Dev10x/**/bin/mktmp.sh:*)"
+        keep_read = "Read(~/.claude/plugins/marketplaces/Dev10x-Guru/**)"
+        keep_bash = "Bash(git log:*)"
+        settings_file.write_text(
+            json.dumps({"permissions": {"allow": [dead, keep_read, keep_bash]}})
+        )
+
+        count, messages = update_paths.purge_dead_glob_script_rules(settings_file)
+
+        assert count == 1
+        assert len(messages) == 1
+        allow = json.loads(settings_file.read_text())["permissions"]["allow"]
+        assert dead not in allow
+        assert keep_read in allow
+        assert keep_bash in allow
+
+    def test_returns_zero_when_no_dead_globs(self, settings_file: Path) -> None:
+        settings_file.write_text(json.dumps({"permissions": {"allow": ["Bash(git log:*)"]}}))
+
+        count, messages = update_paths.purge_dead_glob_script_rules(settings_file)
+
+        assert count == 0
+        assert messages == []
+
+    def test_dry_run_does_not_write(self, settings_file: Path) -> None:
+        dead = "Bash(~/.claude/plugins/cache/Dev10x-Guru/Dev10x/**/bin/mktmp.sh:*)"
+        settings_file.write_text(json.dumps({"permissions": {"allow": [dead]}}))
+        original = settings_file.read_text()
+
+        count, _messages = update_paths.purge_dead_glob_script_rules(settings_file, dry_run=True)
+
+        assert count == 1
+        assert settings_file.read_text() == original
+
+    def test_handles_invalid_json(self, settings_file: Path) -> None:
+        settings_file.write_text("{invalid}")
+
+        count, messages = update_paths.purge_dead_glob_script_rules(settings_file)
+
+        assert count == 0
+        assert messages and "SKIP" in messages[0]
+
+
+class TestEnsureScriptsReplacesDeadGlobs:
+    def test_purges_dead_glob_and_adds_concrete(self, tmp_path: Path) -> None:
+        cache_dir = tmp_path / "cache"
+        plugin_root = cache_dir / "0.78.0"
+        (plugin_root / "bin").mkdir(parents=True)
+        (plugin_root / "bin" / "mktmp.sh").touch()
+
+        settings = tmp_path / "settings.local.json"
+        dead = "Bash(~/.claude/plugins/cache/Dev10x-Guru/Dev10x/**/bin/mktmp.sh:*)"
+        settings.write_text(json.dumps({"permissions": {"allow": [dead]}}))
+
+        result = update_paths.ensure_scripts(
+            config={"plugin_cache": str(cache_dir)},
+            settings_files=[settings],
+            dry_run=False,
+            quiet=True,
+        )
+
+        assert result["exit_code"] == 0
+        allow = json.loads(settings.read_text())["permissions"]["allow"]
+        assert dead not in allow
+        assert f"Bash({plugin_root}/bin/mktmp.sh:*)" in allow
+
+
+class TestEnsureScriptsFunction:
+    @pytest.fixture()
+    def cache_dir(self, tmp_path: Path) -> Path:
+        cache = tmp_path / "cache"
+        (cache / "0.78.0" / "bin").mkdir(parents=True)
+        (cache / "0.78.0" / "bin" / "mktmp.sh").touch()
+        return cache
+
+    def _concrete(self, cache_dir: Path) -> str:
+        return f"Bash({cache_dir / '0.78.0'}/bin/mktmp.sh:*)"
+
+    def test_noop_when_already_covered(self, tmp_path: Path, cache_dir: Path) -> None:
+        settings = tmp_path / "settings.local.json"
+        settings.write_text(json.dumps({"permissions": {"allow": [self._concrete(cache_dir)]}}))
+        original = settings.read_text()
+
+        result = update_paths.ensure_scripts(
+            config={"plugin_cache": str(cache_dir)},
+            settings_files=[settings],
+            dry_run=False,
+            quiet=True,
+        )
+
+        assert result["files_changed"] == 0
+        assert settings.read_text() == original
+        assert any("complete script coverage" in m for m in result["messages"])
+
+    def test_quiet_false_reports_messages(self, tmp_path: Path, cache_dir: Path) -> None:
+        settings = tmp_path / "settings.local.json"
+        dead = "Bash(~/.claude/plugins/cache/Dev10x-Guru/Dev10x/**/bin/mktmp.sh:*)"
+        settings.write_text(json.dumps({"permissions": {"allow": [dead]}}))
+
+        result = update_paths.ensure_scripts(
+            config={"plugin_cache": str(cache_dir)},
+            settings_files=[settings],
+            dry_run=False,
+            quiet=False,
+        )
+
+        joined = "\n".join(result["messages"])
+        assert "Plugin root:" in joined
+        assert "dead ** cache glob removed" in joined
+        assert "Updated 1 files" in joined
+
+    def test_dry_run_reports_would_update(self, tmp_path: Path, cache_dir: Path) -> None:
+        settings = tmp_path / "settings.local.json"
+        dead = "Bash(~/.claude/plugins/cache/Dev10x-Guru/Dev10x/**/bin/mktmp.sh:*)"
+        settings.write_text(json.dumps({"permissions": {"allow": [dead]}}))
+        original = settings.read_text()
+
+        result = update_paths.ensure_scripts(
+            config={"plugin_cache": str(cache_dir)},
+            settings_files=[settings],
+            dry_run=True,
+            quiet=False,
+        )
+
+        assert settings.read_text() == original
+        assert any("Would update" in m for m in result["messages"])
+
+    def test_purges_when_concrete_already_present(self, tmp_path: Path, cache_dir: Path) -> None:
+        settings = tmp_path / "settings.local.json"
+        dead = "Bash(~/.claude/plugins/cache/Dev10x-Guru/Dev10x/**/bin/mktmp.sh:*)"
+        settings.write_text(
+            json.dumps({"permissions": {"allow": [dead, self._concrete(cache_dir)]}})
+        )
+
+        result = update_paths.ensure_scripts(
+            config={"plugin_cache": str(cache_dir)},
+            settings_files=[settings],
+            dry_run=False,
+            quiet=True,
+        )
+
+        allow = json.loads(settings.read_text())["permissions"]["allow"]
+        assert dead not in allow
+        assert self._concrete(cache_dir) in allow
+        assert result["files_changed"] == 1
+
+    def test_errors_when_no_versions(self, tmp_path: Path) -> None:
+        empty_cache = tmp_path / "empty-cache"
+        empty_cache.mkdir()
+        settings = tmp_path / "settings.local.json"
+        settings.write_text(json.dumps({"permissions": {"allow": []}}))
+
+        result = update_paths.ensure_scripts(
+            config={"plugin_cache": str(empty_cache)},
+            settings_files=[settings],
+            dry_run=False,
+            quiet=True,
+        )
+
+        assert result["exit_code"] == 1
+        assert any("No versions found" in e for e in result["errors"])
+
+    def test_reports_when_no_scripts(self, tmp_path: Path) -> None:
+        cache = tmp_path / "cache"
+        (cache / "0.78.0").mkdir(parents=True)
+        settings = tmp_path / "settings.local.json"
+        settings.write_text(json.dumps({"permissions": {"allow": []}}))
+
+        result = update_paths.ensure_scripts(
+            config={"plugin_cache": str(cache)},
+            settings_files=[settings],
+            dry_run=False,
+            quiet=True,
+        )
+
+        assert result["exit_code"] == 0
+        assert any("No callable scripts" in m for m in result["messages"])


### PR DESCRIPTION
**When** I run a Dev10x skill that calls a plugin script, **I want to** have the script's permission rule actually match the command, **so I can** work without re-approving the same script on every invocation.

---

[`b6b0b10b`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/472/commits/b6b0b10b3161b4fa2b72d505774d75e9e292b30d) 🐛 GH-471 Enable plugin scripts to run without re-prompting
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/471

---