### PR TITLE
🐛 GH-469 Prevent bash/sh/zsh exec from bypassing DX003

### DIFF
--- a/references/permission-architecture.md
+++ b/references/permission-architecture.md
@@ -92,6 +92,25 @@ Source: [Claude Code permissions docs](https://code.claude.com/docs/en/permissio
 — "Rules are evaluated `deny → ask → allow`; the first matching rule
 wins" and "`Bash(git *)` matches `git log --oneline --all`".
 
+### Interpreter footguns are hook-enforced (GH-469)
+
+The most dangerous `Bash(<verb> *)` catch-all is the interpreter one
+(`bash *`, `sh *`, `zsh *`, `python3 *`) — it grants arbitrary code
+execution and a total rule bypass. Protection for these does **not**
+rely on a permission deny-rule (which is unreliable: it does not
+suppress the option-2 UI footgun and does not reliably merge
+global→project). Instead, the `DX003` execution-safety validator
+(`src/dev10x/validators/execution_safety.py`, `MINIMAL` profile) runs
+on **every** Bash call and blocks inline code (`bash -c`, `python3 -c`)
+and untrusted absolute script paths, steering to the Write-tool /
+uv-script pattern or an approved dir (`~/.claude/{tools,skills,hooks}/`,
+`/tmp/Dev10x/`).
+
+**Rule of thumb:** footgun catch-alls are **hook-enforced** (a
+PreToolUse validator that always runs); permission deny-rules are
+**belt-and-suspenders** — a defensive second layer, never the primary
+guard.
+
 ### The fix: pre-approve the safe surface
 
 The only safe defense is to **enumerate the safe commands as `allow`

--- a/src/dev10x/validators/execution_safety.py
+++ b/src/dev10x/validators/execution_safety.py
@@ -6,8 +6,14 @@ block-python3-inline.py.
 Blocks:
   1. Shell-based file writes (cat >, echo >, printf >)
   2. In-place file editors (sed -i, perl -i, gawk -i inplace, dd of=)
-  3. python3 -c inline code
-  4. python3 with untrusted absolute paths
+  3. Interpreter inline code (python3 -c, bash/sh/zsh -c)
+  4. Interpreters running untrusted absolute script paths
+     (python3/bash/sh/zsh <untrusted-abs-path>)
+
+The interpreter guard (GH-469) treats bash/sh/zsh as siblings of
+python3: the `bash <verb> *` catch-all is the higher-severity footgun
+(arbitrary shell, total rule bypass), so it must be hook-enforced here
+rather than left to an unreliable permission deny-rule.
 """
 
 from __future__ import annotations
@@ -81,6 +87,30 @@ Benefits:
 
 If the script needs no third-party deps, the # /// block can be omitted."""
 
+SHELL_INTERPRETERS = ("bash", "sh", "zsh")
+
+# Shell interpreters may additionally run scripts staged under the Dev10x
+# temp dir (GH-370 pre-approves /tmp/Dev10x/ execution); python3 keeps the
+# narrower APPROVED_ABS_PREFIXES set.
+SHELL_APPROVED_ABS_PREFIXES = (*APPROVED_ABS_PREFIXES, "/tmp/Dev10x/")
+
+SHELL_INTERP_MSG = """\
+\U0001f6ab  shell inline/untrusted script execution blocked.
+
+`bash`/`sh`/`zsh` running inline code (`-c`) or an untrusted absolute
+script path bypasses every PreToolUse guardrail. Use one of:
+
+  - Inline logic — Write a self-contained uv script to
+    /tmp/Dev10x/<name>.py via the Write tool, then `uv run --script` it
+    (auditable diff, declared deps, no rule bypass).
+  - An existing script — run it directly via its shebang
+    (./script.sh) instead of `bash script.sh`.
+  - A staged script — place it under an approved dir and run it
+    there: ~/.claude/{tools,skills,hooks}/ or /tmp/Dev10x/.
+
+Relative paths (e.g. `bash ./build.sh`) and approved-dir absolute paths
+are allowed; only inline `-c` and untrusted absolute paths are blocked."""
+
 
 def _strip_env_prefix(parts: list[str]) -> list[str]:
     i = 0
@@ -89,9 +119,9 @@ def _strip_env_prefix(parts: list[str]) -> list[str]:
     return parts[i:]
 
 
-def _is_approved_path(path: str) -> bool:
+def _is_approved_path(path: str, prefixes: tuple[str, ...] = APPROVED_ABS_PREFIXES) -> bool:
     expanded = os.path.expanduser(path)
-    return any(expanded.startswith(p) or path.startswith(p) for p in APPROVED_ABS_PREFIXES)
+    return any(expanded.startswith(p) or path.startswith(p) for p in prefixes)
 
 
 def _has_inplace_flag(*, argv: list[str], cmd: str) -> bool:
@@ -152,7 +182,7 @@ class ExecutionSafetyValidator(ValidatorBase):
         result = self._check_inplace_edit(command=inp.command)
         if result:
             return result
-        return self._check_python3_inline(command=inp.command)
+        return self._check_interpreter(command=inp.command)
 
     def _check_shell_writes(self, *, command: str) -> HookResult | None:
         if SHELL_WRITE_RE.search(command):
@@ -194,8 +224,47 @@ class ExecutionSafetyValidator(ValidatorBase):
 
         return None
 
-    def _check_python3_inline(self, *, command: str) -> HookResult | None:
-        if "python3" not in command:
+    def _check_interpreter(self, *, command: str) -> HookResult | None:
+        """Block inline code and untrusted absolute script paths for
+        python3 and the shell interpreters (bash/sh/zsh).
+
+        python3 keeps its `-m` carve-out and the narrow approved-prefix
+        set; the shell interpreters additionally allow /tmp/Dev10x/.
+        First match wins (python3 checked before the shells).
+        """
+        result = self._check_one_interpreter(
+            command=command,
+            interpreter="python3",
+            approved=APPROVED_ABS_PREFIXES,
+            message=PYTHON3_INLINE_MSG,
+            allow_module=True,
+        )
+        if result:
+            return result
+
+        for interpreter in SHELL_INTERPRETERS:
+            result = self._check_one_interpreter(
+                command=command,
+                interpreter=interpreter,
+                approved=SHELL_APPROVED_ABS_PREFIXES,
+                message=SHELL_INTERP_MSG,
+                allow_module=False,
+            )
+            if result:
+                return result
+
+        return None
+
+    def _check_one_interpreter(
+        self,
+        *,
+        command: str,
+        interpreter: str,
+        approved: tuple[str, ...],
+        message: str,
+        allow_module: bool,
+    ) -> HookResult | None:
+        if interpreter not in command:
             return None
 
         first_cmd = command.split("|")[0].strip()
@@ -207,16 +276,16 @@ class ExecutionSafetyValidator(ValidatorBase):
 
         parts = _strip_env_prefix(parts)
 
-        if not parts or parts[0] != "python3":
+        if not parts or parts[0] != interpreter:
             return None
 
         argv = parts[1:]
 
-        if "-m" in argv:
+        if allow_module and "-m" in argv:
             return None
 
         if any(a == "-c" or a.startswith("-c") for a in argv):
-            return HookResult(message=PYTHON3_INLINE_MSG)
+            return HookResult(message=message)
 
         script = next(
             (a for a in argv if not a.startswith("-")),
@@ -226,7 +295,7 @@ class ExecutionSafetyValidator(ValidatorBase):
         if script is None or not os.path.isabs(os.path.expanduser(script)):
             return None
 
-        if _is_approved_path(script):
+        if _is_approved_path(script, approved):
             return None
 
-        return HookResult(message=PYTHON3_INLINE_MSG)
+        return HookResult(message=message)

--- a/tests/validators/test_execution_safety.py
+++ b/tests/validators/test_execution_safety.py
@@ -6,6 +6,7 @@ import pytest
 
 from dev10x.validators.execution_safety import (
     INPLACE_EDIT_MSG,
+    SHELL_INTERP_MSG,
     ExecutionSafetyValidator,
 )
 from tests.fakers import BashHookInputFaker
@@ -222,3 +223,93 @@ class TestPython3InlineEdgeCases:
         inp = _make_input(command="echo python3 rocks")
         result = validator.validate(inp=inp)
         assert result is None
+
+
+class TestShellInterpreter:
+    """GH-469: bash/sh/zsh are siblings of python3 in the interpreter guard."""
+
+    @pytest.fixture()
+    def validator(self) -> ExecutionSafetyValidator:
+        return ExecutionSafetyValidator()
+
+    # --- Positive cases: untrusted/inline shell execution must be blocked ---
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "bash /tmp/x.sh",
+            "sh /tmp/x.sh",
+            "zsh /tmp/x.sh",
+            "bash /tmp/classify_branches.sh",
+        ],
+    )
+    def test_blocks_untrusted_abs_script(
+        self, validator: ExecutionSafetyValidator, command: str
+    ) -> None:
+        inp = _make_input(command=command)
+        result = validator.validate(inp=inp)
+        assert result is not None
+        assert result.message == SHELL_INTERP_MSG
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "bash -c 'rm -rf /tmp/x'",
+            "sh -c 'echo hi'",
+            "zsh -c 'print hi'",
+        ],
+    )
+    def test_blocks_inline_c(self, validator: ExecutionSafetyValidator, command: str) -> None:
+        inp = _make_input(command=command)
+        result = validator.validate(inp=inp)
+        assert result is not None
+        assert result.message == SHELL_INTERP_MSG
+
+    def test_blocks_env_prefix_stripped_bash(self, validator: ExecutionSafetyValidator) -> None:
+        inp = _make_input(command="FOO=1 bash /tmp/x.sh")
+        result = validator.validate(inp=inp)
+        assert result is not None
+        assert result.message == SHELL_INTERP_MSG
+
+    # --- Negative cases: approved / relative forms must NOT be flagged ---
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "bash ~/.claude/tools/x.sh",
+            "bash ~/.claude/skills/foo/run.sh",
+            "bash ~/.claude/hooks/h.sh",
+            "bash /tmp/Dev10x/x.sh",
+            "sh /tmp/Dev10x/setup.sh",
+            "zsh /tmp/Dev10x/run.zsh",
+            "bash ./build.sh",
+            "bash build.sh",
+        ],
+    )
+    def test_allows_approved_and_relative(
+        self, validator: ExecutionSafetyValidator, command: str
+    ) -> None:
+        inp = _make_input(command=command)
+        result = validator.validate(inp=inp)
+        assert result is None
+
+    def test_unbalanced_quotes_returns_none(self, validator: ExecutionSafetyValidator) -> None:
+        inp = _make_input(command="bash -c 'echo hi")
+        result = validator.validate(inp=inp)
+        assert result is None
+
+    def test_interpreter_as_argument_returns_none(
+        self, validator: ExecutionSafetyValidator
+    ) -> None:
+        # 'bash' appears only as an argument, not the command
+        inp = _make_input(command="echo bash /tmp/x.sh")
+        result = validator.validate(inp=inp)
+        assert result is None
+
+    def test_dev10x_tmp_not_approved_for_python3(
+        self, validator: ExecutionSafetyValidator
+    ) -> None:
+        # /tmp/Dev10x/ is a shell-only carve-out; python3 keeps the narrow set
+        inp = _make_input(command="python3 /tmp/Dev10x/x.py")
+        result = validator.validate(inp=inp)
+        assert result is not None


### PR DESCRIPTION
**When** an agent runs `bash /tmp/script.sh`, `sh -c '…'`, or `zsh /tmp/x.sh`, **I want** the DX003 execution-safety hook to block and steer it the same way it already does for `python3`, **so** the high-severity `bash *` catch-all is enforced by an always-on validator rather than an unreliable permission deny-rule the UI still offers.

---

[`958f5044`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/475/commits/958f50443314d998eb24d0d5e80dcdd3033d94ae) 🐛 GH-469 Prevent bash/sh/zsh exec from bypassing DX003
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/469

---