### PR TITLE
✨ GH-473 Enable cross-fork PRs through create_pr

### DIFF
--- a/skills/gh-pr-create/instructions.md
+++ b/skills/gh-pr-create/instructions.md
@@ -348,6 +348,43 @@ This script:
 4. Updates the body with linked commits (using `generate-commit-list.sh`)
 5. Outputs the PR number
 
+### Step 6b: Cross-Fork PRs (GH-473)
+
+When contributing to an external repo from your own fork (the head
+repo differs from the base repo), pass the fork owner via the
+`head_repo` parameter so the wrapper opens the PR with
+`--head <head_repo>:<branch>` — instead of dropping to a raw
+`gh pr create --head` that bypasses the Job Story, commit list,
+summary comment, and notify flow.
+
+```
+mcp__plugin_Dev10x_cli__create_pr(
+    title=..., job_story=..., issue_id=...,
+    head_repo="<fork-owner>",   # e.g. "octocat"
+)
+```
+
+With `head_repo` set, `create-pr.sh` pushes the head branch to the
+fork owner's remote (matched by remote-URL owner, then a `fork`
+remote, then `origin`) and adds `--head <fork-owner>:<branch>` to
+`gh pr create`. All wrapper behavior (JTBD body, linked commit
+list, `Fixes:` line, summary comment) is preserved.
+
+**Detect-fork-remote heuristic.** Before setting `head_repo`,
+confirm the head differs from the base. Inspect the remotes:
+
+```bash
+git remote -v
+```
+
+The base/upstream owner is the owner of `origin`'s URL; the fork
+owner is the owner of whichever remote you push to (often a remote
+literally named `fork`, or one whose URL owner is your GitHub
+login). When the two owners differ, infer `head_repo=<fork-owner>`
+and **confirm the inferred head with the user** before creating the
+PR (same confirm-before-act pattern as base-branch detection). For
+same-repo PRs the owners match — omit `head_repo` entirely.
+
 ### Step 7: Mark N/A Checklist Items in PR Body
 
 Analyze `git diff origin/$BASE_BRANCH..HEAD` to determine which checklist items

--- a/skills/gh-pr-create/scripts/create-pr.sh
+++ b/skills/gh-pr-create/scripts/create-pr.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 # Create a PR with two-pass body generation.
 # Usage: create-pr.sh <title> <job_story> <issue_id> \
-#            [<fixes_url>] [<base_branch>] [<closes_csv>] [<draft>]
+#            [<fixes_url>] [<base_branch>] [<closes_csv>] [<draft>] [<head_repo>]
 #   closes_csv: comma-separated issue numbers to add as Closes #N lines (GH-186)
 #   draft: "true" (default) or "false" — pass "false" in solo-maintainer mode (GH-184)
+#   head_repo: fork owner for a cross-fork PR (GH-473). When set, the head
+#     branch is pushed to that owner's remote and the PR opens with
+#     --head <head_repo>:<branch> against the upstream base.
 # Outputs the PR number on success.
 set -euo pipefail
 
@@ -14,6 +17,7 @@ FIXES_URL="${4:-}"
 BASE_BRANCH="${5:-}"
 CLOSES_CSV="${6:-}"
 DRAFT="${7:-true}"
+HEAD_REPO="${8:-}"
 
 FIXES_LINE=""
 if [ -n "$FIXES_URL" ]; then
@@ -50,8 +54,19 @@ if [ -f .github/checklist.md ]; then
     CHECKLIST=$(sed "s/ISSUE-NO/$ISSUE/" .github/checklist.md)
 fi
 
-# Push branch
-git push --set-upstream origin "$BRANCH_NAME"
+# Push branch. For a cross-fork PR (GH-473), push the head to the fork
+# owner's remote (matched by URL owner, then a `fork` remote, then origin)
+# rather than to the upstream base remote.
+PUSH_REMOTE=origin
+if [ -n "$HEAD_REPO" ]; then
+    MATCHED_REMOTE=$(git remote -v | awk -v o="$HEAD_REPO/" '$2 ~ o {print $1; exit}')
+    if [ -n "$MATCHED_REMOTE" ]; then
+        PUSH_REMOTE="$MATCHED_REMOTE"
+    elif git remote get-url fork >/dev/null 2>&1; then
+        PUSH_REMOTE=fork
+    fi
+fi
+git push --set-upstream "$PUSH_REMOTE" "$BRANCH_NAME"
 
 # First pass: create PR with plain commit list + checklist
 COMMITS=$(git log "origin/$BASE_BRANCH..HEAD" --reverse --format="- %s")
@@ -59,6 +74,9 @@ BODY=$(printf '%s\n\n---\n\n%s%s%s\n\n---\n\n%s' \
     "$JOB_STORY" "$COMMITS" "$CLOSES_BLOCK" "$FIXES_LINE" "$CHECKLIST")
 
 CREATE_ARGS=(--base "$BASE_BRANCH" --title "$TITLE" --body "$BODY")
+if [ -n "$HEAD_REPO" ]; then
+    CREATE_ARGS+=(--head "$HEAD_REPO:$BRANCH_NAME")
+fi
 if [ "$DRAFT" = "true" ]; then
     CREATE_ARGS=(--draft "${CREATE_ARGS[@]}")
 fi

--- a/src/dev10x/github/__init__.py
+++ b/src/dev10x/github/__init__.py
@@ -832,12 +832,14 @@ async def create_pr(
     base_branch: str | None = None,
     closes: list[int] | None = None,
     draft: bool = True,
+    head_repo: str | None = None,
 ) -> Result[dict[str, Any]]:
     args = [title, job_story, issue_id]
     args.append(fixes_url or "")
     args.append(base_branch or "")
     args.append(",".join(str(n) for n in closes) if closes else "")
     args.append("true" if draft else "false")
+    args.append(head_repo or "")
 
     result = await async_run_script(
         "skills/gh-pr-create/scripts/create-pr.sh",

--- a/src/dev10x/mcp/github_tools.py
+++ b/src/dev10x/mcp/github_tools.py
@@ -452,6 +452,7 @@ async def create_pr(
     base_branch: str | None = None,
     closes: list[int] | None = None,
     draft: bool = True,
+    head_repo: str | None = None,
     cwd: str | None = None,
     ctx: Context | None = None,
 ) -> dict:
@@ -469,6 +470,10 @@ async def create_pr(
         draft: Create as draft (default True). Pass False in
             solo-maintainer mode so the PR is immediately
             ready-for-review (GH-184).
+        head_repo: Fork owner for a cross-fork PR (GH-473). When set,
+            the head branch is pushed to that owner's remote and the
+            PR opens with `--head <head_repo>:<branch>` against the
+            upstream base. Omit for same-repo PRs.
         cwd: Effective working directory (GH-979). Pass the worktree
             path after EnterWorktree so the PR is created from the
             worktree's branch, not the main repo's.
@@ -494,6 +499,7 @@ async def create_pr(
                 base_branch=base_branch,
                 closes=closes,
                 draft=draft,
+                head_repo=head_repo,
             )
         ).to_dict()
 

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -1802,8 +1802,8 @@ class TestCreatePr:
         )
 
         called_args = mock_run.call_args.args
-        # Trailing args: fixes_url, base_branch, closes_csv, draft
-        assert called_args[-4:] == ("", "", "", "true")
+        # Trailing args: fixes_url, base_branch, closes_csv, draft, head_repo
+        assert called_args[-5:] == ("", "", "", "true", "")
 
     @pytest.mark.asyncio
     @patch("dev10x.github.async_run_script", new_callable=AsyncMock)
@@ -1822,7 +1822,27 @@ class TestCreatePr:
         )
 
         called_args = mock_run.call_args.args
-        assert called_args[-2:] == ("184,185,186", "false")
+        # Trailing args: closes_csv, draft, head_repo
+        assert called_args[-3:] == ("184,185,186", "false", "")
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run_script", new_callable=AsyncMock)
+    async def test_emits_head_repo_for_cross_fork_pr(
+        self,
+        mock_run: AsyncMock,
+    ) -> None:
+        mock_run.return_value = _completed(stdout="https://github.com/o/r/pull/7\n7")
+
+        await gh.create_pr(
+            title="t",
+            job_story="js",
+            issue_id="GH-473",
+            head_repo="octocat",
+        )
+
+        called_args = mock_run.call_args.args
+        # head_repo is the final positional arg passed to create-pr.sh
+        assert called_args[-1] == "octocat"
 
     @pytest.mark.asyncio
     @patch("dev10x.github.async_run_script", new_callable=AsyncMock)


### PR DESCRIPTION
**When** I contribute to an external repo from my own fork (head repo ≠ base repo), **I want** `create_pr` / `Dev10x:gh-pr-create` to open the PR with a cross-fork head, **so** I don't have to drop to raw `gh pr create --head <fork-owner>:<branch>` and bypass the wrapper's Job-Story / summary-comment / notify flow.

---

[`87d01a9c`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/477/commits/87d01a9c16651b0cda01a6d77a478af905c956d1) ✨ GH-473 Enable cross-fork PRs through create_pr
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/473

---