### PR TITLE
✨ GH-470 Surface promotable read-only MCP tools and domains

### DIFF
--- a/skills/plugin-maintenance/SKILL.md
+++ b/skills/plugin-maintenance/SKILL.md
@@ -25,6 +25,7 @@ allowed-tools:
   - Bash(uvx dev10x permission merge-worktree:*)
   - Bash(uvx dev10x permission clean:*)
   - Bash(uvx dev10x permission enumerate-mcp:*)
+  - Bash(uvx dev10x permission promote-plan:*)
   - Bash(uvx dev10x permission ensure-base:*)
   - Bash(uvx dev10x permission ensure-reads:*)
   - Bash(uvx dev10x permission ensure-scripts:*)
@@ -524,6 +525,31 @@ uvx dev10x permission enumerate-mcp --dry-run
 ```bash
 uvx dev10x permission enumerate-mcp
 ```
+
+### 6b. Promotion plan — read-only MCP tools + research domains *(full only, GH-470)*
+
+MCP approvals are scoped per tool-name × per project-directory, so a
+read-only tool (claude.ai-hosted Slack/Linear/etc.) re-prompts in every
+project. This step reports which read-only MCP tools and project-local
+research `WebFetch(domain:*)` rules **would** be promoted to global
+settings, so they stop re-prompting per project.
+
+**Increment 1 is a DRY RUN — it makes no changes.** Tools are classified
+read-vs-write by a name-token heuristic (write-precedence: any write token
+excludes the tool). Writes are never promoted; sensitivity-flagged reads
+(private/DM/secret access) are reported separately as opt-in. Plugin tools
+are excluded — they go through step 6 (enumerate-mcp) instead. The
+heuristic carries false-positive risk (e.g. a `get_access_to_*` grant
+reads as `read`), so a human reviews the plan before any promotion lands.
+
+```bash
+uvx dev10x permission promote-plan
+```
+
+> **Deferred (Increment 2):** actually writing the approved read-only set
+> + research domains into global `~/.claude/settings.json` is a follow-up
+> once the classifier is validated against real allow-lists. Until then
+> this step is report-only.
 
 ### 7. Ensure script coverage **[bootstrap]**
 

--- a/src/dev10x/commands/permission.py
+++ b/src/dev10x/commands/permission.py
@@ -470,6 +470,37 @@ def enumerate_mcp(*, dry_run: bool, quiet: bool) -> None:
     mod.enumerate_settings(settings_files, dry_run=dry_run, quiet=quiet)
 
 
+@permission.command(name="promote-plan")
+@click.option("--quiet", is_flag=True, help="Suppress config line")
+def promote_plan(*, quiet: bool) -> None:
+    """Dry-run plan: read-only MCP tools + research domains to promote (GH-470).
+
+    Increment 1 — reports what WOULD be promoted to global settings; makes
+    NO changes. Read-only tools and project-local research WebFetch domains
+    are classified and deduped against global; writes and sensitivity-flagged
+    reads are excluded from the default promotable set. Actual promotion is
+    deferred to a follow-up (Increment 2).
+    """
+    from dev10x.skills.permission import promote as mod
+    from dev10x.skills.permission import update_paths as paths_mod
+
+    config_path = paths_mod.find_config()
+    if not quiet:
+        click.echo(f"Config: {config_path}")
+    config = paths_mod.load_config(config_path)
+
+    settings_files = paths_mod.find_settings_files(
+        roots=config.get("roots", []),
+        include_user=False,
+    )
+    global_settings = Path.home() / ".claude" / "settings.json"
+    plan = mod.build_promotion_plan(
+        project_settings_paths=settings_files,
+        global_settings_path=global_settings,
+    )
+    click.echo(mod.render_promotion_plan(plan))
+
+
 @permission.command(name="merge-worktree")
 @click.option("--dry-run", is_flag=True, help="Show changes without modifying files")
 @click.option("--restore", is_flag=True, help="Restore settings from most recent backups")

--- a/src/dev10x/skills/permission/promote.py
+++ b/src/dev10x/skills/permission/promote.py
@@ -1,0 +1,268 @@
+"""Dry-run promotion plan for read-only MCP tools and research WebFetch
+domains (GH-470, Increment 1).
+
+MCP approvals are scoped per tool-name x per project-directory, so a
+read-only tool used across many projects re-prompts in each one. This
+module classifies discovered MCP tools as read-only vs write using a
+name-token heuristic and builds a DRY-RUN plan describing which tools
+and research-fetch domains WOULD be promoted to global settings.
+
+**No writes.** This module never mutates settings — it only reports a
+plan a human reviews. Actual promotion to global settings is deferred to
+a follow-up (Increment 2). The heuristic carries false-positive risk —
+e.g. a grant named ``get_access_to_*`` reads as ``read`` by token — so a
+reviewable dry-run is the safety floor before any auto-write lands.
+
+Classification (write-precedence — safer to under-promote):
+
+- A tool is ``write`` if its short name contains ANY write token.
+- Else ``read`` if it contains any read token.
+- Else ``unknown``.
+
+Only read tools are promotable. Sensitivity-flagged read tools (private
+/ DM / secret access) are reported separately as opt-in — never folded
+into the default promotable set. Plugin-distributed tools are skipped:
+they are promoted through ``enumerate-mcp`` + base_permissions, not here.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from dev10x.skills.permission.enumerate_mcp import (
+    _server_prefix_from_tool,
+    _source_type_from_prefix,
+)
+
+# Verb tokens (matched against the short tool name split on `_`).
+READ_TOKENS = frozenset(
+    {
+        "read",
+        "search",
+        "list",
+        "get",
+        "find",
+        "fetch",
+        "query",
+        "lookup",
+        "show",
+        "check",
+        "describe",
+        "view",
+        "count",
+        "whoami",
+    }
+)
+WRITE_TOKENS = frozenset(
+    {
+        "create",
+        "update",
+        "delete",
+        "remove",
+        "send",
+        "schedule",
+        "add",
+        "edit",
+        "save",
+        "set",
+        "post",
+        "merge",
+        "close",
+        "reopen",
+        "deploy",
+        "respond",
+        "reply",
+        "transition",
+        "move",
+        "copy",
+        "archive",
+        "label",
+        "unlabel",
+        "submit",
+        "complete",
+        "authenticate",
+        "manage",
+        "change",
+        "download",
+        "upload",
+        "prepare",
+        "run",
+        "execute",
+        "build",
+        "rename",
+        "open",
+        "write",
+        "minimize",
+        "request",
+        "start",
+        "push",
+        "notify",
+    }
+)
+# Read tools whose target is private/DM/secret — promotable only on opt-in.
+SENSITIVE_TOKENS = frozenset(
+    {"private", "secret", "secrets", "credential", "credentials", "password", "dm"}
+)
+
+_WEBFETCH_RE = re.compile(r"^WebFetch\(domain:(?P<domain>.+)\)$")
+
+
+def _short_name(full_tool_name: str) -> str:
+    """Return the tool name after the final ``__`` separator, lowercased."""
+    return full_tool_name.rsplit("__", 1)[-1].lower()
+
+
+def _tokens(full_tool_name: str) -> set[str]:
+    return set(_short_name(full_tool_name).split("_"))
+
+
+def classify_mcp_tool(full_tool_name: str) -> str:
+    """Classify a fully-qualified MCP tool name as read/write/unknown.
+
+    Write-precedence: any write token wins, so a write is never
+    misclassified as promotable.
+    """
+    tokens = _tokens(full_tool_name)
+    if tokens & WRITE_TOKENS:
+        return "write"
+    if tokens & READ_TOKENS:
+        return "read"
+    return "unknown"
+
+
+def is_sensitivity_flagged(full_tool_name: str) -> bool:
+    """Return True when the tool reads private/DM/secret data (opt-in only)."""
+    return bool(_tokens(full_tool_name) & SENSITIVE_TOKENS)
+
+
+def _read_allow_rules(path: Path) -> list[str]:
+    """Return the ``permissions.allow`` list, or [] if missing/unreadable."""
+    try:
+        data = json.loads(Path(path).read_text())
+    except (OSError, json.JSONDecodeError):
+        return []
+    allow = data.get("permissions", {}).get("allow", [])
+    return [r for r in allow if isinstance(r, str)]
+
+
+def collect_webfetch_domains(path: Path) -> set[str]:
+    """Return the set of ``WebFetch(domain:X)`` domains in an allow list."""
+    domains: set[str] = set()
+    for rule in _read_allow_rules(path):
+        match = _WEBFETCH_RE.match(rule)
+        if match:
+            domains.add(match.group("domain"))
+    return domains
+
+
+@dataclass
+class PromotionPlan:
+    """Dry-run description of what WOULD be promoted to global settings.
+
+    Every field is advisory — the caller renders and reviews it. No
+    promotion is executed by building this plan.
+    """
+
+    read_promotable: list[str] = field(default_factory=list)
+    sensitive_opt_in: list[str] = field(default_factory=list)
+    writes_excluded: list[str] = field(default_factory=list)
+    unknown_excluded: list[str] = field(default_factory=list)
+    domains_promotable: list[str] = field(default_factory=list)
+    already_global_tools: int = 0
+    already_global_domains: int = 0
+
+    @property
+    def has_promotable(self) -> bool:
+        return bool(self.read_promotable or self.domains_promotable)
+
+
+def build_promotion_plan(
+    *,
+    project_settings_paths: Iterable[Path],
+    global_settings_path: Path,
+) -> PromotionPlan:
+    """Build a dry-run promotion plan from project-local settings.
+
+    Reads project-local allow rules, classifies each concrete (non-
+    wildcard) MCP tool, and dedups against the global allow list. Only
+    claude.ai-hosted and user-installed servers are considered — plugin-
+    distributed tools are promoted through ``enumerate-mcp`` instead.
+    """
+    global_allow = set(_read_allow_rules(global_settings_path))
+    global_domains = collect_webfetch_domains(global_settings_path)
+
+    plan = PromotionPlan()
+    seen: set[str] = set()
+
+    for path in project_settings_paths:
+        for rule in _read_allow_rules(path):
+            if not rule.startswith("mcp__") or rule.endswith("*"):
+                continue
+            if rule in seen:
+                continue
+            seen.add(rule)
+
+            prefix = _server_prefix_from_tool(rule)
+            if prefix is None:
+                continue
+            source_type, _ = _source_type_from_prefix(prefix)
+            if source_type == "plugin":
+                continue
+            if rule in global_allow:
+                plan.already_global_tools += 1
+                continue
+
+            kind = classify_mcp_tool(rule)
+            if kind == "write":
+                plan.writes_excluded.append(rule)
+            elif kind == "unknown":
+                plan.unknown_excluded.append(rule)
+            elif is_sensitivity_flagged(rule):
+                plan.sensitive_opt_in.append(rule)
+            else:
+                plan.read_promotable.append(rule)
+
+    project_domains: set[str] = set()
+    for path in project_settings_paths:
+        project_domains |= collect_webfetch_domains(path)
+    plan.already_global_domains = len(project_domains & global_domains)
+    plan.domains_promotable = sorted(project_domains - global_domains)
+
+    plan.read_promotable.sort()
+    plan.sensitive_opt_in.sort()
+    plan.writes_excluded.sort()
+    plan.unknown_excluded.sort()
+    return plan
+
+
+def render_promotion_plan(plan: PromotionPlan) -> str:
+    """Render a human-readable dry-run report of the promotion plan."""
+    lines = ["MCP / research-domain promotion plan (DRY RUN — no files modified):", ""]
+
+    def _section(title: str, items: list[str], marker: str) -> None:
+        lines.append(f"{title} ({len(items)}):")
+        for item in items:
+            lines.append(f"  {marker} {item}")
+        if not items:
+            lines.append("  (none)")
+        lines.append("")
+
+    _section("Read-only tools — would promote to global allow", plan.read_promotable, "+")
+    _section("Research WebFetch domains — would promote to global", plan.domains_promotable, "+")
+    _section("Sensitive read tools — promote only on explicit opt-in", plan.sensitive_opt_in, "?")
+    _section("Writes — never auto-promoted", plan.writes_excluded, "-")
+    _section("Unclassified — excluded (review manually)", plan.unknown_excluded, "-")
+
+    lines.append(
+        f"Already global: {plan.already_global_tools} tool(s), "
+        f"{plan.already_global_domains} domain(s) — skipped (idempotent)."
+    )
+    lines.append(
+        "Increment 1 is read-only: this plan performs NO writes. "
+        "Review it, then apply via the follow-up promotion step (Increment 2)."
+    )
+    return "\n".join(lines)

--- a/tests/skills/permission/test_promote.py
+++ b/tests/skills/permission/test_promote.py
@@ -1,0 +1,178 @@
+"""Tests for the dry-run MCP/domain promotion planner (GH-470, Increment 1)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dev10x.skills.permission.promote import (
+    PromotionPlan,
+    build_promotion_plan,
+    classify_mcp_tool,
+    collect_webfetch_domains,
+    is_sensitivity_flagged,
+    render_promotion_plan,
+)
+
+
+def _write_settings(path: Path, allow: list[str]) -> Path:
+    path.write_text(json.dumps({"permissions": {"allow": allow}}))
+    return path
+
+
+class TestClassifyMcpTool:
+    @pytest.mark.parametrize(
+        "tool",
+        [
+            "mcp__claude_ai_Slack__slack_read_channel",
+            "mcp__claude_ai_Slack__list_channel_members",
+            "mcp__claude_ai_Slack__get_reactions",
+            "mcp__claude_ai_Slack__search_channels",
+            "mcp__claude_ai_Sentry__whoami",
+        ],
+    )
+    def test_read_tools(self, tool: str):
+        assert classify_mcp_tool(tool) == "read"
+
+    @pytest.mark.parametrize(
+        "tool",
+        [
+            "mcp__claude_ai_Slack__create_canvas",
+            "mcp__claude_ai_Slack__send_message_draft",
+            "mcp__claude_ai_Slack__add_reaction",
+            "mcp__claude_ai_Slack__schedule_message",
+            "mcp__claude_ai_Square__complete_authentication",
+        ],
+    )
+    def test_write_tools(self, tool: str):
+        assert classify_mcp_tool(tool) == "write"
+
+    def test_write_precedence_over_read(self):
+        # Contains both a read token (get) and a write token (update).
+        assert classify_mcp_tool("mcp__svc__get_and_update_thing") == "write"
+
+    def test_unknown_when_no_verb_token(self):
+        assert classify_mcp_tool("mcp__svc__tool_guidance") == "unknown"
+
+    def test_malformed_name_without_separator(self):
+        assert classify_mcp_tool("noseparator") == "unknown"
+
+
+class TestSensitivityFlag:
+    def test_private_search_is_flagged(self):
+        assert is_sensitivity_flagged("mcp__claude_ai_Slack__search_public_and_private")
+
+    def test_plain_read_not_flagged(self):
+        assert not is_sensitivity_flagged("mcp__claude_ai_Slack__search_channels")
+
+
+class TestCollectWebfetchDomains:
+    def test_extracts_domains(self, tmp_path: Path):
+        settings = _write_settings(
+            tmp_path / "s.json",
+            ["WebFetch(domain:arxiv.org)", "WebFetch(domain:doi.org)", "Bash(ls:*)"],
+        )
+        assert collect_webfetch_domains(settings) == {"arxiv.org", "doi.org"}
+
+    def test_missing_file_returns_empty(self, tmp_path: Path):
+        assert collect_webfetch_domains(tmp_path / "absent.json") == set()
+
+    def test_unreadable_json_returns_empty(self, tmp_path: Path):
+        bad = tmp_path / "bad.json"
+        bad.write_text("{not valid json")
+        assert collect_webfetch_domains(bad) == set()
+
+    def test_non_string_rules_ignored(self, tmp_path: Path):
+        path = tmp_path / "s.json"
+        path.write_text(json.dumps({"permissions": {"allow": ["WebFetch(domain:x.org)", 42]}}))
+        assert collect_webfetch_domains(path) == {"x.org"}
+
+
+class TestPromotionPlanFlags:
+    def test_has_promotable_true_for_tools(self):
+        assert PromotionPlan(read_promotable=["t"]).has_promotable
+
+    def test_has_promotable_true_for_domains(self):
+        assert PromotionPlan(domains_promotable=["d"]).has_promotable
+
+    def test_has_promotable_false_when_empty(self):
+        assert not PromotionPlan().has_promotable
+
+
+class TestBuildPromotionPlan:
+    def test_classifies_and_dedups(self, tmp_path: Path):
+        project = _write_settings(
+            tmp_path / "project.json",
+            [
+                "mcp__claude_ai_Slack__slack_read_channel",  # read → promotable
+                "mcp__claude_ai_Slack__search_public_and_private",  # sensitive
+                "mcp__claude_ai_Slack__send_message",  # write
+                "mcp__claude_ai_HubSpot__tool_guidance",  # unknown
+                "mcp__claude_ai_Linear__get_issue",  # already global
+                "mcp__plugin_Dev10x_cli__pr_get",  # plugin → skipped
+                "mcp__claude_ai_Slack__*",  # wildcard → skipped
+                "mcp__onlyone",  # malformed prefix → skipped
+                "Bash(ls:*)",  # non-mcp → skipped
+                "WebFetch(domain:arxiv.org)",  # promotable domain
+                "WebFetch(domain:already.global)",  # already global domain
+            ],
+        )
+        global_settings = _write_settings(
+            tmp_path / "global.json",
+            [
+                "mcp__claude_ai_Linear__get_issue",
+                "WebFetch(domain:already.global)",
+            ],
+        )
+
+        plan = build_promotion_plan(
+            project_settings_paths=[project],
+            global_settings_path=global_settings,
+        )
+
+        assert plan.read_promotable == ["mcp__claude_ai_Slack__slack_read_channel"]
+        assert plan.sensitive_opt_in == ["mcp__claude_ai_Slack__search_public_and_private"]
+        assert plan.writes_excluded == ["mcp__claude_ai_Slack__send_message"]
+        assert plan.unknown_excluded == ["mcp__claude_ai_HubSpot__tool_guidance"]
+        assert plan.already_global_tools == 1
+        assert plan.domains_promotable == ["arxiv.org"]
+        assert plan.already_global_domains == 1
+
+    def test_dedups_across_multiple_project_files(self, tmp_path: Path):
+        tool = "mcp__claude_ai_Slack__slack_read_channel"
+        a = _write_settings(tmp_path / "a.json", [tool])
+        b = _write_settings(tmp_path / "b.json", [tool])
+        global_settings = _write_settings(tmp_path / "g.json", [])
+
+        plan = build_promotion_plan(
+            project_settings_paths=[a, b],
+            global_settings_path=global_settings,
+        )
+        assert plan.read_promotable == [tool]
+
+
+class TestRenderPromotionPlan:
+    def test_renders_sections_and_items(self):
+        plan = PromotionPlan(
+            read_promotable=["mcp__claude_ai_Slack__slack_read_channel"],
+            domains_promotable=["arxiv.org"],
+            sensitive_opt_in=["mcp__claude_ai_Slack__search_public_and_private"],
+            writes_excluded=["mcp__claude_ai_Slack__send_message"],
+            unknown_excluded=["mcp__svc__tool_guidance"],
+            already_global_tools=2,
+            already_global_domains=3,
+        )
+        out = render_promotion_plan(plan)
+        assert "DRY RUN" in out
+        assert "+ mcp__claude_ai_Slack__slack_read_channel" in out
+        assert "+ arxiv.org" in out
+        assert "? mcp__claude_ai_Slack__search_public_and_private" in out
+        assert "- mcp__claude_ai_Slack__send_message" in out
+        assert "2 tool(s), 3 domain(s)" in out
+
+    def test_renders_none_for_empty_sections(self):
+        out = render_promotion_plan(PromotionPlan())
+        assert "(none)" in out
+        assert "NO writes" in out


### PR DESCRIPTION
**When** I (a solo maintainer) approve the same read-only MCP tool or research-fetch domain in project after project, **I want to** see a deduped dry-run plan of exactly which read-only tools and domains could move to global settings, **so I can** stop re-approving the per-tool × per-project prompt matrix without hand-auditing allow-lists.

---

[`6202a0d0`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/479/commits/6202a0d0f9406ecf9c6271ffa47b7748abb89f1b) ✨ GH-470 Surface promotable read-only MCP tools and domains
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/470

---