### PR TITLE
Add slack-sdk to uvx runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "msgpack>=1.0",
     "pyjwt[crypto]>=2.8",
     "pyyaml>=6.0",
+    "slack-sdk>=3.27",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -266,6 +266,7 @@ dependencies = [
     { name = "msgpack" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "pyyaml" },
+    { name = "slack-sdk" },
 ]
 
 [package.optional-dependencies]
@@ -294,6 +295,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9" },
+    { name = "slack-sdk", specifier = ">=3.27" },
 ]
 provides-extras = ["dev"]
 
@@ -894,6 +896,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6c/25/3fc9114abf979a41673ce877c08016f8e660ad6cf508c3957f537d2e9fa9/ruff-0.15.6-py3-none-win32.whl", hash = "sha256:bbf67d39832404812a2d23020dda68fee7f18ce15654e96fb1d3ad21a5fe436c", size = 10616872, upload-time = "2026-03-12T23:05:42.451Z" },
     { url = "https://files.pythonhosted.org/packages/89/7a/09ece68445ceac348df06e08bf75db72d0e8427765b96c9c0ffabc1be1d9/ruff-0.15.6-py3-none-win_amd64.whl", hash = "sha256:aee25bc84c2f1007ecb5037dff75cef00414fdf17c23f07dc13e577883dca406", size = 11787271, upload-time = "2026-03-12T23:05:20.168Z" },
     { url = "https://files.pythonhosted.org/packages/7f/d0/578c47dd68152ddddddf31cd7fc67dc30b7cdf639a86275fda821b0d9d98/ruff-0.15.6-py3-none-win_arm64.whl", hash = "sha256:c34de3dd0b0ba203be50ae70f5910b17188556630e2178fd7d79fc030eb0d837", size = 11060497, upload-time = "2026-03-12T23:05:25.968Z" },
+]
+
+[[package]]
+name = "slack-sdk"
+version = "3.42.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/00/16258bfa547559b2c936b50c882b4f0a36ebf6b69639eb763d8fa5e8d6cb/slack_sdk-3.42.0.tar.gz", hash = "sha256:873db9e1f632ac650ffdbf9d8ba825f3e9e7e576a1e4f9604ccb2a15b3727e3d", size = 252136, upload-time = "2026-05-18T17:50:44.727Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/ef/8a1556bd4843443993fc116783790a7cc553601a37f7d965ec26eef95e76/slack_sdk-3.42.0-py2.py3-none-any.whl", hash = "sha256:eb39aff97e476e10cc5a8ac29bd2e79a9959e880d9fe0c03b4e8f05b2ac996ff", size = 315469, upload-time = "2026-05-18T17:50:41.972Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #483.

`dev10x skill notify slack-send` delegates to `dev10x.skills.notifications.slack_notify`, which imports `slack_sdk` when sending a message or uploading files. The package metadata used by `uvx dev10x` did not include `slack-sdk`, so the uvx-installed environment can miss that runtime dependency.

Changes:
- Add `slack-sdk>=3.27` to the project runtime dependencies.
- Regenerate `uv.lock` with `uv lock` so uv-based installs include it.

Validation:
- `python -m uv lock`
- `python -m uv run --extra dev pytest tests/commands/test_skill_notify.py`

The focused test file reported 9 passed. The command then failed the repository-wide coverage gate because only one test file was selected, leaving total coverage below the configured 75% threshold.