### PR TITLE
✨ GH-481 Reduce permission friction and tooling gaps (6-issue bundle)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,11 @@ dependencies = [
     "msgpack>=1.0",
     "pyjwt[crypto]>=2.8",
     "pyyaml>=6.0",
+    # GH-483: `dev10x skill notify slack-send` imports slack_sdk in-process
+    # (src/dev10x/skills/notifications/slack_notify.py). It must be a base
+    # dependency so the uvx-distributed env can send Slack notifications —
+    # `uvx dev10x` installs base deps only, not optional extras.
+    "slack-sdk>=3.21",
 ]
 
 [project.urls]

--- a/skills/git-groom/instructions.md
+++ b/skills/git-groom/instructions.md
@@ -202,6 +202,18 @@ always re-run `git log --oneline <base>..HEAD` to get the current SHAs.
 Any commit (rebase, amend, reset) changes all descendant SHAs. Using
 analysis-time SHAs in execution scripts will silently target wrong commits.
 
+**Stale local base (GH-486):** Resolve the range against
+`origin/<base>` (or the fork-point), not a possibly-stale local
+`<base>`. Local `develop` lags `origin/develop` after rebase-merge,
+long-lived feature work, or worktrees sharing an outdated ref —
+anchoring on it mis-computes the commit range. The `rebase_groom`
+MCP tool now qualifies a bare branch name to its `origin/<base>`
+remote-tracking ref automatically and reports a `base_notice` when
+the local ref lags. When analyzing by hand, prefer
+`git merge-base --fork-point origin/develop HEAD` over
+`git merge-base develop HEAD`, and `git log --oneline origin/develop..HEAD`
+for the range.
+
 ### Phase 2: Choose Strategy
 
 After analysis, queue the strategy decision in task metadata.

--- a/skills/project-audit/SKILL.md
+++ b/skills/project-audit/SKILL.md
@@ -26,6 +26,7 @@ allowed-tools:
   - Skill(Dev10x:project-scope)
   - Skill(Dev10x:adr)
   - Skill(Dev10x:ticket-create)
+  - Skill(Dev10x:git-commit)
   - mcp__plugin_Dev10x_cli__detect_tracker
 ---
 
@@ -164,10 +165,18 @@ After all agents return:
    - Coverage gaps (G, H findings)
 5. **Write findings memo** — create `docs/memos/architecture-audit-YYYY-MM-DD.md`
    with full findings, priority matrix, and milestone proposals.
-6. **Draft ADR proposals** — for HIGH-impact findings that represent
+6. **Persist the memo (commit it) — REQUIRED (GH-481).** The memo is
+   the durable artifact of an expensive multi-agent audit. Left as an
+   untracked working-tree file it is the most easily-lost form of work:
+   any `git clean`, worktree reset, or branch switch discards it
+   silently. Immediately commit it via `Skill(Dev10x:git-commit)` so it
+   lands in history regardless of whether Phase 5 runs. Do NOT end the
+   skill (or proceed to the gate) with the memo uncommitted.
+7. **Draft ADR proposals** — for HIGH-impact findings that represent
    architectural decisions, propose ADRs via `Skill(Dev10x:adr)`.
 
-**If `--memo-only`:** Stop here. Present memo and skip Phase 5.
+**If `--memo-only`:** Commit the memo (step 6), then stop here.
+Present the memo and skip Phase 5.
 
 ### Synthesis Review Gate
 

--- a/src/dev10x/domain/sensitivity.py
+++ b/src/dev10x/domain/sensitivity.py
@@ -211,10 +211,26 @@ _DEFAULT_PATTERNS: list[SensitivityPattern] = [
         r"\b(?:bastion|jumphost|jump-host|wireguard\d*|cloudflared|tailscale)\b",
         "bastion/VPN host",
     ),
-    # Production marker in hostnames/targets
+    # Production marker in hostnames/targets (GH-482).
+    #
+    # A bare ``prod-`` / ``prod.`` substring over-matches: filenames
+    # (``prod-synthetic.yml``), branch slugs
+    # (``feature/prod-synthetic-cohesion``), and grep literals all carry
+    # the token without touching production infrastructure.  Narrow the
+    # match to a genuine host context:
+    #   • a ``scheme://prod-`` or ``user@prod-`` reference, or
+    #   • a dotted FQDN whose ``prod`` label is followed by a real
+    #     network domain suffix (``.internal``, ``.com``, ``.amazonaws.com``…).
+    # A code/config extension (``.yml``, ``.json``, …) is not a domain
+    # suffix, so file paths and slugs no longer fire.
     _compile(
         SensitivityLabel.INFRA,
-        r"\bprod(?:uction)?[-.]",
+        r"(?:"
+        r"(?:://|@)prod(?:uction)?[-.]"
+        r"|"
+        r"\bprod(?:uction)?[-.][a-z0-9.-]*"
+        r"\.(?:internal|local|amazonaws\.com|com|net|org|io|cloud|aws)\b"
+        r")",
         "production host/resource",
     ),
     # RFC 1918 private IPs frequently used as prod pivot targets (10.x, 172.16-31.x, 192.168.x)

--- a/src/dev10x/git/__init__.py
+++ b/src/dev10x/git/__init__.py
@@ -100,25 +100,26 @@ async def _resolve_groom_base(base_ref: str) -> tuple[str, str | None]:
         return base_ref, None
 
     remote = f"origin/{base_ref}"
-    check = await async_run(
-        args=["git", "show-ref", "--verify", "--quiet", f"refs/remotes/{remote}"],
-        timeout=15,
-    )
-    if check.returncode != 0:
-        return base_ref, None
-
-    notice: str | None = None
+    # One round-trip: `rev-list --count base..origin/base` exits non-zero
+    # when either ref is absent (no remote-tracking ref), and emits the
+    # lag count when both exist — so a single call both detects the
+    # remote and measures staleness.
     behind = await async_run(
         args=["git", "rev-list", "--count", f"{base_ref}..{remote}"],
         timeout=15,
     )
+    if behind.returncode != 0:
+        return base_ref, None
+
+    effective = qualify_base_ref(base_ref, remote_exists=True)
     count = behind.stdout.strip()
-    if behind.returncode == 0 and count.isdigit() and int(count) > 0:
+    notice: str | None = None
+    if count.isdigit() and int(count) > 0:
         notice = (
             f"local {base_ref} is {count} commit(s) behind {remote} — "
-            f"grooming against {remote} (fork-point), not the stale local ref"
+            f"grooming against {effective} (fork-point), not the stale local ref"
         )
-    return remote, notice
+    return effective, notice
 
 
 async def rebase_groom(*, seq_path: str, base_ref: str) -> Result[dict[str, Any]]:

--- a/src/dev10x/git/__init__.py
+++ b/src/dev10x/git/__init__.py
@@ -12,8 +12,8 @@ import json
 from typing import Any
 
 from dev10x.domain.common.branch_name import BranchName
-from dev10x.domain.common.result import Result, err, ok
-from dev10x.subprocess_utils import async_run_script, parse_key_value_output
+from dev10x.domain.common.result import Result, SuccessResult, err, ok
+from dev10x.subprocess_utils import async_run, async_run_script, parse_key_value_output
 
 
 def _ok_json_or_kv(stdout: str) -> Result[dict[str, Any]]:
@@ -72,13 +72,66 @@ async def push_safe(
     return await _run_git_script("skills/git/scripts/git-push-safe.sh", *cmd_args)
 
 
+def qualify_base_ref(base_ref: str, *, remote_exists: bool) -> str:
+    """Prefer ``origin/<base>`` over a possibly-stale local branch (GH-486).
+
+    A bare local branch name (``develop``) may lag ``origin/develop``
+    after rebase-merge advances the remote, long-lived feature work, or
+    worktrees sharing an outdated local ref. Grooming against the stale
+    local ref mis-computes the commit range. When the remote-tracking
+    ref exists, groom against it instead. Already-qualified refs (those
+    containing ``/``, e.g. ``origin/develop``) and SHAs pass through
+    unchanged.
+    """
+    if "/" in base_ref:
+        return base_ref
+    return f"origin/{base_ref}" if remote_exists else base_ref
+
+
+async def _resolve_groom_base(base_ref: str) -> tuple[str, str | None]:
+    """Resolve the effective groom base ref and a stale-local notice.
+
+    Returns ``(effective_ref, notice)``. ``notice`` is non-None only when
+    the local branch lags its remote-tracking counterpart, so the caller
+    can surface "grooming against origin/<base>" instead of silently
+    using a stale ref (GH-486).
+    """
+    if "/" in base_ref:
+        return base_ref, None
+
+    remote = f"origin/{base_ref}"
+    check = await async_run(
+        args=["git", "show-ref", "--verify", "--quiet", f"refs/remotes/{remote}"],
+        timeout=15,
+    )
+    if check.returncode != 0:
+        return base_ref, None
+
+    notice: str | None = None
+    behind = await async_run(
+        args=["git", "rev-list", "--count", f"{base_ref}..{remote}"],
+        timeout=15,
+    )
+    count = behind.stdout.strip()
+    if behind.returncode == 0 and count.isdigit() and int(count) > 0:
+        notice = (
+            f"local {base_ref} is {count} commit(s) behind {remote} — "
+            f"grooming against {remote} (fork-point), not the stale local ref"
+        )
+    return remote, notice
+
+
 async def rebase_groom(*, seq_path: str, base_ref: str) -> Result[dict[str, Any]]:
-    return await _run_git_script(
+    effective_ref, notice = await _resolve_groom_base(base_ref)
+    result = await _run_git_script(
         "skills/git/scripts/git-rebase-groom.sh",
         seq_path,
-        base_ref,
+        effective_ref,
         conflict_aware=True,
     )
+    if notice is not None and isinstance(result, SuccessResult):
+        result.value["base_notice"] = notice
+    return result
 
 
 async def create_worktree(

--- a/src/dev10x/github/__init__.py
+++ b/src/dev10x/github/__init__.py
@@ -1183,29 +1183,69 @@ async def issue_reopen(
     )
 
 
+def _resolve_comment_body(*, body: str | None, body_file: str | None) -> Result[str]:
+    """Resolve a comment body from inline text or a file path (GH-484).
+
+    ``body`` is literal text — there is no ``@file`` / ``--body-file``
+    expansion at this boundary, so passing ``body="@/path.md"`` posts the
+    literal path string. To post the *contents* of a file, pass
+    ``body_file`` instead.
+
+    Args:
+        body: Inline literal comment text, or ``None``.
+        body_file: Path to a file whose contents become the body, or
+            ``None``. Mutually exclusive with ``body``.
+
+    Returns:
+        ``ok(text)`` with the resolved body, or ``err(...)`` when both or
+        neither source is supplied, or the file does not exist.
+    """
+    if body_file is not None:
+        if body is not None:
+            return err("Pass either 'body' or 'body_file', not both.")
+        path = Path(body_file).expanduser()
+        if not path.is_file():
+            return err(f"body_file not found: {body_file}")
+        return ok(path.read_text(encoding="utf-8"))
+    if body is None:
+        return err("Provide either 'body' (inline text) or 'body_file' (path).")
+    return ok(body)
+
+
 async def issue_comment(
     *,
     number: int,
-    body: str,
+    body: str | None = None,
     repo: str | None = None,
+    body_file: str | None = None,
 ) -> Result[dict[str, Any]]:
     """Post a comment on a GitHub issue (GH-220).
 
     Wraps ``gh issue comment N --body-file <tmp>``. Body is written
     to a temp file to avoid heredoc/quoting issues.
 
+    ``body`` is literal text — there is no ``@file`` expansion. To post
+    the contents of a file, pass ``body_file`` instead (GH-484).
+
     Args:
         number: Issue number to comment on.
-        body: Comment body (Markdown supported).
+        body: Comment body (Markdown supported). Literal text.
         repo: Repository (owner/repo). Auto-detected if omitted.
+        body_file: Path to a file whose contents become the body.
+            Mutually exclusive with ``body``.
 
     Returns:
         On success: ``{"url": str}`` — the comment permalink.
     """
     import tempfile
 
+    body_result = _resolve_comment_body(body=body, body_file=body_file)
+    if isinstance(body_result, ErrorResult):
+        return body_result
+    resolved_body = body_result.value
+
     fd = tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False, encoding="utf-8")
-    fd.write(body)
+    fd.write(resolved_body)
     fd.close()
     body_path = Path(fd.name)
 
@@ -1227,8 +1267,9 @@ async def issue_comment(
 async def issue_comment_edit(
     *,
     comment_id: int,
-    body: str,
+    body: str | None = None,
     repo: str | None = None,
+    body_file: str | None = None,
 ) -> Result[dict[str, Any]]:
     """Edit an existing GitHub issue or PR comment body (GH-283).
 
@@ -1239,16 +1280,26 @@ async def issue_comment_edit(
     Body is written to a temp file to avoid heredoc/quoting issues at
     the gh CLI boundary, matching the ``issue_comment`` pattern.
 
+    ``body`` is literal text — there is no ``@file`` expansion. To
+    replace with the contents of a file, pass ``body_file`` (GH-484).
+
     Args:
         comment_id: Numeric ID of the comment to edit (from the
             ``/comments/<id>`` URL fragment).
-        body: New body text (full replacement, not a delta).
+        body: New body text (full replacement, not a delta). Literal text.
         repo: Repository (owner/repo). Auto-detected if omitted.
+        body_file: Path to a file whose contents become the new body.
+            Mutually exclusive with ``body``.
 
     Returns:
         On success: ``{"id": int, "body": str, "html_url": str}``.
     """
     import tempfile
+
+    body_result = _resolve_comment_body(body=body, body_file=body_file)
+    if isinstance(body_result, ErrorResult):
+        return body_result
+    resolved_body = body_result.value
 
     repo_result = await _resolve_repo(repo)
     if isinstance(repo_result, ErrorResult):
@@ -1256,7 +1307,7 @@ async def issue_comment_edit(
     canonical_repo = str(repo_result.value)
 
     fd = tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False, encoding="utf-8")
-    fd.write(body)
+    fd.write(resolved_body)
     fd.close()
     body_path = Path(fd.name)
 

--- a/src/dev10x/mcp/github_tools.py
+++ b/src/dev10x/mcp/github_tools.py
@@ -208,10 +208,13 @@ async def pr_comment_reply(
 ) -> dict:
     """Reply to a PR review comment thread.
 
+    `body` is literal text — there is no `@file` / `--body-file`
+    expansion; pass the reply content inline (GH-484).
+
     Args:
         pr_number: PR number
         comment_id: Root comment ID to reply to
-        body: Reply text (supports markdown)
+        body: Reply text (supports markdown). Literal text.
         repo: Repository (owner/repo). If omitted, uses current repo
         cwd: Effective working directory (GH-979).
 
@@ -248,9 +251,12 @@ async def pr_issue_comment(
 
     For inline review-thread replies, use `pr_comment_reply` instead.
 
+    `body` is literal text — there is no `@file` / `--body-file`
+    expansion; pass the comment content inline (GH-484).
+
     Args:
         pr_number: PR number (treated as the parent issue for comment routing)
-        body: Comment body (supports markdown)
+        body: Comment body (supports markdown). Literal text.
         repo: Repository (owner/repo). If omitted, uses current repo
         cwd: Effective working directory (GH-979).
 
@@ -720,20 +726,27 @@ async def issue_reopen(
 @server.tool()
 async def issue_comment(
     number: int,
-    body: str,
+    body: str | None = None,
     repo: str | None = None,
     cwd: str | None = None,
+    body_file: str | None = None,
 ) -> dict:
     """Post a Markdown comment on a GitHub issue (GH-220).
 
     Wraps `gh issue comment N --body-file <tmp>` so callers don't
     need to manage heredoc/quoting at the Bash boundary.
 
+    `body` is literal text — there is no `@file` / `--body-file`
+    expansion (passing `body="@/path.md"` posts the literal path string).
+    To post the contents of a file, pass `body_file` instead (GH-484).
+
     Args:
         number: Issue number to comment on.
-        body: Comment body (Markdown supported).
+        body: Comment body (Markdown supported). Literal text.
         repo: Repository (owner/repo). Auto-detected if omitted.
         cwd: Effective working directory (GH-979).
+        body_file: Path to a file whose contents become the body.
+            Mutually exclusive with `body`.
 
     Returns:
         Dictionary with key: url (the comment permalink).
@@ -747,6 +760,7 @@ async def issue_comment(
                 number=number,
                 body=body,
                 repo=repo,
+                body_file=body_file,
             )
         ).to_dict()
 
@@ -754,9 +768,10 @@ async def issue_comment(
 @server.tool()
 async def issue_comment_edit(
     comment_id: int,
-    body: str,
+    body: str | None = None,
     repo: str | None = None,
     cwd: str | None = None,
+    body_file: str | None = None,
 ) -> dict:
     """Edit an existing GitHub issue or PR comment body (GH-283).
 
@@ -764,12 +779,18 @@ async def issue_comment_edit(
     `/repos/{owner}/{repo}/issues/comments/{id}`. Works on issue
     comments and PR issue-level comments.
 
+    `body` is literal text — there is no `@file` / `--body-file`
+    expansion. To replace with the contents of a file, pass `body_file`
+    instead (GH-484).
+
     Args:
         comment_id: Numeric ID of the comment to edit (from
             /comments/<id> URL fragment).
-        body: New body text (full replacement; not a delta).
+        body: New body text (full replacement; not a delta). Literal text.
         repo: Repository (owner/repo). Auto-detected if omitted.
         cwd: Effective working directory (GH-979).
+        body_file: Path to a file whose contents become the new body.
+            Mutually exclusive with `body`.
 
     Returns:
         Dictionary with keys: id, body, html_url.
@@ -783,6 +804,7 @@ async def issue_comment_edit(
                 comment_id=comment_id,
                 body=body,
                 repo=repo,
+                body_file=body_file,
             )
         ).to_dict()
 

--- a/src/dev10x/validators/prefix_friction.py
+++ b/src/dev10x/validators/prefix_friction.py
@@ -16,7 +16,7 @@ import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, ClassVar
 
-from dev10x.domain import HookInput, HookResult
+from dev10x.domain import HookAllow, HookInput, HookResult
 from dev10x.domain.claude_paths import ClaudeDir
 from dev10x.domain.common.allow_rule import AllowRule, AllowRuleLoader
 from dev10x.domain.profile_tier import ProfileTier
@@ -51,6 +51,61 @@ GIT_SUBCOMMAND_RE = re.compile(r"\bgit\s+(log|diff|rebase)\b")
 CD_NOOP_RE = re.compile(r'^cd\s+("(?:[^"]+)"|\'(?:[^\']+)\'|\S+)\s*&&\s*(.*)')
 CD_REVPARSE_RE = re.compile(r'^cd\s+"?\$\(git\s+rev-parse\s+--show-toplevel\)"?\s*&&\s*(.*)')
 CD_GIT_CHAIN_RE = re.compile(r'^cd\s+("(?:[^"]+)"|\'(?:[^\']+)\'|\S+)\s*&&\s*git\b\s*(.*)')
+
+# GH-485: `uv run [ENV-FLAGS] <inner>` places environment-only flags
+# between `uv run` and the tool, shifting the matched prefix so existing
+# allow rules (`Bash(uv run pytest:*)`, `Bash(python manage.py:*)`) never
+# fire — every monorepo tool would otherwise need its own
+# `uv run --directory * <tool>` rule (whack-a-mole), pushing users toward
+# the `uv run *` fence-tool footgun. We strip the env-only prefix and
+# re-match the inner command; the inner command's own tier governs, so
+# auto-approval can never widen what the inner command isn't already
+# allowed to do.
+#
+# `--with <pkg>` installs an arbitrary dependency, but the inner command
+# still governs execution — per GH-485 option (a) we strip it too and
+# rely on the inner tier rather than minting a separate broad-ask.
+_UV_RUN_RE = re.compile(r"^\s*uv\s+run\b(?P<rest>.*)$", re.DOTALL)
+_UV_ENV_VALUE_FLAGS = frozenset({"--directory", "--project", "--python", "--with", "--extra"})
+_UV_ENV_BOOL_FLAGS = frozenset({"--frozen", "--no-project", "--locked", "--no-sync"})
+_UV_RUN_ENV_TRIGGER_RE = re.compile(
+    r"^\s*uv\s+run\s+--(?:directory|project|python|with|extra|frozen|no-project|locked|no-sync)\b"
+)
+
+
+def _strip_uv_run_env_flags(command: str) -> str | None:
+    """Return the inner command after stripping ``uv run`` + env-only flags.
+
+    Returns ``None`` when the command is not a ``uv run`` invocation or
+    when no env-only flag was present (the plain ``uv run <tool>`` form
+    already matches its allow rule natively, so there is nothing to fix).
+    """
+    match = _UV_RUN_RE.match(command)
+    if not match:
+        return None
+    tokens = match.group("rest").split()
+    idx = 0
+    stripped_any = False
+    while idx < len(tokens):
+        token = tokens[idx]
+        if token in _UV_ENV_VALUE_FLAGS:
+            idx += 2
+            stripped_any = True
+            continue
+        if any(token.startswith(f"{flag}=") for flag in _UV_ENV_VALUE_FLAGS):
+            idx += 1
+            stripped_any = True
+            continue
+        if token in _UV_ENV_BOOL_FLAGS:
+            idx += 1
+            stripped_any = True
+            continue
+        break
+    if not stripped_any:
+        return None
+    inner = " ".join(tokens[idx:]).strip()
+    return inner or None
+
 
 # GH-119: redirect followed by positional args swallows the post-redirect
 # tokens in Claude Code's command-shape classifier, breaking allow-rule
@@ -223,6 +278,12 @@ MERGE_BASE_MSG = (
 )
 
 
+UV_RUN_NORMALIZE_MSG = (
+    "✓ `uv run` env-flags stripped — inner command `{inner}` matches an "
+    "existing Bash allow-rule (Dev10x DX007)."
+)
+
+
 def _load_all_allow_patterns() -> list[str]:
     patterns: list[str] = []
     for path in SETTINGS_FILES:
@@ -284,6 +345,7 @@ class PrefixFrictionValidator(ValidatorBase):
     # ``validate`` walks this list in order; the last entry is the
     # fall-through ``&&``-chaining check.
     _CHECKS: ClassVar[tuple[str, ...]] = (
+        "_check_uv_run_inner_allow",
         "_check_cd_revparse_chain",
         "_check_git_c_noop",
         "_check_env_prefix_git",
@@ -311,13 +373,35 @@ class PrefixFrictionValidator(ValidatorBase):
             or any(re.search(rf"\b{kw}\b", cmd) for kw in _LOOP_KEYWORDS)
             or "xargs" in cmd
             or "-exec" in cmd
+            # GH-485: `uv run [env-flags] <inner>` prefix normalization
+            or _UV_RUN_ENV_TRIGGER_RE.match(cmd) is not None
         )
 
-    def validate(self, inp: HookInput) -> HookResult | None:
+    def validate(self, inp: HookInput) -> HookResult | HookAllow | None:
         for check_name in self._CHECKS:
-            result: HookResult | None = getattr(self, check_name)(inp=inp)
+            result: HookResult | HookAllow | None = getattr(self, check_name)(inp=inp)
             if result is not None:
                 return result
+        return None
+
+    def _check_uv_run_inner_allow(self, *, inp: HookInput) -> HookAllow | None:
+        inner = _strip_uv_run_env_flags(inp.command)
+        if inner is None:
+            return None
+        if self._allow_patterns is None:
+            self._allow_patterns = _load_all_allow_patterns()
+        if not self._allow_patterns:
+            return None
+        # Match both the bare inner command (`python manage.py …` →
+        # `Bash(python manage.py:*)`) and the env-flag-stripped normalized
+        # form (`uv run pytest …` → `Bash(uv run pytest:*)`). Either hit
+        # means the inner command is independently allowed.
+        normalized = f"uv run {inner}"
+        if (
+            _matches_allow_rule(inner, self._allow_patterns) is not None
+            or _matches_allow_rule(normalized, self._allow_patterns) is not None
+        ):
+            return HookAllow(message=UV_RUN_NORMALIZE_MSG.format(inner=inner))
         return None
 
     def _check_cd_revparse_chain(self, *, inp: HookInput) -> HookResult | None:
@@ -515,6 +599,6 @@ class PrefixFrictionValidator(ValidatorBase):
         from dev10x.domain import HookRetry as _HookRetry
 
         result = self.validate(inp=inp)
-        if result is None:
+        if result is None or isinstance(result, HookAllow):
             return None
         return _HookRetry(message=result.message)

--- a/src/dev10x/validators/prefix_friction.py
+++ b/src/dev10x/validators/prefix_friction.py
@@ -62,23 +62,29 @@ CD_GIT_CHAIN_RE = re.compile(r'^cd\s+("(?:[^"]+)"|\'(?:[^\']+)\'|\S+)\s*&&\s*git
 # auto-approval can never widen what the inner command isn't already
 # allowed to do.
 #
-# `--with <pkg>` installs an arbitrary dependency, but the inner command
-# still governs execution — per GH-485 option (a) we strip it too and
-# rely on the inner tier rather than minting a separate broad-ask.
+# `--with <pkg>` installs an arbitrary dependency into the ephemeral
+# env — a supply-chain surface, unlike the pure-environment flags. It is
+# therefore NOT stripped: its presence DISQUALIFIES the command from
+# auto-approval, so `uv run --with <pkg> <tool>` falls through to the
+# normal `uv run` fence-tool ask rather than being silently approved
+# (GH-485 `--with` caveat; aligns with the fence-tool ask policy).
 _UV_RUN_RE = re.compile(r"^\s*uv\s+run\b(?P<rest>.*)$", re.DOTALL)
-_UV_ENV_VALUE_FLAGS = frozenset({"--directory", "--project", "--python", "--with", "--extra"})
+_UV_ENV_VALUE_FLAGS = frozenset({"--directory", "--project", "--python", "--extra"})
 _UV_ENV_BOOL_FLAGS = frozenset({"--frozen", "--no-project", "--locked", "--no-sync"})
-_UV_RUN_ENV_TRIGGER_RE = re.compile(
-    r"^\s*uv\s+run\s+--(?:directory|project|python|with|extra|frozen|no-project|locked|no-sync)\b"
-)
 
 
 def _strip_uv_run_env_flags(command: str) -> str | None:
     """Return the inner command after stripping ``uv run`` + env-only flags.
 
-    Returns ``None`` when the command is not a ``uv run`` invocation or
-    when no env-only flag was present (the plain ``uv run <tool>`` form
-    already matches its allow rule natively, so there is nothing to fix).
+    Returns ``None`` when the command is not a ``uv run`` invocation, when
+    no env-only flag was present (plain ``uv run <tool>`` already matches
+    its allow rule natively), or when ``--with <pkg>`` is present — an
+    arbitrary-package install must not be auto-approved (see above), so its
+    presence disqualifies the command and leaves the fence-tool ask intact.
+
+    This doubles as the ``should_run`` gate: a non-``None`` return is
+    exactly the set of commands the uv-run normalization check acts on, so
+    the flag list lives here in one place.
     """
     match = _UV_RUN_RE.match(command)
     if not match:
@@ -88,19 +94,17 @@ def _strip_uv_run_env_flags(command: str) -> str | None:
     stripped_any = False
     while idx < len(tokens):
         token = tokens[idx]
+        if token == "--with" or token.startswith("--with="):
+            return None
         if token in _UV_ENV_VALUE_FLAGS:
             idx += 2
-            stripped_any = True
-            continue
-        if any(token.startswith(f"{flag}=") for flag in _UV_ENV_VALUE_FLAGS):
+        elif token in _UV_ENV_BOOL_FLAGS or any(
+            token.startswith(f"{flag}=") for flag in _UV_ENV_VALUE_FLAGS
+        ):
             idx += 1
-            stripped_any = True
-            continue
-        if token in _UV_ENV_BOOL_FLAGS:
-            idx += 1
-            stripped_any = True
-            continue
-        break
+        else:
+            break
+        stripped_any = True
     if not stripped_any:
         return None
     inner = " ".join(tokens[idx:]).strip()
@@ -373,8 +377,9 @@ class PrefixFrictionValidator(ValidatorBase):
             or any(re.search(rf"\b{kw}\b", cmd) for kw in _LOOP_KEYWORDS)
             or "xargs" in cmd
             or "-exec" in cmd
-            # GH-485: `uv run [env-flags] <inner>` prefix normalization
-            or _UV_RUN_ENV_TRIGGER_RE.match(cmd) is not None
+            # GH-485: `uv run [env-flags] <inner>` prefix normalization —
+            # the strip helper is the single source of truth for the flag set.
+            or _strip_uv_run_env_flags(cmd) is not None
         )
 
     def validate(self, inp: HookInput) -> HookResult | HookAllow | None:

--- a/tests/domain/test_sensitivity.py
+++ b/tests/domain/test_sensitivity.py
@@ -176,6 +176,9 @@ class TestInfraClassification:
             # production hostnames
             "curl https://prod.myapp.example.com/health",
             "ping production.db.internal",
+            # GH-482: real prod host via user@ and dotted FQDN still fire
+            "ssh deploy@prod-web01.example.com",
+            "psql -h prod-db.acme.internal -U app",
             # RFC 1918 private IPs
             "curl http://10.0.1.42/api",
             "ssh 172.16.0.10",
@@ -196,6 +199,13 @@ class TestInfraClassification:
             "ping localhost",
             "curl http://127.0.0.1:8000/health",
             "git push origin develop",
+            # GH-482: `prod-` in filenames, branch slugs, and grep
+            # literals must NOT trip the production-host pattern.
+            "yq '.' .github/workflows/prod-synthetic.yml",
+            "pre-commit run --files .github/workflows/prod-synthetic.yml",
+            "grep -rln 'purge-prod-synthetic' .github/workflows/",
+            "git checkout -b wonka/CANDY-935/prod-synthetic-cohesion origin/develop",
+            "gh workflow run prod-synthetic.yml",
         ],
     )
     def test_safe_network_commands_not_infra(

--- a/tests/git/test_git.py
+++ b/tests/git/test_git.py
@@ -249,26 +249,21 @@ class TestResolveGroomBase:
     ) -> None:
         from dev10x.git import _resolve_groom_base
 
-        # show-ref succeeds (remote exists), rev-list reports 3 commits behind.
-        mock_run.side_effect = [
-            _completed(returncode=0),
-            _completed(returncode=0, stdout="3\n"),
-        ]
+        # Single rev-list call reports 3 commits behind (both refs exist).
+        mock_run.return_value = _completed(returncode=0, stdout="3\n")
         effective, notice = await _resolve_groom_base("develop")
 
         assert effective == "origin/develop"
         assert notice is not None
         assert "3 commit(s) behind origin/develop" in notice
+        assert mock_run.await_count == 1
 
     @pytest.mark.asyncio
     @patch("dev10x.git.async_run", new_callable=AsyncMock)
     async def test_local_up_to_date_no_notice(self, mock_run: AsyncMock) -> None:
         from dev10x.git import _resolve_groom_base
 
-        mock_run.side_effect = [
-            _completed(returncode=0),
-            _completed(returncode=0, stdout="0\n"),
-        ]
+        mock_run.return_value = _completed(returncode=0, stdout="0\n")
         effective, notice = await _resolve_groom_base("develop")
 
         assert effective == "origin/develop"
@@ -279,6 +274,7 @@ class TestResolveGroomBase:
     async def test_no_remote_tracking_ref_uses_local(self, mock_run: AsyncMock) -> None:
         from dev10x.git import _resolve_groom_base
 
+        # rev-list exits non-zero when either ref is absent → local base.
         mock_run.return_value = _completed(returncode=1)
         effective, notice = await _resolve_groom_base("develop")
 
@@ -301,10 +297,7 @@ class TestResolveGroomBase:
     async def test_rebase_groom_attaches_base_notice(
         self, mock_run: AsyncMock, mock_script: AsyncMock
     ) -> None:
-        mock_run.side_effect = [
-            _completed(returncode=0),
-            _completed(returncode=0, stdout="2\n"),
-        ]
+        mock_run.return_value = _completed(returncode=0, stdout="2\n")
         mock_script.return_value = _completed(stdout="commits_rewritten=2")
 
         result = await rebase_groom(seq_path="/tmp/seq.txt", base_ref="develop")

--- a/tests/git/test_git.py
+++ b/tests/git/test_git.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import subprocess
+from collections.abc import Iterator
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -32,6 +33,15 @@ CONFLICT_STDOUT = (
 
 
 class TestRebaseGroomConflictDetection:
+    @pytest.fixture(autouse=True)
+    def _no_remote_base(self) -> Iterator[AsyncMock]:
+        # By default the remote-tracking ref does not resolve, so
+        # _resolve_groom_base passes the bare base through unchanged and
+        # makes no real git calls (GH-486).
+        with patch("dev10x.git.async_run", new_callable=AsyncMock) as mock:
+            mock.return_value = _completed(returncode=1)
+            yield mock
+
     @pytest.fixture()
     def conflict_result(self) -> subprocess.CompletedProcess[str]:
         return _completed(returncode=1, stdout=CONFLICT_STDOUT)
@@ -201,3 +211,105 @@ class TestPushSafeStructuredOutput:
 
         assert isinstance(result, ErrorResult)
         assert "BLOCKED" in result.error
+
+
+class TestQualifyBaseRef:
+    """GH-486: prefer origin/<base> over a possibly-stale local branch."""
+
+    def test_bare_branch_qualified_when_remote_exists(self) -> None:
+        from dev10x.git import qualify_base_ref
+
+        assert qualify_base_ref("develop", remote_exists=True) == "origin/develop"
+
+    def test_bare_branch_unchanged_when_no_remote(self) -> None:
+        from dev10x.git import qualify_base_ref
+
+        assert qualify_base_ref("develop", remote_exists=True) == "origin/develop"
+        assert qualify_base_ref("feature-x", remote_exists=False) == "feature-x"
+
+    def test_already_qualified_ref_passes_through(self) -> None:
+        from dev10x.git import qualify_base_ref
+
+        assert qualify_base_ref("origin/develop", remote_exists=True) == "origin/develop"
+
+    def test_sha_like_ref_passes_through(self) -> None:
+        from dev10x.git import qualify_base_ref
+
+        # A path-ish / slash-bearing ref is treated as already-qualified.
+        assert qualify_base_ref("refs/heads/develop", remote_exists=True) == "refs/heads/develop"
+
+
+class TestResolveGroomBase:
+    """GH-486: resolve effective base ref + stale-local notice."""
+
+    @pytest.mark.asyncio
+    @patch("dev10x.git.async_run", new_callable=AsyncMock)
+    async def test_local_behind_origin_resolves_to_origin_with_notice(
+        self, mock_run: AsyncMock
+    ) -> None:
+        from dev10x.git import _resolve_groom_base
+
+        # show-ref succeeds (remote exists), rev-list reports 3 commits behind.
+        mock_run.side_effect = [
+            _completed(returncode=0),
+            _completed(returncode=0, stdout="3\n"),
+        ]
+        effective, notice = await _resolve_groom_base("develop")
+
+        assert effective == "origin/develop"
+        assert notice is not None
+        assert "3 commit(s) behind origin/develop" in notice
+
+    @pytest.mark.asyncio
+    @patch("dev10x.git.async_run", new_callable=AsyncMock)
+    async def test_local_up_to_date_no_notice(self, mock_run: AsyncMock) -> None:
+        from dev10x.git import _resolve_groom_base
+
+        mock_run.side_effect = [
+            _completed(returncode=0),
+            _completed(returncode=0, stdout="0\n"),
+        ]
+        effective, notice = await _resolve_groom_base("develop")
+
+        assert effective == "origin/develop"
+        assert notice is None
+
+    @pytest.mark.asyncio
+    @patch("dev10x.git.async_run", new_callable=AsyncMock)
+    async def test_no_remote_tracking_ref_uses_local(self, mock_run: AsyncMock) -> None:
+        from dev10x.git import _resolve_groom_base
+
+        mock_run.return_value = _completed(returncode=1)
+        effective, notice = await _resolve_groom_base("develop")
+
+        assert effective == "develop"
+        assert notice is None
+
+    @pytest.mark.asyncio
+    async def test_already_qualified_ref_skips_git(self) -> None:
+        from dev10x.git import _resolve_groom_base
+
+        # No patch needed: a slash-bearing ref returns immediately.
+        effective, notice = await _resolve_groom_base("origin/main")
+
+        assert effective == "origin/main"
+        assert notice is None
+
+    @pytest.mark.asyncio
+    @patch("dev10x.git.async_run_script", new_callable=AsyncMock)
+    @patch("dev10x.git.async_run", new_callable=AsyncMock)
+    async def test_rebase_groom_attaches_base_notice(
+        self, mock_run: AsyncMock, mock_script: AsyncMock
+    ) -> None:
+        mock_run.side_effect = [
+            _completed(returncode=0),
+            _completed(returncode=0, stdout="2\n"),
+        ]
+        mock_script.return_value = _completed(stdout="commits_rewritten=2")
+
+        result = await rebase_groom(seq_path="/tmp/seq.txt", base_ref="develop")
+
+        assert isinstance(result, SuccessResult)
+        assert "base_notice" in result.value
+        # The script is invoked with the origin-qualified ref.
+        assert mock_script.call_args.args[2] == "origin/develop"

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -2366,3 +2366,91 @@ class TestUnresolvedThreadsIncludesReactions:
         )
         query = called_fields.get("query", "")
         assert "reactionGroups" in query
+
+
+class TestResolveCommentBody:
+    """GH-484: body is literal; body_file reads file contents."""
+
+    def test_inline_body_passthrough(self) -> None:
+        result = gh._resolve_comment_body(body="hello world", body_file=None)
+        assert isinstance(result, SuccessResult)
+        assert result.value == "hello world"
+
+    def test_at_path_is_literal_not_expanded(self) -> None:
+        # The whole point of GH-484: "@/path" is posted verbatim.
+        result = gh._resolve_comment_body(body="@/tmp/plan.md", body_file=None)
+        assert isinstance(result, SuccessResult)
+        assert result.value == "@/tmp/plan.md"
+
+    def test_body_file_reads_contents(self, tmp_path) -> None:
+        path = tmp_path / "comment.md"
+        path.write_text("## From file\nbody text", encoding="utf-8")
+        result = gh._resolve_comment_body(body=None, body_file=str(path))
+        assert isinstance(result, SuccessResult)
+        assert result.value == "## From file\nbody text"
+
+    def test_both_sources_is_error(self, tmp_path) -> None:
+        path = tmp_path / "c.md"
+        path.write_text("x", encoding="utf-8")
+        result = gh._resolve_comment_body(body="inline", body_file=str(path))
+        assert isinstance(result, ErrorResult)
+
+    def test_neither_source_is_error(self) -> None:
+        result = gh._resolve_comment_body(body=None, body_file=None)
+        assert isinstance(result, ErrorResult)
+
+    def test_missing_file_is_error(self) -> None:
+        result = gh._resolve_comment_body(body=None, body_file="/nonexistent/path.md")
+        assert isinstance(result, ErrorResult)
+        assert "not found" in result.error
+
+
+class TestIssueCommentBodyFile:
+    """GH-484: issue_comment / issue_comment_edit honor body_file."""
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run", new_callable=AsyncMock)
+    async def test_issue_comment_posts_file_contents(self, mock_run: AsyncMock, tmp_path) -> None:
+        path = tmp_path / "body.md"
+        path.write_text("file body", encoding="utf-8")
+        mock_run.return_value = _completed(stdout="https://github.com/o/r/issues/1#c1")
+
+        result = await gh.issue_comment(number=1, body_file=str(path), repo="o/r")
+
+        assert isinstance(result, SuccessResult)
+        assert result.value["url"] == "https://github.com/o/r/issues/1#c1"
+        mock_run.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run", new_callable=AsyncMock)
+    async def test_issue_comment_both_sources_errors_without_api_call(
+        self, mock_run: AsyncMock
+    ) -> None:
+        result = await gh.issue_comment(number=1, body="x", body_file="/x.md", repo="o/r")
+        assert isinstance(result, ErrorResult)
+        mock_run.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github._resolve_repo", new_callable=AsyncMock)
+    @patch("dev10x.github.async_run", new_callable=AsyncMock)
+    async def test_issue_comment_edit_uses_file_contents(
+        self, mock_run: AsyncMock, mock_repo: AsyncMock, tmp_path
+    ) -> None:
+        path = tmp_path / "edit.md"
+        path.write_text("edited body", encoding="utf-8")
+        mock_repo.return_value = ok("o/r")
+        mock_run.return_value = _completed(
+            stdout=json.dumps({"id": 9, "body": "edited body", "html_url": "u"})
+        )
+
+        result = await gh.issue_comment_edit(comment_id=9, body_file=str(path), repo="o/r")
+
+        assert isinstance(result, SuccessResult)
+        assert result.value["id"] == 9
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.async_run", new_callable=AsyncMock)
+    async def test_issue_comment_edit_neither_source_errors(self, mock_run: AsyncMock) -> None:
+        result = await gh.issue_comment_edit(comment_id=9, repo="o/r")
+        assert isinstance(result, ErrorResult)
+        mock_run.assert_not_awaited()

--- a/tests/skills/slack/test_slack_notify_module.py
+++ b/tests/skills/slack/test_slack_notify_module.py
@@ -176,3 +176,24 @@ class TestResolveMentions:
         mod.set_workspace("aperture")
         assert mod.resolve_mentions("ping @aperture") == "ping <!subteam^S_APE>"
         assert mod.resolve_mentions("ping @default") == "ping @default"
+
+
+class TestUvxEnvImportSmoke:
+    """GH-483: the in-process slack notify path must have slack_sdk available.
+
+    `uvx dev10x skill notify slack-send` imports slack_sdk inside
+    slack_notify.py. slack-sdk is declared as a base dependency so the
+    uvx-distributed env provisions it; this smoke test fails loudly if
+    that dependency is ever dropped from pyproject.
+    """
+
+    def test_slack_sdk_importable(self) -> None:
+        import importlib
+
+        assert importlib.import_module("slack_sdk") is not None
+
+    def test_webclient_importable_for_send_path(self) -> None:
+        # Mirrors the exact import inside slack_notify.send_slack_message.
+        from slack_sdk import WebClient
+
+        assert WebClient is not None

--- a/tests/validators/test_prefix_friction.py
+++ b/tests/validators/test_prefix_friction.py
@@ -503,13 +503,27 @@ class TestUvRunEnvFlagNormalization:
             "uv run --directory apps/api python manage.py makemigrations core",
             "uv run --frozen --directory apps/api pytest",
             "uv run --directory=apps/api pytest tests/",
-            "uv run --with httpx python manage.py shell",
         ],
     )
     def test_should_run_true_for_uv_run_env_flags(
         self, validator: PrefixFrictionValidator, command: str
     ) -> None:
         assert validator.should_run(inp=_make_input(command=command)) is True
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # --with disqualifies (no env-flag normalization), and plain
+            # `uv run <tool>` needs no normalization — neither should_run.
+            "uv run --with httpx python manage.py shell",
+            "uv run pytest tests/",
+            "ls -la",
+        ],
+    )
+    def test_should_run_false_when_no_normalization(
+        self, validator: PrefixFrictionValidator, command: str
+    ) -> None:
+        assert validator.should_run(inp=_make_input(command=command)) is False
 
     @pytest.mark.parametrize(
         "command",
@@ -530,14 +544,19 @@ class TestUvRunEnvFlagNormalization:
         assert isinstance(result, HookAllow)
         assert "DX007" in result.message
 
-    def test_with_pkg_stripped_inner_governs(self, validator: PrefixFrictionValidator) -> None:
-        from dev10x.domain import HookAllow
-
-        # `--with httpx` is stripped; inner `python manage.py shell` governs.
+    def test_with_pkg_disqualifies_auto_approval(self, validator: PrefixFrictionValidator) -> None:
+        # `--with httpx` installs an arbitrary package — never auto-approve;
+        # falls through to the fence-tool ask (no HookAllow).
         result = validator.validate(
             inp=_make_input(command="uv run --with httpx python manage.py shell")
         )
-        assert isinstance(result, HookAllow)
+        assert result is None
+
+    def test_with_eq_form_disqualifies_auto_approval(
+        self, validator: PrefixFrictionValidator
+    ) -> None:
+        result = validator.validate(inp=_make_input(command="uv run --with=httpx pytest tests/"))
+        assert result is None
 
     def test_inner_ask_command_not_approved(self, validator: PrefixFrictionValidator) -> None:
         # `python -c ...` is not in the allow list — inner tier governs, so

--- a/tests/validators/test_prefix_friction.py
+++ b/tests/validators/test_prefix_friction.py
@@ -483,3 +483,121 @@ class TestShellLoopWrap:
         inp = _make_input(command="ls | xargs cat")
         result = validator.validate(inp=inp)
         assert result is None
+
+
+class TestUvRunEnvFlagNormalization:
+    """GH-485: strip `uv run` env-flags and approve when the inner command
+    is independently allowed (inner tier governs)."""
+
+    @pytest.fixture()
+    def validator(self) -> PrefixFrictionValidator:
+        v = PrefixFrictionValidator()
+        v._allow_patterns = ["uv run pytest", "uv run mypy", "python manage.py", "pytest"]
+        return v
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "uv run --directory apps/api pytest tests/",
+            "uv run --extra dev mypy src/",
+            "uv run --directory apps/api python manage.py makemigrations core",
+            "uv run --frozen --directory apps/api pytest",
+            "uv run --directory=apps/api pytest tests/",
+            "uv run --with httpx python manage.py shell",
+        ],
+    )
+    def test_should_run_true_for_uv_run_env_flags(
+        self, validator: PrefixFrictionValidator, command: str
+    ) -> None:
+        assert validator.should_run(inp=_make_input(command=command)) is True
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "uv run --directory apps/api pytest tests/test_foo.py",
+            "uv run --extra dev mypy src/",
+            "uv run --directory apps/api python manage.py makemigrations core",
+            "uv run --frozen --directory apps/api pytest -k smoke",
+            "uv run --directory=apps/api pytest tests/",
+        ],
+    )
+    def test_inner_allowed_commands_auto_approved(
+        self, validator: PrefixFrictionValidator, command: str
+    ) -> None:
+        from dev10x.domain import HookAllow
+
+        result = validator.validate(inp=_make_input(command=command))
+        assert isinstance(result, HookAllow)
+        assert "DX007" in result.message
+
+    def test_with_pkg_stripped_inner_governs(self, validator: PrefixFrictionValidator) -> None:
+        from dev10x.domain import HookAllow
+
+        # `--with httpx` is stripped; inner `python manage.py shell` governs.
+        result = validator.validate(
+            inp=_make_input(command="uv run --with httpx python manage.py shell")
+        )
+        assert isinstance(result, HookAllow)
+
+    def test_inner_ask_command_not_approved(self, validator: PrefixFrictionValidator) -> None:
+        # `python -c ...` is not in the allow list — inner tier governs, so
+        # no auto-approval; the command falls through to ask/deny.
+        result = validator.validate(
+            inp=_make_input(command="uv run --directory apps/api python -c 'import os'")
+        )
+        assert result is None
+
+    def test_inner_denied_command_not_approved(self, validator: PrefixFrictionValidator) -> None:
+        result = validator.validate(
+            inp=_make_input(command="uv run --directory apps/api rm -rf /tmp/x")
+        )
+        assert result is None
+
+    def test_plain_uv_run_without_env_flags_no_opinion(
+        self, validator: PrefixFrictionValidator
+    ) -> None:
+        # No env flag present → nothing to normalize; let native matching
+        # handle the already-covered `uv run pytest` form.
+        assert validator.should_run(inp=_make_input(command="uv run pytest tests/")) is False
+
+    def test_no_allow_patterns_no_opinion(self) -> None:
+        v = PrefixFrictionValidator()
+        v._allow_patterns = []
+        result = v.validate(inp=_make_input(command="uv run --directory apps/api pytest"))
+        assert result is None
+
+    def test_lazy_loads_allow_patterns_when_unset(self) -> None:
+        from unittest.mock import patch
+
+        from dev10x.domain import HookAllow
+
+        v = PrefixFrictionValidator()  # _allow_patterns starts None
+        with patch(
+            "dev10x.validators.prefix_friction._load_all_allow_patterns",
+            return_value=["uv run pytest"],
+        ):
+            result = v.validate(inp=_make_input(command="uv run --directory apps/api pytest"))
+        assert isinstance(result, HookAllow)
+
+    def test_correct_returns_none_for_uv_run_allow(
+        self, validator: PrefixFrictionValidator
+    ) -> None:
+        # A HookAllow from validate() must not be turned into a retry.
+        result = validator.correct(inp=_make_input(command="uv run --directory apps/api pytest"))
+        assert result is None
+
+    def test_correct_returns_retry_for_friction_command(
+        self, validator: PrefixFrictionValidator
+    ) -> None:
+        from dev10x.domain import HookRetry
+
+        result = validator.correct(
+            inp=_make_input(command="mkdir -p /tmp/foo && ~/.claude/tools/x.sh")
+        )
+        assert isinstance(result, HookRetry)
+
+    def test_correct_returns_none_when_no_friction(
+        self, validator: PrefixFrictionValidator
+    ) -> None:
+        result = validator.correct(inp=_make_input(command="uv run --directory apps/api rm -rf x"))
+        assert result is None

--- a/uv.lock
+++ b/uv.lock
@@ -266,6 +266,7 @@ dependencies = [
     { name = "msgpack" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "pyyaml" },
+    { name = "slack-sdk" },
 ]
 
 [package.optional-dependencies]
@@ -294,6 +295,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9" },
+    { name = "slack-sdk", specifier = ">=3.21" },
 ]
 provides-extras = ["dev"]
 
@@ -894,6 +896,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6c/25/3fc9114abf979a41673ce877c08016f8e660ad6cf508c3957f537d2e9fa9/ruff-0.15.6-py3-none-win32.whl", hash = "sha256:bbf67d39832404812a2d23020dda68fee7f18ce15654e96fb1d3ad21a5fe436c", size = 10616872, upload-time = "2026-03-12T23:05:42.451Z" },
     { url = "https://files.pythonhosted.org/packages/89/7a/09ece68445ceac348df06e08bf75db72d0e8427765b96c9c0ffabc1be1d9/ruff-0.15.6-py3-none-win_amd64.whl", hash = "sha256:aee25bc84c2f1007ecb5037dff75cef00414fdf17c23f07dc13e577883dca406", size = 11787271, upload-time = "2026-03-12T23:05:20.168Z" },
     { url = "https://files.pythonhosted.org/packages/7f/d0/578c47dd68152ddddddf31cd7fc67dc30b7cdf639a86275fda821b0d9d98/ruff-0.15.6-py3-none-win_arm64.whl", hash = "sha256:c34de3dd0b0ba203be50ae70f5910b17188556630e2178fd7d79fc030eb0d837", size = 11060497, upload-time = "2026-03-12T23:05:25.968Z" },
+]
+
+[[package]]
+name = "slack-sdk"
+version = "3.42.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/00/16258bfa547559b2c936b50c882b4f0a36ebf6b69639eb763d8fa5e8d6cb/slack_sdk-3.42.0.tar.gz", hash = "sha256:873db9e1f632ac650ffdbf9d8ba825f3e9e7e576a1e4f9604ccb2a15b3727e3d", size = 252136, upload-time = "2026-05-18T17:50:44.727Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/ef/8a1556bd4843443993fc116783790a7cc553601a37f7d965ec26eef95e76/slack_sdk-3.42.0-py2.py3-none-any.whl", hash = "sha256:eb39aff97e476e10cc5a8ac29bd2e79a9959e880d9fe0c03b4e8f05b2ac996ff", size = 315469, upload-time = "2026-05-18T17:50:41.972Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**When** I run the Dev10x toolchain day-to-day — grooming branches, sending Slack notifications, auditing projects, and hitting the bash permission validators on every command — **I want to** close the audit-surfaced gaps where those tools mis-fire or quietly lose work, **so I can** trust the tooling to stay out of my way instead of blocking read-only commands, dropping audit memos, or failing Slack sends.

---

[`f071a49c`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/489/commits/f071a49cc71061c5b33fe7df62211b1585b08625) ✨ GH-481 Reduce permission friction and tooling gaps (6-issue bundle)
[`dc8940d6`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/489/commits/dc8940d6a0f125f2b186e5b2583f327a5a953384) 🔒 GH-485 Prevent auto-approving uv run --with installs (self-review)
Closes #482
Closes #483
Closes #484
Closes #485
Closes #486
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/481

---