### PR TITLE
🐛 GH-474 Resolve live skill-audit tooling findings

### DIFF
--- a/skills/git-worktree/SKILL.md
+++ b/skills/git-worktree/SKILL.md
@@ -114,6 +114,13 @@ subsequent Bash calls, git commands, and skills operate inside it.
 The session is now in the worktree. Resume the calling skill's next step
 (ticket status, job story, summary). No restart needed.
 
+**CWD & push discipline (GH-474 #6):** Although the session CWD is the
+worktree, prefer **absolute paths** in Bash calls — a `cd X` in one call
+does not persist to the next, so `cd subdir; <relative-path>` patterns
+break when the CWD resets between calls. For pushing, raw `git push` is
+hook-blocked on this worktree; use `Skill(Dev10x:git)` (which wraps
+`push_safe`) instead of `git push` directly.
+
 ---
 
 ## Path B — External + New Session

--- a/src/dev10x/audit/permissions_model.py
+++ b/src/dev10x/audit/permissions_model.py
@@ -63,9 +63,20 @@ MKTMP_PATH_RE = re.compile(r"/tmp/Dev10x/[^/]+/[^/]+\.[A-Za-z0-9]{6,}\.\w+$")
 # the operation actually succeeded (GH-41 — Projects classic on `gh pr edit`).
 EXIT_FALSE_POSITIVE_RE = re.compile(r"^gh\s+pr\s+edit\b")
 
-# PreToolUse hook denial signal in tool result text (best-effort —
-# only available when the parser captures result blocks).
+# PreToolUse hook denial signal in tool result text (GH-474 #8). A Dev10x
+# validator blocks with a ``BLOCKED:`` message; a generic hook failure reads
+# ``hook error``.
 HOOK_BLOCK_RE = re.compile(r"^BLOCKED:|hook error", re.MULTILINE)
+
+# Native Claude Code permission denial recorded in a tool result (GH-474 #8).
+PERMISSION_DENY_RE = re.compile(r'permissionDecision"\s*:\s*"deny"')
+
+# Tool-result block as rendered by extract_session.py — the input parser
+# discards these, so denials hidden in results were invisible (GH-474 #8).
+TOOL_RESULT_BLOCK_RE = re.compile(
+    r"<details><summary>Tool result \([^)]*\)</summary>\n\n```\n(.*?)\n```\n</details>",
+    re.DOTALL,
+)
 
 
 @dataclass
@@ -289,6 +300,50 @@ def detect_known_friction(
                     )
                 )
 
+    return findings
+
+
+def _turn_for_offset(turn_matches: list[re.Match[str]], pos: int) -> tuple[int, str]:
+    turn, time = 0, "?"
+    for tm in turn_matches:
+        if tm.start() <= pos:
+            turn, time = int(tm.group(1)), tm.group(2)
+        else:
+            break
+    return turn, time
+
+
+def detect_hook_denials(text: str) -> list[Finding]:
+    """Surface PreToolUse hook denials recorded in tool-result blocks (GH-474 #8).
+
+    ``parse_tool_calls`` only captures tool *input* blocks, so a call the
+    permission layer denied (``permissionDecision: deny``) or a Dev10x
+    validator blocked (``BLOCKED: ...``) never reaches the unmatched-call
+    analysis. Phase 4 then reports "0 unmatched calls" while the session was
+    riddled with hook friction. Scan the result blocks the input parser drops
+    and emit one finding per denial so the report reflects the real friction.
+    """
+    turn_matches = list(TURN_RE.finditer(text))
+    findings: list[Finding] = []
+    idx = 0
+    for m in TOOL_RESULT_BLOCK_RE.finditer(text):
+        content = m.group(1)
+        if not (HOOK_BLOCK_RE.search(content) or PERMISSION_DENY_RE.search(content)):
+            continue
+        turn, time = _turn_for_offset(turn_matches, m.start())
+        first_line = next((ln for ln in content.splitlines() if ln.strip()), content)
+        idx += 1
+        findings.append(
+            Finding(
+                index=idx,
+                turn=turn,
+                time=time,
+                tool="(hook)",
+                command_display=first_line.strip()[:60],
+                classification="HOOK_DENIAL",
+                fix="Route through the documented skill/MCP wrapper; do not retry the raw command",
+            )
+        )
     return findings
 
 

--- a/src/dev10x/skills/audit/analyze_permissions.py
+++ b/src/dev10x/skills/audit/analyze_permissions.py
@@ -34,10 +34,12 @@ from dev10x.audit.permissions_model import (
     HOOK_BLOCK_RE,
     MKTMP_PATH_RE,
     MULTI_WORD_COMMANDS,
+    PERMISSION_DENY_RE,
     PERMISSION_TOOLS,
     SUBSHELL_RE,
     TOOL_INPUT_BLOCK_RE,
     TOOL_RE,
+    TOOL_RESULT_BLOCK_RE,
     TURN_RE,
     Finding,
     HygieneFinding,
@@ -47,6 +49,7 @@ from dev10x.audit.permissions_model import (
     classify_toxicity,
     classify_unmatched,
     count_nuisance_patterns,
+    detect_hook_denials,
     detect_known_friction,
     matches_allow_rule,
     parse_additional_directories,
@@ -68,10 +71,12 @@ __all__ = [
     "HOOK_BLOCK_RE",
     "MKTMP_PATH_RE",
     "MULTI_WORD_COMMANDS",
+    "PERMISSION_DENY_RE",
     "PERMISSION_TOOLS",
     "SUBSHELL_RE",
     "TOOL_INPUT_BLOCK_RE",
     "TOOL_RE",
+    "TOOL_RESULT_BLOCK_RE",
     "TURN_RE",
     "Finding",
     "HygieneFinding",
@@ -81,6 +86,7 @@ __all__ = [
     "classify_toxicity",
     "classify_unmatched",
     "count_nuisance_patterns",
+    "detect_hook_denials",
     "detect_known_friction",
     "matches_allow_rule",
     "parse_additional_directories",
@@ -119,6 +125,12 @@ def main() -> None:
     for offset, finding in enumerate(extra, start=1):
         finding.index = base_count + offset
     findings.extend(extra)
+
+    denials = detect_hook_denials(text=transcript)
+    base_count = len(findings)
+    for offset, finding in enumerate(denials, start=1):
+        finding.index = base_count + offset
+    findings.extend(denials)
 
     skills_dir = os.path.expanduser("~/.claude/skills")
     tools_dir = os.path.expanduser("~/.claude/tools")

--- a/src/dev10x/validators/sql_safety.py
+++ b/src/dev10x/validators/sql_safety.py
@@ -65,6 +65,24 @@ def _is_psql_binary(token: str) -> bool:
     return token == "psql" or token.endswith("/psql")
 
 
+def _is_exempt_psql_wrapper(parts: list[str]) -> bool:
+    """psql wrapped by ``docker exec`` or ``op run`` is exempt (GH-474 #4).
+
+    ``docker exec <container> psql …`` runs inside a container — the container,
+    not the host hook, is the trust boundary — and ``op run -- psql …`` routes
+    through the sanctioned 1Password secrets wrapper. Neither is a direct host
+    psql call, so the read-only-SQL gate does not apply.
+    """
+    if not parts:
+        return False
+    command = os.path.basename(parts[0])
+    if command == "docker" and "exec" in parts[1:]:
+        return True
+    if command == "op" and "run" in parts[1:]:
+        return True
+    return False
+
+
 def _is_db_sh(token: str) -> bool:
     return token.endswith("db.sh") or token.endswith("/db.sh")
 
@@ -236,6 +254,8 @@ class SqlSafetyValidator(ValidatorBase):
                 seg_parts = shlex.split(seg)
             except ValueError:
                 seg_parts = []
+            if _is_exempt_psql_wrapper(seg_parts):
+                continue
             if any(_is_psql_binary(t) for t in seg_parts):
                 return HookResult(message=DIRECT_PSQL_MSG)
         return None

--- a/tests/audit/test_permissions_model.py
+++ b/tests/audit/test_permissions_model.py
@@ -5,9 +5,17 @@ from pathlib import Path
 
 from dev10x.audit.permissions_model import (
     ToolCall,
+    detect_hook_denials,
     detect_known_friction,
     parse_additional_directories,
 )
+
+
+def _result_block(*, tool_id: str, content: str) -> str:
+    return (
+        f"<details><summary>Tool result ({tool_id}...)</summary>\n\n"
+        f"```\n{content}\n```\n</details>\n\n"
+    )
 
 
 class TestParseAdditionalDirectories:
@@ -153,3 +161,47 @@ class TestDetectKnownFriction:
             "WORKSPACE_GATE",
             "WRITE_OVERWRITE_GATE",
         ]
+
+
+class TestDetectHookDenials:
+    """Phase 4 must surface hook denials hidden in tool-result blocks (GH-474 #8)."""
+
+    def test_flags_blocked_validator_message(self) -> None:
+        transcript = (
+            "## Turn 5 [12:00:00] ASSISTANT\n\n"
+            "**Tool: `Bash`**\n```\ncommand=psql -h localhost\n```\n\n"
+            "## Turn 6 [12:00:01] USER\n\n"
+            + _result_block(
+                tool_id="toolu_abc12",
+                content="BLOCKED: Direct psql calls are not allowed.",
+            )
+        )
+        findings = detect_hook_denials(text=transcript)
+        assert [f.classification for f in findings] == ["HOOK_DENIAL"]
+        assert findings[0].turn == 6
+
+    def test_flags_permission_decision_deny(self) -> None:
+        transcript = "## Turn 2 [09:00:00] USER\n\n" + _result_block(
+            tool_id="toolu_xyz99",
+            content='{"hookSpecificOutput": {"permissionDecision":"deny"}}',
+        )
+        findings = detect_hook_denials(text=transcript)
+        assert [f.classification for f in findings] == ["HOOK_DENIAL"]
+        assert findings[0].turn == 2
+
+    def test_ignores_benign_tool_results(self) -> None:
+        transcript = "## Turn 3 [09:00:00] USER\n\n" + _result_block(
+            tool_id="toolu_ok000", content="SELECT 1\n 1"
+        )
+        assert detect_hook_denials(text=transcript) == []
+
+    def test_finds_multiple_denials(self) -> None:
+        transcript = (
+            "## Turn 1 [09:00:00] USER\n\n"
+            + _result_block(tool_id="toolu_a", content="BLOCKED: nope")
+            + "## Turn 2 [09:00:01] USER\n\n"
+            + _result_block(tool_id="toolu_b", content="hook error: denied")
+        )
+        findings = detect_hook_denials(text=transcript)
+        assert [f.classification for f in findings] == ["HOOK_DENIAL", "HOOK_DENIAL"]
+        assert [f.index for f in findings] == [1, 2]

--- a/tests/skills/audit/test_analyze_permissions.py
+++ b/tests/skills/audit/test_analyze_permissions.py
@@ -62,6 +62,34 @@ def test_main_writes_report_to_file(
     assert "# Phase 4: Permission Friction Analysis" in output.read_text()
 
 
+def test_main_surfaces_hook_denials(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    transcript = tmp_path / "transcript.md"
+    # A denied call lives only in a tool-result block, which the input
+    # parser drops — main() must still surface it via detect_hook_denials.
+    transcript.write_text(
+        TRANSCRIPT
+        + "## Turn 2 [12:01:00] USER\n\n"
+        + "<details><summary>Tool result (toolu_x...)</summary>\n\n"
+        + "```\nBLOCKED: Direct psql calls are not allowed.\n```\n</details>\n\n"
+    )
+    settings = tmp_path / "settings.json"
+    settings.write_text(json.dumps({"permissions": {"allow": ["Bash(ls:*)"]}}))
+    output = tmp_path / "report.md"
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["analyze-permissions.py", str(transcript), str(settings), str(output)],
+    )
+    adapter.main()
+
+    assert "HOOK_DENIAL" in output.read_text()
+
+
 def test_main_writes_to_stdout_with_default_settings(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/validators/test_sql_safety.py
+++ b/tests/validators/test_sql_safety.py
@@ -68,6 +68,42 @@ class TestDirectPsql:
         assert "Direct psql calls" in result.message
 
 
+class TestWrappedPsqlExemption:
+    """psql wrapped by docker exec / op run is exempt (GH-474 #4)."""
+
+    @pytest.fixture()
+    def validator(self) -> SqlSafetyValidator:
+        return SqlSafetyValidator()
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "docker exec dvi-enum-test psql -U postgres -d testdb -c 'SELECT 1'",
+            "op run --env-file=.env -- psql -h localhost -d mydb -c 'SELECT 1'",
+            "/usr/local/bin/op run -- psql -d mydb -c 'SELECT 1'",
+        ],
+    )
+    def test_allows_wrapped_psql(self, validator: SqlSafetyValidator, command: str) -> None:
+        inp = _make_input(command=command)
+        result = validator.validate(inp=inp)
+        assert result is None
+
+    def test_still_blocks_bare_psql_after_exempt_segment(
+        self, validator: SqlSafetyValidator
+    ) -> None:
+        command = "docker exec c psql -c 'SELECT 1' | psql -h prod -d db"
+        inp = _make_input(command=command)
+        result = validator.validate(inp=inp)
+        assert result is not None
+        assert "Direct psql calls" in result.message
+
+    def test_handles_empty_pipe_segment(self, validator: SqlSafetyValidator) -> None:
+        inp = _make_input(command="| psql -h prod -d db")
+        result = validator.validate(inp=inp)
+        assert result is not None
+        assert "Direct psql calls" in result.message
+
+
 class TestSqlValidation:
     @pytest.fixture()
     def validator(self) -> SqlSafetyValidator:


### PR DESCRIPTION
**When** I run skill-audit or local DB work from inside a worktree, **I want to** have containerized/op-run psql allowed and PreToolUse hook denials surfaced in the Phase 4 friction report, **so I can** trust the audit and stop fighting false blocks.

---

[`fb71aa69`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/492/commits/fb71aa69787f654e8b431bb26b0ffd23c4f42b7d) 🐛 GH-474 Allow containerized and op-run psql through the DB gate
[`abde0dc6`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/492/commits/abde0dc6e9c46c1b1a93d713aabd18fa40e237f6) 🐛 GH-474 Surface hook denials in permission-friction analysis
[`a4d960aa`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/492/commits/a4d960aab1dd307320d02bacffdd4418f1d4cdfe) 📝 GH-474 Document worktree CWD and push discipline
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/474

---