### PR TITLE
✨ GH-480 Enable promoting read-only MCP tools to global settings

### DIFF
--- a/skills/plugin-maintenance/SKILL.md
+++ b/skills/plugin-maintenance/SKILL.md
@@ -534,22 +534,35 @@ project. This step reports which read-only MCP tools and project-local
 research `WebFetch(domain:*)` rules **would** be promoted to global
 settings, so they stop re-prompting per project.
 
-**Increment 1 is a DRY RUN — it makes no changes.** Tools are classified
-read-vs-write by a name-token heuristic (write-precedence: any write token
-excludes the tool). Writes are never promoted; sensitivity-flagged reads
-(private/DM/secret access) are reported separately as opt-in. Plugin tools
-are excluded — they go through step 6 (enumerate-mcp) instead. The
-heuristic carries false-positive risk (e.g. a `get_access_to_*` grant
-reads as `read`), so a human reviews the plan before any promotion lands.
+Tools are classified read-vs-write by a name-token heuristic
+(write-precedence: any write token excludes the tool). Writes are never
+promoted; sensitivity-flagged reads (private/DM/secret access) are reported
+separately as opt-in. Plugin tools are excluded — they go through step 6
+(enumerate-mcp) instead. Grant verbs (`access`/`grant`/`authorize`) count
+as writes, so a `get_access_to_*` grant is correctly excluded despite its
+`get` prefix (GH-480).
+
+1. Dry run (REQUIRED — review the plan before applying):
 
 ```bash
 uvx dev10x permission promote-plan
 ```
 
-> **Deferred (Increment 2):** actually writing the approved read-only set
-> + research domains into global `~/.claude/settings.json` is a follow-up
-> once the classifier is validated against real allow-lists. Until then
-> this step is report-only.
+2. Apply the plan (Increment 2, GH-480) — writes the read-only set +
+   research domains into global `~/.claude/settings.json`, backup-guarded
+   and idempotent:
+
+```bash
+uvx dev10x permission promote-plan --apply
+```
+
+**Apply is opt-in, not automatic.** Run it only after reviewing the
+dry-run plan above — auto-writing permission grants into *global* settings
+is hard to reverse and the heuristic carries false-positive risk.
+Sensitivity-flagged reads need a second opt-in (`--apply
+--include-sensitive`); writes are never promoted. Preview the exact write
+with `--apply --dry-run`. Recover a bad run from the timestamped backup the
+command prints.
 
 ### 7. Ensure script coverage **[bootstrap]**
 

--- a/src/dev10x/commands/permission.py
+++ b/src/dev10x/commands/permission.py
@@ -472,14 +472,41 @@ def enumerate_mcp(*, dry_run: bool, quiet: bool) -> None:
 
 @permission.command(name="promote-plan")
 @click.option("--quiet", is_flag=True, help="Suppress config line")
-def promote_plan(*, quiet: bool) -> None:
-    """Dry-run plan: read-only MCP tools + research domains to promote (GH-470).
+@click.option(
+    "--apply",
+    "apply_changes",
+    is_flag=True,
+    help="Write the plan into global settings (Increment 2, GH-480). Default is dry-run report.",
+)
+@click.option(
+    "--include-sensitive",
+    is_flag=True,
+    help="With --apply: also promote sensitivity-flagged reads (private/DM/secret). Opt-in.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="With --apply: show what would be written without modifying files.",
+)
+def promote_plan(
+    *,
+    quiet: bool,
+    apply_changes: bool,
+    include_sensitive: bool,
+    dry_run: bool,
+) -> None:
+    """Promote read-only MCP tools + research domains to global settings (GH-470/GH-480).
 
-    Increment 1 — reports what WOULD be promoted to global settings; makes
-    NO changes. Read-only tools and project-local research WebFetch domains
-    are classified and deduped against global; writes and sensitivity-flagged
-    reads are excluded from the default promotable set. Actual promotion is
-    deferred to a follow-up (Increment 2).
+    Without ``--apply`` this reports a DRY-RUN plan and makes NO changes:
+    read-only tools and project-local research WebFetch domains are classified
+    and deduped against global; writes and sensitivity-flagged reads are
+    excluded from the default promotable set.
+
+    With ``--apply`` (Increment 2, GH-480) the read-only set + research domains
+    are written into global ``~/.claude/settings.json`` — backup-guarded and
+    idempotent. Sensitivity-flagged reads are promoted only with the explicit
+    ``--include-sensitive`` opt-in; writes are never promoted. Combine
+    ``--apply --dry-run`` to preview exactly which rules the write would add.
     """
     from dev10x.skills.permission import promote as mod
     from dev10x.skills.permission import update_paths as paths_mod
@@ -498,7 +525,17 @@ def promote_plan(*, quiet: bool) -> None:
         project_settings_paths=settings_files,
         global_settings_path=global_settings,
     )
-    click.echo(mod.render_promotion_plan(plan))
+    if not apply_changes:
+        click.echo(mod.render_promotion_plan(plan))
+        return
+
+    result = mod.apply_promotion_plan(
+        plan=plan,
+        global_settings_path=global_settings,
+        include_sensitive=include_sensitive,
+        dry_run=dry_run,
+    )
+    click.echo(mod.render_promotion_result(result, dry_run=dry_run))
 
 
 @permission.command(name="merge-worktree")

--- a/src/dev10x/skills/permission/promote.py
+++ b/src/dev10x/skills/permission/promote.py
@@ -7,11 +7,15 @@ module classifies discovered MCP tools as read-only vs write using a
 name-token heuristic and builds a DRY-RUN plan describing which tools
 and research-fetch domains WOULD be promoted to global settings.
 
-**No writes.** This module never mutates settings — it only reports a
-plan a human reviews. Actual promotion to global settings is deferred to
-a follow-up (Increment 2). The heuristic carries false-positive risk —
-e.g. a grant named ``get_access_to_*`` reads as ``read`` by token — so a
-reviewable dry-run is the safety floor before any auto-write lands.
+**Two-phase by design.** ``build_promotion_plan`` only *reports* a plan a
+human reviews — it never mutates settings. ``apply_promotion_plan``
+(Increment 2, GH-480) writes the approved read-only set + research domains
+into global settings, backup-guarded and idempotent, behind an explicit
+opt-in (the ``--apply`` flag). The heuristic carries false-positive risk —
+e.g. a grant named ``get_access_to_*`` would read as ``read`` by its ``get``
+token, so ``access``/``grant``/``authorize`` are write tokens
+(write-precedence) — and the dry-run plan remains the safety floor a human
+reviews before any auto-write lands.
 
 Classification (write-precedence — safer to under-promote):
 
@@ -101,6 +105,14 @@ WRITE_TOKENS = frozenset(
         "start",
         "push",
         "notify",
+        # Grant/authorization verbs are side-effecting. A ``get_access_to_*``
+        # tool reads as ``read`` by its ``get`` token but actually mints an
+        # access grant — write-precedence keeps it out of the auto-promotable
+        # set (GH-480: classifier corpus false-positive, e.g.
+        # ``get_access_to_vercel_url``).
+        "access",
+        "grant",
+        "authorize",
     }
 )
 # Read tools whose target is private/DM/secret — promotable only on opt-in.
@@ -262,7 +274,120 @@ def render_promotion_plan(plan: PromotionPlan) -> str:
         f"{plan.already_global_domains} domain(s) — skipped (idempotent)."
     )
     lines.append(
-        "Increment 1 is read-only: this plan performs NO writes. "
-        "Review it, then apply via the follow-up promotion step (Increment 2)."
+        "This is the dry-run plan (NO writes). Apply it with "
+        "`dev10x permission promote-plan --apply` (Increment 2, GH-480)."
     )
+    return "\n".join(lines)
+
+
+@dataclass
+class PromotionResult:
+    """Outcome of applying a :class:`PromotionPlan` to global settings.
+
+    ``added_*`` list the rules newly written; ``already_present`` counts
+    plan rules that were already in the global allow list (the idempotent
+    skip path). ``backup_path`` is the timestamped backup created before
+    the write, or ``None`` when nothing was written (dry-run or no-op).
+    """
+
+    added_tools: list[str] = field(default_factory=list)
+    added_sensitive: list[str] = field(default_factory=list)
+    added_domains: list[str] = field(default_factory=list)
+    already_present: int = 0
+    backup_path: Path | None = None
+
+    @property
+    def total_added(self) -> int:
+        return len(self.added_tools) + len(self.added_sensitive) + len(self.added_domains)
+
+
+def apply_promotion_plan(
+    *,
+    plan: PromotionPlan,
+    global_settings_path: Path,
+    include_sensitive: bool = False,
+    dry_run: bool = False,
+) -> PromotionResult:
+    """Write a plan's read-only tools + research domains into global settings.
+
+    Backup-guarded and idempotent: a timestamped backup is created before any
+    write, and rules already present in the live global allow list are counted
+    (``already_present``) rather than re-appended. Writes are never promoted —
+    the plan's ``read_promotable`` already excludes them via write-precedence.
+    Sensitivity-flagged reads (``plan.sensitive_opt_in``) are written ONLY when
+    ``include_sensitive`` is True — an explicit opt-in, never the default.
+
+    The append is re-checked against the *live* allow list under an exclusive
+    lock, so a concurrent writer cannot cause a duplicate rule.
+    """
+    domain_rules = [f"WebFetch(domain:{domain})" for domain in plan.domains_promotable]
+    sensitive_rules = list(plan.sensitive_opt_in) if include_sensitive else []
+    candidates: list[tuple[str, str]] = (
+        [("tool", rule) for rule in plan.read_promotable]
+        + [("sensitive", rule) for rule in sensitive_rules]
+        + [("domain", rule) for rule in domain_rules]
+    )
+
+    existing = set(_read_allow_rules(global_settings_path))
+    result = PromotionResult()
+    pending: list[str] = []
+    for kind, rule in candidates:
+        if rule in existing:
+            result.already_present += 1
+            continue
+        pending.append(rule)
+        if kind == "tool":
+            result.added_tools.append(rule)
+        elif kind == "sensitive":
+            result.added_sensitive.append(rule)
+        else:
+            result.added_domains.append(rule)
+
+    if dry_run or not pending:
+        return result
+
+    from dev10x.skills.permission.backup import create_backup
+    from dev10x.skills.permission.file_lock import locked_json_update
+
+    result.backup_path = create_backup(global_settings_path)
+    with locked_json_update(path=global_settings_path) as live:
+        permissions = live.setdefault("permissions", {})
+        allow = permissions.setdefault("allow", [])
+        live_present = {rule for rule in allow if isinstance(rule, str)}
+        # Re-check every candidate against the LIVE allow list (not the
+        # pre-lock read) so a concurrent writer or a stale plan cannot
+        # introduce a duplicate rule.
+        for _kind, rule in candidates:
+            if rule not in live_present:
+                allow.append(rule)
+                live_present.add(rule)
+        permissions["allow"] = allow
+    return result
+
+
+def render_promotion_result(result: PromotionResult, *, dry_run: bool = False) -> str:
+    """Render a human-readable report of an :func:`apply_promotion_plan` run."""
+    header = "DRY RUN — no files modified" if dry_run else "applied to global settings"
+    verb = "Would promote" if dry_run else "Promoted"
+    lines = [f"MCP / research-domain promotion ({header}):", ""]
+
+    def _section(title: str, items: list[str]) -> None:
+        lines.append(f"{verb} {title} ({len(items)}):")
+        for item in items:
+            lines.append(f"  + {item}")
+        if not items:
+            lines.append("  (none)")
+        lines.append("")
+
+    _section("read-only tools", result.added_tools)
+    _section("research WebFetch domains", result.added_domains)
+    _section("sensitive read tools (opt-in)", result.added_sensitive)
+
+    lines.append(
+        f"Already present in global: {result.already_present} rule(s) — skipped (idempotent)."
+    )
+    if result.backup_path is not None:
+        lines.append(f"Backup: {result.backup_path}")
+    elif not dry_run and result.total_added == 0:
+        lines.append("No changes — global settings already contained every promotable rule.")
     return "\n".join(lines)

--- a/tests/commands/test_permission_promote.py
+++ b/tests/commands/test_permission_promote.py
@@ -1,0 +1,67 @@
+"""Tests for `dev10x permission promote-plan [--apply]` (GH-470 / GH-480)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from dev10x.commands.permission import promote_plan
+
+READ_TOOL = "mcp__claude_ai_Slack__slack_read_channel"
+DOMAIN_RULE = "WebFetch(domain:arxiv.org)"
+
+
+@pytest.fixture
+def env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Wire promote-plan to a tmp global file + a tmp project settings file.
+
+    Returns the global settings path so tests can assert on writes.
+    """
+    home = tmp_path / "home"
+    (home / ".claude").mkdir(parents=True)
+    global_settings = home / ".claude" / "settings.json"
+    global_settings.write_text(json.dumps({"permissions": {"allow": []}}))
+
+    project = tmp_path / "proj" / ".claude" / "settings.local.json"
+    project.parent.mkdir(parents=True)
+    project.write_text(json.dumps({"permissions": {"allow": [READ_TOOL, DOMAIN_RULE]}}))
+
+    from dev10x.skills.permission import update_paths as paths_mod
+
+    monkeypatch.setattr(paths_mod, "find_config", lambda: tmp_path / "config.yaml")
+    monkeypatch.setattr(paths_mod, "load_config", lambda _path: {"roots": []})
+    monkeypatch.setattr(paths_mod, "find_settings_files", lambda **_kw: [project])
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
+    return global_settings
+
+
+def test_dry_run_plan_is_default(env: Path) -> None:
+    result = CliRunner().invoke(promote_plan, ["--quiet"])
+    assert result.exit_code == 0
+    assert "DRY RUN — no files modified" in result.output
+    assert json.loads(env.read_text())["permissions"]["allow"] == []
+
+
+def test_apply_writes_to_global(env: Path) -> None:
+    result = CliRunner().invoke(promote_plan, ["--apply", "--quiet"])
+    assert result.exit_code == 0
+    assert "applied to global settings" in result.output
+    allow = json.loads(env.read_text())["permissions"]["allow"]
+    assert READ_TOOL in allow
+    assert DOMAIN_RULE in allow
+
+
+def test_apply_dry_run_previews_without_writing(env: Path) -> None:
+    result = CliRunner().invoke(promote_plan, ["--apply", "--dry-run", "--quiet"])
+    assert result.exit_code == 0
+    assert "DRY RUN — no files modified" in result.output
+    assert json.loads(env.read_text())["permissions"]["allow"] == []
+
+
+def test_config_line_printed_without_quiet(env: Path) -> None:
+    result = CliRunner().invoke(promote_plan, [])
+    assert result.exit_code == 0
+    assert "Config:" in result.output

--- a/tests/skills/permission/test_promote.py
+++ b/tests/skills/permission/test_promote.py
@@ -9,11 +9,14 @@ import pytest
 
 from dev10x.skills.permission.promote import (
     PromotionPlan,
+    PromotionResult,
+    apply_promotion_plan,
     build_promotion_plan,
     classify_mcp_tool,
     collect_webfetch_domains,
     is_sensitivity_flagged,
     render_promotion_plan,
+    render_promotion_result,
 )
 
 
@@ -176,3 +179,178 @@ class TestRenderPromotionPlan:
         out = render_promotion_plan(PromotionPlan())
         assert "(none)" in out
         assert "NO writes" in out
+
+
+class TestClassifierCorpus:
+    """Validate the read/write classifier against a real allow-list corpus (GH-480 AC)."""
+
+    @pytest.mark.parametrize(
+        "tool",
+        [
+            "mcp__claude_ai_Slack__slack_read_channel",
+            "mcp__claude_ai_Slack__search_channels",
+            "mcp__claude_ai_Linear__get_issue",
+            "mcp__claude_ai_Linear__list_projects",
+            "mcp__claude_ai_Sentry__find_organizations",
+            "mcp__claude_ai_Sentry__whoami",
+        ],
+    )
+    def test_real_read_tools(self, tool: str):
+        assert classify_mcp_tool(tool) == "read"
+
+    @pytest.mark.parametrize(
+        "tool",
+        [
+            "mcp__claude_ai_Linear__create_issue",
+            "mcp__claude_ai_Slack__send_message_draft",
+            "mcp__claude_ai_Vercel__deploy_to_vercel",
+            "mcp__claude_ai_Google_Calendar__update_event",
+        ],
+    )
+    def test_real_write_tools(self, tool: str):
+        assert classify_mcp_tool(tool) == "write"
+
+    def test_get_access_grant_is_write_not_read(self):
+        # GH-480 known false-positive: reads as `read` by the `get` token but
+        # actually mints an access grant. Write-precedence must exclude it.
+        assert classify_mcp_tool("mcp__claude_ai_Vercel__get_access_to_vercel_url") == "write"
+
+    def test_get_access_grant_excluded_from_promotable(self, tmp_path: Path):
+        grant = "mcp__claude_ai_Vercel__get_access_to_vercel_url"
+        plan = build_promotion_plan(
+            project_settings_paths=[_write_settings(tmp_path / "p.json", [grant])],
+            global_settings_path=_write_settings(tmp_path / "g.json", []),
+        )
+        assert plan.read_promotable == []
+        assert plan.writes_excluded == [grant]
+
+    def test_private_search_is_read_but_sensitive(self):
+        # GH-480 known false-positive: a read that must NOT be default-promoted.
+        tool = "mcp__claude_ai_Slack__slack_search_public_and_private"
+        assert classify_mcp_tool(tool) == "read"
+        assert is_sensitivity_flagged(tool)
+
+
+class TestApplyPromotionPlan:
+    READ_TOOL = "mcp__claude_ai_Slack__slack_read_channel"
+    SENSITIVE = "mcp__claude_ai_Slack__slack_search_public_and_private"
+
+    def _global(self, tmp_path: Path, allow: list[str]) -> Path:
+        return _write_settings(tmp_path / "global.json", allow)
+
+    def test_writes_tools_and_domains_with_backup(self, tmp_path: Path):
+        g = self._global(tmp_path, ["pre-existing-rule"])
+        plan = PromotionPlan(read_promotable=[self.READ_TOOL], domains_promotable=["arxiv.org"])
+
+        result = apply_promotion_plan(plan=plan, global_settings_path=g)
+
+        allow = json.loads(g.read_text())["permissions"]["allow"]
+        assert self.READ_TOOL in allow
+        assert "WebFetch(domain:arxiv.org)" in allow
+        assert "pre-existing-rule" in allow
+        assert result.added_tools == [self.READ_TOOL]
+        assert result.added_domains == ["WebFetch(domain:arxiv.org)"]
+        assert result.added_sensitive == []
+        assert result.total_added == 2
+        assert result.backup_path is not None and result.backup_path.is_file()
+
+    def test_idempotent_rerun_adds_nothing(self, tmp_path: Path):
+        g = self._global(tmp_path, [self.READ_TOOL])
+        plan = PromotionPlan(read_promotable=[self.READ_TOOL])
+
+        result = apply_promotion_plan(plan=plan, global_settings_path=g)
+
+        assert result.added_tools == []
+        assert result.already_present == 1
+        assert result.backup_path is None
+        assert json.loads(g.read_text())["permissions"]["allow"] == [self.READ_TOOL]
+
+    def test_dry_run_makes_no_changes(self, tmp_path: Path):
+        g = self._global(tmp_path, [])
+        plan = PromotionPlan(read_promotable=[self.READ_TOOL])
+
+        result = apply_promotion_plan(plan=plan, global_settings_path=g, dry_run=True)
+
+        assert result.added_tools == [self.READ_TOOL]
+        assert result.backup_path is None
+        assert json.loads(g.read_text())["permissions"]["allow"] == []
+
+    def test_sensitive_excluded_by_default(self, tmp_path: Path):
+        g = self._global(tmp_path, [])
+        plan = PromotionPlan(sensitive_opt_in=[self.SENSITIVE])
+
+        result = apply_promotion_plan(plan=plan, global_settings_path=g)
+
+        assert result.added_sensitive == []
+        assert self.SENSITIVE not in json.loads(g.read_text())["permissions"]["allow"]
+        assert result.backup_path is None
+
+    def test_sensitive_included_on_opt_in(self, tmp_path: Path):
+        g = self._global(tmp_path, [])
+        plan = PromotionPlan(sensitive_opt_in=[self.SENSITIVE])
+
+        result = apply_promotion_plan(plan=plan, global_settings_path=g, include_sensitive=True)
+
+        assert result.added_sensitive == [self.SENSITIVE]
+        assert self.SENSITIVE in json.loads(g.read_text())["permissions"]["allow"]
+
+    def test_empty_plan_is_noop(self, tmp_path: Path):
+        g = self._global(tmp_path, ["x"])
+
+        result = apply_promotion_plan(plan=PromotionPlan(), global_settings_path=g)
+
+        assert result.total_added == 0
+        assert result.backup_path is None
+        assert json.loads(g.read_text())["permissions"]["allow"] == ["x"]
+
+    def test_creates_settings_when_global_missing(self, tmp_path: Path):
+        g = tmp_path / "absent.json"  # does not exist yet
+        plan = PromotionPlan(read_promotable=[self.READ_TOOL])
+
+        result = apply_promotion_plan(plan=plan, global_settings_path=g)
+
+        assert self.READ_TOOL in json.loads(g.read_text())["permissions"]["allow"]
+        assert result.backup_path is None  # create_backup returns None for a missing file
+
+    def test_stale_plan_rule_already_live_is_skipped(self, tmp_path: Path):
+        # A plan listing a rule already in global (stale plan / concurrent add):
+        # the live re-check under the lock must skip it without duplicating.
+        already = "mcp__claude_ai_Linear__get_issue"
+        g = self._global(tmp_path, [already])
+        plan = PromotionPlan(read_promotable=[already, self.READ_TOOL])
+
+        result = apply_promotion_plan(plan=plan, global_settings_path=g)
+
+        allow = json.loads(g.read_text())["permissions"]["allow"]
+        assert allow.count(already) == 1
+        assert allow.count(self.READ_TOOL) == 1
+        assert result.added_tools == [self.READ_TOOL]
+        assert result.already_present == 1
+
+
+class TestRenderPromotionResult:
+    def test_renders_added_sections_and_backup(self):
+        result = PromotionResult(
+            added_tools=["mcp__claude_ai_Slack__slack_read_channel"],
+            added_domains=["WebFetch(domain:arxiv.org)"],
+            added_sensitive=["mcp__claude_ai_Slack__slack_search_public_and_private"],
+            already_present=2,
+            backup_path=Path("/tmp/settings.json.bak.20260609T000000Z"),
+        )
+        out = render_promotion_result(result)
+        assert "applied to global settings" in out
+        assert "Promoted read-only tools (1)" in out
+        assert "+ mcp__claude_ai_Slack__slack_read_channel" in out
+        assert "+ WebFetch(domain:arxiv.org)" in out
+        assert "Already present in global: 2" in out
+        assert "Backup: /tmp/settings.json.bak.20260609T000000Z" in out
+
+    def test_dry_run_header_and_verb(self):
+        out = render_promotion_result(PromotionResult(added_tools=["t"]), dry_run=True)
+        assert "DRY RUN — no files modified" in out
+        assert "Would promote read-only tools (1)" in out
+
+    def test_no_changes_message_when_empty(self):
+        out = render_promotion_result(PromotionResult())
+        assert "No changes" in out
+        assert "(none)" in out


### PR DESCRIPTION
**When** I work across many projects and worktrees and keep re-approving the same read-only MCP tools, **I want to** apply the reviewed promotion plan so the safe read-only set and research domains land in my global settings, **so I can** stop re-approving them per directory while writes and sensitive reads stay gated behind explicit opt-in.

---

[`20325440`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/493/commits/2032544020e84e837d8ade4780b2008bbee4728a) ✨ GH-480 Enable promoting read-only MCP tools to global settings
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/480

---