### PR TITLE
📝 Record 2026-06-10 A–I audit verification memo

### DIFF
--- a/docs/memos/architecture-audit-2026-06-10-verification.md
+++ b/docs/memos/architecture-audit-2026-06-10-verification.md
@@ -1,0 +1,226 @@
+# Architecture Audit Verification Pass — 2026-06-10 (Phases A–I, second run)
+
+Independent re-run of `/Dev10x:project-audit` (all 9 phases, 9 parallel
+read-only Explore agents) executed the same day as the per-package
+audit recorded in `architecture-audit-2026-06-10.md` (77 issues,
+#494–#570, milestones PKG-M1…PKG-M11). This pass was deduplicated
+issue-by-issue against that backlog.
+
+**Outcome:**
+
+- **121 raw findings**, ~110 after intra-run merging
+- **~45 independently confirm already-filed issues** (table below) —
+  strong signal the morning backlog is real, not agent noise
+- **~28 new actionable findings** that escaped the morning run's
+  per-agent issue caps (agents bundled LOWs and capped at 5–10 issues)
+- **2 corrections to the morning memo's "clean bills of health"**
+- No new ADRs needed: every HIGH finding is an enforcement gap against
+  ADR-0007/0008/0009/0011, not a new architectural question
+
+## Corrections to "clean bills of health"
+
+The morning memo states two clean bills this pass contradicts:
+
+1. **"CWD discipline: no bare `subprocess.run`/`os.getcwd` in
+   long-lived paths"** — found `effective_cwd() or os.getcwd()`
+   fallbacks in `domain/events/hook_input.py:29`,
+   `hooks/permission_diagnostics.py:148`,
+   `audit/permissions_model.py:246`, plus bare `subprocess.run` in
+   package module `skills/notifications/slack_notify.py:92` (not a
+   uv-script) and an unmarked entry-script
+   `skills/git_fixup/find_fixup_target.py` (no `# /// script` header,
+   so not clearly exempt).
+2. **"MCP boundary: zero ADR-0009 violations"** —
+   `mcp/roots_tools.py:35` returns bare dicts (no Result envelope),
+   and `platform/registry.py:64,149` raises `KeyError`/`ValueError`
+   that no MCP wrapper catches.
+
+## New findings — HIGH priority
+
+### N1. Unlocked read-modify-write on settings files (Phase E)
+
+| Site | Location |
+|---|---|
+| `update_file` | `src/dev10x/skills/permission/update_paths.py:168` |
+| `generalize_permissions` | `src/dev10x/skills/permission/update_paths.py:760` |
+| `canonicalize_settings_file` (also no backup) | `src/dev10x/skills/permission/doctor.py:131` |
+| `doctor_apply_deprecations` / `doctor_enable_group` | `src/dev10x/commands/permission.py:983,1026` |
+
+Five mutators bypass `locked_json_update` while every sibling settings
+mutator in the same files uses it. Parallel fanout agents targeting a
+shared `settings.local.json` lose updates (lost-update race).
+Fix: wrap each in `locked_json_update` + `create_backup`.
+Impact HIGH / Effort S each. → PKG-M11.
+
+### N2. Lock & atomicity model drift (Phase A)
+
+- Two lock-sidecar conventions coexist (`file_lock` appends `.lock`;
+  `locked_json_update` replaces the suffix) with a prose-only warning —
+  silent mutual-exclusion break if both are ever used on one path
+  (`src/dev10x/domain/file_locks.py:20-34`).
+- `Plan.save()` hand-rolls mkstemp/rename **without fsync**, out of
+  sync with canonical `atomic_write_text`
+  (`src/dev10x/domain/documents/plan.py:138-161`).
+- Multi-file permission migrations have no Unit of Work: a third-file
+  failure leaves files 1–2 mutated with no rollback
+  (`src/dev10x/hooks/session_policy.py:110-200`,
+  `skills/permission/update_paths.py`).
+
+Impact HIGH / Effort S–M. → PKG-M11 (extends #555/#544 theme).
+
+### N3. Daemon PID-file double-start race (Phase E)
+
+`write_pid_file` is a truncate-write with no `O_EXCL`; two
+near-simultaneous daemon starts both pass the stale check and the
+second overwrites the first's PID — `shutdown_daemon` then kills the
+wrong process and leaves a zombie health server
+(`src/dev10x/mcp/daemon.py:108`). Impact HIGH / Effort M. → PKG-M2.
+
+### N4. `DEV10X_HOOK_AUDIT_DIR` default-path conflict (Phase C)
+
+Same env var, two fallbacks: `audit/log_reader.py:39` defaults to
+`/tmp/Dev10x/logs`; `audit/__init__.py:37` defaults to
+`/tmp/Dev10x/hook-audit`. In a default install the reader and writer
+use different directories — `analyze_permissions` finds nothing.
+Impact HIGH / Effort S. → PKG-M8.
+
+### N5. `ClaudeDir`/`Dev10xConfigDir` bypasses defeat env overrides (Phase C)
+
+`slack_review_request.py:29`, `slack_notify.py:23` hardcode
+`Path.home()/".claude"/"memory"/...`; `analyze_permissions.py:110,135`
+uses `os.path.expanduser("~/.claude/...")`. All bypass
+`DEV10X_CLAUDE_HOME`/`DEV10X_CONFIG_HOME` and lazy migration — tests
+can touch production config. Impact HIGH / Effort S. → PKG-M1.
+
+### N6. `PLUGIN_NAMES` regex divergence (Phase C)
+
+Three independent definitions; `clean_project_files.py:42` also
+matches bare `dev10x` while `doctor.py:37` and `update_paths.py:42`
+do not — observable behavior difference for short-slug projects.
+Impact HIGH / Effort S. → PKG-M1.
+
+### N7. GH-315 Bug C: dual permission config files (Phase D)
+
+`merge-worktree`/`clean` read `upgrade-cleanup-projects.yaml` while
+six other subcommands read `projects.yaml`
+(`skills/permission/update_paths.py:15` documents this as a known,
+unfixed bug). User edits to one file silently don't affect some
+subcommands. Impact HIGH / Effort M. → PKG-M1.
+
+### N8. `platform/registry.py` raises through the MCP boundary (Phase H)
+
+`PlatformCatalog.lookup()` raises `KeyError`; `get_platform_config()`
+raises `ValueError`; no MCP wrapper catches them (ADR-0009 violation,
+see correction 2). Impact HIGH / Effort S. → PKG-M7.
+
+### N9. `os.getcwd()` fallback stragglers post-GH-979 (Phase H)
+
+See correction 1. Replace `effective_cwd() or os.getcwd()` with the
+`subprocess_utils` sentinel convention. Extends #495 (spec_drift
+only). Impact HIGH / Effort M. → PKG-M11.
+
+### N10. MCP tool adapter modules without direct tests (Phase G)
+
+`git_tools.py`, `misc_tools.py`, `roots_tools.py` (extends #556's
+audit/plan scope): `cwd` forwarding, result mapping, and error paths
+are invisible — tests mock below the adapter.
+Impact HIGH / Effort M. → PKG-M10.
+
+### N11. `update_paths.py`: 1,283 lines / 13 tests (Phase G)
+
+`ensure_base_permissions`, `generalize_permissions`,
+`purge_dead_glob_script_rules`, `verify_script_coverage` etc. are
+untested — the most destructive, highest-churn permission module.
+Impact HIGH / Effort L. → PKG-M10.
+
+### N12. Global 75% coverage floor masks 0% packages (Phase G)
+
+`commands/hook.py` (335 lines, 0 tests), `session/queries.py`, and
+the MCP tool modules can sit at 0% while the global gate passes. Add
+per-package floors. Impact MEDIUM-HIGH / Effort S. → PKG-M10.
+
+## New findings — MEDIUM (bundle candidates)
+
+| ID | Finding | Location (primary) | Effort | Milestone |
+|---|---|---|---|---|
+| N13 | Template-Method bundle: `_bulk_execute` ×3, repo-resolution boilerplate ×10 (`_resolve_repo` called twice in issue_edit/close/reopen), `gh_json`/`gh_run` ×2, `_restore` ×3, JSON-envelope emit ×3 | `github/__init__.py:1437-1571,1094-1176`; `skills/permission/*`; `hooks/session_dispatch.py` | M | PKG-M11 (extends #541, #557) |
+| N14 | MCP wrapper boilerplate ×30 → `@github_tool` decorator | `mcp/github_tools.py` | L | PKG-M2 |
+| N15 | Transcript grammar duplicated & diverged (`TURN_RE` trailing group) | `audit/permissions_model.py:25` vs `skills/audit/analyze_actions.py:27` | M | PKG-M8 |
+| N16 | Two `RuleMatch` classes — same name, different semantics | `domain/rules/rule_engine.py:21` vs `hooks/permission_diagnostics.py:40` | S | PKG-M11 |
+| N17 | `doctor.Catalog` vs `PolicyCatalog` — two loaders for `baseline-permissions.yaml` | `skills/permission/doctor.py:324` | L | PKG-M1 |
+| N18 | Missing `permission/service.py` layer; MCP + CLI adapters reach into `skills/permission` directly (`plan/` shows the correct shape) | `permission/__init__.py:30`, `commands/permission.py` | L | PKG-M11 (extends #525, #529) |
+| N19 | `session.yaml` has no Document owner — 3 ad-hoc readers/writers; root cause of #513/#515 | `domain/session_rules.py:41`, `hooks/session_policy.py:89`, `commands/init.py:67` | M | PKG-M11 (fix vehicle for #513/#515) |
+| N20 | `domain/` imports `subprocess_utils` — layering inversion vs ADR-0008 | `domain/events/hook_input.py:9`, `domain/git_context.py:21` | M | PKG-M4 |
+| N21 | `audit_emit._get_writer()` lazy import instead of startup injection (ADR-0008 "cycles hidden behind lazy imports") | `hooks/audit_emit.py:31-38` | S | PKG-M7 |
+| N22 | `github_tools.py` mixes GitHub/CI/release tool contexts; `github/slack.py` misplaced | `mcp/github_tools.py:1232-1301`, `github/slack.py` | S | PKG-M2 |
+| N23 | Protected-branch set defined in 4 places (canonical `frozenset` ignored); `detect_base_branch` ×3 implementations | `domain/common/branch_name.py:17` vs `validators/pr_base.py:23`, `skills/git_fixup/find_fixup_target.py:71`, `github/__init__.py:766` | M | PKG-M11 |
+| N24 | Partial VO adoption: `RepositoryRef` (30+ `repo: str` MCP params), `BranchName` (`push_safe` takes raw strings), `TicketId` (callers re-compile `TICKET_ID_PATTERN`), shared bash-token regexes (`ENV_VAR_RE` ×2, `GIT_C_RE` ×2 with conflicting semantics) | `mcp/github_tools.py`, `git/__init__.py:65`, `validators/commit_jtbd.py:93` | M | PKG-M11 (extends #508, #510, #514) |
+| N25 | Validator Protocol gaps: chain should call `should_run`→`validate` (not overridable `run()`); `Corrector` Protocol declared but never isinstance-checked — capability string mis-declaration raises swallowed `AttributeError` | `validators/base.py:49-95`, `validators/registry.py:212-226` | S | PKG-M3 (sibling of #494) |
+| N26 | `RuleEngine` rebuilt from YAML on every hook invocation — no mtime-keyed cache | `domain/rules/rule_engine.py:27-83`, `hooks/edit_validator.py` | S | PKG-M3 |
+| N27 | `slack_notify.py`: bare `subprocess.run` + `raise RuntimeError` in package code; Slack sends scattered across 3 call sites with 3 error styles | `skills/notifications/slack_notify.py:87-137` | M | PKG-M1 (sibling of #537) |
+| N28 | Smaller items: `collect_prs` pure logic untested; `pr_notify` arg-building untested; upgrade-cleanup / git-worktree skills lack evals; `RemovalResult` accumulator anti-pattern; status-string enums (`DeprecationAction`, `McpSourceType`, `FindingScope`); `_write_if_missing` + `migrate_path` TOCTOU; `install_version` lexicographic version sort breaks at 0.10.x (adds evidence to #506); GitHub App key/config non-atomic writes | various | S–M | PKG-M10 / PKG-M1 / PKG-M2 |
+
+LOW-impact items (naming/docs/hygiene: `Task` wither documentation,
+`ValidatorFilter`→Specification naming, `Config` placement, logger
+naming, `fetch_*` vs `get_*`, bare `import subprocess` in
+`session/queries.py`, 4th Rule archetype doc for `cli_friction.Rule`,
+`platform/registry.py` Catalog/Registry file split) should ride along
+existing LOW bundles (#534, #539, #566) rather than new issues.
+
+## Already tracked — independent confirmation
+
+| This run re-found | Tracked as |
+|---|---|
+| `session_persist` spawns 5 `GitContext` per call | #552 |
+| `collect_prs` N+1 `gh` per ticket | #550 |
+| `review_threads` sequential per-PR API calls | #561 |
+| `SessionStore.update` lock-release gap (TOCTOU) | #558 |
+| `file_lock` blocking flock without timeout | #555 |
+| `write_applied_version` raw `write_text` | #544 |
+| `init.py` TOCTOU + roots staleness + audit raw write | #562 |
+| `skill_metrics` TextIOWrapper append | #548 |
+| Policy-rule file I/O (`ReadFrictionLevelRule`, `BuildAutonomyReassuranceRule`) | #513, #515 |
+| Policy rules placed in `hooks/` not `domain/` | #524 |
+| `_migrate_rules`/`_deduplicate_rules` compat-shim leak | #521 |
+| `Plan.metadata` raw dict + `archive_slug` leak | #527 |
+| `Finding.metadata` untyped bag, TDA in 4 remediators | #518 |
+| `PlaybookDiff`/`PlayDiff` raw string status | #535 |
+| Result[T] gaps in `install_version` + skills layer | #533 |
+| Config loading: parallel implementations | #536 |
+| Logger naming `log`/`logger`/`_log` | #538 |
+| Module-level singletons → named Registry | #522 |
+| `ValidatorChain` fail-open on validator exceptions | #494 |
+| spec_drift ad-hoc ticket regex / bare subprocess | #514, #495 |
+| `_version_tuple` duplication | #506 |
+| McpToolName parsing scattered | #508 |
+| MCP audit/plan tools passthrough-only tests | #556 |
+| Fanout swarm dispatch untested | #553 |
+| PR lifecycle skills lack evals | #547 |
+| `session/queries.py`, commands CLI untested | #568 |
+| MCP daemon/StreamableHTTP no integration tests | #563 |
+| session_dispatch emit-skeleton duplication | #551, #557 |
+| `permission.py` command boilerplate ×8 | #541 |
+| Tool-name dispatch ×4 modules | #543 |
+| `ci_check_status` dual gh calls, `pr_notify` import | #566 |
+
+One nuance vs #549 (mixed ISO timestamp formats): timezone-awareness
+itself is fully consistent (`datetime.now(UTC)` everywhere) — #549's
+scope is format strings only.
+
+## Proposed milestone assignment (new findings)
+
+All new findings map onto **existing** PKG milestones — no new
+milestone structure:
+
+- **PKG-M1 (skills)**: N5, N6, N7, N17, N27, parts of N28
+- **PKG-M2 (mcp)**: N3, N14, N22, parts of N28
+- **PKG-M3 (validators)**: N25, N26
+- **PKG-M4 (domain)**: N20
+- **PKG-M7 (runtime/infra)**: N8, N21
+- **PKG-M8 (workflow/audit)**: N4, N15
+- **PKG-M10 (tests)**: N10, N11, N12, parts of N28
+- **PKG-M11 (cross-cutting)**: N1, N2, N9, N13, N16, N18, N19, N23, N24
+
+Suggested blocking chains: N2 (lock model) blocks N1 (apply locks);
+N19 (`SessionYamlDocument`) blocks #513/#515 remediation; N12
+(per-package floors) lands after N10/N11 raise the packages it gates.

--- a/docs/memos/architecture-audit-2026-06-10.md
+++ b/docs/memos/architecture-audit-2026-06-10.md
@@ -1,0 +1,121 @@
+# Architecture & Per-Package Audit — 2026-06-10
+
+Full-project audit via `Dev10x:project-audit` (all phases A–I) extended
+with per-package specialized review agents: dead-code detection (vulture
++ manual verification), code-review rule violations, and direct issue
+filing by the agents themselves.
+
+**Initiative prefix:** `PKG` (registered in `references/milestone-naming.md`)
+**Label:** `audit-2026-06-10`
+**Issues filed:** 77 (#494–#570) across 11 milestones
+**Agents:** 10 package reviewers (opus) + 9 audit-phase agents A–I (sonnet)
+
+## Backlog by milestone
+
+| Milestone | Issues | HIGH |
+|-----------|-------:|-----:|
+| PKG-M1: skills package | #532 #537 #540 #546 | 1 |
+| PKG-M2: mcp package | #498 #501 #502 | 0 |
+| PKG-M3: validators package | #494 #495 #497 | 1 |
+| PKG-M4: domain package | #504 #505 #509 #511 #520 | 0 |
+| PKG-M5: commands & CLI | #519 #525 #528 | 0 |
+| PKG-M6: github package | #496 #499 #500 #503 | 1 |
+| PKG-M7: runtime & infra | #512 #517 | 0 |
+| PKG-M8: workflow packages | #507 | 0 |
+| PKG-M9: plugin assets | #545 #554 | 0 |
+| PKG-M10: test suite | #564 #565 #567 #568 #569 #570 | 1 |
+| PKG-M11: cross-cutting (A–I) | 44 issues #506–#566 | 18 |
+| **Total** | **77** | **22** |
+
+## HIGH-impact findings (start here)
+
+**Safety / correctness:**
+- #494 ValidatorChain fails open silently when a safety validator raises
+- #496 Six unguarded `json.loads` on `gh` stdout (github package)
+- #532 `resolve_config` can `sys.exit` the long-lived MCP server in-process
+- #544 Non-atomic version-stamp write; #548 broken atomic-append on
+  metrics JSONL; #555 `file_lock` has no timeout — crashed holder hangs
+  the daemon (Phase E)
+- #564 `except Exception: pass` in CWD-handler test is the root cause of
+  the historical repo-root MagicMock junk
+
+**Performance (hook hot paths & N+1):**
+- #559 SpecDriftValidator runs 3 git subprocesses on EVERY Edit/Write
+- #550 N+1 `gh pr list` per ticket in release collect_prs
+- #561 sequential awaits in review-comment multi-fetch
+
+**Architecture / consistency:**
+- #529 Extract SessionService (Service Layer for session hooks)
+- #533 Result[T] adoption stops at the most-called domain helpers
+- #536 19 ad-hoc config-load sites bypass the canonical cached loader
+- #541 permission.py repeats 8× command boilerplate; #543 tool-name
+  dispatch duplicated across 4 modules
+- #508 `mcp__` tool-name identity parsed by 3 incompatible regexes + 5
+  ad-hoc checks (Value Object candidate)
+- #513 #515 ADR-0007 D3 violations — `PolicyRule.apply()` doing file I/O
+
+**Test coverage (Phase G — all HIGH):**
+- #547 PR-lifecycle skills, #553 fanout/worktree, #556 MCP
+  audit/plan tools, #560 work-on pipeline, #563 daemon lifecycle.
+  Together ≈46% of the last 200 merged PRs ship into these areas
+  with thin-or-no coverage.
+
+## Dead code: verified results
+
+Vulture reported 186 candidates at ≥60% confidence; after repo-wide
+verification agents confirmed the overwhelming majority are FALSE
+POSITIVES (click decorators, FastMCP `@server.tool` surface, validator
+string-registry, hook orchestrator imports). Genuinely dead and filed:
+
+- #500 github `_clear_cache` (test-only)
+- #504 domain: 11 dead members + borderline field
+- #512 runtime: 2 items incl. dual-impl drift `task_plan_sync.read_plan`
+- #519 commands: `STARTER_GITMOJI_YAML`, `parse_json_output`
+- #540 skills: ~9 fully-tested modules with ZERO production callers
+  ("wire or remove" — same class as ADR-0010's `batch_find_prs`)
+- #545 assets: `bin/skill-audit-counts.py`, unwired
+  `session-start-reload.py` shim
+- #569 tests: dead faker fixtures
+- #501 mcp: daemon/session_store stack is unwired forward-compat infra
+  (roadmap #338 never landed)
+
+## Clean bills of health
+
+- MCP boundary: every `@server.tool` unwraps `Result[T]` via
+  `.to_dict()` (ADR-0009) — zero violations found
+- CWD discipline (GH-979): no bare `subprocess.run`/`os.getcwd`/
+  module-scope `GitContext()` in long-lived paths
+- hooks.json wiring: all 8 entries audit-wrapped, direct-shebang,
+  no `uv run --project` anti-pattern
+- LazyGroup CLI startup discipline intact; validator registry
+  DX001–DX015 consistent with docs; ADR-0011 GH-240 fixes all present
+- Test suite collects cleanly: 3896 tests, no orphaned files
+- Dependency directions clean: no domain→commands, no FastMCP wire
+  types outside mcp/
+
+## Suggested execution order
+
+1. **Safety first:** #494, #532, #555, #548, #544, #496 (fail-open,
+   crash, and data-loss classes)
+2. **Hot-path performance:** #559 (every Edit/Write pays it), #550, #561
+3. **Dead-code removals:** low-risk, shrink the surface before refactors
+   (#500 #504 #512 #519 #540 #545)
+4. **Consistency refactors:** #536, #533, #543, #541, #508 (each reduces
+   the cost of everything after it)
+5. **Coverage debt:** #556 (S effort, highest ROI per Phase G), then
+   #547, #553, #560, #563
+6. **Naming/vocabulary:** pattern-naming issues (#516 #522 #526) and
+   remaining MEDIUM/LOW bundles
+
+## Process notes
+
+- The Phase 2 selection gate and Phase 4 synthesis gate were skipped:
+  the user explicitly pre-selected the full scope (all phases +
+  dead code + per-package milestones + agent-filed issues) in the
+  invocation, and agents filed issues directly per that instruction.
+- Each agent capped issue count (5–10) and bundled LOW findings to
+  keep the backlog actionable; per-finding evidence lives in the
+  issue bodies under a Verification section.
+- Findings are static-analysis based; agents flagged their own
+  uncertainty in issue bodies — confirm "no production caller" claims
+  before deleting (especially #540, #505, #528).

--- a/references/milestone-naming.md
+++ b/references/milestone-naming.md
@@ -46,6 +46,7 @@ MCP-M6: Installable GitHub bot/Action
 |--------|-----------|--------|
 | `AUD` | Architecture audit series (2026-05-18) | closed (archived) |
 | `MCP` | MCP knowledge primitives roadmap | active |
+| `PKG` | Per-package architecture & code-review audit (2026-06-10) | active |
 
 When starting a new initiative that spans multiple milestones, register
 its prefix here before creating the first milestone. Pick a prefix that


### PR DESCRIPTION
**When** a second full audit pass runs the same day its predecessor filed a 77-issue backlog, **I want to** persist the deduplicated verification memo in repo history, **so I can** trust the #494–#570 backlog, trace the 19 new issues (#571–#588) to their evidence, and keep the two clean-bill corrections from getting lost.

---

[`be530464`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/589/commits/be530464288879a30c4c95bbf1bccbe9dbaf6ee9) 📝 Persist 2026-06-10 per-package audit memo
[`635caf61`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/589/commits/635caf612b6126809d4bb17391a3e386f2ad10d4) 📝 Record 2026-06-10 A–I audit verification memo

Fixes: none — self-motivated
