### PR TITLE
✅ GH-614 Strengthen PAP fixture corpus via evidence triage

### DIFF
--- a/tests/fixtures/permission-friction/README.md
+++ b/tests/fixtures/permission-friction/README.md
@@ -71,8 +71,16 @@ gh api repos/Dev10x-Guru/Dev10x-Claude/issues/271/comments --paginate \
   tests/fixtures/permission-friction
 ```
 
-Current counts: 315 evidence entries → 51 no-command notes, 91 with both
-effect & class (69 "clean" / 22 incoherent per the parser), 173
-unclassified. The classified `<class>.yaml` files are the hand-verified
-subset; `unclassified.yaml` + the remaining candidates await triage (see
-`docs/specs/GH-271-phase0-handoff.md`).
+Current counts: 315 evidence entries → 51 no-command notes, then split
+into **74 hand-verified classified rows** across the five `<class>.yaml`
+files and a **166-row `unclassified.yaml` triage backlog**.
+
+History: PR #613 shipped the initial 39-row seed (Phase 0). The Phase 0.1
+follow-up (#614) promoted 35 more rows — 28 from the parser candidate set
+(correcting the 22 incoherent "suspect" tags and collapsing `<run-id>`/
+path duplicates) and 7 clean shapes pulled out of the backlog. The
+remaining backlog rows are intentionally unpromoted: duplicates of
+shapes already classified, path-form / prefix-shift friction patterns
+(not effect/class cases), or chained/sensitive commands. The backlog is
+a feature, not a gap — a correct ~75-row corpus beats a noisy 315-row
+one. See `docs/specs/GH-271-phase0-handoff.md` for the triage spec.

--- a/tests/fixtures/permission-friction/arbitrary-code.yaml
+++ b/tests/fixtures/permission-friction/arbitrary-code.yaml
@@ -67,3 +67,15 @@ rows:
       is especially dangerous (fetch-and-exec, data exfil) — broad `ask`,
       forbid the catch-all. The catalog allows only `curl -fsSL`/`-s*`
       read forms.
+
+  - id: "#59"
+    command: "python3 -m json.tool <file> > /dev/null"
+    tool: Bash
+    friction: null
+    effect: deny
+    reversibility: none
+    rule: "Bash(python3 -m:*)"
+    notes: >
+      `python3 -m <module>` runs arbitrary Python — same tier as `-c`. For
+      JSON validation the structured alternative is `jq empty <file>`;
+      forbid the inline-module shape.

--- a/tests/fixtures/permission-friction/destructive.yaml
+++ b/tests/fixtures/permission-friction/destructive.yaml
@@ -108,3 +108,63 @@ rows:
     notes: >
       Privilege-escalated recursive delete. Privilege-escalation tier is
       denied for any shape; `rm -rf` is irreversible → deny/none.
+
+  - id: "#1"
+    command: "gh run cancel <run-id> --repo <org>/<repo>"
+    tool: Bash
+    friction: null
+    effect: ask
+    reversibility: assisted
+    rule: "Bash(gh run cancel:*)"
+    notes: >
+      Cancels a CI run (re-runnable → assisted). Catalog enumerates
+      `gh run view/list/watch` as allow but NOT `cancel`/`rerun`/`delete`
+      → ask. Re-derived from extractor `destructive`+`allow` (incoherent).
+
+  - id: "#32"
+    command: 'gh pr close <pr> --comment "<rationale>"'
+    tool: Bash
+    friction: null
+    effect: ask
+    reversibility: assisted
+    rule: "Bash(gh pr close:*)"
+    notes: >
+      Closes a PR (shared state), reversible via reopen → assisted.
+      Re-derived from extractor `fence-tool`. (#318 `gh pr close
+      --delete-branch` is the same verb plus a branch delete — still ask.)
+
+  - id: "#43"
+    command: "git rebase --onto origin/develop <upstream> <branch>"
+    tool: Bash
+    friction: permission-prompt
+    effect: ask
+    reversibility: assisted
+    rule: "Bash(git rebase:*)"
+    notes: >
+      Rewrites history; reachable via reflog → assisted. Re-derived from
+      extractor's wrong `Bash(git push --force:*)` rule (this is a rebase,
+      not a force-push).
+
+  - id: "#201"
+    command: "rm -f <worktree>/.coverage <worktree>/.coverage.*"
+    tool: Bash
+    friction: hook-block
+    effect: ask
+    reversibility: trivial
+    rule: "Bash(rm:*)"
+    notes: >
+      Deletes generated coverage artifacts (regenerable by re-running
+      tests → trivial). `rm` is destructive class → never allow → ask.
+      Re-derived from extractor `destructive`+`allow` (incoherent).
+
+  - id: "#261"
+    command: "gh workflow run <workflow>.yml --repo <org>/<repo> --ref <branch>"
+    tool: Bash
+    friction: null
+    effect: ask
+    reversibility: assisted
+    rule: "Bash(gh workflow run:*)"
+    notes: >
+      Triggers CI workflow execution — not read-only; cancellable →
+      assisted. New `gh workflow` subcommand family, not in catalog.
+      (#309 is the identical command — collapsed into this canonical row.)

--- a/tests/fixtures/permission-friction/fence-tool.yaml
+++ b/tests/fixtures/permission-friction/fence-tool.yaml
@@ -87,3 +87,71 @@ rows:
     reversibility: assisted
     rule: "Bash(uv run *)"
     notes: Same shape as #200 with `--directory`; migration write → ask.
+
+  - id: "#31"
+    command: "npx vercel inspect <deployment-id> --logs"
+    tool: Bash
+    friction: permission-prompt
+    effect: ask
+    reversibility: none
+    rule: "Bash(npx:*)"
+    notes: >
+      `npx` fetches+executes a package — fence-tool broad ask. Read intent
+      (`inspect --logs`) does not launder the npx surface.
+
+  - id: "#146"
+    command: "uvx dev10x permission --help"
+    tool: Bash
+    friction: null
+    effect: ask
+    reversibility: none
+    rule: "Bash(uvx dev10x:*)"
+    notes: >
+      `uvx` is a fence-tool (ephemeral install + run). Option-2 here kept
+      the subcommand `Bash(uvx dev10x *)` rather than stripping to
+      `Bash(uvx *)`; the `dev10x`-scoped form is the narrow ask.
+
+  - id: "#157"
+    command: "uv run --directory apps/api lint-imports"
+    tool: Bash
+    friction: null
+    effect: ask
+    reversibility: none
+    rule: "Bash(uv run *)"
+    notes: "`uv run <tool>` is a fence-tool surface → broad ask."
+
+  - id: "#168"
+    command: "npm install"
+    tool: Bash
+    friction: null
+    effect: ask
+    reversibility: assisted
+    rule: "Bash(npm install:*)"
+    notes: >
+      Installs deps and runs lifecycle scripts (arbitrary downstream) →
+      fence-tool ask. Project policy prefers `pnpm`; lockfile changes are
+      assisted-reversible.
+
+  - id: "#274"
+    command: "DJANGO_SETTINGS_MODULE=<mod> uv run python manage.py check --deploy --fail-level ERROR"
+    tool: Bash
+    friction: hook-block
+    effect: ask
+    reversibility: none
+    rule: "Bash(uv run *)"
+    notes: >
+      `manage.py check` is read-only, but it runs behind the `uv run`
+      fence + an env-var prefix (which itself shifts the allow prefix) →
+      ask. Re-derived from extractor `arbitrary-code`+`allow`.
+
+  - id: "#277"
+    command: "uv add --project apps/e2e <package>"
+    tool: Bash
+    friction: null
+    effect: ask
+    reversibility: assisted
+    rule: "Bash(uv add:*)"
+    notes: >
+      `uv add` resolves+installs a dependency and edits pyproject/lock
+      (assisted-reversible) → fence-tool ask. Re-derived from extractor
+      `arbitrary-code`+`allow`.

--- a/tests/fixtures/permission-friction/safe-read.yaml
+++ b/tests/fixtures/permission-friction/safe-read.yaml
@@ -140,3 +140,220 @@ rows:
     notes: >
       Read tool — effect allow. Re-derived from the extractor's `deny`,
       which was wrong for a read.
+
+  - id: "#19"
+    command: "jq -r '<filter>' <file> | sort -t$'\\t' -k2"
+    tool: Bash
+    friction: null
+    effect: allow
+    reversibility: trivial
+    rule: "Bash(jq:*)"
+    notes: >
+      `jq` is the endorsed read-only structured JSON tool; piping to
+      `sort` stays read-only. Re-derived from extractor `arbitrary-code`
+      (wrong — jq is a safe alternative, not arbitrary code).
+
+  - id: "#53"
+    command: "Read(<repo>/.github/workflows/<file>.yml · lines 1-100)"
+    tool: Read
+    friction: option-2-footgun
+    effect: allow
+    reversibility: trivial
+    rule: null
+    notes: >
+      Read tool, range read — never mutates. Re-derived from extractor
+      `destructive`. The friction was the session-only option-2 accept.
+
+  - id: "#75"
+    command: 'mcp__claude_ai_Slack__slack_search_users(query, limit)'
+    tool: mcp__claude_ai_Slack__slack_search_users
+    friction: permission-prompt
+    effect: allow
+    reversibility: trivial
+    rule: "mcp__claude_ai_Slack__slack_search_users"
+    notes: Search/enumeration is read-only.
+
+  - id: "#90"
+    command: 'mcp__claude_ai_Sentry__get_sentry_resource(url)'
+    tool: mcp__claude_ai_Sentry__get_sentry_resource
+    friction: permission-prompt
+    effect: allow
+    reversibility: trivial
+    rule: "mcp__claude_ai_Sentry__get_sentry_resource"
+    notes: >
+      Fetches a Sentry resource by URL — read-only. Re-derived from the
+      extractor's `destructive` (wrong for a getter).
+
+  - id: "#101"
+    command: "bash -n <script> && shellcheck <script>"
+    tool: Bash
+    friction: option-2-footgun
+    effect: allow
+    reversibility: trivial
+    rule: "Bash(bash -n:*)"
+    notes: >
+      `bash -n` is a syntax check — it does NOT execute the script (no
+      `-c`); `shellcheck` is lint-only. Distinct from arbitrary-code
+      `bash <script>` (#72/#307).
+
+  - id: "#142"
+    command: "dev10x --help"
+    tool: Bash
+    friction: null
+    effect: allow
+    reversibility: trivial
+    rule: "Bash(dev10x --help)"
+    notes: Help output — read-only.
+
+  - id: "#165"
+    command: 'WebFetch(url: "http://api.nbp.pl/api/exchangerates/rates/a/usd/<date>/?format=json")'
+    tool: WebFetch
+    friction: null
+    effect: allow
+    reversibility: trivial
+    rule: "WebFetch(domain:api.nbp.pl)"
+    notes: Public exchange-rate API GET — read-only content.
+
+  - id: "#180"
+    command: "<venv>/bin/python --version"
+    tool: Bash
+    friction: null
+    effect: allow
+    reversibility: trivial
+    rule: "Bash(python --version)"
+    notes: >
+      Version probe. Re-derived from extractor `safe-write` — `--version`
+      mutates nothing.
+
+  - id: "#206"
+    command: "git clean -nd"
+    tool: Bash
+    friction: null
+    effect: allow
+    reversibility: trivial
+    rule: "Bash(git clean -n:*)"
+    notes: >
+      `-n` is a DRY RUN — lists what would be removed, deletes nothing.
+      Read-only despite the `git clean` verb. (#252 is the same `-n`
+      dry-run shape with a MagicMock junk-file arg.)
+
+  - id: "#262"
+    command: 'find <root> -type f -name "*.py" -exec grep -l "<pattern>" {} \;'
+    tool: Bash
+    friction: null
+    effect: allow
+    reversibility: trivial
+    rule: "Bash(find:*)"
+    notes: >
+      `find -exec grep -l` is a read-only search. Re-derived from
+      extractor `arbitrary-code`. Distinct from destructive `find -delete`
+      (#66).
+
+  - id: "#271"
+    command: "dig +short <rds-endpoint>"
+    tool: Bash
+    friction: null
+    effect: allow
+    reversibility: trivial
+    rule: "Bash(dig:*)"
+    notes: >
+      DNS resolution only — read-only, no DB connection. Re-derived from
+      extractor `destructive`.
+
+  - id: "#275"
+    command: 'find / -path "<pattern>" 2>/dev/null | head -1'
+    tool: Bash
+    friction: null
+    effect: allow
+    reversibility: trivial
+    rule: "Bash(find:*)"
+    notes: >
+      Read-only path search. Re-derived from extractor `safe-write`.
+      (#285 `find / -iname SKILL.md -path "*deep-research*"` is the same
+      read-only find shape.)
+
+  - id: "#299"
+    command: "ls <dir1> <dir2>"
+    tool: Bash
+    friction: null
+    effect: allow
+    reversibility: trivial
+    rule: "Bash(ls:*)"
+    notes: Directory listing — read-only.
+
+  - id: "#300"
+    command: "aws-vault list"
+    tool: Bash
+    friction: null
+    effect: allow
+    reversibility: trivial
+    rule: "Bash(aws-vault list:*)"
+    notes: >
+      Lists configured profiles/sessions — read-only. Re-derived from
+      extractor `arbitrary-code`.
+
+  - id: "#303"
+    command: "aws-vault exec <profile> -- aws sts get-caller-identity"
+    tool: Bash
+    friction: null
+    effect: allow
+    reversibility: trivial
+    rule: "Bash(aws-vault exec:*)"
+    notes: >
+      The concrete sub-command (`sts get-caller-identity`) is a read-only
+      identity probe. NB: `aws-vault exec <p> -- <anything>` is a broad
+      exec surface; the narrow allow is the read sub-form.
+
+  - id: "#2"
+    command: 'rg -rn "<pattern>" /work/<org>'
+    tool: Bash
+    friction: permission-prompt
+    effect: allow
+    reversibility: trivial
+    rule: "Bash(rg:*)"
+    notes: >
+      `rg` (ripgrep) is the endorsed read-only search tool. Friction was a
+      workspace-boundary gap (parent `/work/<org>` not registered), not the
+      verb — `rg` itself never mutates.
+
+  - id: "#308"
+    command: 'grep -rE "<pattern>" src/<path>/'
+    tool: Bash
+    friction: null
+    effect: allow
+    reversibility: trivial
+    rule: "Bash(grep:*)"
+    notes: Recursive content search — read-only.
+
+  - id: "#169"
+    command: "du -sh <dir1> <dir2> <dir3>"
+    tool: Bash
+    friction: null
+    effect: allow
+    reversibility: trivial
+    rule: "Bash(du:*)"
+    notes: Disk-usage report — read-only.
+
+  - id: "#96"
+    command: 'mcp__claude_ai_Sentry__search_issues(organizationSlug, query, limit)'
+    tool: mcp__claude_ai_Sentry__search_issues
+    friction: null
+    effect: allow
+    reversibility: trivial
+    rule: "mcp__claude_ai_Sentry__search_issues"
+    notes: >
+      Sentry issue search — read-only. (Sibling read tools
+      `find_organizations`/`search_issue_events`/`get_sentry_resource`
+      share this shape; see #90 for the getter.)
+
+  - id: "#150"
+    command: 'mcp__claude_ai_Linear__get_issue(id, includeRelations: true)'
+    tool: mcp__claude_ai_Linear__get_issue
+    friction: permission-prompt
+    effect: allow
+    reversibility: trivial
+    rule: "mcp__claude_ai_Linear__get_issue"
+    notes: >
+      Linear issue read — never mutates. Prompted despite a present rule
+      (enumerated-tool gap). Sibling `list_comments` (#148) is the same
+      read shape.

--- a/tests/fixtures/permission-friction/safe-write.yaml
+++ b/tests/fixtures/permission-friction/safe-write.yaml
@@ -62,3 +62,38 @@ rows:
     notes: >
       Headless screenshot writes one file locally. Browser automation is
       broad enough to warrant ask rather than a blanket allow.
+
+  - id: "#70"
+    command: 'mcp__claude_ai_Google_Calendar__create_event(summary, startTime, ...)'
+    tool: mcp__claude_ai_Google_Calendar__create_event
+    friction: permission-prompt
+    effect: ask
+    reversibility: trivial
+    rule: "mcp__claude_ai_Google_Calendar__create_event"
+    notes: >
+      Writes an external calendar event, trivially reversible (delete).
+      External-state write → ask. Re-derived from extractor `destructive`.
+
+  - id: "#178"
+    command: "sed -i 's|<old>|<new>|g' .idea/workspace.xml"
+    tool: Bash
+    friction: permission-prompt
+    effect: ask
+    reversibility: trivial
+    rule: "Bash(sed -i:*)"
+    notes: >
+      `sed -i` edits a local file in place (reversible via git). Prefer
+      the Edit tool; the in-place mutation warrants ask. Re-derived from
+      extractor `destructive`+`allow` (incoherent).
+
+  - id: "#145"
+    command: "mktemp /tmp/gh-issue-body-XXXXXX.md"
+    tool: Bash
+    friction: null
+    effect: allow
+    reversibility: trivial
+    rule: "Bash(mktemp:*)"
+    notes: >
+      Creates a temp file under /tmp — local, trivially reversible. Prefer
+      the Dev10x `mktmp` MCP wrapper (scoped, audited); raw `mktemp` is the
+      friction signal, not a risk.

--- a/tests/fixtures/permission-friction/unclassified.yaml
+++ b/tests/fixtures/permission-friction/unclassified.yaml
@@ -11,12 +11,6 @@
 command_class: null
 status: triage-backlog
 rows:
-- id: '#2'
-  command: rg -rn "<pattern>|<pattern2>" /work/<org>
-  tool: Bash
-  notes: Session has `additionalDirectories` registered for each individual sibling
-    repo (`/work/<org>/<repo-a>`, `/work/<org>/<repo-b>`, …) but **not** the shared
-    parent `/work/<org>`.
 - id: '#4'
   command: grep -rln "<pattern>" /work/<org>/ --include="*.yml" --include="*.yaml"
     2>/dev/null | head -20
@@ -194,12 +188,6 @@ rows:
   command: ls -la /home/janusz/.claude/plans/ 2>/dev/null | head -20
   tool: Bash
   notes: ls -la /home/janusz/.claude/plans/ 2>/dev/null | head -20
-- id: '#59'
-  command: python3 -m json.tool skills/work-on/evals/evals.json > /dev/null && echo
-    "JSON OK"
-  tool: Bash
-  notes: python3 -m json.tool skills/work-on/evals/evals.json > /dev/null && echo
-    "JSON OK"
 - id: '#60'
   command: bin/render-worktree-config.sh
   tool: Bash
@@ -321,12 +309,6 @@ rows:
   tool: Bash
   notes: aws-vault exec production -- kubectl --context production -n blue get deploy
     2>&1 | head -40
-- id: '#96'
-  command: 'mcp__claude_ai_Sentry__search_issues(organizationSlug: "...", query: "...",
-    limit: 10)'
-  tool: mcp__claude_ai_Sentry__search_issues
-  notes: 'mcp__claude_ai_Sentry__search_issues(organizationSlug: "...", query: "...",
-    limit: 10)'
 - id: '#97'
   command: aws-vault exec production -- kubectl --context production -n blue get rs
     -l app=<name> 2>&1 | head -20
@@ -529,10 +511,6 @@ rows:
   tool: null
   notes: /home/janusz/.claude/plugins/cache/Dev10x-Guru/Dev10x/0.74.0/skills/slack-review-request/scripts/slack-review-request.py
     prepare --pr <N> --repo <org>/<repo>
-- id: '#145'
-  command: mktemp /tmp/gh-issue-body-XXXXXX.md
-  tool: Bash
-  notes: raw `mktemp` is worse than the Dev10x script
 - id: '#147'
   command: gh api graphql -f query='...reviewThreads(first:100){nodes{isResolved}}...'
     ... -F number=305 --jq '[...]'
@@ -549,11 +527,6 @@ rows:
     → Error: No such option ''--summary''.'
   tool: null
   notes: uvx dev10x permission ensure-base --dry-run --summary
-- id: '#150'
-  command: 'mcp__claude_ai_Linear__get_issue(id: "PAY-252", includeRelations: true)'
-  tool: mcp__claude_ai_Linear__get_issue
-  notes: 'enumerated Linear tools (#148 list_comments, #150 get_issue) prompt while
-    the rule is present.'
 - id: '#151'
   command: grep -rl '"mcp__plugin_Dev10x_*"' /home/janusz/.claude/... /work/<org>
     /work/<org> /work/dx /work/wooyek --include=settings.local.json --include=settings.json
@@ -618,11 +591,6 @@ rows:
   tool: null
   notes: command -v shellcheck >/dev/null && shellcheck bin/release.sh || echo "shellcheck
     not installed - skipping"
-- id: '#169'
-  command: du -sh /work/krysmiau/Challengers-website/docs /work/krysmiau/Challengers-website/LOGO\  /work/krysmiau/Challengers-website/public
-  tool: null
-  notes: du -sh /work/krysmiau/Challengers-website/docs /work/krysmiau/Challengers-website/LOGO\
-    /work/krysmiau/Challengers-website/public
 - id: '#170'
   command: mkdir -p /work/krysmiau/Challengers-website/.claude/Dev10x
   tool: null
@@ -918,10 +886,6 @@ rows:
   command: git -P log --oneline origin/main -15
   tool: Bash
   notes: git -P log --oneline origin/main -15
-- id: '#308'
-  command: grep -rE "(bash|sh|zsh)" src/dev10x/validators/
-  tool: Bash
-  notes: '"should''ve been covered long ago"'
 - id: '#310'
   command: "mcp__claude_ai_Slack__slack_list_channel_members(channel_id=\"<channel-id>\"\
     ,\n  response_format=\"concise\")"


### PR DESCRIPTION
**When** GH-271's permission-friction evidence is being turned into a PAP classifier test corpus, **I want to** promote the unambiguous rows from the triage backlog and the parser-candidate set into the typed fixtures, **so I can** test the future classifier against more correctly-classified real commands — without fabricating labels for the genuinely ambiguous remainder.

---

[`dea78231`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/615/commits/dea782310a764ce250b475a737fa1bcceaad1845) ✅ GH-614 Strengthen PAP fixture corpus via evidence triage
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/614

---