### PR TITLE
✅ GH-616 Align permission fixtures with maintainer policy

### DIFF
--- a/tests/fixtures/permission-friction/arbitrary-code.yaml
+++ b/tests/fixtures/permission-friction/arbitrary-code.yaml
@@ -79,3 +79,16 @@ rows:
       `python3 -m <module>` runs arbitrary Python — same tier as `-c`. For
       JSON validation the structured alternative is `jq empty <file>`;
       forbid the inline-module shape.
+
+  - id: "#180"
+    command: "<venv>/bin/python --version"
+    tool: Bash
+    friction: null
+    effect: deny
+    reversibility: none
+    rule: "Bash(<venv>/bin/python:*)"
+    notes: >
+      Invoking the venv interpreter directly bypasses the `uv` environment
+      fence (lockfile, resolved env). Use `uv run python` instead. Deny the
+      direct-binary shape even for `--version`. (Maintainer-directed
+      reclassification, GH-616.)

--- a/tests/fixtures/permission-friction/destructive.yaml
+++ b/tests/fixtures/permission-friction/destructive.yaml
@@ -133,18 +133,6 @@ rows:
       Re-derived from extractor `fence-tool`. (#318 `gh pr close
       --delete-branch` is the same verb plus a branch delete — still ask.)
 
-  - id: "#43"
-    command: "git rebase --onto origin/develop <upstream> <branch>"
-    tool: Bash
-    friction: permission-prompt
-    effect: ask
-    reversibility: assisted
-    rule: "Bash(git rebase:*)"
-    notes: >
-      Rewrites history; reachable via reflog → assisted. Re-derived from
-      extractor's wrong `Bash(git push --force:*)` rule (this is a rebase,
-      not a force-push).
-
   - id: "#201"
     command: "rm -f <worktree>/.coverage <worktree>/.coverage.*"
     tool: Bash

--- a/tests/fixtures/permission-friction/fence-tool.yaml
+++ b/tests/fixtures/permission-friction/fence-tool.yaml
@@ -60,13 +60,14 @@ rows:
     command: "DJANGO_SETTINGS_MODULE=<mod> uv run python manage.py makemigrations <app>"
     tool: Bash
     friction: null
-    effect: ask
+    effect: deny
     reversibility: assisted
-    rule: "Bash(uv run *)"
+    rule: "Bash(DJANGO_SETTINGS_MODULE=:*)"
     notes: >
-      `uv run` fence-tool + env-var prefix (which itself shifts the
-      allow-rule prefix). makemigrations writes a migration file
-      (assisted-reversible) → ask.
+      Manually injecting `DJANGO_SETTINGS_MODULE=` is an anti-pattern: the
+      project should detect its own run mode (its settings/env), not have
+      the agent force the settings module. Deny the env-prefix form to
+      push the correct invocation. (Maintainer-directed, GH-616.)
 
   - id: "#233"
     command: "uv run --with pytest pytest <test>"
@@ -92,24 +93,27 @@ rows:
     command: "npx vercel inspect <deployment-id> --logs"
     tool: Bash
     friction: permission-prompt
-    effect: ask
-    reversibility: none
-    rule: "Bash(npx:*)"
+    effect: allow
+    reversibility: trivial
+    rule: "Bash(npx vercel inspect:*)"
     notes: >
-      `npx` fetches+executes a package — fence-tool broad ask. Read intent
-      (`inspect --logs`) does not launder the npx surface.
+      `npx vercel inspect --logs` is a read-only deployment inspection.
+      Narrow allow on the specific read sub-form (same pattern as
+      `railway --version` #225); bare `npx *` stays ask. (Maintainer-
+      directed reclassification, GH-616.)
 
   - id: "#146"
     command: "uvx dev10x permission --help"
     tool: Bash
     friction: null
-    effect: ask
-    reversibility: none
+    effect: allow
+    reversibility: trivial
     rule: "Bash(uvx dev10x:*)"
     notes: >
-      `uvx` is a fence-tool (ephemeral install + run). Option-2 here kept
-      the subcommand `Bash(uvx dev10x *)` rather than stripping to
-      `Bash(uvx *)`; the `dev10x`-scoped form is the narrow ask.
+      `dev10x` is the project's OWN trusted CLI — `uvx dev10x <anything>`
+      is not arbitrary downstream code, so the whole family is allowed via
+      the narrow `Bash(uvx dev10x:*)` rule. Bare `uvx *` / `npx *` stay
+      ask. (Maintainer-directed reclassification, GH-616.)
 
   - id: "#157"
     command: "uv run --directory apps/api lint-imports"
@@ -136,13 +140,14 @@ rows:
     command: "DJANGO_SETTINGS_MODULE=<mod> uv run python manage.py check --deploy --fail-level ERROR"
     tool: Bash
     friction: hook-block
-    effect: ask
+    effect: deny
     reversibility: none
-    rule: "Bash(uv run *)"
+    rule: "Bash(DJANGO_SETTINGS_MODULE=:*)"
     notes: >
-      `manage.py check` is read-only, but it runs behind the `uv run`
-      fence + an env-var prefix (which itself shifts the allow prefix) →
-      ask. Re-derived from extractor `arbitrary-code`+`allow`.
+      Same anti-pattern as #200: a manual `DJANGO_SETTINGS_MODULE=` prefix
+      forces the run mode the project should detect itself. Deny the
+      env-prefix form even for the read-only `check` verb. (Maintainer-
+      directed, GH-616.)
 
   - id: "#277"
     command: "uv add --project apps/e2e <package>"

--- a/tests/fixtures/permission-friction/safe-read.yaml
+++ b/tests/fixtures/permission-friction/safe-read.yaml
@@ -214,17 +214,6 @@ rows:
     rule: "WebFetch(domain:api.nbp.pl)"
     notes: Public exchange-rate API GET — read-only content.
 
-  - id: "#180"
-    command: "<venv>/bin/python --version"
-    tool: Bash
-    friction: null
-    effect: allow
-    reversibility: trivial
-    rule: "Bash(python --version)"
-    notes: >
-      Version probe. Re-derived from extractor `safe-write` — `--version`
-      mutates nothing.
-
   - id: "#206"
     command: "git clean -nd"
     tool: Bash

--- a/tests/fixtures/permission-friction/safe-write.yaml
+++ b/tests/fixtures/permission-friction/safe-write.yaml
@@ -92,8 +92,23 @@ rows:
     friction: null
     effect: allow
     reversibility: trivial
-    rule: "Bash(mktemp:*)"
+    rule: "Bash(mktmp:*)"
     notes: >
       Creates a temp file under /tmp — local, trivially reversible. Prefer
-      the Dev10x `mktmp` MCP wrapper (scoped, audited); raw `mktemp` is the
+      the Dev10x `mktmp` MCP wrapper (scoped, audited); raw `mktmp` is the
       friction signal, not a risk.
+
+  - id: "#43"
+    command: "git rebase --onto origin/develop <upstream> <branch>"
+    tool: Bash
+    friction: permission-prompt
+    effect: allow
+    reversibility: assisted
+    rule: "Bash(git rebase --onto origin/develop:*)"
+    notes: >
+      Rebasing a local feature branch onto a known-good remote base only
+      rewrites LOCAL branch history — no shared/remote state, no
+      force-push — and is reflog-recoverable. Routine, expected op → allow.
+      Distinct from the INTERACTIVE forms #30/#46 (`rebase -i` /
+      `--continue`), which keep `destructive`/`ask`. (Maintainer-directed
+      reclassification, GH-616; revises reflection #43.)


### PR DESCRIPTION
**When** the maintainer spot-checks the Phase 0.1 fixture corpus (PR #615), **I want to** correct the six rows whose effect was set too conservatively or too liberally, **so I can** keep the PAP test corpus aligned with the maintainer's actual permission policy.

---

[`cff46a3b`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/617/commits/cff46a3b649a23faa75ffe412791df6fc0781496) ✅ GH-616 Align permission fixtures with maintainer policy
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/616

---