### PR TITLE
🥅 GH-555 Bound waits and atomic writes across shared-state files

### DIFF
--- a/docs/adr/0011-file-atomicity-and-locking-model.md
+++ b/docs/adr/0011-file-atomicity-and-locking-model.md
@@ -103,6 +103,18 @@ Implications:
   (e.g. write all changes to a staging dir, then rename a manifest
   pointer).
 
+**Two-pass narrowing (validate-then-write).**
+`MigratePluginPermissionsRule.apply` runs a dry-run pass first:
+`SettingsDocument.preview_replacements` reads and computes the
+migrated content for every targeted file *without writing*, so a
+parse failure (the common case — a hand-edited corrupt
+`settings.local.json`) is detected before any file is written. Only
+after every file's content is computed does the apply pass call
+`SettingsDocument.write_migrated` per file. This does not provide a
+true cross-file rollback, but it shrinks the inconsistency window to
+genuine write-time I/O errors (disk full, `EACCES`), which are far
+rarer than the parse failures the dry-run pass now catches up front.
+
 We accept this boundary because:
 
 1. The current call sites have natural retry semantics — the next

--- a/docs/adr/0011-file-atomicity-and-locking-model.md
+++ b/docs/adr/0011-file-atomicity-and-locking-model.md
@@ -63,6 +63,19 @@ arriving between `unlink` and the next `open(O_CREAT)` would receive a
 fresh inode and acquire an independent flock, breaking mutual
 exclusion.
 
+**Lock acquisition timeout.** `file_lock`, `locked_json_update`, and
+`locked_yaml_update` acquire the flock via non-blocking `LOCK_NB`
+attempts in a poll loop bounded by a `timeout` parameter (default
+`LOCK_TIMEOUT_SECONDS` = 10 s). On expiry they raise
+`LockTimeoutError` (a subclass of `OSError`) carrying an actionable
+"locked by another process — please try again" message. Without this
+guard, a holder wedged in an uninterruptible D-state on a network
+filesystem, or a `finally` block that raised before `LOCK_UN`, would
+block the caller — and, for the long-lived MCP daemon, its async event
+loop — indefinitely with no diagnostic. Callers that genuinely need an
+unbounded wait pass `timeout=0` to fall back to a single blocking
+`LOCK_EX`.
+
 ### Layer 3 — `locked_json_update` / `locked_yaml_update`
 
 Composite helpers that combine layers 1 and 2 in a single context
@@ -146,7 +159,9 @@ empirically for the known caller paths.
   re-execution on the next hook firing.
 - Lock contention is theoretically possible if a long-running
   operation holds `file_lock` on a hot path. In practice the
-  load → mutate → save cycles are sub-millisecond.
+  load → mutate → save cycles are sub-millisecond, and the
+  acquisition timeout (default 10 s) converts a wedged holder into a
+  surfaced `LockTimeoutError` rather than an indefinite hang.
 
 ### Migration
 

--- a/src/dev10x/audit/__init__.py
+++ b/src/dev10x/audit/__init__.py
@@ -21,6 +21,7 @@ from typing import Any
 from dev10x.audit.log_reader import iter_records, prune, summarize
 from dev10x.domain.claude_paths import ClaudeDir
 from dev10x.domain.common.result import Result, err, ok
+from dev10x.domain.file_locks import atomic_write_text
 from dev10x.subprocess_utils import async_run_script
 
 __all__ = [
@@ -117,7 +118,7 @@ async def analyze_permissions(
     output = report.render_markdown()
 
     if output_path:
-        Path(output_path).write_text(output)
+        atomic_write_text(Path(output_path), output)
         return ok({"success": True, "output": f"Phase 4 output written to {output_path}"})
 
     return ok({"success": True, "output": output.strip()})

--- a/src/dev10x/commands/init.py
+++ b/src/dev10x/commands/init.py
@@ -6,6 +6,7 @@ and prints a quick-start card covering the top 5 workflows.
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
@@ -74,10 +75,19 @@ def _session_yaml_template() -> str:
 
 
 def _write_if_missing(path: Path, content: str) -> bool:
-    if path.exists():
-        return False
+    # GH-562: claim the file atomically with O_EXCL instead of a
+    # check-then-write. Two concurrent `dev10x init` runs (CI matrix)
+    # otherwise both see the file absent and the second clobbers any
+    # interactive customization the first made.
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(content)
+    try:
+        fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+    except FileExistsError:
+        return False
+    try:
+        os.write(fd, content.encode("utf-8"))
+    finally:
+        os.close(fd)
     return True
 
 

--- a/src/dev10x/domain/documents/plan.py
+++ b/src/dev10x/domain/documents/plan.py
@@ -9,9 +9,7 @@ finding B1/B10) — load/save round-trip preserves all fields.
 from __future__ import annotations
 
 import json
-import os
 import re
-import tempfile
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -20,6 +18,7 @@ from typing import Any
 import yaml
 
 from dev10x.domain.documents.task import Task, TaskStatus
+from dev10x.domain.file_locks import atomic_write_text
 
 
 def _now_iso() -> str:
@@ -136,29 +135,13 @@ class Plan:
         )
 
     def save(self, *, path: Path) -> None:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        plan_data = self.to_dict()
-        fd, tmp_path = tempfile.mkstemp(
-            dir=str(path.parent),
-            prefix=".plan-",
-            suffix=".yaml.tmp",
+        content = yaml.dump(
+            self.to_dict(),
+            default_flow_style=False,
+            sort_keys=False,
+            allow_unicode=True,
         )
-        try:
-            with os.fdopen(fd, "w") as f:
-                yaml.dump(
-                    plan_data,
-                    f,
-                    default_flow_style=False,
-                    sort_keys=False,
-                    allow_unicode=True,
-                )
-            os.rename(tmp_path, str(path))
-        except Exception:
-            try:
-                os.unlink(tmp_path)
-            except OSError:
-                pass
-            raise
+        atomic_write_text(path, content)
 
     def to_dict(self) -> dict[str, Any]:
         result: dict[str, Any] = {}

--- a/src/dev10x/domain/documents/settings_document.py
+++ b/src/dev10x/domain/documents/settings_document.py
@@ -60,23 +60,58 @@ class SettingsDocument:
         so the caller can decide whether to skip the file.
         """
         with file_lock(self.path):
-            settings = json.loads(self.path.read_text())
-            permissions = settings.get("permissions", {})
-            migrated = 0
-            changed = False
-            for key in ("allow", "deny"):
-                raw = permissions.get(key, [])
-                if not raw:
-                    continue
-                new_rules, count = _migrate_rules(rules=raw, replacements=replacements)
-                new_rules = _deduplicate_rules(rules=new_rules)
-                migrated += count
-                if count:
-                    permissions[key] = new_rules
-                    changed = True
-            if changed:
-                atomic_write_text(self.path, json.dumps(settings, indent=2) + "\n")
+            new_content, migrated = self.preview_replacements(replacements=replacements)
+            if new_content is not None:
+                atomic_write_text(self.path, new_content)
         return migrated
+
+    def preview_replacements(
+        self, *, replacements: list[tuple[str, str]]
+    ) -> tuple[str | None, int]:
+        """Compute the migrated file content without writing it.
+
+        Returns ``(new_content, count)`` where ``new_content`` is the
+        serialised JSON to write, or ``None`` when nothing changed.
+        Raises ``json.JSONDecodeError`` / ``OSError`` on read/parse
+        failure so a multi-file caller can validate every file *before*
+        writing any of them (the dry-run pass of a two-pass migration,
+        ADR-0011 Layer 4).
+
+        This reads ``self.path`` WITHOUT holding ``file_lock``. The
+        two-pass migration in ``MigratePluginPermissionsRule`` tolerates
+        the read/write gap deliberately (the apply pass re-locks per
+        file). A caller that needs the preview to stay consistent with
+        the subsequent write MUST hold ``file_lock(self.path)`` across
+        both calls itself — ``apply_replacements`` is the locked
+        single-file path for that case.
+        """
+        settings = json.loads(self.path.read_text())
+        permissions = settings.get("permissions", {})
+        migrated = 0
+        changed = False
+        for key in ("allow", "deny"):
+            raw = permissions.get(key, [])
+            if not raw:
+                continue
+            new_rules, count = _migrate_rules(rules=raw, replacements=replacements)
+            new_rules = _deduplicate_rules(rules=new_rules)
+            migrated += count
+            if count:
+                permissions[key] = new_rules
+                changed = True
+        if not changed:
+            return None, migrated
+        return json.dumps(settings, indent=2) + "\n", migrated
+
+    def write_migrated(self, content: str) -> None:
+        """Atomically write precomputed migrated ``content`` under lock.
+
+        The apply pass of a two-pass migration: the content was already
+        computed and validated by :meth:`preview_replacements`, so the
+        only remaining failure mode is a write-time I/O error.
+        """
+        with file_lock(self.path):
+            atomic_write_text(self.path, content)
 
 
 __all__ = ["SettingsDocument", "_migrate_rules", "_deduplicate_rules"]

--- a/src/dev10x/domain/file_locks.py
+++ b/src/dev10x/domain/file_locks.py
@@ -40,6 +40,7 @@ import fcntl
 import json
 import os
 import tempfile
+import time
 from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
@@ -47,19 +48,65 @@ from typing import Any
 
 import yaml
 
+#: Default seconds to wait for an exclusive lock before giving up.
+LOCK_TIMEOUT_SECONDS = 10.0
+
+#: Poll interval while waiting on a contended lock.
+_LOCK_RETRY_INTERVAL = 0.05
+
+
+class LockTimeoutError(OSError):
+    """Raised when an exclusive file lock cannot be acquired in time.
+
+    Subclasses :class:`OSError` so existing ``except OSError`` handlers
+    still catch it, while call sites that want an actionable retry
+    message can match it specifically.
+    """
+
 
 def _lock_path_for(path: Path) -> Path:
     return path.with_suffix(path.suffix + ".lock") if path.suffix else path.with_suffix(".lock")
 
 
+def _acquire_exclusive(lock_fd: int, target: Path, timeout: float) -> None:
+    """Acquire an exclusive ``flock``, raising after ``timeout`` seconds.
+
+    Uses non-blocking ``LOCK_NB`` attempts in a poll loop so a crashed or
+    wedged lock-holder cannot freeze the caller (and, for the MCP daemon,
+    its async event loop) indefinitely. A non-positive ``timeout`` falls
+    back to a single blocking acquire — callers can opt out of the guard
+    when an unbounded wait is genuinely desired.
+    """
+    if timeout <= 0:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        return
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return
+        except BlockingIOError:
+            if time.monotonic() >= deadline:
+                raise LockTimeoutError(
+                    f"{target} is locked by another process — could not acquire "
+                    f"the lock within {timeout:g}s. Please try again."
+                ) from None
+            time.sleep(_LOCK_RETRY_INTERVAL)
+
+
 @contextmanager
-def file_lock(path: Path) -> Generator[None, None, None]:
+def file_lock(path: Path, *, timeout: float = LOCK_TIMEOUT_SECONDS) -> Generator[None, None, None]:
     """Acquire exclusive ``flock`` on ``<path>.lock`` for the duration.
 
     Sidecar naming follows the module convention: ``.lock`` is
     *appended* to the full target name via :func:`_lock_path_for`
     (e.g. ``plan.yaml`` → ``plan.yaml.lock``). See the module docstring
     for the reason this differs from :func:`locked_json_update`.
+
+    Raises :class:`LockTimeoutError` when the lock cannot be acquired
+    within ``timeout`` seconds (default :data:`LOCK_TIMEOUT_SECONDS`),
+    so a crashed or wedged holder cannot block the caller forever. Pass
+    ``timeout=0`` for the legacy unbounded blocking behaviour.
 
     The sidecar lock file is deliberately not unlinked on release.
     Unlinking is unsafe: a third writer arriving between ``unlink`` and
@@ -69,7 +116,7 @@ def file_lock(path: Path) -> Generator[None, None, None]:
     path.parent.mkdir(parents=True, exist_ok=True)
     lock_fd = os.open(str(_lock_path_for(path)), os.O_CREAT | os.O_RDWR)
     try:
-        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        _acquire_exclusive(lock_fd, path, timeout)
         yield
     finally:
         fcntl.flock(lock_fd, fcntl.LOCK_UN)
@@ -103,17 +150,22 @@ def atomic_write_text(path: Path, content: str) -> None:
 
 
 @contextmanager
-def locked_json_update(path: Path) -> Generator[dict[str, Any], None, None]:
+def locked_json_update(
+    path: Path, *, timeout: float = LOCK_TIMEOUT_SECONDS
+) -> Generator[dict[str, Any], None, None]:
     """Lock ``path``, yield its JSON content as a dict, atomically write back.
 
     Uses a ``.lock`` sidecar that replaces the path's suffix (e.g.
     ``settings.local.json`` → ``settings.local.lock``), preserving
     the historical naming used by the permission-skill call sites.
+
+    Raises :class:`LockTimeoutError` when the lock cannot be acquired
+    within ``timeout`` seconds. Pass ``timeout=0`` for unbounded waits.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     lock_fd = os.open(str(path.with_suffix(".lock")), os.O_CREAT | os.O_RDWR)
     try:
-        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        _acquire_exclusive(lock_fd, path, timeout)
         if path.exists():
             data = json.loads(path.read_text())
         else:
@@ -126,7 +178,9 @@ def locked_json_update(path: Path) -> Generator[dict[str, Any], None, None]:
 
 
 @contextmanager
-def locked_yaml_update(path: Path) -> Generator[dict[str, Any], None, None]:
+def locked_yaml_update(
+    path: Path, *, timeout: float = LOCK_TIMEOUT_SECONDS
+) -> Generator[dict[str, Any], None, None]:
     """Lock ``path``, yield its YAML content as a dict, atomically write back.
 
     Sidecar naming follows the module convention: ``.lock`` is
@@ -134,11 +188,14 @@ def locked_yaml_update(path: Path) -> Generator[dict[str, Any], None, None]:
     (e.g. ``plan.yaml`` → ``plan.yaml.lock``). See the module
     docstring for the reason this differs from
     :func:`locked_json_update`.
+
+    Raises :class:`LockTimeoutError` when the lock cannot be acquired
+    within ``timeout`` seconds. Pass ``timeout=0`` for unbounded waits.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     lock_fd = os.open(str(_lock_path_for(path)), os.O_CREAT | os.O_RDWR)
     try:
-        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        _acquire_exclusive(lock_fd, path, timeout)
         if path.exists():
             try:
                 data = yaml.safe_load(path.read_text()) or {}

--- a/src/dev10x/domain/install_version.py
+++ b/src/dev10x/domain/install_version.py
@@ -26,6 +26,7 @@ import yaml
 
 from dev10x.domain.common.result import Result, err, ok
 from dev10x.domain.dev10x_paths import Dev10xConfigDir
+from dev10x.domain.file_locks import atomic_write_text
 
 
 def read_plugin_version(*, plugin_root: Path | None = None) -> str | None:
@@ -78,10 +79,9 @@ def write_applied_version(
     Creates parent directories as needed. Returns the path written.
     """
     path = version_yaml or Dev10xConfigDir.version_yaml()
-    path.parent.mkdir(parents=True, exist_ok=True)
     timestamp = (now or datetime.now(UTC)).isoformat()
     payload = {"plugin_version": plugin_version, "upgraded_at": timestamp}
-    path.write_text(yaml.safe_dump(payload, sort_keys=True))
+    atomic_write_text(path, yaml.safe_dump(payload, sort_keys=True))
     return path
 
 

--- a/src/dev10x/hooks/session_policy.py
+++ b/src/dev10x/hooks/session_policy.py
@@ -139,19 +139,28 @@ class MigratePluginPermissionsRule(PolicyRule[tuple[int, list[str]]]):
             if f.exists()
         ]
 
-        total_migrated = 0
-        files_changed: list[str] = []
-
+        # Two-pass dry-run-then-apply (ADR-0011 Layer 4): compute and
+        # validate every file's migrated content before writing any of
+        # them. This keeps all parse/transform failures in the read pass
+        # so a corrupt file can no longer leave an already-written sibling
+        # mismatched. The only failure left in the write pass is a true
+        # I/O error, which we surface instead of swallowing.
+        planned: list[tuple[SettingsDocument, str, int]] = []
         for settings_file in settings_files:
+            doc = SettingsDocument(path=settings_file)
             try:
-                count = SettingsDocument(path=settings_file).apply_replacements(
-                    replacements=replacements
-                )
+                new_content, count = doc.preview_replacements(replacements=replacements)
             except (json.JSONDecodeError, OSError):
                 continue
-            if count:
-                total_migrated += count
-                files_changed.append(settings_file.name)
+            if count and new_content is not None:
+                planned.append((doc, new_content, count))
+
+        total_migrated = 0
+        files_changed: list[str] = []
+        for doc, new_content, count in planned:
+            doc.write_migrated(new_content)
+            total_migrated += count
+            files_changed.append(doc.path.name)
 
         return total_migrated, files_changed
 

--- a/src/dev10x/hooks/skill.py
+++ b/src/dev10x/hooks/skill.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import sys
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -74,8 +75,16 @@ def skill_metrics(data: dict | None = None) -> None:
 
     metrics_file = metrics_dir / f"{project_hash}_{date_tag}.jsonl"
     entry = json.dumps({"skill": skill_name, "session": session_id, "timestamp": timestamp})
-    with metrics_file.open("a") as f:
-        f.write(entry + "\n")
+    # GH-548: single os.write to an O_APPEND fd so concurrent hook
+    # processes never interleave partial JSON lines. TextIOWrapper may
+    # split one logical record across multiple syscalls, breaking the
+    # POSIX atomic-append guarantee. Mirrors audit/log_reader.append_record.
+    line = (entry + "\n").encode("utf-8")
+    fd = os.open(str(metrics_file), os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o644)
+    try:
+        os.write(fd, line)
+    finally:
+        os.close(fd)
 
     cutoff = now - timedelta(days=30)
     for old_file in metrics_dir.glob("*.jsonl"):

--- a/src/dev10x/mcp/roots_manager.py
+++ b/src/dev10x/mcp/roots_manager.py
@@ -183,6 +183,15 @@ class ClientRootsManager:
             return
         try:
             result = await session.list_roots()
+            if self._session is not session:
+                # GH-562: a concurrent set_session() detached or swapped
+                # the session at the await yield point. The roots we just
+                # fetched belong to a session that is no longer active —
+                # discard them rather than overwrite _roots with a ghost set.
+                log.debug(
+                    "ClientRootsManager: session changed during roots/list — discarding result"
+                )
+                return
             self._roots = [
                 ClientRoot(uri=str(r.uri), name=getattr(r, "name", None)) for r in result.roots
             ]

--- a/src/dev10x/mcp/session_store.py
+++ b/src/dev10x/mcp/session_store.py
@@ -200,20 +200,7 @@ class SessionStore:
             The :class:`SessionEntry` for this session ID.
         """
         with self._lock:
-            self._evict_expired_locked()
-            if session_id in self._sessions:
-                entry = self._sessions[session_id]
-                entry.touch()
-                return entry
-
-            # Enforce capacity limit: evict the oldest entry.
-            if len(self._sessions) >= self._max:
-                self._evict_oldest_locked()
-
-            entry = SessionEntry(session_id=session_id)
-            self._sessions[session_id] = entry
-            log.debug("SessionStore: created session %r", session_id)
-            return entry
+            return self._get_or_create_locked(session_id)
 
     def get(self, session_id: str) -> SessionEntry | None:
         """Return the session entry or ``None`` if it does not exist.
@@ -242,11 +229,11 @@ class SessionStore:
         Returns:
             The updated :class:`SessionEntry`.
         """
-        entry = self.get_or_create(session_id)
         with self._lock:
+            entry = self._get_or_create_locked(session_id)
             entry.data.update(kwargs)
             entry.touch()
-        return entry
+            return entry
 
     def remove(self, session_id: str) -> bool:
         """Delete the session, returning True when it existed.
@@ -317,6 +304,30 @@ class SessionStore:
     # ------------------------------------------------------------------
     # Private helpers (caller must hold _lock)
     # ------------------------------------------------------------------
+
+    def _get_or_create_locked(self, session_id: str) -> SessionEntry:
+        """Return or create the entry. Caller MUST hold ``_lock``.
+
+        Extracted so :meth:`update` can run get-or-create and the data
+        mutation inside a single critical section (GH-558). Splitting
+        them across two lock acquisitions left a TOCTOU window where a
+        concurrent ``remove`` or capacity eviction could drop the entry
+        between the read and the write, silently losing the update.
+        """
+        self._evict_expired_locked()
+        if session_id in self._sessions:
+            entry = self._sessions[session_id]
+            entry.touch()
+            return entry
+
+        # Enforce capacity limit: evict the oldest entry.
+        if len(self._sessions) >= self._max:
+            self._evict_oldest_locked()
+
+        entry = SessionEntry(session_id=session_id)
+        self._sessions[session_id] = entry
+        log.debug("SessionStore: created session %r", session_id)
+        return entry
 
     def _evict_expired_locked(self) -> int:
         expired = [sid for sid, e in self._sessions.items() if e.is_expired(self._ttl)]

--- a/src/dev10x/skills/audit/analyze_actions.py
+++ b/src/dev10x/skills/audit/analyze_actions.py
@@ -18,11 +18,42 @@ Usage:
 If output.md is omitted, writes to stdout.
 """
 
+import io
+import os
 import re
 import sys
+import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TextIO
+
+
+def _atomic_write_text(output_path: str, content: str) -> None:
+    """Crash-safe write via mkstemp + fsync + os.replace (GH-562).
+
+    This standalone uv-script cannot import
+    ``dev10x.domain.file_locks.atomic_write_text``, so the same
+    temp-then-rename pattern is inlined here.
+    """
+    target = Path(output_path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(target.parent), suffix=".tmp")
+    try:
+        os.write(fd, content.encode("utf-8"))
+        os.fsync(fd)
+        os.close(fd)
+        os.replace(tmp, str(target))
+    except BaseException:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise
+
 
 TURN_RE = re.compile(
     r"^## Turn (\d+) \[([^\]]+)\] (USER|ASSISTANT)(.*)",
@@ -326,8 +357,9 @@ def main() -> None:
 
     if len(sys.argv) >= 3:
         output_path = sys.argv[2]
-        with open(output_path, "w") as f:
-            write_output(rows=rows, out=f)
+        buf = io.StringIO()
+        write_output(rows=rows, out=buf)
+        _atomic_write_text(output_path, buf.getvalue())
         print(f"Phase 1 output written to {output_path}", file=sys.stderr)
     else:
         write_output(rows=rows, out=sys.stdout)

--- a/src/dev10x/skills/audit/analyze_permissions.py
+++ b/src/dev10x/skills/audit/analyze_permissions.py
@@ -18,6 +18,7 @@ If settings.json is omitted, uses ~/.claude/settings.local.json.
 If output.md is omitted, writes to stdout.
 """
 
+import io
 import os
 import sys
 from pathlib import Path
@@ -58,6 +59,7 @@ from dev10x.audit.permissions_model import (
     propose_allow_rules,
     write_output,
 )
+from dev10x.domain.file_locks import atomic_write_text
 
 __all__ = [
     "ALLOW_RULE_RE",
@@ -139,8 +141,9 @@ def main() -> None:
     proposals = propose_allow_rules(findings=findings)
 
     if output_path:
-        with open(output_path, "w") as f:
-            write_output(findings=findings, hygiene=hygiene, proposals=proposals, out=f)
+        buf = io.StringIO()
+        write_output(findings=findings, hygiene=hygiene, proposals=proposals, out=buf)
+        atomic_write_text(Path(output_path), buf.getvalue())
         print(f"Phase 4 output written to {output_path}", file=sys.stderr)
     else:
         write_output(findings=findings, hygiene=hygiene, proposals=proposals, out=sys.stdout)

--- a/src/dev10x/skills/audit/extract_session.py
+++ b/src/dev10x/skills/audit/extract_session.py
@@ -11,12 +11,43 @@ Usage:
 If output.md is omitted, writes to stdout.
 """
 
+import io
 import json
+import os
 import re
 import sys
+import tempfile
 from datetime import datetime
 from pathlib import Path
 from typing import TextIO
+
+
+def _atomic_write_text(output_path: str, content: str) -> None:
+    """Crash-safe write via mkstemp + fsync + os.replace (GH-562).
+
+    This standalone uv-script cannot import
+    ``dev10x.domain.file_locks.atomic_write_text``, so the same
+    temp-then-rename pattern is inlined here.
+    """
+    target = Path(output_path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(target.parent), suffix=".tmp")
+    try:
+        os.write(fd, content.encode("utf-8"))
+        os.fsync(fd)
+        os.close(fd)
+        os.replace(tmp, str(target))
+    except BaseException:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise
+
 
 SKIP_TYPES = {"file-history-snapshot", "progress", "system"}
 
@@ -225,8 +256,9 @@ def main() -> None:
     jsonl_path = sys.argv[1]
     if len(sys.argv) >= 3:
         output_path = sys.argv[2]
-        with open(output_path, "w") as f:
-            process_jsonl(jsonl_path=jsonl_path, out=f)
+        buf = io.StringIO()
+        process_jsonl(jsonl_path=jsonl_path, out=buf)
+        _atomic_write_text(output_path, buf.getvalue())
         print(f"Extracted to {output_path}", file=sys.stderr)
     else:
         process_jsonl(jsonl_path=jsonl_path, out=sys.stdout)

--- a/tests/commands/test_init.py
+++ b/tests/commands/test_init.py
@@ -7,7 +7,22 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
-from dev10x.commands.init import init
+from dev10x.commands.init import _write_if_missing, init
+
+
+class TestWriteIfMissing:
+    """GH-562: O_EXCL atomic claim replaces the check-then-write race."""
+
+    def test_writes_when_absent(self, tmp_path: Path) -> None:
+        target = tmp_path / "nested" / "file.yaml"
+        assert _write_if_missing(target, "hello") is True
+        assert target.read_text() == "hello"
+
+    def test_returns_false_and_preserves_existing(self, tmp_path: Path) -> None:
+        target = tmp_path / "file.yaml"
+        target.write_text("original")
+        assert _write_if_missing(target, "replacement") is False
+        assert target.read_text() == "original"
 
 
 class TestInitNonInteractive:

--- a/tests/domain/documents/test_settings_document.py
+++ b/tests/domain/documents/test_settings_document.py
@@ -82,6 +82,50 @@ def test_invalid_json_raises(settings_path: Path) -> None:
         SettingsDocument(path=settings_path).apply_replacements(replacements=REPLACEMENTS)
 
 
+def test_preview_replacements_does_not_write(settings_path: Path) -> None:
+    original = json.dumps({"permissions": {"allow": ["Bash(/old/v1/x)"]}}, indent=2) + "\n"
+    settings_path.write_text(original)
+
+    new_content, count = SettingsDocument(path=settings_path).preview_replacements(
+        replacements=REPLACEMENTS
+    )
+
+    assert count == 1
+    assert new_content is not None
+    assert "/new/v2/" in new_content
+    # The on-disk file is untouched by the dry-run pass.
+    assert settings_path.read_text() == original
+
+
+def test_preview_replacements_returns_none_when_unchanged(settings_path: Path) -> None:
+    _write(settings_path, {"permissions": {"allow": ["Bash(/other/run.sh)"]}})
+
+    new_content, count = SettingsDocument(path=settings_path).preview_replacements(
+        replacements=REPLACEMENTS
+    )
+
+    assert count == 0
+    assert new_content is None
+
+
+def test_preview_replacements_raises_on_bad_json(settings_path: Path) -> None:
+    settings_path.write_text("{not valid json")
+
+    with pytest.raises(json.JSONDecodeError):
+        SettingsDocument(path=settings_path).preview_replacements(replacements=REPLACEMENTS)
+
+
+def test_write_migrated_persists_precomputed_content(settings_path: Path) -> None:
+    settings_path.write_text(json.dumps({"permissions": {"allow": ["Bash(/old/v1/x)"]}}) + "\n")
+    doc = SettingsDocument(path=settings_path)
+    new_content, _ = doc.preview_replacements(replacements=REPLACEMENTS)
+    assert new_content is not None
+
+    doc.write_migrated(new_content)
+
+    assert json.loads(settings_path.read_text())["permissions"]["allow"] == ["Bash(/new/v2/x)"]
+
+
 def test_migrate_rules_counts_each_rewrite() -> None:
     result, count = _migrate_rules(
         rules=["/old/a", "/old/b", "/keep/c"], replacements=REPLACEMENTS

--- a/tests/domain/test_file_locks.py
+++ b/tests/domain/test_file_locks.py
@@ -1,19 +1,44 @@
 from __future__ import annotations
 
+import fcntl
 import json
 import multiprocessing as mp
+import os
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
 import yaml
 
 from dev10x.domain.file_locks import (
+    LOCK_TIMEOUT_SECONDS,
+    LockTimeoutError,
     atomic_write_bytes,
     atomic_write_text,
     file_lock,
     locked_json_update,
     locked_yaml_update,
 )
+
+
+@contextmanager
+def _hold_sidecar(sidecar: Path) -> Iterator[None]:
+    """Hold an exclusive flock on ``sidecar`` from an independent fd.
+
+    flock is associated with the open file description, so a second
+    ``os.open`` of the same sidecar inside the same process contends
+    exactly as a separate process would.
+    """
+    sidecar.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(sidecar), os.O_CREAT | os.O_RDWR)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
 
 
 class TestAtomicWriteText:
@@ -55,6 +80,55 @@ class TestFileLock:
         target = tmp_path / "data"
         with file_lock(target):
             assert (tmp_path / "data.lock").exists()
+
+
+class TestLockTimeout:
+    def test_default_timeout_constant(self) -> None:
+        assert LOCK_TIMEOUT_SECONDS == 10.0
+
+    def test_raises_when_held(self, tmp_path: Path) -> None:
+        target = tmp_path / "data.json"
+        with _hold_sidecar(tmp_path / "data.json.lock"):
+            with pytest.raises(LockTimeoutError) as exc:
+                with file_lock(target, timeout=0.2):
+                    pass
+        assert "locked by another process" in str(exc.value)
+
+    def test_is_oserror_subclass(self, tmp_path: Path) -> None:
+        target = tmp_path / "data.json"
+        with _hold_sidecar(tmp_path / "data.json.lock"):
+            with pytest.raises(OSError):
+                with file_lock(target, timeout=0.1):
+                    pass
+
+    def test_locked_json_update_times_out(self, tmp_path: Path) -> None:
+        target = tmp_path / "settings.json"
+        with _hold_sidecar(tmp_path / "settings.lock"):
+            with pytest.raises(LockTimeoutError):
+                with locked_json_update(target, timeout=0.1):
+                    pass
+
+    def test_locked_yaml_update_times_out(self, tmp_path: Path) -> None:
+        target = tmp_path / "plan.yaml"
+        with _hold_sidecar(tmp_path / "plan.yaml.lock"):
+            with pytest.raises(LockTimeoutError):
+                with locked_yaml_update(target, timeout=0.1):
+                    pass
+
+    def test_acquires_after_holder_releases(self, tmp_path: Path) -> None:
+        target = tmp_path / "data.json"
+        with _hold_sidecar(tmp_path / "data.json.lock"):
+            pass  # released here
+        with file_lock(target, timeout=0.5):
+            assert (tmp_path / "data.json.lock").exists()
+
+    def test_zero_timeout_blocks_until_available(self, tmp_path: Path) -> None:
+        target = tmp_path / "data.json"
+        start = time.monotonic()
+        with file_lock(target, timeout=0):
+            pass
+        # Uncontended acquire returns immediately under the legacy path.
+        assert time.monotonic() - start < 1.0
 
 
 class TestLockedJsonUpdate:

--- a/tests/domain/test_file_locks.py
+++ b/tests/domain/test_file_locks.py
@@ -131,6 +131,39 @@ class TestLockTimeout:
         assert time.monotonic() - start < 1.0
 
 
+class TestSidecarNamingConvention:
+    """ADR-0011: the two lock helpers must never share a sidecar path.
+
+    `file_lock`/`locked_yaml_update` append `.lock` to the full name
+    (`settings.local.json` → `settings.local.json.lock`), while
+    `locked_json_update` replaces the suffix (`settings.local.json` →
+    `settings.local.lock`). Mixing them on one target would create two
+    independent sidecars and silently break mutual exclusion.
+    """
+
+    def test_append_vs_replace_diverge_for_json_target(self, tmp_path: Path) -> None:
+        target = tmp_path / "settings.local.json"
+        append_sidecar = target.with_suffix(target.suffix + ".lock")
+        replace_sidecar = target.with_suffix(".lock")
+        assert append_sidecar.name == "settings.local.json.lock"
+        assert replace_sidecar.name == "settings.local.lock"
+        assert append_sidecar != replace_sidecar
+
+    def test_file_lock_uses_append_convention(self, tmp_path: Path) -> None:
+        target = tmp_path / "settings.local.json"
+        with file_lock(target):
+            assert (tmp_path / "settings.local.json.lock").exists()
+            assert not (tmp_path / "settings.local.lock").exists()
+
+    def test_locked_json_update_uses_replace_convention(self, tmp_path: Path) -> None:
+        target = tmp_path / "settings.local.json"
+        target.write_text(json.dumps({}))
+        with locked_json_update(target):
+            pass
+        assert (tmp_path / "settings.local.lock").exists()
+        assert not (tmp_path / "settings.local.json.lock").exists()
+
+
 class TestLockedJsonUpdate:
     def test_load_mutate_save_cycle(self, tmp_path: Path) -> None:
         target = tmp_path / "settings.json"

--- a/tests/domain/test_install_version.py
+++ b/tests/domain/test_install_version.py
@@ -85,6 +85,17 @@ def test_write_applied_version_persists_timestamp(claude_home: Path) -> None:
     }
 
 
+def test_write_applied_version_is_atomic(tmp_path: Path) -> None:
+    # GH-544: routes through atomic_write_text — creates the parent dir
+    # and leaves no stale temp file behind.
+    target = tmp_path / "nested" / "version.yml"
+    written = write_applied_version(plugin_version="0.79.0", version_yaml=target)
+    assert written == target
+    assert yaml.safe_load(target.read_text())["plugin_version"] == "0.79.0"
+    leftovers = [p.name for p in (tmp_path / "nested").iterdir() if p.suffix == ".tmp"]
+    assert leftovers == []
+
+
 def test_install_state_needs_bootstrap_when_config_missing(
     claude_home: Path, plugin_root: Path
 ) -> None:

--- a/tests/domain/test_plan.py
+++ b/tests/domain/test_plan.py
@@ -125,6 +125,16 @@ class TestPlanSave:
 
         assert path.exists()
 
+    def test_save_leaves_no_stale_tmp(self, tmp_path: Path) -> None:
+        # GH-571: Plan.save now routes through atomic_write_text
+        # (mkstemp + fsync + rename), so no .tmp sidecar survives.
+        path = tmp_path / "plan.yaml"
+
+        Plan(metadata={"status": "new"}).save(path=path)
+
+        leftovers = [p.name for p in tmp_path.iterdir() if p.suffix == ".tmp"]
+        assert leftovers == []
+
 
 class TestPlanIsNew:
     def test_true_when_no_metadata(self) -> None:

--- a/tests/domain/test_policy_rule.py
+++ b/tests/domain/test_policy_rule.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -26,3 +27,47 @@ from dev10x.hooks.session_policy import (
 )
 def test_policy_classes_satisfy_protocol(rule: PolicyRule) -> None:
     assert isinstance(rule, PolicyRule)
+
+
+class TestMigrateTwoPass:
+    """GH-571: the migration rewrites all settings files via a
+    validate-then-write two-pass (ADR-0011 Layer 4)."""
+
+    def _setup(self, tmp_path: Path) -> tuple[MigratePluginPermissionsRule, Path, Path, str]:
+        cache = tmp_path / ".claude" / "plugins" / "cache" / "Dev10x-Guru" / "Dev10x"
+        old = cache / "0.78.0"
+        new = cache / "0.79.0"
+        old.mkdir(parents=True)
+        new.mkdir(parents=True)
+        old_abs = str(old) + "/"
+        claude = tmp_path / ".claude"
+        settings = claude / "settings.json"
+        local = claude / "settings.local.json"
+        settings.write_text(
+            json.dumps({"permissions": {"allow": [f"Bash({old_abs}run.sh:*)"]}}, indent=2)
+        )
+        local.write_text(json.dumps({"permissions": {"allow": [f"Read({old_abs}x)"]}}, indent=2))
+        rule = MigratePluginPermissionsRule(plugin_root=new, home_path=tmp_path)
+        return rule, settings, local, str(new) + "/"
+
+    def test_migrates_all_valid_files(self, tmp_path: Path) -> None:
+        rule, settings, local, new_abs = self._setup(tmp_path)
+
+        total, files = rule.apply()
+
+        assert total == 2
+        assert set(files) == {"settings.json", "settings.local.json"}
+        assert new_abs in settings.read_text()
+        assert new_abs in local.read_text()
+
+    def test_corrupt_file_skipped_valid_file_still_migrated(self, tmp_path: Path) -> None:
+        rule, settings, local, new_abs = self._setup(tmp_path)
+        local.write_text("{corrupt json")
+
+        total, files = rule.apply()
+
+        assert total == 1
+        assert files == ["settings.json"]
+        assert new_abs in settings.read_text()
+        # The corrupt file is never written — its bytes are untouched.
+        assert local.read_text() == "{corrupt json"

--- a/tests/hooks/test_skill_hooks.py
+++ b/tests/hooks/test_skill_hooks.py
@@ -115,6 +115,30 @@ class TestSkillMetrics:
         assert entry["session"] == "sess-xyz"
         assert "timestamp" in entry
 
+    def test_appends_without_truncating_prior_entries(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # GH-548: the O_APPEND write must add to the file, never truncate
+        # a prior concurrent writer's line.
+        import dev10x.hooks.skill as mod
+
+        monkeypatch.setattr(mod, "_get_toplevel", lambda: str(tmp_path))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        payload = json.dumps(
+            {"tool_input": {"skill": "Dev10x:git-commit"}, "session_id": "sess-1"}
+        )
+        runner.invoke(cli, ["hook", "skill", "metrics"], input=payload)
+        runner.invoke(cli, ["hook", "skill", "metrics"], input=payload)
+
+        metrics_files = list((tmp_path / ".claude" / "projects" / "_metrics").glob("*.jsonl"))
+        lines = metrics_files[0].read_text().splitlines()
+        assert len(lines) == 2
+        assert all(json.loads(line)["skill"] == "Dev10x:git-commit" for line in lines)
+
     def test_exits_silently_without_skill(
         self,
         runner: CliRunner,

--- a/tests/mcp/test_roots.py
+++ b/tests/mcp/test_roots.py
@@ -164,6 +164,26 @@ class TestClientRootsManager:
         assert mgr.roots[0].uri == f"file://{tmp_path}"
 
     @pytest.mark.asyncio
+    async def test_refresh_discards_roots_when_session_changes_during_await(
+        self, tmp_path: Path
+    ) -> None:
+        # GH-562: a concurrent set_session(None) at the await yield point
+        # must not let the fetched (now-stale) roots overwrite _roots.
+        mgr = ClientRootsManager(enabled=True)
+        session = AsyncMock()
+
+        async def _list_roots() -> Any:
+            mgr.set_session(session=None)  # detach while awaiting
+            return _make_list_roots_result([f"file://{tmp_path}"])
+
+        session.list_roots = _list_roots
+        mgr.set_session(session=session)
+
+        await mgr.refresh()
+
+        assert mgr.roots is None
+
+    @pytest.mark.asyncio
     async def test_refresh_noop_when_disabled(self) -> None:
         mgr = ClientRootsManager(enabled=False)
         session = AsyncMock()

--- a/tests/mcp/test_session_store.py
+++ b/tests/mcp/test_session_store.py
@@ -247,6 +247,14 @@ class TestUpdate:
         assert entry is not None
         assert entry.data["a"] == 99
 
+    def test_update_mutates_live_stored_entry(self, store: SessionStore) -> None:
+        # GH-558: get-or-create and the data mutation now run in one
+        # critical section, so update never writes to a detached entry.
+        # The object returned by update must be the same object the
+        # store holds and serves to a subsequent get.
+        returned = store.update("s", a=1)
+        assert store.get("s") is returned
+
 
 # ---------------------------------------------------------------------------
 # SessionStore.remove

--- a/tests/skills/audit/test_atomic_output.py
+++ b/tests/skills/audit/test_atomic_output.py
@@ -1,0 +1,48 @@
+"""GH-562: the standalone audit uv-scripts write reports atomically.
+
+extract_session.py and analyze_actions.py cannot import
+dev10x.domain.file_locks (PEP 723 standalone scripts), so each inlines
+an `_atomic_write_text` helper that mirrors atomic_write_text. These
+tests exercise that helper directly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dev10x.skills.audit.analyze_actions import _atomic_write_text as actions_write
+from dev10x.skills.audit.extract_session import _atomic_write_text as session_write
+
+WRITERS = [actions_write, session_write]
+
+
+@pytest.mark.parametrize("writer", WRITERS)
+def test_writes_content(writer, tmp_path: Path) -> None:
+    target = tmp_path / "report.md"
+    writer(str(target), "# Report\n")
+    assert target.read_text() == "# Report\n"
+
+
+@pytest.mark.parametrize("writer", WRITERS)
+def test_creates_parent_directory(writer, tmp_path: Path) -> None:
+    target = tmp_path / "nested" / "deep" / "report.md"
+    writer(str(target), "content")
+    assert target.read_text() == "content"
+
+
+@pytest.mark.parametrize("writer", WRITERS)
+def test_leaves_no_stale_tmp(writer, tmp_path: Path) -> None:
+    target = tmp_path / "report.md"
+    writer(str(target), "content")
+    leftovers = [p.name for p in tmp_path.iterdir() if p.suffix == ".tmp"]
+    assert leftovers == []
+
+
+@pytest.mark.parametrize("writer", WRITERS)
+def test_overwrites_existing(writer, tmp_path: Path) -> None:
+    target = tmp_path / "report.md"
+    target.write_text("old")
+    writer(str(target), "new")
+    assert target.read_text() == "new"


### PR DESCRIPTION
**When** parallel worktrees and the long-lived MCP daemon write shared plan, settings, version, and metrics files concurrently, **I want to** bound every lock acquisition with a timeout and route every write through the atomic primitive, **so I can** trust that a crashed or racing process surfaces a clear error instead of hanging the daemon or leaving a torn/interleaved file.

---

[`95160080`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/618/commits/95160080aa4959235c826ff9047e697cb4325ed0) 🥅 GH-555 Enable bounded waits on contended file locks
[`26434488`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/618/commits/26434488bcfeff23fc5410023fb93f8924271818) ♻️ GH-571 Unify the lock and atomic-write model
[`cabd8cfa`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/618/commits/cabd8cfa650383396502d1a36e6d52bffd84a4a9) 🥅 GH-544 Protect the applied-version stamp from torn writes
[`4a0b5245`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/618/commits/4a0b52456d748ae849af3a2373cf6c1fd78dbecd) 🥅 GH-548 Keep concurrent skill-metric lines from interleaving
[`a9002edb`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/618/commits/a9002edba5c4e4a0889b7a9302c2e3a03269aacb) 🥅 GH-558 Close the SessionStore.update lost-update race
[`f863de59`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/618/commits/f863de59c3339f8d459322b52f923997cdfde55f) 🥅 GH-562 Harden three low-severity concurrency edges
[`09cb9f40`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/618/commits/09cb9f4051843b1da6eefb483ba6f54081556a30) fixup! 🥅 GH-555 Enable bounded waits on contended file locks
[`b0f9baf2`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/618/commits/b0f9baf288c6ff92d0c4fe10e336b70a2a2de221) fixup! 🥅 GH-548 Keep concurrent skill-metric lines from interleaving
[`ff265b3d`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/618/commits/ff265b3de8c1efbd5a21bd796a8ad8ab085a5703) fixup! 🥅 GH-562 Harden three low-severity concurrency edges
[`b00d34d3`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/618/commits/b00d34d3c8dc9aa1419149e85170af8327f74210) fixup! 🥅 GH-555 Enable bounded waits on contended file locks
[`e335090e`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/618/commits/e335090e2ea0fd382bd882d00f2e4f77aa0bf934) fixup! ♻️ GH-571 Unify the lock and atomic-write model
[`eeb54d8b`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/618/commits/eeb54d8b61223f4f3264c10120c0bd9959b2f925) fixup! 🥅 GH-562 Harden three low-severity concurrency edges
Closes #555
Closes #571
Closes #544
Closes #548
Closes #558
Closes #562
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/555

---