### PR TITLE
🐛 GH-498 Harden MCP roots refresh and daemon PID safety

### DIFF
--- a/src/dev10x/mcp/daemon.py
+++ b/src/dev10x/mcp/daemon.py
@@ -37,6 +37,8 @@ import socket
 import time
 from pathlib import Path
 
+from dev10x.domain.file_locks import atomic_write_text
+
 log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -95,17 +97,48 @@ def socket_file_path(pid_dir: Path | None = None) -> Path:
     return (pid_dir or _pid_dir()) / _SOCKET_NAME
 
 
-def write_pid_file(pid: int | None = None, pid_dir: Path | None = None) -> Path:
+def write_pid_file(
+    pid: int | None = None,
+    pid_dir: Path | None = None,
+    *,
+    exclusive: bool = False,
+) -> Path:
     """Write *pid* (default: ``os.getpid()``) to the PID file.
 
     Creates the directory if it does not exist.  Returns the path written.
 
+    The write is always atomic — full content is committed before the
+    file becomes visible — so a crash mid-write can never leave the
+    zero-byte PID file that :func:`read_pid_file` would have to discard.
+
+    Args:
+        pid: PID to record.  Defaults to ``os.getpid()``.
+        pid_dir: Override the PID-file directory.
+        exclusive: When True, fail if the PID file already exists
+            (``O_CREAT | O_EXCL``).  This is the restart-safety primitive
+            two daemons racing to start rely on: the loser of the race
+            gets :class:`FileExistsError` and must abort instead of
+            silently overwriting the winner's PID.
+
     Raises:
+        FileExistsError: When *exclusive* is True and the PID file
+            already exists.
         OSError: If the file cannot be written.
     """
     target = pid_file_path(pid_dir)
     target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_text(str(pid if pid is not None else os.getpid()))
+    content = str(pid if pid is not None else os.getpid())
+    if exclusive:
+        # O_EXCL makes the create-or-fail decision atomic at the kernel
+        # level, closing the stale-check → write race in
+        # DaemonLifecycle.start.
+        fd = os.open(str(target), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+        try:
+            os.write(fd, content.encode("utf-8"))
+        finally:
+            os.close(fd)
+    else:
+        atomic_write_text(target, content)
     log.debug("Wrote PID file: %s", target)
     return target
 
@@ -486,7 +519,18 @@ class DaemonLifecycle:
         import threading
 
         clear_stale_lock_files(self._pid_dir)
-        write_pid_file(pid_dir=self._pid_dir)
+        try:
+            write_pid_file(pid_dir=self._pid_dir, exclusive=True)
+        except FileExistsError as exc:
+            # A live daemon already owns the PID file (stale files were
+            # just cleared, so this one is alive), or a second start lost
+            # the O_EXCL race. Either way, refuse to start a second
+            # instance rather than overwriting the running daemon's PID.
+            raise RuntimeError(
+                "Daemon already running or lost the startup race — refusing "
+                "to start a second instance. Stop the existing daemon "
+                "(shutdown_daemon) or clear stale lock files and retry."
+            ) from exc
 
         server = HealthServer(self._pid_dir)
         server.start()

--- a/src/dev10x/mcp/roots_manager.py
+++ b/src/dev10x/mcp/roots_manager.py
@@ -34,6 +34,7 @@ DEV10X_ROOTS_ENABLED
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 from pathlib import Path
@@ -211,6 +212,13 @@ class ClientRootsManager:
 
 _manager: ClientRootsManager | None = None
 
+# GH-498: the event loop holds only weak references to bare
+# ``create_task`` results, so a fire-and-forget refresh can be garbage
+# collected mid-flight and silently leave the roots cache stale. Retain
+# a strong reference until the task finishes (mirrors the lifespan-local
+# retention in ``_app.py``).
+_background_tasks: set[asyncio.Task[None]] = set()
+
 
 def get_manager() -> ClientRootsManager | None:
     """Return the currently registered :class:`ClientRootsManager`, or ``None``."""
@@ -237,7 +245,6 @@ def wire_roots_to_server(
             (e.g. ``fastmcp_instance._mcp_server``).
         manager: The roots manager to attach.
     """
-    import asyncio
 
     import mcp.types as mcp_types
 
@@ -259,7 +266,9 @@ def wire_roots_to_server(
         notification: mcp_types.RootsListChangedNotification,
     ) -> None:
         log.debug("ClientRootsManager: roots/list_changed received — refreshing")
-        asyncio.create_task(manager.refresh(), name="dev10x-roots-refresh")
+        task = asyncio.create_task(manager.refresh(), name="dev10x-roots-refresh")
+        _background_tasks.add(task)
+        task.add_done_callback(_background_tasks.discard)
 
     # Chain with the existing InitializedNotification handler (GH-341 resource
     # watcher registers one first).

--- a/src/dev10x/mcp/roots_manager.py
+++ b/src/dev10x/mcp/roots_manager.py
@@ -38,7 +38,9 @@ import asyncio
 import logging
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+
+from dev10x.domain.common.result import Result, ok
 
 if TYPE_CHECKING:  # pragma: no cover
     from mcp.server.session import ServerSession
@@ -223,6 +225,33 @@ _background_tasks: set[asyncio.Task[None]] = set()
 def get_manager() -> ClientRootsManager | None:
     """Return the currently registered :class:`ClientRootsManager`, or ``None``."""
     return _manager
+
+
+def list_roots() -> Result[dict[str, Any]]:
+    """Return the client-declared roots payload (GH-344, GH-502).
+
+    Backing domain function for the ``list_client_roots`` MCP tool. Returns
+    a :class:`~dev10x.domain.common.result.Result` so the handler can unwrap
+    it via ``.to_dict()`` like every other tool at the MCP boundary
+    (ADR-0009). There is no error path today — the payload is always a
+    success — but the two-layer shape keeps the tool consistent and leaves
+    room for a future failure mode without changing the wire contract.
+
+    The ``roots`` value is ``None`` when no session has been established
+    yet, an empty list when the client declares no roots, and a list of
+    ``{"uri", "name"}`` dicts otherwise. ``enabled`` reflects
+    ``DEV10X_ROOTS_ENABLED``.
+    """
+    manager = get_manager()
+    if manager is None:
+        return ok({"roots": None, "enabled": False})
+    roots = manager.roots
+    return ok(
+        {
+            "roots": [r.to_dict() for r in roots] if roots is not None else None,
+            "enabled": manager.enabled,
+        }
+    )
 
 
 def wire_roots_to_server(

--- a/src/dev10x/mcp/roots_tools.py
+++ b/src/dev10x/mcp/roots_tools.py
@@ -28,14 +28,6 @@ async def list_client_roots() -> dict:
           yet (e.g. the tool is called before the MCP handshake).
         * ``enabled`` — ``bool``, False when ``DEV10X_ROOTS_ENABLED=0``.
     """
-    from dev10x.mcp.roots_manager import get_manager
+    from dev10x.mcp.roots_manager import list_roots
 
-    manager = get_manager()
-    if manager is None:
-        return {"roots": None, "enabled": False}
-
-    roots = manager.roots
-    return {
-        "roots": [r.to_dict() for r in roots] if roots is not None else None,
-        "enabled": manager.enabled,
-    }
+    return list_roots().to_dict()

--- a/tests/mcp/test_daemon.py
+++ b/tests/mcp/test_daemon.py
@@ -415,6 +415,17 @@ class TestDaemonLifecycle:
         finally:
             lifecycle.stop()
 
+    def test_start_refuses_when_live_daemon_owns_pid(self, tmp_pid_dir: Path) -> None:
+        # A live PID survives clear_stale_lock_files, so the exclusive
+        # write hits FileExistsError and start must refuse rather than
+        # overwrite the running daemon's PID (GH-573 race guard).
+        write_pid_file(pid=os.getpid(), pid_dir=tmp_pid_dir)
+        lifecycle = DaemonLifecycle(tmp_pid_dir)
+        with pytest.raises(RuntimeError, match="already running or lost the startup race"):
+            lifecycle.start()
+        # The incumbent PID is untouched.
+        assert read_pid_file(tmp_pid_dir) == os.getpid()
+
     def test_stop_is_idempotent(self, tmp_pid_dir: Path) -> None:
         lifecycle = DaemonLifecycle(tmp_pid_dir)
         lifecycle.start()


### PR DESCRIPTION
**When** the Dev10x MCP server runs over long sessions in streamable-http or stdio mode, **I want** the client-roots cache, the list_client_roots tool, and the daemon PID handling to behave reliably, **so I can** trust roots-scoped CWD checks and never let a restart SIGTERM the wrong process.

---

[`2f67278a`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/620/commits/2f67278aca7488d327ad7e17f5ac6bca118e56b5) 🐛 GH-498 Keep roots cache fresh by retaining the refresh task
[`49c15552`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/620/commits/49c15552a0a27780d63383d28496df6dcfc93f42) ♻️ GH-502 Align list_client_roots with the Result boundary contract
[`12ba74f9`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/620/commits/12ba74f935d62b6fc02ae2adf7146f14caf3b6d7) 🐛 GH-573 Prevent the daemon from killing the wrong process
Closes #498
Closes #502
Closes #573
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/498

---