### PR TITLE
✨ GH-346 Enable review-comment pattern mining

### DIFF
--- a/.claude/rules/mcp-tools.md
+++ b/.claude/rules/mcp-tools.md
@@ -158,6 +158,7 @@ supporting each tool:
 | `audit_hook_log_path` | `cli` | GH-29 | v0.69.0+ |
 | `audit_hook_recent` | `cli` | GH-29 | v0.69.0+ |
 | `record_upgrade` | `cli` | GH-109 | v0.72.0+ |
+| `cluster_review_comments` | `cli` | GH-346 | v0.80.0+ |
 | `query` | `db` | PR #126 | v0.25.0+ |
 
 When adding a new tool, update this table and note any dependencies on

--- a/src/dev10x/github/review_patterns.py
+++ b/src/dev10x/github/review_patterns.py
@@ -1,0 +1,313 @@
+"""Cluster & score PR review-comment patterns (GH-346).
+
+Self-contained learning step for the review-bot initiative: fetches
+merged-PR review comments, groups them into recurring candidate
+patterns, and scores each by frequency so the top-N findings can feed
+a candidate-rules report (GH-347).
+
+This module is intentionally free-standing — it fetches its own data
+via ``gh`` rather than depending on the GH-345 harvest module, which
+was removed in GH-540 as unreachable code. It is wired as the
+``cluster_review_comments`` MCP tool in ``github_tools.py`` so it stays
+production-reachable.
+
+Internal functions return ``Result[T]`` per ADR-0009; the
+``@server.tool()`` boundary calls ``.to_dict()``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from dev10x.domain.common.result import Result, SuccessResult, err, ok
+from dev10x.subprocess_utils import async_run
+
+logger = logging.getLogger(__name__)
+
+# Words that carry no signal for clustering review feedback. Kept small
+# and review-specific rather than a full NLP stop-list.
+_STOPWORDS = frozenset(
+    {
+        "a",
+        "an",
+        "the",
+        "this",
+        "that",
+        "these",
+        "those",
+        "is",
+        "are",
+        "was",
+        "were",
+        "be",
+        "to",
+        "of",
+        "in",
+        "on",
+        "for",
+        "and",
+        "or",
+        "but",
+        "if",
+        "it",
+        "we",
+        "you",
+        "i",
+        "should",
+        "would",
+        "could",
+        "can",
+        "will",
+        "please",
+        "here",
+        "there",
+        "not",
+        "no",
+        "yes",
+        "do",
+        "does",
+        "with",
+        "as",
+        "at",
+        "by",
+        "from",
+    }
+)
+
+# Number of significant tokens kept in a cluster signature. A short
+# signature groups paraphrased feedback ("rename pm to payment_method"
+# and "payment_method, not pm") under one pattern without over-merging.
+_SIGNATURE_TOKENS = 6
+
+_FENCED_CODE = re.compile(r"```.*?```", re.DOTALL)
+_INLINE_CODE = re.compile(r"`[^`]*`")
+_URL = re.compile(r"https?://\S+")
+_NON_WORD = re.compile(r"[^a-z0-9\s]")
+_DIGITS = re.compile(r"\b\d+\b")
+
+
+@dataclass(frozen=True)
+class ReviewComment:
+    """A single inline review comment harvested from a merged PR."""
+
+    repo: str
+    pr_number: int
+    body: str
+    path: str = ""
+    line: int | None = None
+    author: str = ""
+
+
+@dataclass(frozen=True)
+class CandidatePattern:
+    """A recurring review-comment pattern, scored by frequency."""
+
+    signature: str
+    frequency: int
+    files: list[str] = field(default_factory=list)
+    authors: list[str] = field(default_factory=list)
+    examples: list[str] = field(default_factory=list)
+
+    @property
+    def score(self) -> int:
+        return self.frequency
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "signature": self.signature,
+            "frequency": self.frequency,
+            "score": self.score,
+            "files": self.files,
+            "authors": self.authors,
+            "examples": self.examples,
+        }
+
+
+def _normalize(body: str) -> str:
+    """Reduce a comment body to a stable clustering signature.
+
+    Strips code spans, URLs, numbers, and punctuation, drops stopwords,
+    then keeps the first ``_SIGNATURE_TOKENS`` significant tokens. Two
+    comments that share a signature land in the same cluster.
+    """
+    text = _FENCED_CODE.sub(" ", body)
+    text = _INLINE_CODE.sub(" ", text)
+    text = _URL.sub(" ", text)
+    text = text.lower()
+    text = _DIGITS.sub(" ", text)
+    text = _NON_WORD.sub(" ", text)
+    tokens = [t for t in text.split() if t and t not in _STOPWORDS]
+    return " ".join(tokens[:_SIGNATURE_TOKENS])
+
+
+def cluster_and_score(
+    comments: list[ReviewComment],
+    *,
+    top_n: int = 20,
+) -> list[CandidatePattern]:
+    """Group comments by normalized signature and rank by frequency.
+
+    Comments whose signature is empty (pure code/URL/punctuation) are
+    skipped. Ordering is deterministic: frequency desc, then number of
+    distinct files desc, then signature asc.
+    """
+    buckets: dict[str, list[ReviewComment]] = {}
+    for comment in comments:
+        signature = _normalize(comment.body)
+        if not signature:
+            continue
+        buckets.setdefault(signature, []).append(comment)
+
+    patterns = [
+        CandidatePattern(
+            signature=signature,
+            frequency=len(members),
+            files=sorted({m.path for m in members if m.path}),
+            authors=sorted({m.author for m in members if m.author}),
+            examples=[m.body for m in members[:3]],
+        )
+        for signature, members in buckets.items()
+    ]
+    patterns.sort(key=lambda p: (-p.frequency, -len(p.files), p.signature))
+    return patterns[:top_n]
+
+
+async def _detect_repo() -> str | None:
+    result = await async_run(
+        args=["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+        timeout=10,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        return result.stdout.strip()
+    return None
+
+
+async def _merged_pr_numbers(*, repo: str, limit: int) -> Result[list[int]]:
+    result = await async_run(
+        args=[
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "merged",
+            "--limit",
+            str(limit),
+            "--json",
+            "number",
+        ],
+        timeout=60,
+    )
+    if result.returncode != 0:
+        return err(result.stderr.strip() or "gh pr list failed")
+    try:
+        payload = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError:
+        return err("could not parse gh pr list output")
+    return ok([int(item["number"]) for item in payload])
+
+
+async def _pr_review_comments(*, repo: str, pr_number: int) -> list[ReviewComment]:
+    result = await async_run(
+        args=[
+            "gh",
+            "api",
+            "--paginate",
+            f"repos/{repo}/pulls/{pr_number}/comments",
+        ],
+        timeout=60,
+    )
+    if result.returncode != 0:
+        logger.warning(
+            "skipping PR review comments",
+            extra={"repo": repo, "pr_number": pr_number, "stderr": result.stderr.strip()},
+        )
+        return []
+    try:
+        payload = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError:
+        logger.warning("unparseable review comments", extra={"repo": repo, "pr_number": pr_number})
+        return []
+    return [
+        ReviewComment(
+            repo=repo,
+            pr_number=pr_number,
+            body=item.get("body", "") or "",
+            path=item.get("path", "") or "",
+            line=item.get("line"),
+            author=(item.get("user") or {}).get("login", "") or "",
+        )
+        for item in payload
+    ]
+
+
+async def fetch_review_comments(*, repo: str, limit: int = 50) -> Result[list[ReviewComment]]:
+    """Fetch inline review comments from recent merged PRs of ``repo``.
+
+    Reuses the project-audit Phase-1 ``gh pr list --state merged`` pattern
+    to find PRs, then pulls each PR's review comments. Per-PR failures are
+    logged and skipped (fail-soft) so a single bad PR never aborts the run.
+    """
+    numbers_result = await _merged_pr_numbers(repo=repo, limit=limit)
+    if not isinstance(numbers_result, SuccessResult):
+        return numbers_result
+    comments: list[ReviewComment] = []
+    for pr_number in numbers_result.value:
+        comments.extend(await _pr_review_comments(repo=repo, pr_number=pr_number))
+    return ok(comments)
+
+
+async def cluster_review_comments(
+    *,
+    repos: list[str] | None = None,
+    limit: int = 50,
+    top_n: int = 20,
+) -> Result[dict[str, Any]]:
+    """Cluster & score review-comment patterns across one or more repos.
+
+    Args:
+        repos: ``owner/name`` repositories to analyze. Defaults to the
+            current repository when omitted.
+        limit: Max merged PRs scanned per repo.
+        top_n: Number of top patterns to return.
+
+    Returns:
+        ``ok({"patterns": [...], "summary": {...}})`` or ``err(...)``.
+    """
+    if top_n < 1:
+        return err("top_n must be at least 1")
+
+    targets = list(repos) if repos else []
+    if not targets:
+        detected = await _detect_repo()
+        if not detected:
+            return err("no repository specified and current repo could not be detected")
+        targets = [detected]
+
+    all_comments: list[ReviewComment] = []
+    scanned: list[str] = []
+    for repo in targets:
+        result = await fetch_review_comments(repo=repo, limit=limit)
+        if not isinstance(result, SuccessResult):
+            logger.warning("skipping repo", extra={"repo": repo, "error": result.error})
+            continue
+        all_comments.extend(result.value)
+        scanned.append(repo)
+
+    patterns = cluster_and_score(all_comments, top_n=top_n)
+    return ok(
+        {
+            "patterns": [pattern.to_dict() for pattern in patterns],
+            "summary": {
+                "repos_scanned": scanned,
+                "comments_analyzed": len(all_comments),
+                "patterns_returned": len(patterns),
+                "top_n": top_n,
+            },
+        }
+    )

--- a/src/dev10x/mcp/github_tools.py
+++ b/src/dev10x/mcp/github_tools.py
@@ -1299,3 +1299,39 @@ async def collect_prs(
             ticket_pattern=ticket_pattern,
         )
     ).to_dict()
+
+
+@server.tool()
+async def cluster_review_comments(
+    repos: list[str] | None = None,
+    limit: int = 50,
+    top_n: int = 20,
+    cwd: str | None = None,
+) -> dict:
+    """Cluster & score PR review-comment patterns (GH-346).
+
+    Fetches inline review comments from recent merged PRs, groups them
+    into recurring candidate patterns, and ranks each by frequency so
+    the top-N findings can feed a candidate-rules report (GH-347).
+
+    Args:
+        repos: ``owner/name`` repositories to analyze. Defaults to the
+            current repository when omitted.
+        limit: Max merged PRs scanned per repo (default 50).
+        top_n: Number of top patterns to return (default 20).
+        cwd: Effective working directory (GH-979).
+
+    Returns:
+        Dictionary with keys: patterns (list), summary (dict); or error.
+    """
+    from dev10x.github import review_patterns
+    from dev10x.subprocess_utils import use_cwd
+
+    with use_cwd(cwd):
+        return (
+            await review_patterns.cluster_review_comments(
+                repos=repos,
+                limit=limit,
+                top_n=top_n,
+            )
+        ).to_dict()

--- a/tests/github/test_review_patterns.py
+++ b/tests/github/test_review_patterns.py
@@ -1,0 +1,275 @@
+"""Unit tests for dev10x.github.review_patterns (GH-346).
+
+Contract class: mock
+  Low-level fetch helpers patch ``async_run`` and supply canned ``gh``
+  output. Orchestrators patch the fetch helpers directly. Clustering
+  and normalization are pure and tested without mocks.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dev10x.domain.common.result import ErrorResult, SuccessResult
+
+rp = pytest.importorskip("dev10x.github.review_patterns", reason="dev10x not installed")
+
+
+def _completed(
+    *,
+    returncode: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=[],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def _comment(
+    body: str, *, path: str = "", author: str = "", pr_number: int = 1
+) -> rp.ReviewComment:
+    return rp.ReviewComment(repo="o/r", pr_number=pr_number, body=body, path=path, author=author)
+
+
+class TestNormalize:
+    def test_strips_code_url_digits_and_punctuation(self) -> None:
+        signature = rp._normalize(
+            "Please rename `pm` to payment_method, see https://x.io item 42!"
+        )
+        assert "pm" not in signature.split()
+        assert "http" not in signature
+        assert "42" not in signature
+        assert "rename" in signature
+
+    def test_drops_stopwords(self) -> None:
+        assert rp._normalize("this is the value") == "value"
+
+    def test_code_only_body_yields_empty_signature(self) -> None:
+        assert rp._normalize("```python\nx = 1\n```") == ""
+
+    def test_truncates_to_signature_token_budget(self) -> None:
+        signature = rp._normalize("alpha beta gamma delta epsilon zeta eta theta")
+        assert len(signature.split()) == rp._SIGNATURE_TOKENS
+
+
+class TestClusterAndScore:
+    def test_groups_by_signature_and_counts_frequency(self) -> None:
+        comments = [
+            _comment("rename pm to payment_method", path="a.py", author="al"),
+            _comment("rename pm to payment_method please", path="b.py", author="bo"),
+            _comment("add a regression test", path="c.py", author="al"),
+        ]
+        patterns = rp.cluster_and_score(comments)
+        assert patterns[0].frequency == 2
+        assert patterns[0].files == ["a.py", "b.py"]
+        assert patterns[0].authors == ["al", "bo"]
+        assert len(patterns) == 2
+
+    def test_skips_empty_signatures(self) -> None:
+        patterns = rp.cluster_and_score([_comment("`code only`"), _comment("real feedback here")])
+        assert len(patterns) == 1
+        assert "real" in patterns[0].signature
+
+    def test_ordering_frequency_then_files_then_signature(self) -> None:
+        comments = [
+            _comment("zzz frequent feedback", path="a.py"),
+            _comment("zzz frequent feedback", path="b.py"),
+            _comment("aaa rare feedback one", path="x.py"),
+            _comment("aaa rare feedback one", path="x.py"),
+        ]
+        # both clusters have frequency 2; the one with more distinct files wins.
+        patterns = rp.cluster_and_score(comments)
+        assert patterns[0].signature.startswith("zzz")
+
+    def test_examples_capped_at_three(self) -> None:
+        comments = [_comment("same recurring note") for _ in range(5)]
+        patterns = rp.cluster_and_score(comments)
+        assert patterns[0].frequency == 5
+        assert len(patterns[0].examples) == 3
+
+    def test_top_n_truncates(self) -> None:
+        comments = [_comment(f"distinct note number {chr(97 + i)}") for i in range(5)]
+        patterns = rp.cluster_and_score(comments, top_n=2)
+        assert len(patterns) == 2
+
+
+class TestCandidatePattern:
+    def test_score_equals_frequency_and_to_dict_shape(self) -> None:
+        pattern = rp.CandidatePattern(
+            signature="rename variable",
+            frequency=3,
+            files=["a.py"],
+            authors=["al"],
+            examples=["rename it"],
+        )
+        assert pattern.score == 3
+        assert pattern.to_dict() == {
+            "signature": "rename variable",
+            "frequency": 3,
+            "score": 3,
+            "files": ["a.py"],
+            "authors": ["al"],
+            "examples": ["rename it"],
+        }
+
+
+class TestDetectRepo:
+    @pytest.mark.asyncio
+    @patch("dev10x.github.review_patterns.async_run", new_callable=AsyncMock)
+    async def test_returns_repo_on_success(self, mock_run: AsyncMock) -> None:
+        mock_run.return_value = _completed(stdout="owner/repo\n")
+        assert await rp._detect_repo() == "owner/repo"
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.review_patterns.async_run", new_callable=AsyncMock)
+    async def test_returns_none_on_failure(self, mock_run: AsyncMock) -> None:
+        mock_run.return_value = _completed(returncode=1, stderr="not a repo")
+        assert await rp._detect_repo() is None
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.review_patterns.async_run", new_callable=AsyncMock)
+    async def test_returns_none_on_empty_stdout(self, mock_run: AsyncMock) -> None:
+        mock_run.return_value = _completed(stdout="  \n")
+        assert await rp._detect_repo() is None
+
+
+class TestMergedPrNumbers:
+    @pytest.mark.asyncio
+    @patch("dev10x.github.review_patterns.async_run", new_callable=AsyncMock)
+    async def test_parses_numbers(self, mock_run: AsyncMock) -> None:
+        mock_run.return_value = _completed(stdout=json.dumps([{"number": 7}, {"number": 9}]))
+        result = await rp._merged_pr_numbers(repo="o/r", limit=50)
+        assert isinstance(result, SuccessResult)
+        assert result.value == [7, 9]
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.review_patterns.async_run", new_callable=AsyncMock)
+    async def test_error_on_nonzero_returncode(self, mock_run: AsyncMock) -> None:
+        mock_run.return_value = _completed(returncode=1, stderr="boom")
+        result = await rp._merged_pr_numbers(repo="o/r", limit=50)
+        assert isinstance(result, ErrorResult)
+        assert result.error == "boom"
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.review_patterns.async_run", new_callable=AsyncMock)
+    async def test_error_on_bad_json(self, mock_run: AsyncMock) -> None:
+        mock_run.return_value = _completed(stdout="not json")
+        result = await rp._merged_pr_numbers(repo="o/r", limit=50)
+        assert isinstance(result, ErrorResult)
+
+
+class TestPrReviewComments:
+    @pytest.mark.asyncio
+    @patch("dev10x.github.review_patterns.async_run", new_callable=AsyncMock)
+    async def test_parses_comments(self, mock_run: AsyncMock) -> None:
+        payload = [
+            {"body": "rename this", "path": "a.py", "line": 4, "user": {"login": "al"}},
+            {"body": "", "path": "b.py"},
+        ]
+        mock_run.return_value = _completed(stdout=json.dumps(payload))
+        comments = await rp._pr_review_comments(repo="o/r", pr_number=3)
+        assert len(comments) == 2
+        assert comments[0].author == "al"
+        assert comments[0].line == 4
+        assert comments[1].author == ""
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.review_patterns.async_run", new_callable=AsyncMock)
+    async def test_failed_fetch_returns_empty(self, mock_run: AsyncMock) -> None:
+        mock_run.return_value = _completed(returncode=1, stderr="403")
+        assert await rp._pr_review_comments(repo="o/r", pr_number=3) == []
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.review_patterns.async_run", new_callable=AsyncMock)
+    async def test_bad_json_returns_empty(self, mock_run: AsyncMock) -> None:
+        mock_run.return_value = _completed(stdout="<html>")
+        assert await rp._pr_review_comments(repo="o/r", pr_number=3) == []
+
+
+class TestFetchReviewComments:
+    @pytest.mark.asyncio
+    @patch("dev10x.github.review_patterns._pr_review_comments", new_callable=AsyncMock)
+    @patch("dev10x.github.review_patterns._merged_pr_numbers", new_callable=AsyncMock)
+    async def test_aggregates_across_prs(
+        self,
+        mock_numbers: AsyncMock,
+        mock_comments: AsyncMock,
+    ) -> None:
+        from dev10x.domain.common.result import ok
+
+        mock_numbers.return_value = ok([1, 2])
+        mock_comments.side_effect = [[_comment("a", pr_number=1)], [_comment("b", pr_number=2)]]
+        result = await rp.fetch_review_comments(repo="o/r", limit=50)
+        assert isinstance(result, SuccessResult)
+        assert len(result.value) == 2
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.review_patterns._merged_pr_numbers", new_callable=AsyncMock)
+    async def test_propagates_pr_list_error(self, mock_numbers: AsyncMock) -> None:
+        from dev10x.domain.common.result import err
+
+        mock_numbers.return_value = err("pr list failed")
+        result = await rp.fetch_review_comments(repo="o/r", limit=50)
+        assert isinstance(result, ErrorResult)
+        assert result.error == "pr list failed"
+
+
+class TestClusterReviewComments:
+    @pytest.mark.asyncio
+    async def test_rejects_non_positive_top_n(self) -> None:
+        result = await rp.cluster_review_comments(repos=["o/r"], top_n=0)
+        assert isinstance(result, ErrorResult)
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.review_patterns.fetch_review_comments", new_callable=AsyncMock)
+    async def test_happy_path_returns_patterns_and_summary(self, mock_fetch: AsyncMock) -> None:
+        from dev10x.domain.common.result import ok
+
+        mock_fetch.return_value = ok(
+            [_comment("rename pm to payment_method"), _comment("rename pm to payment_method")]
+        )
+        result = await rp.cluster_review_comments(repos=["o/r"])
+        assert isinstance(result, SuccessResult)
+        assert result.value["summary"]["comments_analyzed"] == 2
+        assert result.value["summary"]["repos_scanned"] == ["o/r"]
+        assert result.value["patterns"][0]["frequency"] == 2
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.review_patterns._detect_repo", new_callable=AsyncMock)
+    async def test_detects_repo_when_omitted(self, mock_detect: AsyncMock) -> None:
+        from dev10x.domain.common.result import ok
+
+        mock_detect.return_value = "auto/repo"
+        with patch(
+            "dev10x.github.review_patterns.fetch_review_comments",
+            new_callable=AsyncMock,
+            return_value=ok([]),
+        ):
+            result = await rp.cluster_review_comments()
+        assert isinstance(result, SuccessResult)
+        assert result.value["summary"]["repos_scanned"] == ["auto/repo"]
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.review_patterns._detect_repo", new_callable=AsyncMock)
+    async def test_error_when_no_repo_detected(self, mock_detect: AsyncMock) -> None:
+        mock_detect.return_value = None
+        result = await rp.cluster_review_comments()
+        assert isinstance(result, ErrorResult)
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.review_patterns.fetch_review_comments", new_callable=AsyncMock)
+    async def test_skips_repo_on_fetch_error(self, mock_fetch: AsyncMock) -> None:
+        from dev10x.domain.common.result import err, ok
+
+        mock_fetch.side_effect = [err("rate limited"), ok([_comment("good feedback note")])]
+        result = await rp.cluster_review_comments(repos=["bad/repo", "good/repo"])
+        assert isinstance(result, SuccessResult)
+        assert result.value["summary"]["repos_scanned"] == ["good/repo"]


### PR DESCRIPTION
**When** I'm growing the review-bot's rule set, **I want to** see the recurring themes reviewers raise across merged PRs ranked by frequency, **so I can** turn the top findings into candidate rules without hand-reading every thread.

---

[`91b605ce`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/625/commits/91b605ce38a8452f51b3ff89982bc3dfd9265690) ✨ GH-346 Enable review-comment pattern mining
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/346

---