### PR TITLE
♻️ GH-628 Simplify plan archiving onto the Plan aggregate

### DIFF
--- a/src/dev10x/domain/documents/plan.py
+++ b/src/dev10x/domain/documents/plan.py
@@ -102,6 +102,16 @@ TASK_TRANSITIONS: dict[TaskStatus, TaskTransition] = {
 
 @dataclass
 class Plan:
+    """The mutable plan aggregate.
+
+    Owns its own persistence (`load`/`save`), task state machine
+    (`handle_task_*`, `TASK_TRANSITIONS`), and archive lifecycle
+    (`stamp_archived`, `archive_filename`, `archive_to`). The
+    `plan.service` layer wraps this aggregate with the IO/transaction
+    concerns it must NOT own — git-toplevel resolution, file locking,
+    and removing the live plan file.
+    """
+
     metadata: dict[str, Any] = field(default_factory=dict)
     tasks: list[Task] = field(default_factory=list)
 
@@ -151,10 +161,43 @@ class Plan:
             result["tasks"] = [t.to_dict() for t in self.tasks]
         return result
 
+    def stamp_archived(self) -> None:
+        """Record the `archived_at` timestamp on plan metadata.
+
+        Mutation only — does not persist. Callers pair this with
+        `save()` (see `archive`/`archive_to`).
+        """
+        self.metadata["archived_at"] = _now_iso()
+
+    def archive_filename(self, *, timestamp: str) -> str:
+        """Derive the archive filename for this plan at `timestamp`.
+
+        The branch slug is sanitised (slashes → hyphens, capped at 50
+        chars) so the name is filesystem-safe regardless of branch
+        naming convention.
+        """
+        branch_slug = self.metadata.get("branch", "unknown")
+        branch_slug = branch_slug.replace("/", "-")[:50]
+        return f"plan-{timestamp}-{branch_slug}.yaml"
+
     def archive(self, *, path: Path) -> None:
         """Stamp `archived_at` on plan metadata and persist to `path`."""
-        self.metadata["archived_at"] = _now_iso()
+        self.stamp_archived()
         self.save(path=path)
+
+    def archive_to(self, *, archive_dir: Path, timestamp: str) -> Path:
+        """Stamp, persist under `archive_dir`, and return the archive path.
+
+        Encapsulates name derivation and the `archived_at` stamp so the
+        service layer only owns IO orchestration (toplevel resolution,
+        file locking, removing the live plan file). `archive_dir` is
+        created if absent.
+        """
+        archive_dir.mkdir(parents=True, exist_ok=True)
+        archive_path = archive_dir / self.archive_filename(timestamp=timestamp)
+        self.stamp_archived()
+        self.save(path=archive_path)
+        return archive_path
 
     def ensure_metadata(self) -> None:
         if not self.metadata:

--- a/src/dev10x/domain/documents/session_state.py
+++ b/src/dev10x/domain/documents/session_state.py
@@ -122,6 +122,10 @@ class PlanSummary:
         ]
 
     @property
+    def has_remaining_tasks(self) -> bool:
+        return bool(self.pending_tasks)
+
+    @property
     def pending_decisions(self) -> list[Task]:
         return [t for t in self.pending_tasks if t.metadata.get("decision_needed")]
 

--- a/src/dev10x/domain/session_rules.py
+++ b/src/dev10x/domain/session_rules.py
@@ -70,7 +70,7 @@ class DecisionGuidanceRule(PolicyRule[str]):
 
         summary = PlanSummary.from_dict(data=self.plan)
         if not summary.pending_decisions:
-            if summary.pending_tasks:
+            if summary.has_remaining_tasks:
                 return "Session resumed with tasks remaining. Auto-advance through the task list."
             return ""
 

--- a/src/dev10x/plan/service.py
+++ b/src/dev10x/plan/service.py
@@ -1,9 +1,16 @@
 """Plan transaction layer.
 
-Single canonical implementation of the operations that mutate or
-read a project's plan file. Both the CLI hook
-(`dev10x.hooks.task_plan_sync`) and the MCP wrapper
-(`dev10x.plan`) delegate here, eliminating the previously
+The IO/transaction boundary for a project's plan file. This layer
+owns the concerns the `Plan` aggregate must not — git-toplevel
+resolution, file locking, and removing the live plan file — and
+delegates all name derivation, stamping, and persistence to `Plan`
+(`Plan.archive_to`, `Plan.save`, `Plan.set_context`). It stays
+separate from the aggregate deliberately (audit D8): folding this
+IO into domain methods would couple the aggregate to the filesystem
+layout and the lock primitive.
+
+Both the CLI hook (`dev10x.hooks.task_plan_sync`) and the MCP
+wrapper (`dev10x.plan`) delegate here, eliminating the previously
 duplicated `archive()` block and inline imports.
 """
 
@@ -72,15 +79,10 @@ def archive_plan() -> dict[str, Any]:
             return {"archived": False}
 
         plan = Plan.load(path=plan_path)
-        archive_dir = plan_path.parent / "archive"
-        archive_dir.mkdir(parents=True, exist_ok=True)
-
         timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S")
-        branch_slug = plan.metadata.get("branch", "unknown")
-        branch_slug = branch_slug.replace("/", "-")[:50]
-        archive_name = f"plan-{timestamp}-{branch_slug}.yaml"
-        archive_path = archive_dir / archive_name
-
-        plan.archive(path=archive_path)
+        archive_path = plan.archive_to(
+            archive_dir=plan_path.parent / "archive",
+            timestamp=timestamp,
+        )
         plan_path.unlink()
-        return {"archived": True, "archive_name": archive_name}
+        return {"archived": True, "archive_name": archive_path.name}

--- a/tests/domain/test_plan.py
+++ b/tests/domain/test_plan.py
@@ -340,6 +340,51 @@ class TestPlanArchive:
         assert "archived_at" in loaded.metadata
 
 
+class TestPlanStampArchived:
+    def test_sets_timestamp_without_persisting(self, tmp_path: Path) -> None:
+        plan = Plan(metadata={"status": "completed"})
+
+        plan.stamp_archived()
+
+        assert "archived_at" in plan.metadata
+        assert not (tmp_path / "plan.yaml").exists()
+
+
+class TestPlanArchiveFilename:
+    def test_sanitises_branch_slug(self) -> None:
+        plan = Plan(metadata={"branch": "janusz/GH-628/slug"})
+
+        name = plan.archive_filename(timestamp="20260101T000000")
+
+        assert name == "plan-20260101T000000-janusz-GH-628-slug.yaml"
+
+    def test_defaults_to_unknown_when_no_branch(self) -> None:
+        plan = Plan(metadata={"status": "completed"})
+
+        assert plan.archive_filename(timestamp="T") == "plan-T-unknown.yaml"
+
+    def test_caps_branch_slug_at_fifty_chars(self) -> None:
+        plan = Plan(metadata={"branch": "x" * 80})
+
+        name = plan.archive_filename(timestamp="T")
+
+        assert name == f"plan-T-{'x' * 50}.yaml"
+
+
+class TestPlanArchiveTo:
+    def test_creates_dir_stamps_and_returns_path(self, tmp_path: Path) -> None:
+        plan = Plan(metadata={"status": "completed", "branch": "feature/x"})
+        archive_dir = tmp_path / "archive"
+
+        archive_path = plan.archive_to(archive_dir=archive_dir, timestamp="20260101T000000")
+
+        assert archive_path == archive_dir / "plan-20260101T000000-feature-x.yaml"
+        assert archive_path.exists()
+        assert "archived_at" in plan.metadata
+        loaded = Plan.load(path=archive_path)
+        assert "archived_at" in loaded.metadata
+
+
 class TestPlanContextKeys:
     def test_returns_empty_when_no_context(self) -> None:
         assert Plan(metadata={"status": "x"}).context_keys() == []

--- a/tests/domain/test_session_state.py
+++ b/tests/domain/test_session_state.py
@@ -178,6 +178,31 @@ class TestPlanSummaryPendingTasks:
         assert PlanSummary().pending_tasks == []
 
 
+class TestPlanSummaryHasRemainingTasks:
+    def test_true_when_pending_present(self) -> None:
+        summary = PlanSummary(
+            tasks=[
+                {"id": "1", "subject": "A", "status": "pending"},
+                {"id": "2", "subject": "B", "status": "completed"},
+            ],
+        )
+
+        assert summary.has_remaining_tasks is True
+
+    def test_false_when_all_completed_or_deleted(self) -> None:
+        summary = PlanSummary(
+            tasks=[
+                {"id": "1", "subject": "A", "status": "completed"},
+                {"id": "2", "subject": "B", "status": "deleted"},
+            ],
+        )
+
+        assert summary.has_remaining_tasks is False
+
+    def test_false_when_no_tasks(self) -> None:
+        assert PlanSummary().has_remaining_tasks is False
+
+
 class TestPlanSummaryPendingDecisions:
     def test_returns_tasks_with_decision_needed(self) -> None:
         summary = PlanSummary(


### PR DESCRIPTION
**When** the plan service archives a completed session, **I want to** the Plan aggregate to own its archive filename derivation, `archived_at` stamp, and persistence, **so I can** change archive naming or stamping in one cohesive place while the service keeps only its IO/transaction concerns.

---

[`a622c849`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/629/commits/a622c8491dc25cf3f1481b5de59763ffbd82cc1c) ♻️ GH-628 Simplify plan archiving onto the Plan aggregate
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/628

---