### PR TITLE
♻️ GH-249 Simplify validator dispatch and shared registries

### DIFF
--- a/src/dev10x/audit/__init__.py
+++ b/src/dev10x/audit/__init__.py
@@ -18,7 +18,8 @@ from datetime import date
 from pathlib import Path
 from typing import Any
 
-from dev10x.audit.log_reader import iter_records, prune, summarize
+from dev10x.audit.log_reader import iter_records, prune
+from dev10x.audit.summarizer import summarize
 from dev10x.domain.claude_paths import ClaudeDir
 from dev10x.domain.common.result import Result, err, ok
 from dev10x.domain.file_locks import atomic_write_text

--- a/src/dev10x/audit/log_reader.py
+++ b/src/dev10x/audit/log_reader.py
@@ -1,8 +1,9 @@
 """Audit log reader and append API (GH-143).
 
 Owns the JSONL audit log surface: path resolution, record iteration,
-summarization, pruning, and the append API consumed by
-`dev10x.hooks.audit_emit` (the write side).
+pruning, and the append API consumed by `dev10x.hooks.audit_emit`
+(the write side). Record summarization lives in
+`dev10x.audit.summarizer` (re-exported here for the legacy import path).
 
 Two-layer observability:
 
@@ -29,7 +30,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from dev10x.domain.hook_telemetry import HookOutcome, HookPhase
+from dev10x.audit.summarizer import summarize  # noqa: F401  (re-export — audit finding D4)
+from dev10x.domain.hook_telemetry import HookOutcome
 
 SPAN_ID_ENV = "DEV10X_HOOK_SPAN_ID"
 AUDIT_ENABLE_ENV = "DEV10X_HOOK_AUDIT"
@@ -134,71 +136,6 @@ def iter_records(
         except OSError:
             continue
     return records
-
-
-def summarize(*, records: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
-    """Aggregate records by hook name. Joins wrap+body via span_id when both
-    records are present.
-    """
-    by_span: dict[str, dict[str, Any]] = {}
-    body_only: list[dict[str, Any]] = []
-    wrap_only: list[dict[str, Any]] = []
-
-    for rec in records:
-        phase = rec.get("phase")
-        span_id = rec.get("span_id", "")
-        if not span_id:
-            if phase == HookPhase.BODY:
-                body_only.append(rec)
-            elif phase == HookPhase.WRAP:
-                wrap_only.append(rec)
-            continue
-        if not isinstance(phase, str):
-            continue
-        bucket = by_span.setdefault(span_id, {})
-        bucket[phase] = rec
-
-    hook_stats: dict[str, dict[str, Any]] = {}
-    for span in by_span.values():
-        body = span.get(HookPhase.BODY)
-        wrap = span.get(HookPhase.WRAP)
-        record = body or wrap
-        if record is None:
-            continue
-        hook = record.get("hook", "unknown")
-        stats = hook_stats.setdefault(
-            hook,
-            {
-                "count": 0,
-                "total_ms_sum": 0,
-                "body_ms_sum": 0,
-                "startup_ms_sum": 0,
-                "paired_count": 0,
-                "error_count": 0,
-                "block_count": 0,
-            },
-        )
-        stats["count"] += 1
-        outcome = record.get("outcome", "")
-        if outcome == HookOutcome.ERROR:
-            stats["error_count"] += 1
-        elif outcome == HookOutcome.BLOCK:
-            stats["block_count"] += 1
-        if body and wrap:
-            total = int(wrap.get("total_ms") or 0)
-            body_ms = int(body.get("body_ms") or 0)
-            stats["total_ms_sum"] += total
-            stats["body_ms_sum"] += body_ms
-            stats["startup_ms_sum"] += max(total - body_ms, 0)
-            stats["paired_count"] += 1
-
-    for stats in hook_stats.values():
-        paired = stats["paired_count"] or 1
-        stats["total_ms_avg"] = round(stats["total_ms_sum"] / paired, 1)
-        stats["body_ms_avg"] = round(stats["body_ms_sum"] / paired, 1)
-        stats["startup_ms_avg"] = round(stats["startup_ms_sum"] / paired, 1)
-
-    return hook_stats
 
 
 class LogReaderAuditWriter:

--- a/src/dev10x/audit/summarizer.py
+++ b/src/dev10x/audit/summarizer.py
@@ -1,0 +1,79 @@
+"""Audit-record summarization (audit finding D4).
+
+Aggregating raw audit records into per-hook statistics is a distinct
+concern from reading/appending the JSONL log. It lived in
+``audit.log_reader`` only because that was the first home; this module
+owns it now so the reader stays focused on log IO. ``log_reader`` keeps
+a re-export of :func:`summarize` for the existing import path.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from dev10x.domain.hook_telemetry import HookOutcome, HookPhase
+
+
+def summarize(*, records: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Aggregate records by hook name. Joins wrap+body via span_id when both
+    records are present.
+    """
+    by_span: dict[str, dict[str, Any]] = {}
+    body_only: list[dict[str, Any]] = []
+    wrap_only: list[dict[str, Any]] = []
+
+    for rec in records:
+        phase = rec.get("phase")
+        span_id = rec.get("span_id", "")
+        if not span_id:
+            if phase == HookPhase.BODY:
+                body_only.append(rec)
+            elif phase == HookPhase.WRAP:
+                wrap_only.append(rec)
+            continue
+        if not isinstance(phase, str):
+            continue
+        bucket = by_span.setdefault(span_id, {})
+        bucket[phase] = rec
+
+    hook_stats: dict[str, dict[str, Any]] = {}
+    for span in by_span.values():
+        body = span.get(HookPhase.BODY)
+        wrap = span.get(HookPhase.WRAP)
+        record = body or wrap
+        if record is None:
+            continue
+        hook = record.get("hook", "unknown")
+        stats = hook_stats.setdefault(
+            hook,
+            {
+                "count": 0,
+                "total_ms_sum": 0,
+                "body_ms_sum": 0,
+                "startup_ms_sum": 0,
+                "paired_count": 0,
+                "error_count": 0,
+                "block_count": 0,
+            },
+        )
+        stats["count"] += 1
+        outcome = record.get("outcome", "")
+        if outcome == HookOutcome.ERROR:
+            stats["error_count"] += 1
+        elif outcome == HookOutcome.BLOCK:
+            stats["block_count"] += 1
+        if body and wrap:
+            total = int(wrap.get("total_ms") or 0)
+            body_ms = int(body.get("body_ms") or 0)
+            stats["total_ms_sum"] += total
+            stats["body_ms_sum"] += body_ms
+            stats["startup_ms_sum"] += max(total - body_ms, 0)
+            stats["paired_count"] += 1
+
+    for stats in hook_stats.values():
+        paired = stats["paired_count"] or 1
+        stats["total_ms_avg"] = round(stats["total_ms_sum"] / paired, 1)
+        stats["body_ms_avg"] = round(stats["body_ms_sum"] / paired, 1)
+        stats["startup_ms_avg"] = round(stats["startup_ms_sum"] / paired, 1)
+
+    return hook_stats

--- a/src/dev10x/commands/hook.py
+++ b/src/dev10x/commands/hook.py
@@ -24,9 +24,10 @@ def validate_bash() -> None:
     Reads JSON from stdin, dispatches to registered validators.
     Exit codes: 0=allow, 2=block.
     """
+    from dev10x.domain.events.hook_event import HookEventName
     from dev10x.hooks.audit_emit import audit_hook
 
-    _run = audit_hook(name="validate-bash", event="PreToolUse")(_validate_bash_body)
+    _run = audit_hook(name="validate-bash", event=HookEventName.PRE_TOOL_USE)(_validate_bash_body)
     _run()
 
 

--- a/src/dev10x/commands/platform.py
+++ b/src/dev10x/commands/platform.py
@@ -35,7 +35,7 @@ def add(
     playbook_override: str | None,
 ) -> None:
     """Register a platform so skills can target it without path editing."""
-    from dev10x.platform import Registry, known_platforms
+    from dev10x.platform import PlatformRepository, known_platforms
 
     catalog = known_platforms()
     if name not in catalog:
@@ -45,7 +45,7 @@ def add(
         )
         sys.exit(1)
 
-    registry = Registry()
+    registry = PlatformRepository()
     cfg = registry.add(
         name=name,
         config_dir=config_dir.expanduser().resolve() if config_dir else None,
@@ -63,9 +63,9 @@ def add(
 @platform.command(name="list")
 def list_platforms() -> None:
     """Show every registered platform with its configured paths."""
-    from dev10x.platform import Registry
+    from dev10x.platform import PlatformRepository
 
-    registry = Registry()
+    registry = PlatformRepository()
     entries = registry.list()
 
     if not entries:
@@ -85,9 +85,9 @@ def list_platforms() -> None:
 @click.argument("name")
 def remove(*, name: str) -> None:
     """Unregister a platform from the local registry."""
-    from dev10x.platform import Registry
+    from dev10x.platform import PlatformRepository
 
-    registry = Registry()
+    registry = PlatformRepository()
     if registry.remove(name):
         click.echo(f"✓ Removed {name}")
     else:

--- a/src/dev10x/domain/events/hook_event.py
+++ b/src/dev10x/domain/events/hook_event.py
@@ -1,0 +1,25 @@
+"""HookEventName — typed Claude Code hook event identifiers.
+
+The event names (``"PreToolUse"``, ``"SessionStart"``, …) were raw
+string literals scattered across the ``@audit_hook`` decorator, the
+``hookSpecificOutput`` envelopes, and assorted call sites (audit
+finding C8 — 2026-05-18). A typo silently produced a mislabeled audit
+record or an envelope Claude Code ignored.
+
+``HookEventName`` is a :class:`enum.StrEnum`, so each member *is* a
+``str``: it serialises into JSON envelopes and audit records unchanged
+while giving callers a single authoritative spelling to reference.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class HookEventName(StrEnum):
+    PRE_TOOL_USE = "PreToolUse"
+    POST_TOOL_USE = "PostToolUse"
+    PERMISSION_DENIED = "PermissionDenied"
+    SESSION_START = "SessionStart"
+    STOP = "Stop"
+    PRE_COMPACT = "PreCompact"

--- a/src/dev10x/domain/events/hook_input.py
+++ b/src/dev10x/domain/events/hook_input.py
@@ -6,6 +6,7 @@ import sys
 from dataclasses import dataclass
 from typing import Any, NoReturn
 
+from dev10x.domain.events.hook_event import HookEventName
 from dev10x.subprocess_utils import effective_cwd
 
 
@@ -86,7 +87,7 @@ class HookRetry:
     def emit(self) -> NoReturn:
         result: dict[str, Any] = {
             "hookSpecificOutput": {
-                "hookEventName": "PermissionDenied",
+                "hookEventName": HookEventName.PERMISSION_DENIED,
                 "retry": True,
             },
         }

--- a/src/dev10x/domain/gitmoji.py
+++ b/src/dev10x/domain/gitmoji.py
@@ -1,0 +1,33 @@
+"""Gitmoji registry — single source for commit-emoji knowledge (C6).
+
+``GITMOJI_CATEGORIES`` (release-note classification) and
+``BYPASS_GITMOJI`` (commit-JTBD validation bypass) previously lived in
+two unrelated modules — ``skills/release/classifier`` and
+``validators/commit_jtbd``. Co-locating them here gives the project one
+authoritative gitmoji table so the two consumers cannot drift apart.
+"""
+
+from __future__ import annotations
+
+GITMOJI_CATEGORIES: dict[str, str] = {
+    "✨": "feature",
+    "🐛": "bugfix",
+    "♻️": "refactor",
+    "🚚": "refactor",
+    "✅": "test",
+    "📝": "docs",
+    "🔧": "config",
+    "🩹": "fix",
+    "🔥": "cleanup",
+    "⚡": "perf",
+    "🔒": "security",
+    "💄": "ui",
+    "🔖": "version_bump",
+    "⚗️": "experimental",
+    "🧪": "test",
+    "🚑": "hotfix",
+}
+
+# Gitmoji whose commits skip the JTBD outcome-phrasing check: version
+# bumps, docs, and merge commits carry no user-facing "enables X" story.
+BYPASS_GITMOJI: frozenset[str] = frozenset({"🔖", "📝", "🔀"})

--- a/src/dev10x/hooks/audit_emit.py
+++ b/src/dev10x/hooks/audit_emit.py
@@ -21,6 +21,7 @@ from functools import wraps
 from typing import Any, TypeVar
 
 from dev10x.domain.audit_writer import AuditWriter
+from dev10x.domain.events.hook_event import HookEventName
 from dev10x.domain.hook_telemetry import HookPhase
 
 F = TypeVar("F", bound=Callable[..., Any])
@@ -46,12 +47,13 @@ def set_audit_writer(writer: AuditWriter | None) -> None:
     _writer = writer
 
 
-def audit_hook(name: str, *, event: str = "") -> Callable[[F], F]:
+def audit_hook(name: str, *, event: HookEventName | str = "") -> Callable[[F], F]:
     """Decorator: record a body-phase audit entry around the hook function.
 
     Args:
         name: stable hook identifier (e.g., "validate-bash", "session-reload")
-        event: Claude Code event name (e.g., "PreToolUse", "SessionStart")
+        event: Claude Code event name — prefer a :class:`HookEventName`
+            member; a bare string is still accepted for back-compat.
 
     The wrapped function may call sys.exit(); the decorator intercepts
     SystemExit so the audit record is written before the process dies.

--- a/src/dev10x/platform/__init__.py
+++ b/src/dev10x/platform/__init__.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from dev10x.platform.registry import (
     PlatformCatalog,
     PlatformConfig,
-    Registry,
+    PlatformRepository,
     known_platforms,
     registered_platforms,
 )
@@ -20,7 +20,7 @@ from dev10x.platform.registry import (
 __all__ = [
     "PlatformCatalog",
     "PlatformConfig",
-    "Registry",
+    "PlatformRepository",
     "known_platforms",
     "registered_platforms",
 ]

--- a/src/dev10x/platform/registry.py
+++ b/src/dev10x/platform/registry.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 
 import yaml
@@ -40,6 +40,37 @@ class PlatformConfig:
             plugins_dir=Path(data["plugins_dir"]).expanduser(),
             settings_file=Path(data["settings_file"]).expanduser(),
             playbook_override=data.get("playbook_override"),
+        )
+
+    def with_overrides(
+        self,
+        *,
+        config_dir: Path | None = None,
+        playbook_override: str | None = None,
+    ) -> PlatformConfig:
+        """Return a copy with the supplied fields overridden.
+
+        When ``config_dir`` is given, ``plugins_dir`` and
+        ``settings_file`` are rebased onto it, preserving their position
+        relative to the original ``config_dir``. Centralises the
+        field-by-field reconstruction the repository previously inlined
+        (audit finding D5).
+        """
+        if config_dir is None and playbook_override is None:
+            return self
+        if config_dir is not None:
+            plugins_dir = config_dir / self.plugins_dir.relative_to(self.config_dir)
+            settings_file = config_dir / self.settings_file.relative_to(self.config_dir)
+        else:
+            config_dir = self.config_dir
+            plugins_dir = self.plugins_dir
+            settings_file = self.settings_file
+        return replace(
+            self,
+            config_dir=config_dir,
+            plugins_dir=plugins_dir,
+            settings_file=settings_file,
+            playbook_override=playbook_override or self.playbook_override,
         )
 
 
@@ -119,8 +150,13 @@ def known_platforms() -> dict[str, PlatformConfig]:
     return PlatformCatalog().as_dict()
 
 
-class Registry:
-    """Persisted list of platforms the current user has registered."""
+class PlatformRepository:
+    """Persisted list of platforms the current user has registered.
+
+    Named ``PlatformRepository`` (not ``Registry``) because it owns
+    mutable, file-backed state — the unqualified ``Registry`` name is
+    reserved for static lookup tables (audit finding A3).
+    """
 
     def __init__(self, *, path: Path | None = None) -> None:
         self.path = path or REGISTRY_FILE
@@ -147,25 +183,9 @@ class Registry:
         catalog = catalog or PlatformCatalog()
         if not catalog.contains(name):
             raise ValueError(f"Unknown platform '{name}'. Known: {', '.join(catalog.names())}")
-        base = catalog.lookup(name)
-        if config_dir:
-            base = PlatformConfig(
-                name=base.name,
-                display_name=base.display_name,
-                config_dir=config_dir,
-                plugins_dir=config_dir / base.plugins_dir.relative_to(base.config_dir),
-                settings_file=config_dir / base.settings_file.relative_to(base.config_dir),
-                playbook_override=playbook_override or base.playbook_override,
-            )
-        elif playbook_override:
-            base = PlatformConfig(
-                name=base.name,
-                display_name=base.display_name,
-                config_dir=base.config_dir,
-                plugins_dir=base.plugins_dir,
-                settings_file=base.settings_file,
-                playbook_override=playbook_override,
-            )
+        base = catalog.lookup(name).with_overrides(
+            config_dir=config_dir, playbook_override=playbook_override
+        )
 
         with file_lock(self.path):
             registered = self.load()
@@ -187,10 +207,10 @@ class Registry:
         return [registered[name] for name in sorted(registered)]
 
 
-def registered_platforms(*, registry: Registry | None = None) -> list[PlatformConfig]:
+def registered_platforms(*, registry: PlatformRepository | None = None) -> list[PlatformConfig]:
     """Service function: combine catalog defaults with user registrations.
 
     Returns the list of platforms the user has actively registered. Use
     :class:`PlatformCatalog` directly for the static built-in list.
     """
-    return (registry or Registry()).list()
+    return (registry or PlatformRepository()).list()

--- a/src/dev10x/skills/release/classifier.py
+++ b/src/dev10x/skills/release/classifier.py
@@ -6,24 +6,7 @@ importable and unit-testable independently of the release-script glue.
 
 from __future__ import annotations
 
-GITMOJI_CATEGORIES: dict[str, str] = {
-    "✨": "feature",
-    "🐛": "bugfix",
-    "♻️": "refactor",
-    "🚚": "refactor",
-    "✅": "test",
-    "📝": "docs",
-    "🔧": "config",
-    "🩹": "fix",
-    "🔥": "cleanup",
-    "⚡": "perf",
-    "🔒": "security",
-    "💄": "ui",
-    "🔖": "version_bump",
-    "⚗️": "experimental",
-    "🧪": "test",
-    "🚑": "hotfix",
-}
+from dev10x.domain.gitmoji import GITMOJI_CATEGORIES
 
 SKIP_CATEGORIES: set[str] = {"version_bump"}
 MAINTENANCE_CATEGORIES: set[str] = {"test", "docs", "config", "cleanup", "experimental"}

--- a/src/dev10x/validators/__init__.py
+++ b/src/dev10x/validators/__init__.py
@@ -2,8 +2,9 @@
 
 Single-dispatcher architecture: one Python process validates all Bash
 commands by iterating a :class:`ValidatorRegistry`. Each validator
-declares its profile tier, rule_id, and capabilities as class
-attributes (see :mod:`dev10x.validators.base`).
+declares its profile tier and rule_id as class attributes (see
+:mod:`dev10x.validators.base`); correction support is detected
+structurally via the :class:`Corrector` protocol.
 
 Ordering matters: allow-validators run before deny-validators so safe
 patterns get auto-approved before a deny-validator would block them.
@@ -23,6 +24,7 @@ filters built from environment variables:
 
 from __future__ import annotations
 
+import functools
 import os
 from typing import TYPE_CHECKING
 
@@ -141,26 +143,47 @@ _SPECS: list[ValidatorSpec] = [
 ]
 
 
+def _parse_profile_config(
+    *, profile_raw: str | None, disable_raw: str, experimental_raw: str
+) -> tuple[ProfileTier, set[str], bool]:
+    """Parse raw env-var strings into a profile configuration tuple."""
+    active = ProfileTier.from_raw(profile_raw)
+    disabled = {rid.strip().upper() for rid in disable_raw.split(",") if rid.strip()}
+    experimental = experimental_raw.strip().lower() in ("1", "true", "yes", "on")
+    return active, disabled, experimental
+
+
 def _load_profile_config() -> tuple[ProfileTier, set[str], bool]:
     """Read profile configuration from environment variables.
 
     Returns:
         (active_profile, disabled_rule_ids, experimental_enabled)
     """
-    active = ProfileTier.from_raw(os.environ.get("DEV10X_HOOK_PROFILE"))
-
-    disabled_raw = os.environ.get("DEV10X_HOOK_DISABLE", "")
-    disabled = {rid.strip().upper() for rid in disabled_raw.split(",") if rid.strip()}
-
-    experimental_raw = os.environ.get("DEV10X_HOOK_EXPERIMENTAL", "").strip().lower()
-    experimental_enabled = experimental_raw in ("1", "true", "yes", "on")
-
-    return active, disabled, experimental_enabled
+    return _parse_profile_config(
+        profile_raw=os.environ.get("DEV10X_HOOK_PROFILE"),
+        disable_raw=os.environ.get("DEV10X_HOOK_DISABLE", ""),
+        experimental_raw=os.environ.get("DEV10X_HOOK_EXPERIMENTAL", ""),
+    )
 
 
-def _build_registry() -> ValidatorRegistry:
-    """Construct a registry seeded with module specs and env-driven filters."""
-    active, disabled, experimental = _load_profile_config()
+@functools.cache
+def _cached_registry(
+    profile_raw: str | None, disable_raw: str, experimental_raw: str
+) -> ValidatorRegistry:
+    """Build the registry for one exact environment configuration (A10).
+
+    Keyed on the raw env-var strings rather than stored in a
+    process-wide ``_registry`` global, so changing the profile,
+    disable-list, or experimental flag yields a distinct registry
+    instead of silently reusing a stale singleton. Repeated calls with
+    the same configuration return the same instance, preserving the
+    lazy ``_instances`` caching inside :class:`ValidatorRegistry`.
+    """
+    active, disabled, experimental = _parse_profile_config(
+        profile_raw=profile_raw,
+        disable_raw=disable_raw,
+        experimental_raw=experimental_raw,
+    )
     return ValidatorRegistry(
         specs=list(_SPECS),
         filters=[
@@ -171,15 +194,13 @@ def _build_registry() -> ValidatorRegistry:
     )
 
 
-_registry: ValidatorRegistry | None = None
-
-
 def get_registry() -> ValidatorRegistry:
-    """Return the process-wide registry, building it on first access."""
-    global _registry
-    if _registry is None:
-        _registry = _build_registry()
-    return _registry
+    """Return the registry for the current environment (cached per config)."""
+    return _cached_registry(
+        os.environ.get("DEV10X_HOOK_PROFILE"),
+        os.environ.get("DEV10X_HOOK_DISABLE", ""),
+        os.environ.get("DEV10X_HOOK_EXPERIMENTAL", ""),
+    )
 
 
 def get_validators() -> list[Validator]:
@@ -188,9 +209,8 @@ def get_validators() -> list[Validator]:
 
 
 def reset_registry() -> None:
-    """Clear the cached validator registry — used by tests."""
-    global _registry
-    _registry = None
+    """Clear the cached validator registries — used by tests."""
+    _cached_registry.cache_clear()
 
 
 def get_chain() -> ValidatorChain:

--- a/src/dev10x/validators/base.py
+++ b/src/dev10x/validators/base.py
@@ -5,10 +5,11 @@ Two hook integration points:
   PreToolUse        → should_run() + validate()  — block before execution
   PermissionDenied  → should_run() + correct()   — guide after auto-mode denial
 
-Validators declare their capabilities via :attr:`ValidatorBase.capabilities`
-(``"validate"`` always, ``"correct"`` for retry-with-guidance support).
-The dispatcher consults this set instead of runtime ``isinstance`` checks,
-so adding new capabilities (e.g., ``"explain"``) is a one-line change.
+Correction support is structural, not declared: a validator opts into
+the PermissionDenied path simply by implementing :meth:`Corrector.correct`.
+The dispatcher discovers this via ``isinstance(validator, Corrector)``
+against the ``@runtime_checkable`` :class:`Corrector` protocol — no
+separate capability set to keep in sync with the actual methods.
 
 Validators also declare profile-tier metadata as class attributes:
 
@@ -64,7 +65,10 @@ class ValidatorBase:
             name = "foo"
             rule_id = "DX042"
             profile = ProfileTier.STANDARD
-            capabilities = frozenset({"validate", "correct"})
+
+    A validator that also implements :meth:`Corrector.correct` is
+    automatically eligible for the PermissionDenied path — no capability
+    flag to declare.
 
     Removing the previous ``hasattr`` guarded monkey-patching in
     :func:`get_validators` — the metadata now lives on the class itself.
@@ -74,7 +78,6 @@ class ValidatorBase:
     rule_id: ClassVar[str] = ""
     profile: ClassVar[ProfileTier] = ProfileTier.STANDARD
     experimental: ClassVar[bool] = False
-    capabilities: ClassVar[frozenset[str]] = frozenset({"validate"})
 
     def should_run(self, inp: HookInput) -> bool:
         """Fast skip predicate — overridden by concrete validators."""

--- a/src/dev10x/validators/commit_jtbd.py
+++ b/src/dev10x/validators/commit_jtbd.py
@@ -19,6 +19,7 @@ from typing import Any, ClassVar
 from dev10x.domain import HookInput, HookResult
 from dev10x.domain.common.commit_subject import CommitSubject
 from dev10x.domain.common.result import ErrorResult, Result, err, ok
+from dev10x.domain.gitmoji import BYPASS_GITMOJI
 from dev10x.domain.profile_tier import ProfileTier
 from dev10x.validators.base import ValidatorBase
 
@@ -90,8 +91,6 @@ BLOCK_MSG = (
 
 
 GIT_COMMIT_RE = re.compile(r"\bgit\s+commit\b")
-
-BYPASS_GITMOJI: frozenset[str] = frozenset({"🔖", "📝", "🔀"})
 
 
 def _expand_verbs(bases: list[str]) -> list[str]:

--- a/src/dev10x/validators/pipeline_allow.py
+++ b/src/dev10x/validators/pipeline_allow.py
@@ -76,7 +76,6 @@ class PipelineAllowValidator(ValidatorBase):
     name: ClassVar[str] = "pipeline-allow"
     rule_id: ClassVar[str] = "DX011"
     profile: ClassVar[ProfileTier] = ProfileTier.STANDARD
-    capabilities: ClassVar[frozenset[str]] = frozenset({"validate"})
     _allow_patterns: list[str] | None = field(default=None, repr=False)
 
     def should_run(self, inp: HookInput) -> bool:

--- a/src/dev10x/validators/prefix_friction.py
+++ b/src/dev10x/validators/prefix_friction.py
@@ -341,7 +341,6 @@ class PrefixFrictionValidator(ValidatorBase):
     name: ClassVar[str] = "prefix-friction"
     rule_id: ClassVar[str] = "DX007"
     profile: ClassVar[ProfileTier] = ProfileTier.STANDARD
-    capabilities: ClassVar[frozenset[str]] = frozenset({"validate", "correct"})
     _allow_patterns: list[str] | None = field(default=None, repr=False)
 
     # Ordered chain of prefix checks (PrefixCheck = method taking

--- a/src/dev10x/validators/redundant_fetch.py
+++ b/src/dev10x/validators/redundant_fetch.py
@@ -69,7 +69,6 @@ class RedundantFetchValidator(ValidatorBase):
     rule_id: ClassVar[str] = "DX009"
     profile: ClassVar[ProfileTier] = ProfileTier.STANDARD
     experimental: ClassVar[bool] = True
-    capabilities: ClassVar[frozenset[str]] = frozenset({"validate"})
 
     def should_run(self, inp: HookInput) -> bool:
         cmd = inp.command

--- a/src/dev10x/validators/registry.py
+++ b/src/dev10x/validators/registry.py
@@ -22,7 +22,7 @@ import importlib
 import os
 import sys
 import traceback
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol
 
 from dev10x.domain.common.rule_id import RuleId
@@ -97,27 +97,37 @@ class ExperimentalFilter:
         return self.enabled or not spec.experimental
 
 
-@dataclass
 class ValidatorRegistry:
     """Owns validator specs, applies filters, lazy-loads instances.
 
     Construction is cheap: only specs are stored. The first call to
     :meth:`active` imports the surviving modules and instantiates
     validators. Subsequent calls return the cached list.
+
+    The spec list is private (``_specs``): callers seed it through the
+    ``specs=`` constructor argument and mutate it only via
+    :meth:`register`. Read access goes through :meth:`active_specs` /
+    :meth:`find_by_rule_id` — nothing reaches into the backing list.
     """
 
-    specs: list[ValidatorSpec] = field(default_factory=list)
-    filters: list[ValidatorFilter] = field(default_factory=list)
-    _instances: list[Validator] | None = field(default=None, init=False, repr=False)
+    def __init__(
+        self,
+        *,
+        specs: list[ValidatorSpec] | None = None,
+        filters: list[ValidatorFilter] | None = None,
+    ) -> None:
+        self._specs: list[ValidatorSpec] = list(specs) if specs is not None else []
+        self.filters: list[ValidatorFilter] = list(filters) if filters is not None else []
+        self._instances: list[Validator] | None = None
 
     def register(self, spec: ValidatorSpec) -> None:
         """Append a spec; invalidates any cached instances."""
-        self.specs.append(spec)
+        self._specs.append(spec)
         self._instances = None
 
     def active_specs(self) -> list[ValidatorSpec]:
         """Return specs surviving all filters (no validators imported)."""
-        return [spec for spec in self.specs if all(f.keep(spec) for f in self.filters)]
+        return [spec for spec in self._specs if all(f.keep(spec) for f in self.filters)]
 
     def active(self) -> list[Validator]:
         """Return validator instances for all active specs (lazy import)."""
@@ -130,7 +140,7 @@ class ValidatorRegistry:
         target = RuleId.try_parse(rule_id)
         if target is None:
             return None
-        for spec in self.specs:
+        for spec in self._specs:
             if spec.rule_id == str(target):
                 return spec
         return None
@@ -227,8 +237,10 @@ class ValidatorChain:
 
     def correct(self, inp: HookInput) -> HookRetry | None:
         """Invoke ``correct()`` on capable validators; first hit wins."""
+        from dev10x.validators.base import Corrector
+
         for validator in self.registry.active():
-            if "correct" not in getattr(validator, "capabilities", frozenset()):
+            if not isinstance(validator, Corrector):
                 continue
             try:
                 if not validator.should_run(inp=inp):

--- a/src/dev10x/validators/skill_redirect.py
+++ b/src/dev10x/validators/skill_redirect.py
@@ -225,7 +225,6 @@ class SkillRedirectValidator(ValidatorBase):
     name: ClassVar[str] = "skill-redirect"
     rule_id: ClassVar[str] = "DX006"
     profile: ClassVar[ProfileTier] = ProfileTier.STANDARD
-    capabilities: ClassVar[frozenset[str]] = frozenset({"validate", "correct"})
 
     def should_run(self, inp: HookInput) -> bool:
         # Rationale form is the only valid bypass — skip the validator

--- a/tests/platform/test_registry.py
+++ b/tests/platform/test_registry.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from dev10x.platform import PlatformConfig, Registry, known_platforms
+from dev10x.platform import PlatformConfig, PlatformRepository, known_platforms
 
 
 class TestKnownPlatforms:
@@ -44,20 +44,20 @@ class TestKnownPlatforms:
         assert catalog["claude-code"].display_name == "Claude Code"
 
 
-class TestRegistryAdd:
-    """`Registry.add` persists an entry and returns the resolved config."""
+class TestPlatformRepositoryAdd:
+    """`PlatformRepository.add` persists an entry and returns the resolved config."""
 
     @pytest.fixture
-    def registry(self, tmp_path: Path) -> Registry:
-        return Registry(path=tmp_path / "platforms.yaml")
+    def registry(self, tmp_path: Path) -> PlatformRepository:
+        return PlatformRepository(path=tmp_path / "platforms.yaml")
 
-    def test_adds_from_catalog(self, registry: Registry) -> None:
+    def test_adds_from_catalog(self, registry: PlatformRepository) -> None:
         cfg = registry.add(name="windsurf")
         assert cfg.name == "windsurf"
         assert "windsurf" in str(cfg.config_dir)
 
-    def test_add_holds_file_lock(self, registry: Registry) -> None:
-        """A12: Registry.add serializes load→mutate→save via file_lock."""
+    def test_add_holds_file_lock(self, registry: PlatformRepository) -> None:
+        """A12: PlatformRepository.add serializes load→mutate→save via file_lock."""
         from unittest.mock import MagicMock, patch
 
         with patch("dev10x.platform.registry.file_lock") as mock_lock:
@@ -66,7 +66,7 @@ class TestRegistryAdd:
 
         mock_lock.assert_called_once_with(registry.path)
 
-    def test_remove_holds_file_lock(self, registry: Registry) -> None:
+    def test_remove_holds_file_lock(self, registry: PlatformRepository) -> None:
         from unittest.mock import MagicMock, patch
 
         registry.add(name="windsurf")
@@ -76,13 +76,13 @@ class TestRegistryAdd:
 
         mock_lock.assert_called_once_with(registry.path)
 
-    def test_rejects_unknown_platform(self, registry: Registry) -> None:
+    def test_rejects_unknown_platform(self, registry: PlatformRepository) -> None:
         with pytest.raises(ValueError, match="Unknown platform"):
             registry.add(name="not-a-real-platform")
 
     def test_respects_config_dir_override(
         self,
-        registry: Registry,
+        registry: PlatformRepository,
         tmp_path: Path,
     ) -> None:
         override = tmp_path / "custom"
@@ -92,7 +92,7 @@ class TestRegistryAdd:
         # plugins_dir should preserve the structural relationship
         assert cfg.plugins_dir.is_relative_to(override)
 
-    def test_persists_playbook_override(self, registry: Registry) -> None:
+    def test_persists_playbook_override(self, registry: PlatformRepository) -> None:
         cfg = registry.add(
             name="continue",
             playbook_override="playbooks/continue.yaml",
@@ -100,17 +100,17 @@ class TestRegistryAdd:
         assert cfg.playbook_override == "playbooks/continue.yaml"
 
 
-class TestRegistryLoadList:
-    """`Registry.list` returns persisted entries across sessions."""
+class TestPlatformRepositoryLoadList:
+    """`PlatformRepository.list` returns persisted entries across sessions."""
 
     @pytest.fixture
-    def registry(self, tmp_path: Path) -> Registry:
-        return Registry(path=tmp_path / "platforms.yaml")
+    def registry(self, tmp_path: Path) -> PlatformRepository:
+        return PlatformRepository(path=tmp_path / "platforms.yaml")
 
-    def test_list_empty_by_default(self, registry: Registry) -> None:
+    def test_list_empty_by_default(self, registry: PlatformRepository) -> None:
         assert registry.list() == []
 
-    def test_list_returns_registered_entries(self, registry: Registry) -> None:
+    def test_list_returns_registered_entries(self, registry: PlatformRepository) -> None:
         registry.add(name="claude-code")
         registry.add(name="copilot-cli")
 
@@ -118,7 +118,7 @@ class TestRegistryLoadList:
         names = {e.name for e in entries}
         assert names == {"claude-code", "copilot-cli"}
 
-    def test_list_sorted_alphabetically(self, registry: Registry) -> None:
+    def test_list_sorted_alphabetically(self, registry: PlatformRepository) -> None:
         registry.add(name="windsurf")
         registry.add(name="claude-code")
         registry.add(name="cursor")
@@ -127,32 +127,32 @@ class TestRegistryLoadList:
         assert [e.name for e in entries] == ["claude-code", "cursor", "windsurf"]
 
 
-class TestRegistryRemove:
-    """`Registry.remove` deletes a persisted entry."""
+class TestPlatformRepositoryRemove:
+    """`PlatformRepository.remove` deletes a persisted entry."""
 
     @pytest.fixture
-    def registry(self, tmp_path: Path) -> Registry:
-        return Registry(path=tmp_path / "platforms.yaml")
+    def registry(self, tmp_path: Path) -> PlatformRepository:
+        return PlatformRepository(path=tmp_path / "platforms.yaml")
 
-    def test_removes_existing_entry(self, registry: Registry) -> None:
+    def test_removes_existing_entry(self, registry: PlatformRepository) -> None:
         registry.add(name="cursor")
         assert registry.remove("cursor") is True
         assert registry.list() == []
 
-    def test_returns_false_for_unknown_entry(self, registry: Registry) -> None:
+    def test_returns_false_for_unknown_entry(self, registry: PlatformRepository) -> None:
         assert registry.remove("cursor") is False
 
 
-class TestRegistryRoundTrip:
-    """Saved entries survive a fresh Registry instance (file-backed)."""
+class TestPlatformRepositoryRoundTrip:
+    """Saved entries survive a fresh PlatformRepository instance (file-backed)."""
 
     def test_round_trip_preserves_config(self, tmp_path: Path) -> None:
         path = tmp_path / "platforms.yaml"
 
-        first = Registry(path=path)
+        first = PlatformRepository(path=path)
         first.add(name="continue", playbook_override="custom.yaml")
 
-        second = Registry(path=path)
+        second = PlatformRepository(path=path)
         entries = second.list()
         assert len(entries) == 1
         assert entries[0].name == "continue"
@@ -161,7 +161,7 @@ class TestRegistryRoundTrip:
     def test_windows_safe_no_symlinks_stored(self, tmp_path: Path) -> None:
         # The registry must not write symlinks — only a YAML file.
         path = tmp_path / "platforms.yaml"
-        registry = Registry(path=path)
+        registry = PlatformRepository(path=path)
         registry.add(name="claude-code")
 
         assert path.is_file()

--- a/tests/validators/test_registry.py
+++ b/tests/validators/test_registry.py
@@ -38,7 +38,6 @@ class _StubCorrector(ValidatorBase):
     name: ClassVar[str] = "stub-correct"
     rule_id: ClassVar[str] = "DX002"
     profile: ClassVar[ProfileTier] = ProfileTier.STANDARD
-    capabilities: ClassVar[frozenset[str]] = frozenset({"validate", "correct"})
 
     def should_run(self, inp: HookInput) -> bool:
         return True
@@ -301,7 +300,6 @@ class TestValidatorChain:
             name: ClassVar[str] = "raiser"
             rule_id: ClassVar[str] = "DX901"
             profile: ClassVar[ProfileTier] = ProfileTier.STANDARD
-            capabilities: ClassVar[frozenset[str]] = frozenset({"validate", "correct"})
 
             def should_run(self, inp: HookInput) -> bool:
                 return True


### PR DESCRIPTION
**When** I work in the validator, platform, and audit subsystems, **I want to** find one authoritative home for each piece of shared knowledge and no structural-only flags, **so I can** change behavior in a single place without the duplication and stale-singleton traps the M10 audit flagged.

---

[`ec17710a`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/634/commits/ec17710a5b7dc717bd85741765a149fa2df258e8) ♻️ GH-249 Simplify validator dispatch and shared registries
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/633

---