### PR TITLE
📝 GH-344 Resolve Tier 2 path discrepancy in playbook-pattern docs

### DIFF
--- a/.claude/rules/playbook-pattern.md
+++ b/.claude/rules/playbook-pattern.md
@@ -59,18 +59,16 @@ Users can override playbooks using the 3-tier resolution order
 | Tier | Path | Scope |
 |------|------|-------|
 | 1 | `.claude/Dev10x/playbooks/<skill-name>.yaml` | Project-local |
-| 2 | `~/.config/Dev10x/playbooks/<skill-name>.yaml` | Global + repo mapping |
+| 2 | `~/.claude/memory/Dev10x/playbooks/<skill-name>.yaml` | Global + repo mapping |
 | 3 | `${CLAUDE_PLUGIN_ROOT}/skills/<name>/references/playbook.yaml` | Plugin defaults |
 
 Tier 2 (global) is preferred — one file serves multiple repos via
 `projects[].match` globs. The skill loads this file at invocation,
 allowing users to customize behavior without editing the plugin.
 
-> **Note (GH-445):** Tier 2 moved to the XDG-canonical
-> `~/.config/Dev10x/playbooks/`. The old
-> `~/.claude/memory/Dev10x/playbooks/` path remains a deprecated
-> read-only fallback, and the GH-941-era
-> `~/.claude/projects/<key>/memory/` path is removed.
+> **Note (GH-941):** The old `~/.claude/projects/<key>/memory/`
+> path is removed. All tier 2 config lives under
+> `~/.claude/memory/Dev10x/`.
 
 ## Reviewer Expectations
 


### PR DESCRIPTION
**When** reviewing playbook config paths, **I want to** see the correct Tier 2 path documented in playbook-pattern.md, **so I can** configure overrides without following a stale XDG migration reference.

---

[`ef946a1a`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/637/commits/ef946a1ab6fff3eb339b92b8c9c5b19d52ca8177) 📝 GH-344 Resolve Tier 2 path discrepancy in playbook-pattern docs
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/344

---