### PR TITLE
♻️ GH-635 Centralize session-state capture on the aggregate

### DIFF
--- a/src/dev10x/domain/documents/session_state.py
+++ b/src/dev10x/domain/documents/session_state.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 from dev10x.domain.documents.task import Task, TaskStatus
@@ -28,6 +30,45 @@ class SessionState:
             staged_files=data.get("staged_files", []),
             recent_commits=data.get("recent_commits", []),
         )
+
+    @classmethod
+    def capture(
+        cls,
+        *,
+        session_id: str,
+        toplevel: str,
+        run_git: Callable[..., str],
+        timestamp: str,
+    ) -> SessionState:
+        """Build a `SessionState` from the live working tree.
+
+        `run_git` is injected (e.g. the SessionStop hook's `_run_git`)
+        so this domain object stays free of subprocess access — the
+        adapter owns the git invocation, the aggregate owns the field
+        shape. File lists are capped at 20 entries to bound the
+        persisted payload.
+        """
+        worktree = Path(toplevel).name if (Path(toplevel) / ".git").is_file() else ""
+        return cls(
+            timestamp=timestamp,
+            branch=run_git("rev-parse", "--abbrev-ref", "HEAD") or "unknown",
+            worktree=worktree,
+            session_id=session_id,
+            modified_files=run_git("diff", "--name-only").splitlines()[:20],
+            staged_files=run_git("diff", "--cached", "--name-only").splitlines()[:20],
+            recent_commits=run_git("log", "--oneline", "-5").splitlines(),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "timestamp": self.timestamp,
+            "branch": self.branch,
+            "worktree": self.worktree,
+            "session_id": self.session_id,
+            "modified_files": self.modified_files,
+            "staged_files": self.staged_files,
+            "recent_commits": self.recent_commits,
+        }
 
     def _age_hours(self) -> int:
         if not self.timestamp:

--- a/src/dev10x/hooks/session_dispatch.py
+++ b/src/dev10x/hooks/session_dispatch.py
@@ -19,9 +19,9 @@ import subprocess
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
 
 from dev10x.domain.claude_paths import ClaudeDir
+from dev10x.domain.documents.session_state import SessionState
 from dev10x.domain.git_context import GitContext
 from dev10x.domain.session_document import (
     plan_path_for_toplevel,
@@ -237,18 +237,14 @@ def session_persist(data: dict | None = None) -> None:
     state_dir.mkdir(parents=True, exist_ok=True)
     state_dir.chmod(0o700)
 
-    worktree_name = Path(toplevel).name if (Path(toplevel) / ".git").is_file() else ""
-    state: dict[str, Any] = {
-        "session_id": session_id,
-        "branch": _run_git("rev-parse", "--abbrev-ref", "HEAD") or "unknown",
-        "worktree": worktree_name,
-        "working_directory": toplevel,
-        "timestamp": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "modified_files": _run_git("diff", "--name-only").splitlines()[:20],
-        "staged_files": _run_git("diff", "--cached", "--name-only").splitlines()[:20],
-        "recent_commits": _run_git("log", "--oneline", "-5").splitlines(),
-        "has_plan": plan_path_for_toplevel(toplevel=toplevel).exists(),
-    }
+    state = SessionState.capture(
+        session_id=session_id,
+        toplevel=toplevel,
+        run_git=_run_git,
+        timestamp=datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    ).to_dict()
+    state["working_directory"] = toplevel
+    state["has_plan"] = plan_path_for_toplevel(toplevel=toplevel).exists()
     write_state(path=state_path_for_toplevel(toplevel=toplevel), state=state)
 
 

--- a/tests/domain/test_session_state.py
+++ b/tests/domain/test_session_state.py
@@ -94,6 +94,114 @@ class TestSessionStateFromDict:
         assert state.modified_files == []
 
 
+class TestSessionStateToDict:
+    def test_round_trips_through_from_dict(self) -> None:
+        state = SessionState(
+            timestamp="2026-01-01T00:00:00Z",
+            branch="main",
+            worktree="wt",
+            session_id="sid",
+            modified_files=["a.py"],
+            staged_files=["b.py"],
+            recent_commits=["abc Fix"],
+        )
+
+        assert SessionState.from_dict(data=state.to_dict()) == state
+
+    def test_exposes_all_seven_fields(self) -> None:
+        keys = set(SessionState().to_dict())
+
+        assert keys == {
+            "timestamp",
+            "branch",
+            "worktree",
+            "session_id",
+            "modified_files",
+            "staged_files",
+            "recent_commits",
+        }
+
+
+class TestSessionStateCapture:
+    @staticmethod
+    def _fake_git(responses: dict[tuple[str, ...], str]):
+        def run(*args: str) -> str:
+            return responses.get(args, "")
+
+        return run
+
+    def test_populates_fields_from_injected_runner(self, tmp_path) -> None:
+        (tmp_path / ".git").mkdir()  # main repo: .git is a directory
+        run = self._fake_git(
+            {
+                ("rev-parse", "--abbrev-ref", "HEAD"): "feature/x",
+                ("diff", "--name-only"): "a.py\nb.py",
+                ("diff", "--cached", "--name-only"): "c.py",
+                ("log", "--oneline", "-5"): "abc Fix\ndef Add",
+            }
+        )
+
+        state = SessionState.capture(
+            session_id="sid",
+            toplevel=str(tmp_path),
+            run_git=run,
+            timestamp="2026-01-01T00:00:00Z",
+        )
+
+        assert state.session_id == "sid"
+        assert state.timestamp == "2026-01-01T00:00:00Z"
+        assert state.branch == "feature/x"
+        assert state.modified_files == ["a.py", "b.py"]
+        assert state.staged_files == ["c.py"]
+        assert state.recent_commits == ["abc Fix", "def Add"]
+        assert state.worktree == ""
+
+    def test_detects_worktree_when_git_is_a_file(self, tmp_path) -> None:
+        (tmp_path / ".git").write_text("gitdir: /elsewhere\n")  # worktree marker
+
+        state = SessionState.capture(
+            session_id="s",
+            toplevel=str(tmp_path),
+            run_git=lambda *a: "",
+            timestamp="t",
+        )
+
+        assert state.worktree == tmp_path.name
+
+    def test_branch_falls_back_to_unknown_on_empty_output(self, tmp_path) -> None:
+        (tmp_path / ".git").mkdir()
+
+        state = SessionState.capture(
+            session_id="s",
+            toplevel=str(tmp_path),
+            run_git=lambda *a: "",
+            timestamp="t",
+        )
+
+        assert state.branch == "unknown"
+        assert state.modified_files == []
+
+    def test_caps_file_lists_at_twenty(self, tmp_path) -> None:
+        (tmp_path / ".git").mkdir()
+        many = "\n".join(f"f{i}.py" for i in range(30))
+        run = self._fake_git(
+            {
+                ("diff", "--name-only"): many,
+                ("diff", "--cached", "--name-only"): many,
+            }
+        )
+
+        state = SessionState.capture(
+            session_id="s",
+            toplevel=str(tmp_path),
+            run_git=run,
+            timestamp="t",
+        )
+
+        assert len(state.modified_files) == 20
+        assert len(state.staged_files) == 20
+
+
 class TestPlanContextFromDict:
     def test_parses_all_fields(self) -> None:
         ctx = PlanContext.from_dict(


### PR DESCRIPTION
**When** the persisted session-state shape needs to change (new fields, a different capture source), **I want to** have capture and serialization owned by the `SessionState` aggregate rather than hand-built in the SessionStop hook, **so I can** evolve session state in one typed place without touching the adapter or duplicating its field shape.

---

[`f70c23d0`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/638/commits/f70c23d0370a40c07166f3dab95e1b5890277ac3) ♻️ GH-635 Centralize session-state capture on the aggregate
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/635

---