### PR TITLE
✅ GH-580 Enable direct tests for git_tools/misc_tools/roots_tools MCP adapters

### DIFF
--- a/tests/mcp/test_git_tools.py
+++ b/tests/mcp/test_git_tools.py
@@ -1,0 +1,267 @@
+"""Tests for git_tools MCP adapter (GH-580).
+
+Covers argument forwarding (especially cwd), ok/err → dict translation,
+and error paths for each adapter function in src/dev10x/mcp/git_tools.py.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dev10x.domain.common.result import err, ok
+from dev10x.mcp import server_cli as cli_server
+
+
+class TestPushSafe:
+    @pytest.mark.asyncio
+    @patch("dev10x.git.push_safe", new_callable=AsyncMock)
+    async def test_delegates_to_git_module(self, mock_fn: AsyncMock) -> None:
+        mock_fn.return_value = ok({"pushed": True, "branch": "feature"})
+
+        result = await cli_server.push_safe(args=["-u", "origin", "feature"])
+
+        assert result == {"pushed": True, "branch": "feature"}
+        assert mock_fn.call_args.kwargs["args"] == ["-u", "origin", "feature"]
+
+    @pytest.mark.asyncio
+    @patch("dev10x.git.push_safe", new_callable=AsyncMock)
+    async def test_forwards_protected_branches(self, mock_fn: AsyncMock) -> None:
+        mock_fn.return_value = ok({})
+
+        await cli_server.push_safe(
+            args=["origin", "main"],
+            protected_branches=["main", "develop"],
+        )
+
+        assert mock_fn.call_args.kwargs["protected_branches"] == ["main", "develop"]
+
+    @pytest.mark.asyncio
+    @patch("dev10x.git.push_safe", new_callable=AsyncMock)
+    async def test_returns_error_on_failure(self, mock_fn: AsyncMock) -> None:
+        mock_fn.return_value = err("push blocked: protected branch")
+
+        result = await cli_server.push_safe(args=["origin", "main"])
+
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    @patch("dev10x.git.push_safe", new_callable=AsyncMock)
+    async def test_forwards_cwd(self, mock_fn: AsyncMock, tmp_path) -> None:
+        mock_fn.return_value = ok({})
+
+        with patch("dev10x.subprocess_utils.use_cwd") as mock_use_cwd:
+            await cli_server.push_safe(args=["origin", "feature"], cwd=str(tmp_path))
+
+        mock_use_cwd.assert_called_once_with(str(tmp_path))
+
+
+class TestRebaseGroom:
+    @pytest.mark.asyncio
+    @patch("dev10x.git.rebase_groom", new_callable=AsyncMock)
+    async def test_delegates_to_git_module(self, mock_fn: AsyncMock) -> None:
+        mock_fn.return_value = ok({"commits_rewritten": 3})
+
+        result = await cli_server.rebase_groom(seq_path="/tmp/seq", base_ref="develop")
+
+        assert result == {"commits_rewritten": 3}
+        assert mock_fn.call_args.kwargs == {"seq_path": "/tmp/seq", "base_ref": "develop"}
+
+    @pytest.mark.asyncio
+    @patch("dev10x.git.rebase_groom", new_callable=AsyncMock)
+    async def test_returns_error_on_failure(self, mock_fn: AsyncMock) -> None:
+        mock_fn.return_value = err("rebase conflict at HEAD")
+
+        result = await cli_server.rebase_groom(seq_path="/tmp/seq", base_ref="develop")
+
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    @patch("dev10x.git.rebase_groom", new_callable=AsyncMock)
+    async def test_forwards_cwd(self, mock_fn: AsyncMock, tmp_path) -> None:
+        mock_fn.return_value = ok({"commits_rewritten": 0})
+
+        with patch("dev10x.subprocess_utils.use_cwd") as mock_use_cwd:
+            await cli_server.rebase_groom(
+                seq_path="/tmp/seq",
+                base_ref="develop",
+                cwd=str(tmp_path),
+            )
+
+        mock_use_cwd.assert_called_once_with(str(tmp_path))
+
+
+class TestCreateWorktree:
+    @pytest.mark.asyncio
+    @patch("dev10x.git.create_worktree", new_callable=AsyncMock)
+    async def test_delegates_to_git_module(self, mock_fn: AsyncMock) -> None:
+        mock_fn.return_value = ok(
+            {"worktree_path": "/work/.worktrees/feature-1", "branch": "feature", "created": True}
+        )
+
+        result = await cli_server.create_worktree(branch="feature")
+
+        assert result["created"] is True
+        assert mock_fn.call_args.kwargs["branch"] == "feature"
+
+    @pytest.mark.asyncio
+    @patch("dev10x.git.create_worktree", new_callable=AsyncMock)
+    async def test_forwards_base_and_path(self, mock_fn: AsyncMock) -> None:
+        mock_fn.return_value = ok({"worktree_path": "/tmp/wt", "branch": "feat", "created": True})
+
+        await cli_server.create_worktree(branch="feat", base="main", path="/tmp/wt")
+
+        assert mock_fn.call_args.kwargs["base"] == "main"
+        assert mock_fn.call_args.kwargs["path"] == "/tmp/wt"
+
+    @pytest.mark.asyncio
+    @patch("dev10x.git.create_worktree", new_callable=AsyncMock)
+    async def test_returns_error_on_failure(self, mock_fn: AsyncMock) -> None:
+        mock_fn.return_value = err("branch already checked out")
+
+        result = await cli_server.create_worktree(branch="feature")
+
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    @patch("dev10x.git.create_worktree", new_callable=AsyncMock)
+    async def test_forwards_cwd(self, mock_fn: AsyncMock, tmp_path) -> None:
+        mock_fn.return_value = ok({"worktree_path": "/tmp/wt", "branch": "feat", "created": True})
+
+        with patch("dev10x.subprocess_utils.use_cwd") as mock_use_cwd:
+            await cli_server.create_worktree(branch="feat", cwd=str(tmp_path))
+
+        mock_use_cwd.assert_called_once_with(str(tmp_path))
+
+
+class TestMassRewrite:
+    @pytest.mark.asyncio
+    @patch("dev10x.git.mass_rewrite", new_callable=AsyncMock)
+    async def test_delegates_to_git_module(self, mock_fn: AsyncMock) -> None:
+        mock_fn.return_value = ok({"success": True, "output": "3 commits rewritten"})
+
+        result = await cli_server.mass_rewrite(config_path="/tmp/rewrites.json")
+
+        assert result == {"success": True, "output": "3 commits rewritten"}
+        assert mock_fn.call_args.kwargs["config_path"] == "/tmp/rewrites.json"
+
+    @pytest.mark.asyncio
+    @patch("dev10x.git.mass_rewrite", new_callable=AsyncMock)
+    async def test_returns_error_on_failure(self, mock_fn: AsyncMock) -> None:
+        mock_fn.return_value = err("config file not found")
+
+        result = await cli_server.mass_rewrite(config_path="/tmp/missing.json")
+
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    @patch("dev10x.git.mass_rewrite", new_callable=AsyncMock)
+    async def test_forwards_cwd(self, mock_fn: AsyncMock, tmp_path) -> None:
+        mock_fn.return_value = ok({"success": True, "output": ""})
+
+        with patch("dev10x.subprocess_utils.use_cwd") as mock_use_cwd:
+            await cli_server.mass_rewrite(config_path="/tmp/x.json", cwd=str(tmp_path))
+
+        mock_use_cwd.assert_called_once_with(str(tmp_path))
+
+
+class TestStartSplitRebase:
+    @pytest.mark.asyncio
+    @patch("dev10x.git.start_split_rebase", new_callable=AsyncMock)
+    async def test_delegates_to_git_module(self, mock_fn: AsyncMock) -> None:
+        mock_fn.return_value = ok({"success": True, "output": "rebase started"})
+
+        result = await cli_server.start_split_rebase(commit_hash="abc1234")
+
+        assert result == {"success": True, "output": "rebase started"}
+        assert mock_fn.call_args.kwargs["commit_hash"] == "abc1234"
+
+    @pytest.mark.asyncio
+    @patch("dev10x.git.start_split_rebase", new_callable=AsyncMock)
+    async def test_forwards_base_branch(self, mock_fn: AsyncMock) -> None:
+        mock_fn.return_value = ok({"success": True, "output": ""})
+
+        await cli_server.start_split_rebase(commit_hash="abc1234", base_branch="main")
+
+        assert mock_fn.call_args.kwargs["base_branch"] == "main"
+
+    @pytest.mark.asyncio
+    @patch("dev10x.git.start_split_rebase", new_callable=AsyncMock)
+    async def test_returns_error_on_failure(self, mock_fn: AsyncMock) -> None:
+        mock_fn.return_value = err("commit not found")
+
+        result = await cli_server.start_split_rebase(commit_hash="deadbeef")
+
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    @patch("dev10x.git.start_split_rebase", new_callable=AsyncMock)
+    async def test_forwards_cwd(self, mock_fn: AsyncMock, tmp_path) -> None:
+        mock_fn.return_value = ok({"success": True, "output": ""})
+
+        with patch("dev10x.subprocess_utils.use_cwd") as mock_use_cwd:
+            await cli_server.start_split_rebase(commit_hash="abc1234", cwd=str(tmp_path))
+
+        mock_use_cwd.assert_called_once_with(str(tmp_path))
+
+
+class TestNextWorktreeName:
+    @pytest.mark.asyncio
+    @patch("dev10x.git.next_worktree_name", new_callable=AsyncMock)
+    async def test_delegates_to_git_module(self, mock_fn: AsyncMock) -> None:
+        mock_fn.return_value = ok({"path": "/work/.worktrees/proj-02"})
+
+        result = await cli_server.next_worktree_name()
+
+        assert result == {"path": "/work/.worktrees/proj-02"}
+        assert mock_fn.call_args.kwargs["base_dir"] is None
+
+    @pytest.mark.asyncio
+    @patch("dev10x.git.next_worktree_name", new_callable=AsyncMock)
+    async def test_forwards_base_dir(self, mock_fn: AsyncMock) -> None:
+        mock_fn.return_value = ok({"path": "/custom/.worktrees/proj-01"})
+
+        await cli_server.next_worktree_name(base_dir="/custom/.worktrees")
+
+        assert mock_fn.call_args.kwargs["base_dir"] == "/custom/.worktrees"
+
+    @pytest.mark.asyncio
+    @patch("dev10x.git.next_worktree_name", new_callable=AsyncMock)
+    async def test_returns_error_on_failure(self, mock_fn: AsyncMock) -> None:
+        mock_fn.return_value = err("no repo found")
+
+        result = await cli_server.next_worktree_name()
+
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    @patch("dev10x.git.next_worktree_name", new_callable=AsyncMock)
+    async def test_forwards_cwd(self, mock_fn: AsyncMock, tmp_path) -> None:
+        mock_fn.return_value = ok({"path": "/work/.worktrees/proj-01"})
+
+        with patch("dev10x.subprocess_utils.use_cwd") as mock_use_cwd:
+            await cli_server.next_worktree_name(cwd=str(tmp_path))
+
+        mock_use_cwd.assert_called_once_with(str(tmp_path))
+
+
+class TestSetupAliases:
+    @pytest.mark.asyncio
+    @patch("dev10x.git.setup_aliases", new_callable=AsyncMock)
+    async def test_delegates_to_git_module(self, mock_fn: AsyncMock) -> None:
+        mock_fn.return_value = ok({"success": True, "output": "aliases set"})
+
+        result = await cli_server.setup_aliases()
+
+        assert result == {"success": True, "output": "aliases set"}
+        mock_fn.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch("dev10x.git.setup_aliases", new_callable=AsyncMock)
+    async def test_returns_error_on_failure(self, mock_fn: AsyncMock) -> None:
+        mock_fn.return_value = err("git config failed")
+
+        result = await cli_server.setup_aliases()
+
+        assert "error" in result

--- a/tests/mcp/test_misc_tools.py
+++ b/tests/mcp/test_misc_tools.py
@@ -1,0 +1,306 @@
+"""Tests for misc_tools MCP adapter (GH-580).
+
+Covers argument forwarding (especially cwd), ok/err → dict translation,
+and error paths for each adapter function in src/dev10x/mcp/misc_tools.py.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dev10x.domain.common.result import err, ok
+from dev10x.mcp import server_cli as cli_server
+
+
+class TestMktmp:
+    @pytest.mark.asyncio
+    @patch("dev10x.utilities.mktmp", new_callable=AsyncMock)
+    async def test_delegates_to_utilities_module(self, mock_fn: AsyncMock) -> None:
+        mock_fn.return_value = ok({"path": "/tmp/Dev10x/git/msg-abc.txt"})
+
+        result = await cli_server.mktmp(namespace="git", prefix="msg", ext=".txt")
+
+        assert result == {"path": "/tmp/Dev10x/git/msg-abc.txt"}
+        assert mock_fn.call_args.kwargs["namespace"] == "git"
+        assert mock_fn.call_args.kwargs["prefix"] == "msg"
+        assert mock_fn.call_args.kwargs["ext"] == ".txt"
+
+    @pytest.mark.asyncio
+    @patch("dev10x.utilities.mktmp", new_callable=AsyncMock)
+    async def test_forwards_directory_and_create_flags(self, mock_fn: AsyncMock) -> None:
+        mock_fn.return_value = ok({"path": "/tmp/Dev10x/fanout/wave-01/"})
+
+        await cli_server.mktmp(
+            namespace="fanout",
+            prefix="wave",
+            directory=True,
+            create=True,
+        )
+
+        assert mock_fn.call_args.kwargs["directory"] is True
+        assert mock_fn.call_args.kwargs["create"] is True
+
+    @pytest.mark.asyncio
+    @patch("dev10x.utilities.mktmp", new_callable=AsyncMock)
+    async def test_returns_error_on_failure(self, mock_fn: AsyncMock) -> None:
+        mock_fn.return_value = err("cannot create temp dir")
+
+        result = await cli_server.mktmp(namespace="x", prefix="y")
+
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    @patch("dev10x.utilities.mktmp", new_callable=AsyncMock)
+    async def test_forwards_cwd(self, mock_fn: AsyncMock, tmp_path) -> None:
+        mock_fn.return_value = ok({"path": "/tmp/Dev10x/git/msg.txt"})
+
+        with patch("dev10x.subprocess_utils.use_cwd") as mock_use_cwd:
+            await cli_server.mktmp(
+                namespace="git",
+                prefix="msg",
+                cwd=str(tmp_path),
+            )
+
+        mock_use_cwd.assert_called_once_with(str(tmp_path))
+
+
+class TestSlackThreadIsForward:
+    @pytest.mark.asyncio
+    @patch("dev10x.utilities.slack.slack_thread_is_forward", new_callable=AsyncMock)
+    async def test_delegates_to_slack_helper(self, mock_fn: AsyncMock) -> None:
+        mock_fn.return_value = ok(
+            {
+                "is_forward": True,
+                "confidence": "high",
+                "signals": ["short_body", "external_link"],
+                "upstream_hints": [],
+            }
+        )
+
+        result = await cli_server.slack_thread_is_forward(
+            parent_body="FYI see https://example.com",
+            reply_count=0,
+        )
+
+        assert result["is_forward"] is True
+        assert result["confidence"] == "high"
+        assert mock_fn.call_args.kwargs == {
+            "parent_body": "FYI see https://example.com",
+            "reply_count": 0,
+        }
+
+    @pytest.mark.asyncio
+    @patch("dev10x.utilities.slack.slack_thread_is_forward", new_callable=AsyncMock)
+    async def test_returns_error_on_failure(self, mock_fn: AsyncMock) -> None:
+        mock_fn.return_value = err("analysis failed")
+
+        result = await cli_server.slack_thread_is_forward(
+            parent_body="hello world",
+            reply_count=5,
+        )
+
+        assert "error" in result
+
+
+class TestUpdatePaths:
+    @pytest.mark.asyncio
+    @patch("dev10x.permission.update_paths", new_callable=AsyncMock)
+    async def test_delegates_to_permission_module(self, mock_fn: AsyncMock) -> None:
+        mock_fn.return_value = ok({"success": True, "output": "3 paths updated"})
+
+        result = await cli_server.update_paths()
+
+        assert result == {"success": True, "output": "3 paths updated"}
+        mock_fn.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch("dev10x.permission.update_paths", new_callable=AsyncMock)
+    async def test_forwards_all_flags(self, mock_fn: AsyncMock) -> None:
+        mock_fn.return_value = ok({"success": True, "output": ""})
+
+        await cli_server.update_paths(
+            version="1.2.3",
+            dry_run=True,
+            ensure_base=True,
+            generalize=True,
+            ensure_scripts=True,
+            ensure_reads=True,
+            init=True,
+            quiet=True,
+        )
+
+        kw = mock_fn.call_args.kwargs
+        assert kw["version"] == "1.2.3"
+        assert kw["dry_run"] is True
+        assert kw["ensure_base"] is True
+        assert kw["generalize"] is True
+        assert kw["ensure_scripts"] is True
+        assert kw["ensure_reads"] is True
+        assert kw["init"] is True
+        assert kw["quiet"] is True
+
+    @pytest.mark.asyncio
+    @patch("dev10x.permission.update_paths", new_callable=AsyncMock)
+    async def test_returns_error_on_failure(self, mock_fn: AsyncMock) -> None:
+        mock_fn.return_value = err("settings.json not found")
+
+        result = await cli_server.update_paths()
+
+        assert "error" in result
+
+
+class TestGenerateSkillIndex:
+    @pytest.mark.asyncio
+    @patch("dev10x.skill_index.generate_all", new_callable=AsyncMock)
+    async def test_delegates_to_skill_index_module(self, mock_fn: AsyncMock) -> None:
+        mock_fn.return_value = ok({"success": True, "output": "SKILLS.md updated"})
+
+        result = await cli_server.generate_skill_index()
+
+        assert result == {"success": True, "output": "SKILLS.md updated"}
+        assert mock_fn.call_args.kwargs["force"] is False
+
+    @pytest.mark.asyncio
+    @patch("dev10x.skill_index.generate_all", new_callable=AsyncMock)
+    async def test_forwards_force_flag(self, mock_fn: AsyncMock) -> None:
+        mock_fn.return_value = ok({"success": True, "output": ""})
+
+        await cli_server.generate_skill_index(force=True)
+
+        assert mock_fn.call_args.kwargs["force"] is True
+
+    @pytest.mark.asyncio
+    @patch("dev10x.skill_index.generate_all", new_callable=AsyncMock)
+    async def test_returns_error_on_failure(self, mock_fn: AsyncMock) -> None:
+        mock_fn.return_value = err("skills directory not found")
+
+        result = await cli_server.generate_skill_index()
+
+        assert "error" in result
+
+
+class TestRecordUpgrade:
+    @patch("dev10x.domain.install_version.record_upgrade")
+    def test_delegates_to_install_version_module(self, mock_fn: MagicMock) -> None:
+        mock_fn.return_value = ok({"version": "1.2.3", "path": "/home/user/.config/dev10x"})
+
+        import asyncio
+
+        result = asyncio.get_event_loop().run_until_complete(
+            cli_server.record_upgrade(version="1.2.3")
+        )
+
+        assert result == {"version": "1.2.3", "path": "/home/user/.config/dev10x"}
+        assert mock_fn.call_args.kwargs["version"] == "1.2.3"
+
+    @patch("dev10x.domain.install_version.record_upgrade")
+    def test_forwards_none_version(self, mock_fn: MagicMock) -> None:
+        mock_fn.return_value = ok({"version": "0.99.0", "path": "/home/user/.config/dev10x"})
+
+        import asyncio
+
+        asyncio.get_event_loop().run_until_complete(cli_server.record_upgrade())
+
+        assert mock_fn.call_args.kwargs["version"] is None
+
+    @patch("dev10x.domain.install_version.record_upgrade")
+    def test_returns_error_on_failure(self, mock_fn: MagicMock) -> None:
+        mock_fn.return_value = err("plugin.json not found")
+
+        import asyncio
+
+        result = asyncio.get_event_loop().run_until_complete(cli_server.record_upgrade())
+
+        assert "error" in result
+
+
+class TestRunTests:
+    @pytest.mark.asyncio
+    @patch("dev10x.runner.run_tests", new_callable=AsyncMock)
+    async def test_delegates_to_runner_module(self, mock_fn: AsyncMock) -> None:
+        mock_fn.return_value = ok(
+            {
+                "returncode": 0,
+                "summary": "42 passed",
+                "passed": 42,
+                "failed": 0,
+                "skipped": 0,
+                "errors": 0,
+                "coverage_percent": 87,
+                "failed_tests": [],
+                "missing_coverage": [],
+                "stdout": "",
+                "stderr": "",
+            }
+        )
+
+        result = await cli_server.run_tests()
+
+        assert result["returncode"] == 0
+        assert result["passed"] == 42
+        assert mock_fn.call_args.kwargs["args"] is None
+        assert mock_fn.call_args.kwargs["coverage"] is True
+
+    @pytest.mark.asyncio
+    @patch("dev10x.runner.run_tests", new_callable=AsyncMock)
+    async def test_forwards_args_and_flags(self, mock_fn: AsyncMock) -> None:
+        mock_fn.return_value = ok(
+            {
+                "returncode": 0,
+                "summary": "5 passed",
+                "passed": 5,
+                "failed": 0,
+                "skipped": 0,
+                "errors": 0,
+                "coverage_percent": None,
+                "failed_tests": [],
+                "missing_coverage": [],
+                "stdout": "",
+                "stderr": "",
+            }
+        )
+
+        await cli_server.run_tests(
+            args=["tests/mcp/"],
+            coverage=False,
+            timeout=120,
+        )
+
+        assert mock_fn.call_args.kwargs["args"] == ["tests/mcp/"]
+        assert mock_fn.call_args.kwargs["coverage"] is False
+        assert mock_fn.call_args.kwargs["timeout"] == 120
+
+    @pytest.mark.asyncio
+    @patch("dev10x.runner.run_tests", new_callable=AsyncMock)
+    async def test_returns_error_on_failure(self, mock_fn: AsyncMock) -> None:
+        mock_fn.return_value = err("pytest not found")
+
+        result = await cli_server.run_tests()
+
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    @patch("dev10x.runner.run_tests", new_callable=AsyncMock)
+    async def test_forwards_cwd(self, mock_fn: AsyncMock, tmp_path) -> None:
+        mock_fn.return_value = ok(
+            {
+                "returncode": 0,
+                "summary": "",
+                "passed": 0,
+                "failed": 0,
+                "skipped": 0,
+                "errors": 0,
+                "coverage_percent": None,
+                "failed_tests": [],
+                "missing_coverage": [],
+                "stdout": "",
+                "stderr": "",
+            }
+        )
+
+        with patch("dev10x.subprocess_utils.use_cwd") as mock_use_cwd:
+            await cli_server.run_tests(cwd=str(tmp_path))
+
+        mock_use_cwd.assert_called_once_with(str(tmp_path))

--- a/tests/mcp/test_roots_tools.py
+++ b/tests/mcp/test_roots_tools.py
@@ -1,0 +1,65 @@
+"""Tests for roots_tools MCP adapter (GH-580).
+
+Covers ok → dict translation and the three manager states for
+list_client_roots in src/dev10x/mcp/roots_tools.py.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from dev10x.mcp import server_cli as cli_server
+from dev10x.mcp.roots_manager import ClientRoot, ClientRootsManager
+
+
+class TestListClientRoots:
+    @pytest.mark.asyncio
+    async def test_returns_none_roots_and_disabled_when_no_manager(self) -> None:
+        with patch("dev10x.mcp.roots_manager.get_manager", return_value=None):
+            result = await cli_server.list_client_roots()
+
+        assert result == {"roots": None, "enabled": False}
+
+    @pytest.mark.asyncio
+    async def test_returns_none_roots_before_session_established(self) -> None:
+        mgr = ClientRootsManager(enabled=True)
+        with patch("dev10x.mcp.roots_manager.get_manager", return_value=mgr):
+            result = await cli_server.list_client_roots()
+
+        assert result["roots"] is None
+        assert result["enabled"] is True
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_when_client_declares_no_roots(self) -> None:
+        mgr = ClientRootsManager(enabled=True)
+        mgr._roots = []
+        with patch("dev10x.mcp.roots_manager.get_manager", return_value=mgr):
+            result = await cli_server.list_client_roots()
+
+        assert result["roots"] == []
+        assert result["enabled"] is True
+
+    @pytest.mark.asyncio
+    async def test_returns_populated_roots_after_refresh(self, tmp_path) -> None:
+        mgr = ClientRootsManager(enabled=True)
+        mgr._roots = [
+            ClientRoot(uri=f"file://{tmp_path}/work", name="Work"),
+            ClientRoot(uri=f"file://{tmp_path}/home", name=None),
+        ]
+        with patch("dev10x.mcp.roots_manager.get_manager", return_value=mgr):
+            result = await cli_server.list_client_roots()
+
+        assert len(result["roots"]) == 2
+        assert result["roots"][0] == {"uri": f"file://{tmp_path}/work", "name": "Work"}
+        assert result["roots"][1] == {"uri": f"file://{tmp_path}/home", "name": None}
+
+    @pytest.mark.asyncio
+    async def test_enabled_false_when_manager_disabled(self) -> None:
+        mgr = ClientRootsManager(enabled=False)
+        mgr._roots = []
+        with patch("dev10x.mcp.roots_manager.get_manager", return_value=mgr):
+            result = await cli_server.list_client_roots()
+
+        assert result["enabled"] is False


### PR DESCRIPTION
When I maintain the MCP server, I want direct unit tests for every adapter function so CI catches regressions in delegation, error handling, and cwd forwarding without needing an end-to-end server.

---

[`e2a5079d`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/639/commits/e2a5079db1e2ca3afd4c87416be9aa61f35571b3) ✅ GH-580 Enable direct tests for git_tools/misc_tools/roots_tools MCP adapters
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/580

---