### PR TITLE
✅ GH-564 Resolve monkeypatch target and MagicMock CWD pollution

### DIFF
--- a/tests/hooks/test_session_start_hooks.py
+++ b/tests/hooks/test_session_start_hooks.py
@@ -513,6 +513,7 @@ class TestSessionMigratePermissions:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         import dev10x.hooks.session as mod
+        import dev10x.hooks.session_dispatch as dispatch_mod
 
         fake_plugin_root = tmp_path / "plugins" / "cache" / "Dev10x" / "1.0.0"
         fake_old_version = tmp_path / "plugins" / "cache" / "Dev10x" / "0.9.0"
@@ -533,17 +534,10 @@ class TestSessionMigratePermissions:
         )
 
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(dispatch_mod, "_plugin_root", lambda: fake_plugin_root)
 
-        captured = io.StringIO()
-        sys.stdout = captured
-        try:
-            with pytest.raises(SystemExit):
-                monkeypatch.setattr(
-                    "dev10x.hooks.session.Path",
-                    lambda *a, **kw: fake_plugin_root if not a else Path(*a, **kw),
-                )
-                mod.session_migrate_permissions()
-        except Exception:
-            pass
-        finally:
-            sys.stdout = sys.__stdout__
+        mod.session_migrate_permissions()
+
+        updated = json.loads(settings_file.read_text())
+        allow_rules = updated["permissions"]["allow"]
+        assert any(str(fake_plugin_root) in r for r in allow_rules)

--- a/tests/mcp/test_cli_server.py
+++ b/tests/mcp/test_cli_server.py
@@ -7,6 +7,7 @@ GH-493 and will be completed incrementally.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import subprocess
 from unittest.mock import AsyncMock, patch
@@ -1320,6 +1321,12 @@ class TestAuditHookRecent:
 # ── #G1b: cwd activation per CWD-sensitive handler ──────────────
 
 
+@contextlib.contextmanager
+def _noop_cwd_stub(path: str):
+    """Noop use_cwd stub: records the call without binding the CWD ContextVar."""
+    yield
+
+
 CWD_HANDLERS: list[tuple[str, dict]] = [
     (
         "detect_tracker",
@@ -1433,15 +1440,12 @@ class TestCwdParameterActivation:
     ) -> None:
         handler = getattr(cli_server, handler_name)
 
-        with patch("dev10x.subprocess_utils.use_cwd") as mock_use_cwd:
-            try:
+        with patch("dev10x.subprocess_utils.use_cwd", side_effect=_noop_cwd_stub) as mock_use_cwd:
+            with contextlib.suppress(Exception):
+                # Domain calls may fail without real subprocess/network;
+                # we only verify use_cwd is invoked with the right path.
                 await handler(**kwargs, cwd=str(tmp_path))
-            except Exception:
-                # The handler's underlying call may fail (no real
-                # subprocess); we only care that use_cwd was entered.
-                pass
-
-        mock_use_cwd.assert_called_once_with(str(tmp_path))
+            mock_use_cwd.assert_called_once_with(str(tmp_path))
 
 
 # ── GH-247 G1: four untested delegation handlers ─────────────────


### PR DESCRIPTION
**When** test failures hide behind broad exception swallowers, **I want to** replace bare MagicMock context-manager stubs and `except Exception: pass` clauses with correct patterns, **so I can** trust the CWD-activation and permission-migration tests actually validate what they claim.

---

[`91b0ec9f`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/640/commits/91b0ec9f91d85c2b826f53f65b0ed5fe71420c91) ✅ GH-564 Resolve monkeypatch target and MagicMock CWD pollution
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/564

---