### PR TITLE
✅ GH-567 Prevent CI hangs from unbounded subprocess calls

### DIFF
--- a/tests/hooks/test_orchestrators.py
+++ b/tests/hooks/test_orchestrators.py
@@ -25,6 +25,7 @@ def _run(script: Path, payload: dict) -> subprocess.CompletedProcess[str]:
         input=json.dumps(payload),
         capture_output=True,
         text=True,
+        timeout=30,
         cwd=str(SCRIPTS.parent.parent),
         env={
             "DEV10X_HOOK_AUDIT": "0",

--- a/tests/hooks/test_validate_edit_write.py
+++ b/tests/hooks/test_validate_edit_write.py
@@ -28,6 +28,7 @@ def _run_hook(
         input=json.dumps(payload),
         capture_output=True,
         text=True,
+        timeout=30,
     )
 
 
@@ -138,6 +139,7 @@ class TestMalformedInput:
             input="",
             capture_output=True,
             text=True,
+            timeout=30,
         )
         assert result.returncode == 0
 
@@ -147,6 +149,7 @@ class TestMalformedInput:
             input="{invalid json}",
             capture_output=True,
             text=True,
+            timeout=30,
         )
         assert result.returncode == 0
 
@@ -157,5 +160,6 @@ class TestMalformedInput:
             input=json.dumps(payload),
             capture_output=True,
             text=True,
+            timeout=30,
         )
         assert result.returncode == 0


### PR DESCRIPTION
**When** running the test suite in CI, **I want to** have subprocess invocations bounded by a timeout, **so I can** fail fast instead of hanging indefinitely on a frozen script.

---

[`c7c5bd8e`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/641/commits/c7c5bd8e2ab9c3df066f4762974da809a712d403) ✅ GH-567 Prevent CI hangs from unbounded subprocess calls
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/567

---