### PR TITLE
✅ GH-568 Cover untested commands, ConfigLoader, session queries

### DIFF
--- a/tests/commands/test_config.py
+++ b/tests/commands/test_config.py
@@ -1,0 +1,112 @@
+"""Tests for `dev10x config` CLI commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from dev10x.commands.config import config
+
+
+class TestConfigRoot:
+    def test_prints_config_home(self) -> None:
+        runner = CliRunner()
+        with patch(
+            "dev10x.commands.config.Dev10xConfigDir.home",
+            return_value=Path("/fake/config/root"),
+        ):
+            result = runner.invoke(config, ["root"])
+        assert result.exit_code == 0
+        assert "/fake/config/root" in result.output
+
+
+class TestConfigMigrate:
+    def test_no_legacy_files(self) -> None:
+        runner = CliRunner()
+        with patch("dev10x.commands.config.stale_legacy_paths", return_value=[]):
+            result = runner.invoke(config, ["migrate"])
+        assert result.exit_code == 0
+        assert "No legacy" in result.output
+
+    def test_dry_run_lists_stale_paths(self) -> None:
+        stale = [Path("/home/user/.claude/memory/Dev10x/foo.yaml")]
+        runner = CliRunner()
+        with patch("dev10x.commands.config.stale_legacy_paths", return_value=stale):
+            result = runner.invoke(config, ["migrate", "--dry-run"])
+        assert result.exit_code == 0
+        assert "Would migrate 1 legacy entry" in result.output
+        assert "foo.yaml" in result.output
+
+    def test_dry_run_plural(self) -> None:
+        stale = [Path("/a/one.yaml"), Path("/a/two.yaml")]
+        runner = CliRunner()
+        with patch("dev10x.commands.config.stale_legacy_paths", return_value=stale):
+            result = runner.invoke(config, ["migrate", "--dry-run"])
+        assert "2 legacy entries" in result.output
+
+    def test_dry_run_does_not_call_migrate_all(self) -> None:
+        stale = [Path("/home/user/.claude/memory/Dev10x/foo.yaml")]
+        runner = CliRunner()
+        with (
+            patch("dev10x.commands.config.stale_legacy_paths", return_value=stale),
+            patch("dev10x.commands.config.migrate_all") as mock_migrate,
+        ):
+            runner.invoke(config, ["migrate", "--dry-run"])
+        mock_migrate.assert_not_called()
+
+    def test_migrate_reports_moved_files(self) -> None:
+        stale = [Path("/home/user/.claude/memory/Dev10x/foo.yaml")]
+        migrated = [Path("/home/user/.config/Dev10x/foo.yaml")]
+        runner = CliRunner()
+        with (
+            patch("dev10x.commands.config.stale_legacy_paths", return_value=stale),
+            patch("dev10x.commands.config.migrate_all", return_value=migrated),
+        ):
+            result = runner.invoke(config, ["migrate"])
+        assert result.exit_code == 0
+        assert "Migrated 1 entry" in result.output
+        assert "foo.yaml" in result.output
+
+    def test_migrate_nothing_when_destination_populated(self) -> None:
+        stale = [Path("/home/user/.claude/memory/Dev10x/foo.yaml")]
+        runner = CliRunner()
+        with (
+            patch("dev10x.commands.config.stale_legacy_paths", return_value=stale),
+            patch("dev10x.commands.config.migrate_all", return_value=[]),
+        ):
+            result = runner.invoke(config, ["migrate"])
+        assert "Nothing to migrate" in result.output
+
+
+class TestConfigDoctor:
+    def test_clean_state(self) -> None:
+        runner = CliRunner()
+        with patch("dev10x.commands.config.stale_legacy_paths", return_value=[]):
+            result = runner.invoke(config, ["doctor"])
+        assert result.exit_code == 0
+        assert "canonical XDG location" in result.output
+
+    def test_lists_stale_paths(self) -> None:
+        stale = [Path("/home/user/.claude/memory/Dev10x/foo.yaml")]
+        runner = CliRunner()
+        with patch("dev10x.commands.config.stale_legacy_paths", return_value=stale):
+            result = runner.invoke(config, ["doctor"])
+        assert result.exit_code == 0
+        assert "1 legacy Dev10x config entry" in result.output
+        assert "foo.yaml" in result.output
+
+    def test_lists_multiple_stale_paths(self) -> None:
+        stale = [Path("/a/one.yaml"), Path("/a/two.yaml")]
+        runner = CliRunner()
+        with patch("dev10x.commands.config.stale_legacy_paths", return_value=stale):
+            result = runner.invoke(config, ["doctor"])
+        assert "2 legacy Dev10x config entries" in result.output
+
+    def test_suggests_migrate_command_when_stale(self) -> None:
+        stale = [Path("/a/foo.yaml")]
+        runner = CliRunner()
+        with patch("dev10x.commands.config.stale_legacy_paths", return_value=stale):
+            result = runner.invoke(config, ["doctor"])
+        assert "dev10x config migrate" in result.output

--- a/tests/domain/test_config_loader.py
+++ b/tests/domain/test_config_loader.py
@@ -1,0 +1,35 @@
+"""Tests for ConfigLoader Protocol."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dev10x.domain.config_loader import ConfigLoader
+from dev10x.domain.documents.config_document import Config
+
+
+class TestConfigLoaderProtocol:
+    def test_protocol_is_importable(self) -> None:
+        assert ConfigLoader is not None
+
+    def test_callable_satisfies_protocol(self) -> None:
+        def loader(yaml_path: Path, *, ttl_seconds: int = 60) -> Config: ...  # type: ignore[return]
+
+        assert isinstance(loader, ConfigLoader)
+
+    def test_non_callable_does_not_satisfy(self) -> None:
+        assert not isinstance(42, ConfigLoader)
+        assert not isinstance("string", ConfigLoader)
+        assert not isinstance(None, ConfigLoader)
+
+    def test_object_without_call_does_not_satisfy(self) -> None:
+        class NotALoader:
+            pass
+
+        assert not isinstance(NotALoader(), ConfigLoader)
+
+    def test_class_with_call_satisfies_protocol(self) -> None:
+        class MyLoader:
+            def __call__(self, yaml_path: Path, *, ttl_seconds: int = 60) -> Config: ...  # type: ignore[return]
+
+        assert isinstance(MyLoader(), ConfigLoader)

--- a/tests/session/test_queries.py
+++ b/tests/session/test_queries.py
@@ -1,0 +1,278 @@
+"""Tests for SessionContextQuery — session-context assembly dataclass."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dev10x.domain.friction_level import FrictionLevel
+from dev10x.session.queries import (
+    SessionContextQuery,
+    format_compaction_summary,
+    format_reload_context,
+)
+
+
+def _ctx(**kwargs: Any) -> SessionContextQuery:
+    return SessionContextQuery(toplevel="/fake/root", **kwargs)
+
+
+class TestSessionContextQueryDefaults:
+    def test_branch_defaults_to_unknown(self) -> None:
+        ctx = _ctx()
+        assert ctx.branch == "unknown"
+
+    def test_worktree_name_defaults_to_empty(self) -> None:
+        ctx = _ctx()
+        assert ctx.worktree_name == ""
+
+    def test_state_defaults_to_empty_dict(self) -> None:
+        ctx = _ctx()
+        assert ctx.state == {}
+
+    def test_plan_exists_defaults_to_false(self) -> None:
+        ctx = _ctx()
+        assert not ctx.plan_exists
+
+    def test_file_lists_default_to_empty(self) -> None:
+        ctx = _ctx()
+        assert ctx.modified_files == []
+        assert ctx.staged_files == []
+        assert ctx.untracked_files == []
+
+    def test_recent_commits_defaults_to_empty(self) -> None:
+        ctx = _ctx()
+        assert ctx.recent_commits == ""
+
+    def test_is_frozen(self) -> None:
+        ctx = _ctx()
+        with pytest.raises(Exception):
+            ctx.branch = "new-branch"  # type: ignore[misc]
+
+
+class TestFormatReloadContext:
+    def test_returns_empty_when_no_state_and_no_plan(self) -> None:
+        ctx = _ctx(state={}, plan_exists=False)
+        assert format_reload_context(ctx=ctx) == ""
+
+    def test_returns_empty_with_empty_state(self) -> None:
+        ctx = _ctx(state={}, plan_exists=False)
+        assert format_reload_context(ctx=ctx) == ""
+
+
+class TestFormatCompactionSummary:
+    def test_includes_branch_in_output(self, tmp_path: Path) -> None:
+        ctx = _ctx(branch="feature/some-work")
+        result = format_compaction_summary(ctx=ctx, plugin_root=tmp_path)
+        assert "feature/some-work" in result
+
+    def test_includes_toplevel_in_output(self, tmp_path: Path) -> None:
+        ctx = _ctx()
+        result = format_compaction_summary(ctx=ctx, plugin_root=tmp_path)
+        assert "/fake/root" in result
+
+    def test_includes_worktree_when_set(self, tmp_path: Path) -> None:
+        ctx = _ctx(worktree_name="Dev10x-Claude-8")
+        result = format_compaction_summary(ctx=ctx, plugin_root=tmp_path)
+        assert "Dev10x-Claude-8" in result
+
+    def test_omits_worktree_section_when_empty(self, tmp_path: Path) -> None:
+        ctx = _ctx(worktree_name="")
+        result = format_compaction_summary(ctx=ctx, plugin_root=tmp_path)
+        assert "Worktree" not in result
+
+    def test_lists_modified_files(self, tmp_path: Path) -> None:
+        ctx = _ctx(modified_files=["src/foo.py", "src/bar.py"])
+        result = format_compaction_summary(ctx=ctx, plugin_root=tmp_path)
+        assert "src/foo.py" in result
+        assert "src/bar.py" in result
+
+    def test_lists_staged_files(self, tmp_path: Path) -> None:
+        ctx = _ctx(staged_files=["src/baz.py"])
+        result = format_compaction_summary(ctx=ctx, plugin_root=tmp_path)
+        assert "src/baz.py" in result
+
+    def test_lists_untracked_files(self, tmp_path: Path) -> None:
+        ctx = _ctx(untracked_files=["scratch.py"])
+        result = format_compaction_summary(ctx=ctx, plugin_root=tmp_path)
+        assert "scratch.py" in result
+
+    def test_includes_recent_commits(self, tmp_path: Path) -> None:
+        ctx = _ctx(recent_commits="abc1234 Fix something\ndef5678 Add feature")
+        result = format_compaction_summary(ctx=ctx, plugin_root=tmp_path)
+        assert "abc1234" in result
+
+    def test_omits_file_sections_when_empty(self, tmp_path: Path) -> None:
+        ctx = _ctx()
+        result = format_compaction_summary(ctx=ctx, plugin_root=tmp_path)
+        assert "Modified files" not in result
+        assert "Staged files" not in result
+        assert "Untracked files" not in result
+
+    def test_returns_string(self, tmp_path: Path) -> None:
+        ctx = _ctx()
+        assert isinstance(format_compaction_summary(ctx=ctx, plugin_root=tmp_path), str)
+
+
+class TestGatherReload:
+    def test_returns_query_with_correct_toplevel(self, tmp_path: Path) -> None:
+        with (
+            patch("dev10x.session.queries.claim_state_file", return_value={}),
+            patch(
+                "dev10x.session.queries.state_path_for_toplevel",
+                return_value=tmp_path / "state.json",
+            ),
+            patch(
+                "dev10x.session.queries.plan_path_for_toplevel",
+                return_value=tmp_path / "plan.json",
+            ),
+            patch("dev10x.session.queries.ReadFrictionLevelRule") as mock_rule,
+        ):
+            mock_rule.return_value.apply.return_value = FrictionLevel.default()
+            ctx = SessionContextQuery.gather_reload(toplevel=str(tmp_path))
+        assert ctx.toplevel == str(tmp_path)
+
+    def test_plan_exists_false_when_no_plan_file(self, tmp_path: Path) -> None:
+        with (
+            patch("dev10x.session.queries.claim_state_file", return_value={}),
+            patch(
+                "dev10x.session.queries.state_path_for_toplevel",
+                return_value=tmp_path / "state.json",
+            ),
+            patch(
+                "dev10x.session.queries.plan_path_for_toplevel",
+                return_value=tmp_path / "plan.json",
+            ),
+            patch("dev10x.session.queries.ReadFrictionLevelRule") as mock_rule,
+        ):
+            mock_rule.return_value.apply.return_value = FrictionLevel.default()
+            ctx = SessionContextQuery.gather_reload(toplevel=str(tmp_path))
+        assert not ctx.plan_exists
+
+    def test_plan_exists_true_when_plan_file_present(self, tmp_path: Path) -> None:
+        plan_file = tmp_path / "plan.json"
+        plan_file.write_text("{}")
+        with (
+            patch("dev10x.session.queries.claim_state_file", return_value={}),
+            patch(
+                "dev10x.session.queries.state_path_for_toplevel",
+                return_value=tmp_path / "state.json",
+            ),
+            patch(
+                "dev10x.session.queries.plan_path_for_toplevel",
+                return_value=plan_file,
+            ),
+            patch("dev10x.session.queries.read_plan_summary", return_value={"tasks": []}),
+            patch("dev10x.session.queries.ReadFrictionLevelRule") as mock_rule,
+        ):
+            mock_rule.return_value.apply.return_value = FrictionLevel.default()
+            ctx = SessionContextQuery.gather_reload(toplevel=str(tmp_path))
+        assert ctx.plan_exists
+
+    def test_state_comes_from_claim_state_file(self, tmp_path: Path) -> None:
+        fake_state = {"session_id": "test-123", "branch": "main"}
+        with (
+            patch("dev10x.session.queries.claim_state_file", return_value=fake_state),
+            patch(
+                "dev10x.session.queries.state_path_for_toplevel",
+                return_value=tmp_path / "state.json",
+            ),
+            patch(
+                "dev10x.session.queries.plan_path_for_toplevel",
+                return_value=tmp_path / "plan.json",
+            ),
+            patch("dev10x.session.queries.ReadFrictionLevelRule") as mock_rule,
+        ):
+            mock_rule.return_value.apply.return_value = FrictionLevel.default()
+            ctx = SessionContextQuery.gather_reload(toplevel=str(tmp_path))
+        assert ctx.state == fake_state
+
+
+class TestGatherCompaction:
+    def _mock_git(self, *, branch: str = "main", run_return: str = "") -> MagicMock:
+        mock = MagicMock()
+        mock.branch = branch
+        mock.run.return_value = run_return
+        return mock
+
+    def test_returns_query_with_correct_toplevel(self, tmp_path: Path) -> None:
+        with (
+            patch("dev10x.session.queries.GitContext", return_value=self._mock_git()),
+            patch(
+                "dev10x.session.queries.plan_path_for_toplevel",
+                return_value=tmp_path / "plan.json",
+            ),
+            patch("dev10x.session.queries.ReadFrictionLevelRule") as mock_rule,
+        ):
+            mock_rule.return_value.apply.return_value = FrictionLevel.default()
+            ctx = SessionContextQuery.gather_compaction(toplevel=str(tmp_path))
+        assert ctx.toplevel == str(tmp_path)
+
+    def test_branch_comes_from_git_context(self, tmp_path: Path) -> None:
+        with (
+            patch(
+                "dev10x.session.queries.GitContext",
+                return_value=self._mock_git(branch="feature/test"),
+            ),
+            patch(
+                "dev10x.session.queries.plan_path_for_toplevel",
+                return_value=tmp_path / "plan.json",
+            ),
+            patch("dev10x.session.queries.ReadFrictionLevelRule") as mock_rule,
+        ):
+            mock_rule.return_value.apply.return_value = FrictionLevel.default()
+            ctx = SessionContextQuery.gather_compaction(toplevel=str(tmp_path))
+        assert ctx.branch == "feature/test"
+
+    def test_worktree_name_empty_when_git_is_directory(self, tmp_path: Path) -> None:
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        with (
+            patch("dev10x.session.queries.GitContext", return_value=self._mock_git()),
+            patch(
+                "dev10x.session.queries.plan_path_for_toplevel",
+                return_value=tmp_path / "plan.json",
+            ),
+            patch("dev10x.session.queries.ReadFrictionLevelRule") as mock_rule,
+        ):
+            mock_rule.return_value.apply.return_value = FrictionLevel.default()
+            ctx = SessionContextQuery.gather_compaction(toplevel=str(tmp_path))
+        assert ctx.worktree_name == ""
+
+    def test_worktree_name_set_when_git_is_file(self, tmp_path: Path) -> None:
+        git_file = tmp_path / ".git"
+        git_file.write_text("gitdir: ../../.git/worktrees/foo")
+        with (
+            patch("dev10x.session.queries.GitContext", return_value=self._mock_git()),
+            patch(
+                "dev10x.session.queries.plan_path_for_toplevel",
+                return_value=tmp_path / "plan.json",
+            ),
+            patch("dev10x.session.queries.ReadFrictionLevelRule") as mock_rule,
+        ):
+            mock_rule.return_value.apply.return_value = FrictionLevel.default()
+            ctx = SessionContextQuery.gather_compaction(toplevel=str(tmp_path))
+        assert ctx.worktree_name == tmp_path.name
+
+    def test_git_error_yields_empty_files(self, tmp_path: Path) -> None:
+        import subprocess
+
+        mock_git = MagicMock()
+        mock_git.branch = "main"
+        mock_git.run.side_effect = subprocess.CalledProcessError(1, "git")
+        with (
+            patch("dev10x.session.queries.GitContext", return_value=mock_git),
+            patch(
+                "dev10x.session.queries.plan_path_for_toplevel",
+                return_value=tmp_path / "plan.json",
+            ),
+            patch("dev10x.session.queries.ReadFrictionLevelRule") as mock_rule,
+        ):
+            mock_rule.return_value.apply.return_value = FrictionLevel.default()
+            ctx = SessionContextQuery.gather_compaction(toplevel=str(tmp_path))
+        assert ctx.modified_files == []
+        assert ctx.staged_files == []
+        assert ctx.untracked_files == []


### PR DESCRIPTION
**When** maintaining the Dev10x test suite, **I want to** add dedicated tests for source modules that shipped without any, **so I can** catch regressions in the config CLI, ConfigLoader Protocol, and session-context assembly before they reach CI.

---

[`174644ee`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/643/commits/174644ee0b6fccde6f88e05b88ccbdaa776385fb) ✅ GH-568 Cover untested commands, ConfigLoader, session queries
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/568

---