### PR TITLE
✅ GH-565 Surface full failure matrix in data-driven config tests

### DIFF
--- a/tests/domain/test_sensitivity.py
+++ b/tests/domain/test_sensitivity.py
@@ -27,9 +27,9 @@ class TestSensitivityLabel:
         labels = {label.value for label in SensitivityLabel}
         assert labels == {"secret", "credential", "pii", "infra"}
 
-    def test_values_are_lowercase_strings(self) -> None:
-        for label in SensitivityLabel:
-            assert label.value == label.value.lower()
+    @pytest.mark.parametrize("label", list(SensitivityLabel), ids=lambda lbl: lbl.name)
+    def test_value_is_lowercase_string(self, label: SensitivityLabel) -> None:
+        assert label.value == label.value.lower()
 
     def test_repr_includes_name(self) -> None:
         assert "SECRET" in repr(SensitivityLabel.SECRET)

--- a/tests/mcp/test_db_server.py
+++ b/tests/mcp/test_db_server.py
@@ -266,8 +266,11 @@ class TestQueryFunctionSuccess:
         assert isinstance(result, SuccessResult)
         assert "raw_output" in result.value
 
+    @pytest.mark.parametrize("db_alias", ["pp", "ps", "bp", "bs"])
     @patch("dev10x.db.run_script")
-    def test_different_database_aliases(self, mock_run_script: MagicMock) -> None:
+    def test_database_alias_invokes_run_script(
+        self, mock_run_script: MagicMock, db_alias: str
+    ) -> None:
         from dev10x.db import query
 
         mock_result = MagicMock()
@@ -275,10 +278,9 @@ class TestQueryFunctionSuccess:
         mock_result.stdout = json.dumps({"rows": []})
         mock_run_script.return_value = mock_result
 
-        for db_alias in ["pp", "ps", "bp", "bs"]:
-            query(database=db_alias, sql="SELECT 1")
+        query(database=db_alias, sql="SELECT 1")
 
-        assert mock_run_script.call_count == 4
+        assert mock_run_script.call_count == 1
 
 
 class TestServerDbWrapper:

--- a/tests/platform/test_registry.py
+++ b/tests/platform/test_registry.py
@@ -27,14 +27,19 @@ class TestKnownPlatforms:
     ) -> None:
         assert platform_name in catalog
 
-    def test_each_entry_has_config_paths(
+    @pytest.mark.parametrize(
+        "platform_name",
+        ["claude-code", "copilot-cli", "windsurf", "continue", "cursor"],
+    )
+    def test_entry_has_config_paths(
         self,
         catalog: dict[str, PlatformConfig],
+        platform_name: str,
     ) -> None:
-        for cfg in catalog.values():
-            assert cfg.config_dir is not None
-            assert cfg.plugins_dir is not None
-            assert cfg.settings_file is not None
+        cfg = catalog[platform_name]
+        assert cfg.config_dir is not None
+        assert cfg.plugins_dir is not None
+        assert cfg.settings_file is not None
 
     def test_display_name_set_per_platform(
         self,

--- a/tests/skills/upgrade-cleanup/test_update_paths.py
+++ b/tests/skills/upgrade-cleanup/test_update_paths.py
@@ -188,8 +188,8 @@ class TestUpdateFilePublisher:
 
         assert count == 2
         data = json.loads(settings_file.read_text())
-        for rule in data["permissions"]["allow"]:
-            assert "WooYek" not in rule
+        offenders = [rule for rule in data["permissions"]["allow"] if "WooYek" in rule]
+        assert not offenders, f"WooYek not stripped from: {offenders}"
 
     def test_dry_run_does_not_write(self, settings_file: Path) -> None:
         content = json.dumps(

--- a/tests/validators/test_profile_filter.py
+++ b/tests/validators/test_profile_filter.py
@@ -133,15 +133,17 @@ class TestGetValidatorsDisableFiltering:
 class TestRuleIdAssignment:
     def test_every_validator_has_rule_id(self) -> None:
         validators = get_validators()
-        for v in validators:
-            assert hasattr(v, "rule_id")
-            assert v.rule_id.startswith("DX")
+        missing = [type(v).__name__ for v in validators if not hasattr(v, "rule_id")]
+        assert not missing, f"Validators missing rule_id: {missing}"
+        non_dx = [v.rule_id for v in validators if not v.rule_id.startswith("DX")]
+        assert not non_dx, f"rule_ids not starting with DX: {non_dx}"
 
     def test_every_validator_has_profile(self) -> None:
         validators = get_validators()
-        for v in validators:
-            assert hasattr(v, "profile")
-            assert isinstance(v.profile, ProfileTier)
+        missing = [type(v).__name__ for v in validators if not hasattr(v, "profile")]
+        assert not missing, f"Validators missing profile: {missing}"
+        non_tier = [type(v).__name__ for v in validators if not isinstance(v.profile, ProfileTier)]
+        assert not non_tier, f"Validators with non-ProfileTier profile: {non_tier}"
 
     def test_rule_ids_are_unique(self) -> None:
         # Use strict profile to get all validators

--- a/tests/validators/test_skill_redirect.py
+++ b/tests/validators/test_skill_redirect.py
@@ -611,6 +611,19 @@ class TestFrictionLevels:
         assert "Skill(" not in result.message
 
 
+_RULES: list[dict] = yaml.safe_load(_YAML_PATH.read_text())["rules"]
+_HOOK_BLOCK_RULES: list[dict] = [entry for entry in _RULES if entry.get("hook_block")]
+_COMPENSATION_PAIRS: list[tuple[str, str]] = [
+    (entry.get("name", "<unnamed>"), comp["type"])
+    for entry in _RULES
+    for comp in entry.get("compensations", [])
+]
+
+
+def _rule_ids(rules: list[dict]) -> list[str]:
+    return [entry.get("name", f"rule-{i}") for i, entry in enumerate(rules)]
+
+
 class TestYamlSchema:
     def test_yaml_file_is_valid(self) -> None:
         data = yaml.safe_load(_YAML_PATH.read_text())
@@ -618,29 +631,30 @@ class TestYamlSchema:
         assert "rules" in data
         assert data["config"]["friction_level"] in {"strict", "guided", "adaptive"}
 
-    def test_all_hook_block_entries_have_compensations(self) -> None:
-        data = yaml.safe_load(_YAML_PATH.read_text())
-        for entry in data["rules"]:
-            if entry.get("hook_block"):
-                assert "compensations" in entry, f"{entry['name']} missing compensations"
-                assert entry["compensations"], f"{entry['name']} has empty compensations"
+    @pytest.mark.parametrize("entry", _HOOK_BLOCK_RULES, ids=_rule_ids(_HOOK_BLOCK_RULES))
+    def test_hook_block_entry_has_compensations(self, entry: dict) -> None:
+        assert "compensations" in entry, f"{entry['name']} missing compensations"
+        assert entry["compensations"], f"{entry['name']} has empty compensations"
 
-    def test_all_rules_have_name(self) -> None:
-        data = yaml.safe_load(_YAML_PATH.read_text())
-        for entry in data["rules"]:
-            assert "name" in entry, f"Rule missing name: {entry}"
-            assert entry["name"], f"Rule has empty name: {entry}"
+    @pytest.mark.parametrize("entry", _RULES, ids=_rule_ids(_RULES))
+    def test_rule_has_name(self, entry: dict) -> None:
+        assert "name" in entry, f"Rule missing name: {entry}"
+        assert entry["name"], f"Rule has empty name: {entry}"
 
-    def test_all_rules_have_matcher(self) -> None:
-        data = yaml.safe_load(_YAML_PATH.read_text())
-        for entry in data["rules"]:
-            assert "matcher" in entry, f"{entry['name']} missing matcher"
-            assert entry["matcher"] in {
-                "Bash",
-                "Edit|Write",
-            }, f"{entry['name']} has invalid matcher: {entry['matcher']}"
+    @pytest.mark.parametrize("entry", _RULES, ids=_rule_ids(_RULES))
+    def test_rule_has_matcher(self, entry: dict) -> None:
+        assert "matcher" in entry, f"{entry['name']} missing matcher"
+        assert entry["matcher"] in {
+            "Bash",
+            "Edit|Write",
+        }, f"{entry['name']} has invalid matcher: {entry['matcher']}"
 
-    def test_compensation_types_are_valid(self) -> None:
+    @pytest.mark.parametrize(
+        ("rule_name", "comp_type"),
+        _COMPENSATION_PAIRS,
+        ids=[f"{name}:{ctype}" for name, ctype in _COMPENSATION_PAIRS],
+    )
+    def test_compensation_type_is_valid(self, rule_name: str, comp_type: str) -> None:
         valid_types = {
             "use-skill",
             "use-tool",
@@ -651,12 +665,7 @@ class TestYamlSchema:
             "use-file-flag",
             "file-issue",
         }
-        data = yaml.safe_load(_YAML_PATH.read_text())
-        for entry in data["rules"]:
-            for comp in entry.get("compensations", []):
-                assert comp["type"] in valid_types, (
-                    f"{entry['name']} has invalid compensation type: {comp['type']}"
-                )
+        assert comp_type in valid_types, f"{rule_name} has invalid compensation type: {comp_type}"
 
 
 class TestLegitimateSkillCommands:


### PR DESCRIPTION
**When** a data-driven schema test fails, **I want to** see every offending config entry at once instead of just the first, **so I can** fix all violations in a single pass rather than re-running after each one.

---

[`7a8fb67d`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/644/commits/7a8fb67da6e1955ed1446d4758f9ac03957c145d) ✅ GH-565 Surface full failure matrix in data-driven config tests
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/565

---