### PR TITLE
✅ GH-581 Protect destructive update_paths migrations with tests

### DIFF
--- a/tests/skills/upgrade-cleanup/test_update_paths.py
+++ b/tests/skills/upgrade-cleanup/test_update_paths.py
@@ -1,4 +1,6 @@
-"""Tests for publisher rename handling in update-paths.py."""
+"""Tests for update_paths.py: publisher rename, base permissions and
+denies, script rules, dead-glob purging, legacy cleanup, generalization,
+userspace config init, and workspace directories."""
 
 import json
 from pathlib import Path
@@ -7,11 +9,34 @@ import pytest
 
 from dev10x.skills.permission import update_paths
 from dev10x.skills.permission.update_paths import (
+    build_script_allow_rules,
+    collapse_legacy_upgrade_cleanup_rule,
+    collapse_legacy_upgrade_cleanup_rules,
+    ensure_base_denies,
+    ensure_base_permissions,
+    ensure_read_rules,
+    ensure_script_rules,
+    ensure_workspace_directories,
     extract_cache_publisher,
     find_settings_files,
+    generalize_permission,
+    generalize_permissions,
     init_userspace_config,
+    is_dead_glob_script_rule,
+    purge_dead_glob_script_rules,
+    scan_plugin_scripts,
     update_file,
+    verify_script_coverage,
 )
+
+
+def _write_settings(path: Path, *, allow: list[str] | None = None, **sections: object) -> Path:
+    permissions: dict[str, object] = {}
+    if allow is not None:
+        permissions["allow"] = allow
+    permissions.update(sections)
+    path.write_text(json.dumps({"permissions": permissions}))
+    return path
 
 
 class TestExtractCachePublisher:
@@ -323,3 +348,400 @@ class TestInitUserspaceConfig:
 
         assert result["exit_code"] == 1
         assert any("Plugin default config not found" in e for e in result["errors"])
+
+
+class TestEnsureBasePermissions:
+    @pytest.fixture()
+    def settings_file(self, tmp_path: Path) -> Path:
+        return _write_settings(tmp_path / "settings.local.json", allow=[])
+
+    def test_adds_missing_permission(self, settings_file: Path) -> None:
+        count, messages = ensure_base_permissions(
+            settings_file, ["Bash(git status:*)"], expand_mcp=False
+        )
+        assert count == 1
+        data = json.loads(settings_file.read_text())
+        assert "Bash(git status:*)" in data["permissions"]["allow"]
+
+    def test_noop_when_present(self, settings_file: Path) -> None:
+        _write_settings(settings_file, allow=["Bash(git status:*)"])
+        count, messages = ensure_base_permissions(
+            settings_file, ["Bash(git status:*)"], expand_mcp=False
+        )
+        assert count == 0
+        assert messages == []
+
+    def test_dry_run_does_not_write(self, settings_file: Path) -> None:
+        count, _ = ensure_base_permissions(
+            settings_file, ["Bash(git status:*)"], dry_run=True, expand_mcp=False
+        )
+        assert count == 1
+        data = json.loads(settings_file.read_text())
+        assert data["permissions"]["allow"] == []
+
+    def test_invalid_json_skips(self, tmp_path: Path) -> None:
+        bad = tmp_path / "settings.local.json"
+        bad.write_text("{invalid")
+        count, messages = ensure_base_permissions(bad, ["Bash(git:*)"], expand_mcp=False)
+        assert count == 0
+        assert messages and "SKIP" in messages[0]
+
+    def test_removes_nonfunctional_mcp_wildcard(self, settings_file: Path) -> None:
+        _write_settings(settings_file, allow=["mcp__plugin_Dev10x_*"])
+        count, _ = ensure_base_permissions(settings_file, [], expand_mcp=False)
+        assert count == 1
+        data = json.loads(settings_file.read_text())
+        assert "mcp__plugin_Dev10x_*" not in data["permissions"]["allow"]
+
+
+class TestEnsureBaseDenies:
+    @pytest.fixture()
+    def settings_file(self, tmp_path: Path) -> Path:
+        return _write_settings(tmp_path / "settings.local.json", deny=[])
+
+    def test_adds_missing_deny(self, settings_file: Path) -> None:
+        count, _ = ensure_base_denies(settings_file, ["Bash(rm -rf /:*)"])
+        assert count == 1
+        data = json.loads(settings_file.read_text())
+        assert "Bash(rm -rf /:*)" in data["permissions"]["deny"]
+
+    def test_noop_when_present(self, settings_file: Path) -> None:
+        _write_settings(settings_file, deny=["Bash(rm -rf /:*)"])
+        count, messages = ensure_base_denies(settings_file, ["Bash(rm -rf /:*)"])
+        assert count == 0
+        assert messages == []
+
+    def test_dry_run_does_not_write(self, settings_file: Path) -> None:
+        count, _ = ensure_base_denies(settings_file, ["Bash(rm -rf /:*)"], dry_run=True)
+        assert count == 1
+        data = json.loads(settings_file.read_text())
+        assert data["permissions"]["deny"] == []
+
+    def test_invalid_json_skips(self, tmp_path: Path) -> None:
+        bad = tmp_path / "settings.local.json"
+        bad.write_text("{invalid")
+        count, messages = ensure_base_denies(bad, ["Bash(x:*)"])
+        assert count == 0
+        assert messages and "SKIP" in messages[0]
+
+
+class TestScanPluginScripts:
+    def test_finds_scripts_across_globs(self, tmp_path: Path) -> None:
+        (tmp_path / "bin").mkdir()
+        (tmp_path / "bin" / "release.sh").write_text("#!/bin/sh\n")
+        (tmp_path / "hooks" / "scripts").mkdir(parents=True)
+        (tmp_path / "hooks" / "scripts" / "hook.py").write_text("")
+        (tmp_path / "skills" / "foo" / "scripts").mkdir(parents=True)
+        (tmp_path / "skills" / "foo" / "scripts" / "run.sh").write_text("")
+
+        scripts = scan_plugin_scripts(tmp_path)
+
+        names = {p.name for p in scripts}
+        assert names == {"release.sh", "hook.py", "run.sh"}
+
+    def test_returns_sorted_unique(self, tmp_path: Path) -> None:
+        (tmp_path / "bin").mkdir()
+        (tmp_path / "bin" / "a.sh").write_text("")
+        (tmp_path / "bin" / "b.sh").write_text("")
+        scripts = scan_plugin_scripts(tmp_path)
+        assert scripts == sorted(scripts)
+
+    def test_empty_when_no_scripts(self, tmp_path: Path) -> None:
+        assert scan_plugin_scripts(tmp_path) == []
+
+
+class TestBuildScriptAllowRules:
+    def test_builds_bash_rule_per_script(self, tmp_path: Path) -> None:
+        (tmp_path / "bin").mkdir()
+        script = tmp_path / "bin" / "release.sh"
+        script.write_text("")
+        rules = build_script_allow_rules([script], plugin_root=tmp_path)
+        assert rules == [f"Bash({tmp_path}/bin/release.sh:*)"]
+
+    def test_empty_for_no_scripts(self, tmp_path: Path) -> None:
+        assert build_script_allow_rules([], plugin_root=tmp_path) == []
+
+
+class TestIsDeadGlobScriptRule:
+    @pytest.mark.parametrize(
+        "entry",
+        [
+            "Bash(~/.claude/plugins/cache/Pub/Plug/**/scripts/x.sh:*)",
+            "Bash(/home/u/.claude/plugins/cache/Pub/Plug/**:*)",
+        ],
+    )
+    def test_true_for_dead_glob(self, entry: str) -> None:
+        assert is_dead_glob_script_rule(entry) is True
+
+    @pytest.mark.parametrize(
+        "entry",
+        [
+            "Bash(~/.claude/plugins/cache/Pub/Plug/0.1.0/scripts/x.sh:*)",
+            "Read(~/.claude/plugins/marketplaces/Pub/**)",
+            "Bash(git status:*)",
+        ],
+    )
+    def test_false_for_functional_rule(self, entry: str) -> None:
+        assert is_dead_glob_script_rule(entry) is False
+
+
+class TestPurgeDeadGlobScriptRules:
+    def test_removes_dead_glob(self, tmp_path: Path) -> None:
+        path = _write_settings(
+            tmp_path / "settings.local.json",
+            allow=[
+                "Bash(~/.claude/plugins/cache/Pub/Plug/**:*)",
+                "Bash(git status:*)",
+            ],
+        )
+        count, _ = purge_dead_glob_script_rules(path)
+        assert count == 1
+        data = json.loads(path.read_text())
+        assert data["permissions"]["allow"] == ["Bash(git status:*)"]
+
+    def test_noop_without_dead_globs(self, tmp_path: Path) -> None:
+        path = _write_settings(tmp_path / "settings.local.json", allow=["Bash(git status:*)"])
+        count, messages = purge_dead_glob_script_rules(path)
+        assert count == 0
+        assert messages == []
+
+    def test_dry_run_does_not_write(self, tmp_path: Path) -> None:
+        path = _write_settings(
+            tmp_path / "settings.local.json",
+            allow=["Bash(~/.claude/plugins/cache/Pub/Plug/**:*)"],
+        )
+        count, _ = purge_dead_glob_script_rules(path, dry_run=True)
+        assert count == 1
+        data = json.loads(path.read_text())
+        assert len(data["permissions"]["allow"]) == 1
+
+    def test_unreadable_json_skips(self, tmp_path: Path) -> None:
+        bad = tmp_path / "settings.local.json"
+        bad.write_text("{invalid")
+        count, messages = purge_dead_glob_script_rules(bad)
+        assert count == 0
+        assert messages and "SKIP" in messages[0]
+
+
+class TestVerifyScriptCoverage:
+    def test_reports_covered_and_missing(self, tmp_path: Path) -> None:
+        path = _write_settings(
+            tmp_path / "settings.local.json",
+            allow=["Bash(/any/path/release.sh:*)"],
+        )
+        covered, missing = verify_script_coverage(
+            path,
+            ["Bash(/plugin/bin/release.sh:*)", "Bash(/plugin/bin/other.sh:*)"],
+        )
+        assert covered == ["Bash(/plugin/bin/release.sh:*)"]
+        assert missing == ["Bash(/plugin/bin/other.sh:*)"]
+
+    def test_exact_match_counts_as_covered(self, tmp_path: Path) -> None:
+        rule = "Bash(/plugin/bin/release.sh:*)"
+        path = _write_settings(tmp_path / "settings.local.json", allow=[rule])
+        covered, missing = verify_script_coverage(path, [rule])
+        assert covered == [rule]
+        assert missing == []
+
+    def test_dead_glob_is_not_coverage(self, tmp_path: Path) -> None:
+        path = _write_settings(
+            tmp_path / "settings.local.json",
+            allow=["Bash(~/.claude/plugins/cache/Pub/Plug/**/release.sh:*)"],
+        )
+        covered, missing = verify_script_coverage(path, ["Bash(/plugin/bin/release.sh:*)"])
+        assert covered == []
+        assert missing == ["Bash(/plugin/bin/release.sh:*)"]
+
+    def test_invalid_json_treats_all_as_missing(self, tmp_path: Path) -> None:
+        bad = tmp_path / "settings.local.json"
+        bad.write_text("{invalid")
+        covered, missing = verify_script_coverage(bad, ["Bash(x:*)"])
+        assert covered == []
+        assert missing == ["Bash(x:*)"]
+
+
+class TestEnsureReadRules:
+    def test_appends_missing_idempotently(self, tmp_path: Path) -> None:
+        path = _write_settings(tmp_path / "settings.local.json", allow=["Read(~/a/*)"])
+        count, _ = ensure_read_rules(path, ["Read(~/a/*)", "Read(~/b/*)"])
+        assert count == 2
+        data = json.loads(path.read_text())
+        assert data["permissions"]["allow"].count("Read(~/a/*)") == 1
+        assert "Read(~/b/*)" in data["permissions"]["allow"]
+
+    def test_empty_rules_noop(self, tmp_path: Path) -> None:
+        path = _write_settings(tmp_path / "settings.local.json", allow=[])
+        assert ensure_read_rules(path, []) == (0, [])
+
+    def test_dry_run_does_not_write(self, tmp_path: Path) -> None:
+        path = _write_settings(tmp_path / "settings.local.json", allow=[])
+        count, _ = ensure_read_rules(path, ["Read(~/b/*)"], dry_run=True)
+        assert count == 1
+        data = json.loads(path.read_text())
+        assert data["permissions"]["allow"] == []
+
+
+class TestEnsureScriptRules:
+    def test_extends_allow(self, tmp_path: Path) -> None:
+        path = _write_settings(tmp_path / "settings.local.json", allow=[])
+        count, _ = ensure_script_rules(path, ["Bash(/p/x.sh:*)"])
+        assert count == 1
+        data = json.loads(path.read_text())
+        assert "Bash(/p/x.sh:*)" in data["permissions"]["allow"]
+
+    def test_empty_rules_noop(self, tmp_path: Path) -> None:
+        path = _write_settings(tmp_path / "settings.local.json", allow=[])
+        assert ensure_script_rules(path, []) == (0, [])
+
+    def test_dry_run_does_not_write(self, tmp_path: Path) -> None:
+        path = _write_settings(tmp_path / "settings.local.json", allow=[])
+        count, _ = ensure_script_rules(path, ["Bash(/p/x.sh:*)"], dry_run=True)
+        assert count == 1
+        data = json.loads(path.read_text())
+        assert data["permissions"]["allow"] == []
+
+
+class TestGeneralizePermission:
+    @pytest.mark.parametrize(
+        ("entry", "expected"),
+        [
+            ("Bash(/p/foo.sh arg1 arg2:*)", "Bash(/p/foo.sh:*)"),
+            ("Bash(/p/run.py --flag value:*)", "Bash(/p/run.py:*)"),
+            ("Bash(git reset --soft abc123def0:*)", "Bash(git reset --soft:*)"),
+        ],
+    )
+    def test_generalizes_known_patterns(self, entry: str, expected: str) -> None:
+        assert generalize_permission(entry) == expected
+
+    def test_returns_none_when_no_change(self) -> None:
+        assert generalize_permission("Bash(git status:*)") is None
+
+
+class TestGeneralizePermissions:
+    def test_rewrites_in_file(self, tmp_path: Path) -> None:
+        path = _write_settings(
+            tmp_path / "settings.local.json",
+            allow=["Bash(/p/foo.sh arg1:*)"],
+        )
+        count, _ = generalize_permissions(path)
+        assert count == 1
+        data = json.loads(path.read_text())
+        assert "Bash(/p/foo.sh:*)" in data["permissions"]["allow"]
+
+    def test_empty_allow_noop(self, tmp_path: Path) -> None:
+        path = _write_settings(tmp_path / "settings.local.json", allow=[])
+        assert generalize_permissions(path) == (0, [])
+
+    def test_no_replacements_noop(self, tmp_path: Path) -> None:
+        path = _write_settings(tmp_path / "settings.local.json", allow=["Bash(git status:*)"])
+        assert generalize_permissions(path) == (0, [])
+
+    def test_dry_run_does_not_write(self, tmp_path: Path) -> None:
+        path = _write_settings(tmp_path / "settings.local.json", allow=["Bash(/p/foo.sh arg1:*)"])
+        count, _ = generalize_permissions(path, dry_run=True)
+        assert count == 1
+        data = json.loads(path.read_text())
+        assert data["permissions"]["allow"] == ["Bash(/p/foo.sh arg1:*)"]
+
+    def test_invalid_json_skips(self, tmp_path: Path) -> None:
+        bad = tmp_path / "settings.local.json"
+        bad.write_text("{invalid")
+        count, messages = generalize_permissions(bad)
+        assert count == 0
+        assert messages and "SKIP" in messages[0]
+
+
+class TestCollapseLegacyUpgradeCleanupRule:
+    @pytest.mark.parametrize(
+        ("entry", "expected"),
+        [
+            (
+                "Bash(${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/scripts/update-paths.py:*)",
+                "Bash(uvx dev10x permission update-paths:*)",
+            ),
+            (
+                "Bash(~/.claude/plugins/cache/Pub/Plug/0.1.0/skills/upgrade-cleanup/scripts/enumerate-mcp.py:*)",
+                "Bash(uvx dev10x permission enumerate-mcp:*)",
+            ),
+        ],
+    )
+    def test_collapses_legacy_script(self, entry: str, expected: str) -> None:
+        assert collapse_legacy_upgrade_cleanup_rule(entry) == expected
+
+    def test_returns_none_for_unrelated(self) -> None:
+        assert collapse_legacy_upgrade_cleanup_rule("Bash(git status:*)") is None
+
+    def test_returns_none_for_unknown_script(self) -> None:
+        entry = "Bash(${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/scripts/unknown.py:*)"
+        assert collapse_legacy_upgrade_cleanup_rule(entry) is None
+
+
+class TestCollapseLegacyUpgradeCleanupRules:
+    def test_rewrites_and_dedupes(self, tmp_path: Path) -> None:
+        path = _write_settings(
+            tmp_path / "settings.local.json",
+            allow=[
+                "Bash(${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/scripts/update-paths.py:*)",
+                "Bash(git status:*)",
+            ],
+        )
+        count, _ = collapse_legacy_upgrade_cleanup_rules(path)
+        assert count == 1
+        data = json.loads(path.read_text())
+        assert "Bash(uvx dev10x permission update-paths:*)" in data["permissions"]["allow"]
+        assert "Bash(git status:*)" in data["permissions"]["allow"]
+
+    def test_empty_allow_noop(self, tmp_path: Path) -> None:
+        path = _write_settings(tmp_path / "settings.local.json", allow=[])
+        assert collapse_legacy_upgrade_cleanup_rules(path) == (0, [])
+
+    def test_no_replacements_noop(self, tmp_path: Path) -> None:
+        path = _write_settings(tmp_path / "settings.local.json", allow=["Bash(git status:*)"])
+        assert collapse_legacy_upgrade_cleanup_rules(path) == (0, [])
+
+    def test_dry_run_does_not_write(self, tmp_path: Path) -> None:
+        entry = "Bash(${CLAUDE_PLUGIN_ROOT}/skills/upgrade-cleanup/scripts/update-paths.py:*)"
+        path = _write_settings(tmp_path / "settings.local.json", allow=[entry])
+        count, _ = collapse_legacy_upgrade_cleanup_rules(path, dry_run=True)
+        assert count == 1
+        data = json.loads(path.read_text())
+        assert data["permissions"]["allow"] == [entry]
+
+    def test_unreadable_json_skips(self, tmp_path: Path) -> None:
+        bad = tmp_path / "settings.local.json"
+        bad.write_text("{invalid")
+        count, messages = collapse_legacy_upgrade_cleanup_rules(bad)
+        assert count == 0
+        assert messages and "SKIP" in messages[0]
+
+
+class TestEnsureWorkspaceDirectories:
+    def test_adds_missing_directory(self, tmp_path: Path) -> None:
+        path = tmp_path / "settings.local.json"
+        path.write_text(json.dumps({"permissions": {"additionalDirectories": []}}))
+        count, _ = ensure_workspace_directories(path, ["/tmp/Dev10x"])
+        assert count == 1
+        data = json.loads(path.read_text())
+        assert "/tmp/Dev10x" in data["permissions"]["additionalDirectories"]
+
+    def test_noop_when_present(self, tmp_path: Path) -> None:
+        path = tmp_path / "settings.local.json"
+        path.write_text(json.dumps({"permissions": {"additionalDirectories": ["/tmp/Dev10x"]}}))
+        count, messages = ensure_workspace_directories(path, ["/tmp/Dev10x"])
+        assert count == 0
+        assert messages == []
+
+    def test_dry_run_does_not_write(self, tmp_path: Path) -> None:
+        path = tmp_path / "settings.local.json"
+        path.write_text(json.dumps({"permissions": {"additionalDirectories": []}}))
+        count, _ = ensure_workspace_directories(path, ["/tmp/Dev10x"], dry_run=True)
+        assert count == 1
+        data = json.loads(path.read_text())
+        assert data["permissions"]["additionalDirectories"] == []
+
+    def test_invalid_json_skips(self, tmp_path: Path) -> None:
+        bad = tmp_path / "settings.local.json"
+        bad.write_text("{invalid")
+        count, messages = ensure_workspace_directories(bad, ["/tmp/Dev10x"])
+        assert count == 0
+        assert messages and "SKIP" in messages[0]


### PR DESCRIPTION
**When** a change touches update_paths.py's permission migrations, **I want to** have each destructive function family covered by tests, **so I can** catch over-broad allow rules or wrongly-purged rules before they degrade security or break installs.

---

[`a0bbbeba`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/647/commits/a0bbbeba9e9bda53a84f20f5cd9f965be2273c17) ✅ GH-581 Protect destructive update_paths migrations with tests
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/581

---