### PR TITLE
🔥 GH-569 Remove dead faker fixtures from conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,14 +4,6 @@ from pathlib import Path
 import pytest
 
 from dev10x.domain.claude_paths import ClaudeDir
-from tests.fakers import (
-    BashHookInputFaker,
-    CompensationFaker,
-    ConfigFaker,
-    EditHookInputFaker,
-    HookInputFaker,
-    RuleFaker,
-)
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -47,33 +39,3 @@ def _guard_repo_root_magicmock_pollution() -> Generator[None, None, None]:
 def _reset_claude_dir_cache() -> None:
     """Clear ClaudeDir's path cache to keep DEV10X_CLAUDE_HOME overrides isolated."""
     ClaudeDir.reset_cache()
-
-
-@pytest.fixture()
-def hook_input_faker() -> type[HookInputFaker]:
-    return HookInputFaker
-
-
-@pytest.fixture()
-def bash_hook_input_faker() -> type[BashHookInputFaker]:
-    return BashHookInputFaker
-
-
-@pytest.fixture()
-def edit_hook_input_faker() -> type[EditHookInputFaker]:
-    return EditHookInputFaker
-
-
-@pytest.fixture()
-def rule_faker() -> type[RuleFaker]:
-    return RuleFaker
-
-
-@pytest.fixture()
-def compensation_faker() -> type[CompensationFaker]:
-    return CompensationFaker
-
-
-@pytest.fixture()
-def config_faker() -> type[ConfigFaker]:
-    return ConfigFaker


### PR DESCRIPTION
**When** reading tests/conftest.py, **I want to** see only fixtures that tests actually use, **so I can** trust the file reflects the real access pattern instead of maintaining six wrappers no test references.

---

[`3370f275`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/648/commits/3370f275521ca2cc416d2c9b8bf1c01b8c9653a5) 🔥 GH-569 Remove dead faker fixtures from conftest
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/569

---