### PR TITLE
✨ GH-343 Enable server-initiated LLM sampling

### DIFF
--- a/.claude/rules/mcp-tools.md
+++ b/.claude/rules/mcp-tools.md
@@ -159,6 +159,7 @@ supporting each tool:
 | `audit_hook_recent` | `cli` | GH-29 | v0.69.0+ |
 | `record_upgrade` | `cli` | GH-109 | v0.72.0+ |
 | `cluster_review_comments` | `cli` | GH-346 | v0.80.0+ |
+| `request_sampling` | `cli` | GH-343 | v0.80.0+ |
 | `query` | `db` | PR #126 | v0.25.0+ |
 
 When adding a new tool, update this table and note any dependencies on

--- a/src/dev10x/mcp/_app.py
+++ b/src/dev10x/mcp/_app.py
@@ -15,6 +15,10 @@ that fetches and caches the client-declared directory roots via
 ``notifications/roots/list_changed``.  The roots are used to scope
 CWD/worktree operations, complementing the GH-979 effective-CWD
 discipline.
+
+GH-343: The lifespan also creates a :class:`SamplingManager` that captures
+the active MCP session so server tools can request LLM completions from the
+client via ``sampling/createMessage`` without a bespoke API client.
 """
 
 from __future__ import annotations
@@ -28,6 +32,7 @@ from mcp.server.fastmcp import FastMCP
 
 from dev10x.mcp.resource_watcher import KnowledgeResourceWatcher, wire_watcher_to_server
 from dev10x.mcp.roots_manager import ClientRootsManager, wire_roots_to_server
+from dev10x.mcp.sampling_manager import SamplingManager, wire_sampling_to_server
 from dev10x.subprocess_utils import get_plugin_root
 
 log = logging.getLogger(__name__)
@@ -35,7 +40,7 @@ log = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def _server_lifespan(app: FastMCP) -> AsyncIterator[None]:
-    """Lifespan that wires the knowledge-resource watcher and roots manager.
+    """Lifespan that wires the resource watcher, roots, and sampling managers.
 
     On server start:
 
@@ -45,7 +50,10 @@ async def _server_lifespan(app: FastMCP) -> AsyncIterator[None]:
     2. Creates a :class:`~dev10x.mcp.roots_manager.ClientRootsManager` and
        registers its ``InitializedNotification`` handler (chained after the
        watcher's) plus a ``RootsListChangedNotification`` handler (GH-344).
-    3. Starts the resource-watcher poll loop as a background asyncio task.
+    3. Creates a :class:`~dev10x.mcp.sampling_manager.SamplingManager` and
+       registers its ``InitializedNotification`` handler (chained after the
+       roots manager's) so tools can request sampling (GH-343).
+    4. Starts the resource-watcher poll loop as a background asyncio task.
 
     On server shutdown (lifespan exit) the background task is cancelled.
     """
@@ -58,6 +66,11 @@ async def _server_lifespan(app: FastMCP) -> AsyncIterator[None]:
     # GH-344: roots manager chains its handler after the watcher's.
     roots_manager = ClientRootsManager()
     wire_roots_to_server(server=app._mcp_server, manager=roots_manager)
+
+    # GH-343: sampling manager chains its handler after the roots manager's
+    # so server tools can request LLM completions from the client.
+    sampling_manager = SamplingManager()
+    wire_sampling_to_server(server=app._mcp_server, manager=sampling_manager)
 
     task = asyncio.create_task(watcher.run(), name="dev10x-resource-watcher")
     log.debug("Resource watcher task started for root: %s", plugin_root)

--- a/src/dev10x/mcp/sampling_manager.py
+++ b/src/dev10x/mcp/sampling_manager.py
@@ -1,0 +1,261 @@
+"""MCP sampling support for Dev10x (GH-343).
+
+Lets server-side tools request LLM completions from the connected client
+through the MCP ``sampling/createMessage`` request, so a tool can perform a
+reasoning step without shipping its own API client or key.  The client owns
+the model and the credentials; the server merely asks for a completion.
+
+Architecture
+------------
+``SamplingManager`` mirrors :class:`~dev10x.mcp.roots_manager.ClientRootsManager`:
+it is created once per server lifespan in ``_app.py`` and wired to the
+low-level MCP server via an ``InitializedNotification`` handler that captures
+the active :class:`~mcp.server.session.ServerSession`.  Unlike roots, sampling
+is purely on-demand — there is no proactive fetch on initialisation and no
+``list_changed`` notification to listen for.  The manager simply holds the
+session so a later tool call can issue a ``sampling/createMessage`` request.
+
+``request_sampling`` is the backing domain function for the
+``request_sampling`` MCP tool.  It returns a
+:class:`~dev10x.domain.common.result.Result` so the handler unwraps it via
+``.to_dict()`` at the MCP boundary like every other tool (ADR-0009).
+
+Environment variables
+---------------------
+DEV10X_SAMPLING_ENABLED
+    Set to ``0`` (or ``false``/``no``) to disable sampling entirely.
+    Defaults to ``1`` (enabled).  Useful in tests or environments where the
+    client does not implement the sampling capability.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING, Any
+
+from dev10x.domain.common.result import Result, err, ok
+
+if TYPE_CHECKING:  # pragma: no cover
+    from mcp.server.session import ServerSession
+
+log = logging.getLogger(__name__)
+
+_DEFAULT_MAX_TOKENS = 512
+
+
+def _sampling_enabled() -> bool:
+    """Return True when sampling is enabled.
+
+    Reads ``DEV10X_SAMPLING_ENABLED``; defaults to ``True``.
+    Set to ``0``/``false``/``no`` to disable.
+    """
+    raw = os.environ.get("DEV10X_SAMPLING_ENABLED", "").strip()
+    return raw not in ("0", "false", "no")
+
+
+# ── Manager ────────────────────────────────────────────────────────
+
+
+class SamplingManager:
+    """Issue server-initiated ``sampling/createMessage`` requests (GH-343).
+
+    Lifecycle::
+
+        manager = SamplingManager()
+        wire_sampling_to_server(server=app._mcp_server, manager=manager)
+        # (set_session called automatically on InitializedNotification)
+        # tools may call manager.create_message(...) at any time
+
+    Args:
+        enabled: When ``False``, skip all network calls (useful in tests).
+            ``None`` (default) reads ``DEV10X_SAMPLING_ENABLED``.
+    """
+
+    def __init__(self, enabled: bool | None = None) -> None:
+        self._enabled: bool = enabled if enabled is not None else _sampling_enabled()
+        self._session: ServerSession | None = None
+
+    @property
+    def enabled(self) -> bool:
+        """Return whether sampling integration is enabled."""
+        return self._enabled
+
+    @property
+    def has_session(self) -> bool:
+        """Return whether an MCP session is currently attached."""
+        return self._session is not None
+
+    def set_session(self, session: ServerSession | None) -> None:
+        """Attach (or detach) the active MCP session.
+
+        Called by the ``InitializedNotification`` handler.
+
+        Args:
+            session: Active ``ServerSession``, or ``None`` to detach.
+        """
+        self._session = session
+        if session is not None:
+            log.debug("SamplingManager: session attached")
+        else:
+            log.debug("SamplingManager: session detached")
+
+    async def create_message(
+        self,
+        *,
+        prompt: str,
+        system_prompt: str | None = None,
+        max_tokens: int = _DEFAULT_MAX_TOKENS,
+        temperature: float | None = None,
+    ) -> Result[dict[str, Any]]:
+        """Request an LLM completion from the connected client.
+
+        Sends a single user message via ``sampling/createMessage`` and
+        returns the assistant response.
+
+        Args:
+            prompt: The user message to send to the client's LLM.
+            system_prompt: Optional system prompt.
+            max_tokens: Maximum number of tokens to generate.
+            temperature: Optional sampling temperature.
+
+        Returns:
+            On success, ``ok`` with keys ``text`` (the assistant text, or
+            ``None`` for non-text content), ``model``, ``role``,
+            ``stop_reason``, and ``content_type``.  On failure, ``err`` with a
+            descriptive message — sampling disabled, no active session, or the
+            client rejected / does not support the request.
+        """
+        if not self._enabled:
+            return err("Sampling is disabled (DEV10X_SAMPLING_ENABLED=0).")
+        session = self._session
+        if session is None:
+            return err("No active MCP session — cannot request sampling.")
+
+        import mcp.types as mcp_types
+
+        message = mcp_types.SamplingMessage(
+            role="user",
+            content=mcp_types.TextContent(type="text", text=prompt),
+        )
+        try:
+            result = await session.create_message(
+                messages=[message],
+                max_tokens=max_tokens,
+                system_prompt=system_prompt,
+                temperature=temperature,
+            )
+        except Exception as exc:
+            log.debug(
+                "SamplingManager: create_message failed (client may not support sampling)",
+                exc_info=True,
+            )
+            return err(f"Sampling request failed: {exc}")
+
+        content = result.content
+        text = content.text if getattr(content, "type", None) == "text" else None
+        return ok(
+            {
+                "text": text,
+                "content_type": getattr(content, "type", None),
+                "model": result.model,
+                "role": result.role,
+                "stop_reason": result.stopReason,
+            }
+        )
+
+
+# ── module-level registry ──────────────────────────────────────────
+
+_manager: SamplingManager | None = None
+
+
+def get_manager() -> SamplingManager | None:
+    """Return the currently registered :class:`SamplingManager`, or ``None``."""
+    return _manager
+
+
+async def request_sampling(
+    *,
+    prompt: str,
+    system_prompt: str | None = None,
+    max_tokens: int = _DEFAULT_MAX_TOKENS,
+    temperature: float | None = None,
+) -> Result[dict[str, Any]]:
+    """Request an LLM completion from the client (GH-343).
+
+    Backing domain function for the ``request_sampling`` MCP tool.  Resolves
+    the registered :class:`SamplingManager` and delegates to its
+    :meth:`SamplingManager.create_message`.  Returns ``err`` when no manager is
+    registered (the server lifespan has not wired one yet).
+
+    Args:
+        prompt: The user message to send to the client's LLM.
+        system_prompt: Optional system prompt.
+        max_tokens: Maximum number of tokens to generate.
+        temperature: Optional sampling temperature.
+    """
+    manager = get_manager()
+    if manager is None:
+        return err("Sampling is not available — no SamplingManager registered.")
+    return await manager.create_message(
+        prompt=prompt,
+        system_prompt=system_prompt,
+        max_tokens=max_tokens,
+        temperature=temperature,
+    )
+
+
+def wire_sampling_to_server(
+    server: object,
+    manager: SamplingManager,
+) -> None:
+    """Register *manager* with the MCP low-level *server*'s handlers.
+
+    Installs an ``InitializedNotification`` handler that captures the active
+    MCP session so later tool calls can issue ``sampling/createMessage``
+    requests.  When another component (the resource watcher or roots manager)
+    already registered an ``InitializedNotification`` handler, the two are
+    chained so both fire in sequence.
+
+    Args:
+        server: The low-level MCP ``Server`` instance
+            (e.g. ``fastmcp_instance._mcp_server``).
+        manager: The sampling manager to attach.
+    """
+
+    import mcp.types as mcp_types
+
+    global _manager
+    _manager = manager
+
+    async def _on_initialized(notification: mcp_types.InitializedNotification) -> None:
+        try:
+            session = server.request_context.session  # type: ignore[attr-defined]
+            manager.set_session(session=session)
+        except Exception:
+            log.debug(
+                "SamplingManager: could not wire session on initialized",
+                exc_info=True,
+            )
+
+    # Chain with any existing InitializedNotification handler (the resource
+    # watcher and roots manager register theirs first).
+    existing_init = server.notification_handlers.get(  # type: ignore[attr-defined]
+        mcp_types.InitializedNotification
+    )
+
+    if existing_init is not None:
+
+        async def _chained_init(notification: mcp_types.InitializedNotification) -> None:
+            await existing_init(notification)
+            await _on_initialized(notification)
+
+        server.notification_handlers[mcp_types.InitializedNotification] = _chained_init  # type: ignore[attr-defined]
+    else:
+        server.notification_handlers[mcp_types.InitializedNotification] = _on_initialized  # type: ignore[attr-defined]
+
+    log.debug(
+        "SamplingManager: handlers registered (InitializedNotification chained=%s)",
+        existing_init is not None,
+    )

--- a/src/dev10x/mcp/sampling_tools.py
+++ b/src/dev10x/mcp/sampling_tools.py
@@ -1,0 +1,51 @@
+"""MCP tool registrations for server-initiated sampling (GH-343)."""
+
+from __future__ import annotations
+
+from dev10x.mcp._app import server
+
+
+@server.tool()
+async def request_sampling(
+    prompt: str,
+    system_prompt: str | None = None,
+    max_tokens: int = 512,
+    temperature: float | None = None,
+) -> dict:
+    """Request an LLM completion from the connected client (GH-343).
+
+    MCP clients that declare the ``sampling`` capability can run LLM
+    completions on behalf of the server.  This lets a Dev10x tool perform a
+    reasoning step through the client's model — no bespoke API client or key
+    on the server side.  The client owns the model selection and may reject or
+    rewrite the request.
+
+    Args:
+        prompt: The user message to send to the client's LLM.
+        system_prompt: Optional system prompt to steer the completion.
+        max_tokens: Maximum number of tokens to generate (default 512).
+        temperature: Optional sampling temperature.
+
+    Returns:
+        On success, a dictionary with keys:
+
+        * ``text`` — the assistant's text response, or ``null`` when the
+          client returned non-text content.
+        * ``content_type`` — the returned content block type (e.g. ``text``).
+        * ``model`` — the model the client used.
+        * ``role`` — the responder role (typically ``assistant``).
+        * ``stop_reason`` — why sampling stopped, if known.
+
+        On failure, ``{"error": "..."}`` — sampling disabled
+        (``DEV10X_SAMPLING_ENABLED=0``), no active MCP session, no manager
+        registered, or the client rejected / does not support sampling.
+    """
+    from dev10x.mcp.sampling_manager import request_sampling as _request_sampling
+
+    result = await _request_sampling(
+        prompt=prompt,
+        system_prompt=system_prompt,
+        max_tokens=max_tokens,
+        temperature=temperature,
+    )
+    return result.to_dict()

--- a/src/dev10x/mcp/server_cli.py
+++ b/src/dev10x/mcp/server_cli.py
@@ -7,6 +7,7 @@ Tool handlers now live in per-domain modules under `src/dev10x/mcp/`:
   - audit_tools.py   — session audit and hook-log handlers
   - misc_tools.py    — mktmp, slack, permission, skill-index, upgrade handlers
   - roots_tools.py   — client-roots awareness (GH-344)
+  - sampling_tools.py — server-initiated sampling (GH-343)
 
 This module imports all of them (triggering @server.tool() registration)
 and re-exports their names for backward-compatible attribute access.
@@ -31,6 +32,7 @@ from typing import Literal, cast
 # (GH-339). Importing knowledge_prompts triggers @server.prompt()
 # registration (GH-340).
 # Importing roots_tools registers the list_client_roots tool (GH-344).
+# Importing sampling_tools registers the request_sampling tool (GH-343).
 from dev10x.mcp import (  # noqa: E402, F401
     audit_tools,
     git_tools,
@@ -42,6 +44,7 @@ from dev10x.mcp import (  # noqa: E402, F401
     plan_tools,
     release_tools,
     roots_tools,
+    sampling_tools,
 )
 from dev10x.mcp._app import (
     server,  # noqa: F401  (re-exported for callers importing server from server_cli)
@@ -54,6 +57,7 @@ from dev10x.mcp.monitor_tools import *  # noqa: E402, F401, F403
 from dev10x.mcp.plan_tools import *  # noqa: E402, F401, F403
 from dev10x.mcp.release_tools import *  # noqa: E402, F401, F403
 from dev10x.mcp.roots_tools import *  # noqa: E402, F401, F403
+from dev10x.mcp.sampling_tools import *  # noqa: E402, F401, F403
 
 
 def main() -> None:

--- a/tests/mcp/test_sampling.py
+++ b/tests/mcp/test_sampling.py
@@ -1,0 +1,301 @@
+"""Tests for server-initiated sampling (GH-343).
+
+Covers:
+- _sampling_enabled reads the env var correctly
+- SamplingManager.enabled reflects the constructor flag
+- SamplingManager.has_session tracks set_session attach/detach
+- SamplingManager.create_message returns err when disabled
+- SamplingManager.create_message returns err when no session attached
+- SamplingManager.create_message returns ok with text/model/role on success
+- SamplingManager.create_message reports non-text content with text=None
+- SamplingManager.create_message returns err when the client raises
+- request_sampling domain fn returns err when no manager registered
+- request_sampling domain fn delegates to the manager
+- wire_sampling_to_server registers InitializedNotification handler
+- wire_sampling_to_server chains an existing InitializedNotification handler
+- wire_sampling_to_server's handler captures the session
+- wire_sampling_to_server's handler suppresses session-access errors
+- get_manager returns the registered manager
+- request_sampling MCP tool returns error when no manager
+- request_sampling MCP tool returns the populated result on success
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sampling_mod = pytest.importorskip(
+    "dev10x.mcp.sampling_manager",
+    reason="mcp not installed",
+)
+
+SamplingManager = sampling_mod.SamplingManager
+get_manager = sampling_mod.get_manager
+request_sampling = sampling_mod.request_sampling
+wire_sampling_to_server = sampling_mod.wire_sampling_to_server
+_sampling_enabled = sampling_mod._sampling_enabled
+
+
+# ── helpers ────────────────────────────────────────────────────────
+
+
+def _make_create_message_result(
+    *,
+    text: str | None,
+    content_type: str = "text",
+    model: str = "claude-test",
+    role: str = "assistant",
+    stop_reason: str | None = "endTurn",
+) -> Any:
+    """Build a mock CreateMessageResult with the given content."""
+    content = MagicMock()
+    content.type = content_type
+    content.text = text
+    result = MagicMock()
+    result.content = content
+    result.model = model
+    result.role = role
+    result.stopReason = stop_reason
+    return result
+
+
+def _make_server_stub(existing_init_handler: Any = None) -> MagicMock:
+    """Build a minimal low-level server stub."""
+    stub = MagicMock()
+    handlers: dict[type, Any] = {}
+    if existing_init_handler is not None:
+        import mcp.types as mcp_types
+
+        handlers[mcp_types.InitializedNotification] = existing_init_handler
+    stub.notification_handlers = handlers
+    return stub
+
+
+# ── _sampling_enabled ──────────────────────────────────────────────
+
+
+class TestSamplingEnabled:
+    def test_enabled_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("DEV10X_SAMPLING_ENABLED", raising=False)
+        assert _sampling_enabled() is True
+
+    def test_disabled_by_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_SAMPLING_ENABLED", "0")
+        assert _sampling_enabled() is False
+
+    def test_disabled_by_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_SAMPLING_ENABLED", "false")
+        assert _sampling_enabled() is False
+
+    def test_disabled_by_no(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_SAMPLING_ENABLED", "no")
+        assert _sampling_enabled() is False
+
+    def test_enabled_by_one(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEV10X_SAMPLING_ENABLED", "1")
+        assert _sampling_enabled() is True
+
+
+# ── SamplingManager ────────────────────────────────────────────────
+
+
+class TestSamplingManager:
+    def test_enabled_property_reflects_constructor_flag(self) -> None:
+        assert SamplingManager(enabled=True).enabled is True
+        assert SamplingManager(enabled=False).enabled is False
+
+    def test_has_session_starts_false(self) -> None:
+        assert SamplingManager().has_session is False
+
+    def test_set_session_attaches_and_detaches(self) -> None:
+        mgr = SamplingManager()
+        session = AsyncMock()
+        mgr.set_session(session=session)
+        assert mgr.has_session is True
+        mgr.set_session(session=None)
+        assert mgr.has_session is False
+
+    @pytest.mark.asyncio
+    async def test_create_message_err_when_disabled(self) -> None:
+        mgr = SamplingManager(enabled=False)
+        mgr.set_session(session=AsyncMock())
+        result = await mgr.create_message(prompt="hi")
+        assert "error" in result.to_dict()
+
+    @pytest.mark.asyncio
+    async def test_create_message_err_without_session(self) -> None:
+        mgr = SamplingManager(enabled=True)
+        result = await mgr.create_message(prompt="hi")
+        assert "error" in result.to_dict()
+
+    @pytest.mark.asyncio
+    async def test_create_message_success(self) -> None:
+        mgr = SamplingManager(enabled=True)
+        session = AsyncMock()
+        session.create_message = AsyncMock(return_value=_make_create_message_result(text="42"))
+        mgr.set_session(session=session)
+
+        result = await mgr.create_message(
+            prompt="What is 6 times 7?",
+            system_prompt="Answer with a number.",
+            max_tokens=16,
+            temperature=0.0,
+        )
+
+        payload = result.to_dict()
+        assert payload["text"] == "42"
+        assert payload["content_type"] == "text"
+        assert payload["model"] == "claude-test"
+        assert payload["role"] == "assistant"
+        assert payload["stop_reason"] == "endTurn"
+        session.create_message.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_create_message_non_text_content(self) -> None:
+        mgr = SamplingManager(enabled=True)
+        session = AsyncMock()
+        session.create_message = AsyncMock(
+            return_value=_make_create_message_result(text=None, content_type="image")
+        )
+        mgr.set_session(session=session)
+
+        payload = (await mgr.create_message(prompt="draw")).to_dict()
+        assert payload["text"] is None
+        assert payload["content_type"] == "image"
+
+    @pytest.mark.asyncio
+    async def test_create_message_err_when_client_raises(self) -> None:
+        mgr = SamplingManager(enabled=True)
+        session = AsyncMock()
+        session.create_message = AsyncMock(side_effect=RuntimeError("not supported"))
+        mgr.set_session(session=session)
+
+        result = await mgr.create_message(prompt="hi")
+        assert "error" in result.to_dict()
+
+
+# ── request_sampling domain function ───────────────────────────────
+
+
+class TestRequestSamplingDomain:
+    @pytest.mark.asyncio
+    async def test_err_when_no_manager(self) -> None:
+        with patch("dev10x.mcp.sampling_manager.get_manager", return_value=None):
+            result = await request_sampling(prompt="hi")
+        assert "error" in result.to_dict()
+
+    @pytest.mark.asyncio
+    async def test_delegates_to_manager(self) -> None:
+        mgr = SamplingManager(enabled=True)
+        session = AsyncMock()
+        session.create_message = AsyncMock(return_value=_make_create_message_result(text="ok"))
+        mgr.set_session(session=session)
+
+        with patch("dev10x.mcp.sampling_manager.get_manager", return_value=mgr):
+            result = await request_sampling(prompt="hi", max_tokens=8)
+
+        assert result.to_dict()["text"] == "ok"
+
+
+# ── wire_sampling_to_server ────────────────────────────────────────
+
+
+class TestWireSamplingToServer:
+    def test_registers_initialized_handler_when_none_exists(self) -> None:
+        import mcp.types as mcp_types
+
+        stub = _make_server_stub()
+        mgr = SamplingManager()
+        wire_sampling_to_server(server=stub, manager=mgr)
+        assert mcp_types.InitializedNotification in stub.notification_handlers
+
+    @pytest.mark.asyncio
+    async def test_chains_existing_initialized_handler(self) -> None:
+        import mcp.types as mcp_types
+
+        call_log: list[str] = []
+
+        async def existing(n: mcp_types.InitializedNotification) -> None:
+            call_log.append("existing")
+
+        stub = _make_server_stub(existing_init_handler=existing)
+        stub.request_context = MagicMock()
+        stub.request_context.session = AsyncMock()
+
+        mgr = SamplingManager(enabled=True)
+        wire_sampling_to_server(server=stub, manager=mgr)
+
+        handler = stub.notification_handlers[mcp_types.InitializedNotification]
+        await handler(MagicMock(spec=mcp_types.InitializedNotification))
+
+        assert "existing" in call_log
+        assert mgr.has_session is True
+
+    @pytest.mark.asyncio
+    async def test_initialized_handler_captures_session(self) -> None:
+        import mcp.types as mcp_types
+
+        stub = _make_server_stub()
+        stub.request_context = MagicMock()
+        stub.request_context.session = AsyncMock()
+
+        mgr = SamplingManager(enabled=True)
+        wire_sampling_to_server(server=stub, manager=mgr)
+
+        handler = stub.notification_handlers[mcp_types.InitializedNotification]
+        await handler(MagicMock(spec=mcp_types.InitializedNotification))
+
+        assert mgr.has_session is True
+
+    @pytest.mark.asyncio
+    async def test_initialized_handler_suppresses_session_access_error(self) -> None:
+        import mcp.types as mcp_types
+
+        stub = _make_server_stub()
+        stub.request_context = MagicMock()
+        type(stub.request_context).session = property(
+            lambda self: (_ for _ in ()).throw(RuntimeError("no session"))
+        )
+
+        mgr = SamplingManager(enabled=True)
+        wire_sampling_to_server(server=stub, manager=mgr)
+
+        handler = stub.notification_handlers[mcp_types.InitializedNotification]
+        await handler(MagicMock(spec=mcp_types.InitializedNotification))  # Must not raise.
+
+        assert mgr.has_session is False
+
+    def test_get_manager_returns_registered_manager(self) -> None:
+        stub = _make_server_stub()
+        mgr = SamplingManager()
+        wire_sampling_to_server(server=stub, manager=mgr)
+        assert get_manager() is mgr
+
+
+# ── request_sampling MCP tool ──────────────────────────────────────
+
+
+class TestRequestSamplingTool:
+    @pytest.mark.asyncio
+    async def test_returns_error_when_no_manager(self) -> None:
+        cli_server = pytest.importorskip("dev10x.mcp.server_cli", reason="mcp not installed")
+        with patch("dev10x.mcp.sampling_manager.get_manager", return_value=None):
+            result = await cli_server.request_sampling(prompt="hi")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_returns_populated_result_on_success(self) -> None:
+        cli_server = pytest.importorskip("dev10x.mcp.server_cli", reason="mcp not installed")
+        mgr = SamplingManager(enabled=True)
+        session = AsyncMock()
+        session.create_message = AsyncMock(return_value=_make_create_message_result(text="hello"))
+        mgr.set_session(session=session)
+
+        with patch("dev10x.mcp.sampling_manager.get_manager", return_value=mgr):
+            result = await cli_server.request_sampling(prompt="hi", max_tokens=8)
+
+        assert result["text"] == "hello"
+        assert result["model"] == "claude-test"


### PR DESCRIPTION
**When** a Dev10x MCP tool needs an LLM reasoning step mid-operation, **I want to** request a completion through the connected client's sampling capability, **so I can** add model-backed reasoning without shipping a bespoke API client or key on the server.

---

[`c7fc2e42`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/649/commits/c7fc2e42d822b327eeac146629ff7a1e566012e0) ✨ GH-343 Enable server-initiated LLM sampling
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/343

---