### PR TITLE
✅ GH-570 Make faker output reproducible and decouple from host HOME

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ from collections.abc import Generator
 from pathlib import Path
 
 import pytest
+from factory.random import reseed_random
 
 from dev10x.domain.claude_paths import ClaudeDir
 
@@ -39,3 +40,10 @@ def _guard_repo_root_magicmock_pollution() -> Generator[None, None, None]:
 def _reset_claude_dir_cache() -> None:
     """Clear ClaudeDir's path cache to keep DEV10X_CLAUDE_HOME overrides isolated."""
     ClaudeDir.reset_cache()
+
+
+@pytest.fixture(autouse=True)
+def _seed_factory_faker() -> None:
+    """Reseed factory_boy's Faker before each test so generated values are
+    deterministic and a value-specific failure is reproducible (GH-570)."""
+    reseed_random("dev10x-tests")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,14 +4,6 @@ from pathlib import Path
 import pytest
 
 from dev10x.domain.claude_paths import ClaudeDir
-from tests.fakers import (
-    BashHookInputFaker,
-    CompensationFaker,
-    ConfigFaker,
-    EditHookInputFaker,
-    HookInputFaker,
-    RuleFaker,
-)
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -47,33 +39,3 @@ def _guard_repo_root_magicmock_pollution() -> Generator[None, None, None]:
 def _reset_claude_dir_cache() -> None:
     """Clear ClaudeDir's path cache to keep DEV10X_CLAUDE_HOME overrides isolated."""
     ClaudeDir.reset_cache()
-
-
-@pytest.fixture()
-def hook_input_faker() -> type[HookInputFaker]:
-    return HookInputFaker
-
-
-@pytest.fixture()
-def bash_hook_input_faker() -> type[BashHookInputFaker]:
-    return BashHookInputFaker
-
-
-@pytest.fixture()
-def edit_hook_input_faker() -> type[EditHookInputFaker]:
-    return EditHookInputFaker
-
-
-@pytest.fixture()
-def rule_faker() -> type[RuleFaker]:
-    return RuleFaker
-
-
-@pytest.fixture()
-def compensation_faker() -> type[CompensationFaker]:
-    return CompensationFaker
-
-
-@pytest.fixture()
-def config_faker() -> type[ConfigFaker]:
-    return ConfigFaker

--- a/tests/domain/common/test_allow_rule.py
+++ b/tests/domain/common/test_allow_rule.py
@@ -78,10 +78,10 @@ class TestBashMatching:
         assert AllowRule.parse("Bash(ls)").matches("Bash(ls)")
         assert not AllowRule.parse("Bash(ls)").matches("Bash(ls -la)")
 
-    def test_tilde_expands_against_home_command(self) -> None:
-        home = str(Path.home())
+    def test_tilde_expands_against_home_command(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HOME", "/home/testuser")
         rule = AllowRule.parse("Bash(~/.claude/skills/foo.sh:*)")
-        assert rule.matches(f"Bash({home}/.claude/skills/foo.sh --x)")
+        assert rule.matches("Bash(/home/testuser/.claude/skills/foo.sh --x)")
 
 
 class TestPathMatching:

--- a/tests/hooks/test_orchestrators.py
+++ b/tests/hooks/test_orchestrators.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -17,6 +18,10 @@ import pytest
 SCRIPTS = Path(__file__).resolve().parents[2] / "hooks" / "scripts"
 SESSION_START = SCRIPTS / "session-start.py"
 SESSION_STOP = SCRIPTS / "session-stop.py"
+
+# Isolated HOME so orchestrator subprocesses read no real ~/.claude state —
+# decouples assertions from the host's home layout (GH-570).
+_ISOLATED_HOME = tempfile.mkdtemp(prefix="dev10x-orchestrator-home-")
 
 
 def _run(script: Path, payload: dict) -> subprocess.CompletedProcess[str]:
@@ -29,7 +34,7 @@ def _run(script: Path, payload: dict) -> subprocess.CompletedProcess[str]:
         env={
             "DEV10X_HOOK_AUDIT": "0",
             "PATH": "/usr/bin:/bin:/usr/local/bin",
-            "HOME": str(Path.home()),
+            "HOME": _ISOLATED_HOME,
         },
     )
 

--- a/tests/hooks/test_permission_diagnostics.py
+++ b/tests/hooks/test_permission_diagnostics.py
@@ -478,7 +478,7 @@ class TestFormatDiagnostic:
         )
         user_settings = SettingsFile(
             label="user settings",
-            path=Path.home() / ".claude" / "settings.json",
+            path=Path("/home/testuser/.claude/settings.json"),
             precedence=5,
         )
         return DiagnosticResult(

--- a/tests/test_script_loadability.py
+++ b/tests/test_script_loadability.py
@@ -94,7 +94,7 @@ class TestScriptLoadability:
         )
         assert result.returncode == 0, f"Syntax error in {script.name}: {result.stderr}"
 
-    def test_script_imports_resolve_from_repo(self, script: Path) -> None:
+    def test_script_imports_resolve_from_repo(self, script: Path, tmp_path: Path) -> None:
         missing = _has_missing_deps(script=script)
         if missing:
             pytest.skip(f"External dependency {missing!r} not installed")
@@ -115,7 +115,7 @@ class TestScriptLoadability:
             capture_output=True,
             text=True,
             timeout=30,
-            env={"PATH": "", "HOME": str(Path.home())},
+            env={"PATH": "", "HOME": str(tmp_path)},
         )
         assert result.returncode == 0, (
             f"Failed to load {script.name} with src/ on path: {result.stderr}"


### PR DESCRIPTION
**When** a test fails on a faker-generated value or runs in a container with an unusual HOME, **I want to** have deterministic faker seeds and HOME-isolated tests, **so I can** reproduce the failure and trust the suite regardless of the host's home layout.

---

[`3370f275`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/650/commits/3370f275521ca2cc416d2c9b8bf1c01b8c9653a5) 🔥 GH-569 Remove dead faker fixtures from conftest
[`d3486645`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/650/commits/d3486645fa8b99dc9271a4084ef4b99ae7d89cba) ✅ GH-570 Make faker output reproducible and decouple from host HOME
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/570

---