### PR TITLE
♻️ GH-519 Trim dead code and thin permission command shims

### DIFF
--- a/src/dev10x/commands/init.py
+++ b/src/dev10x/commands/init.py
@@ -55,15 +55,6 @@ STARTER_WORK_ON_PLAYBOOK = """# Starter work-on playbook for this project.
 overrides: []
 """
 
-STARTER_GITMOJI_YAML = """# Gitmoji strategy override for this project.
-#
-# Leave default-strategy empty to use plugin defaults.
-# See skills/git-commit/references/gitmoji-defaults.yaml for the base map.
-
-default-strategy: null
-projects: []
-"""
-
 
 def _session_yaml_template() -> str:
     return (

--- a/src/dev10x/commands/permission.py
+++ b/src/dev10x/commands/permission.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -664,97 +663,35 @@ def _resolve_state_path() -> Path:
 )
 def investigate_prepare(*, workdir: str | None) -> None:
     """Materialize fixtures and snapshot the user's settings files."""
-    import json as _json
-    from dataclasses import asdict
-
-    from dev10x.skills.permission_investigator import fixtures
-    from dev10x.skills.permission_investigator.matrix import generate_matrix
+    from dev10x.skills.permission_investigator import runner
 
     work = Path(workdir) if workdir else _investigator_workdir()
-    paths = fixtures.materialize_fixtures(workdir=work, user_home=Path.home())
-
-    snapshot_dir = work / "snapshots"
-    fixtures.snapshot_settings(
-        settings_path=paths.global_settings,
-        snapshot_dir=snapshot_dir,
+    sys.exit(
+        _emit_result(
+            runner.prepare(
+                workdir=work,
+                user_home=Path.home(),
+                default_workdir=_investigator_workdir(),
+            )
+        )
     )
-    fixtures.snapshot_settings(
-        settings_path=paths.project_settings,
-        snapshot_dir=snapshot_dir,
-    )
-
-    matrix = generate_matrix()
-    state = {
-        "fixture": {
-            "fixture_root": str(paths.fixture_root),
-            "fixture_relpath": str(paths.fixture_relpath),
-            "plugin_skill_file": str(paths.plugin_skill_file),
-            "project_settings": str(paths.project_settings),
-            "global_settings": str(paths.global_settings),
-            "workdir": str(paths.workdir),
-            "publisher_root": str(paths.publisher_root),
-        },
-        "cells": [
-            {
-                "cell_id": cell.cell_id,
-                "shape": asdict(cell.shape),
-                "location": cell.location,
-            }
-            for cell in matrix.cells
-        ],
-        "results": {},
-    }
-    real_state_path = _matrix_state_path(workdir=work)
-    real_state_path.parent.mkdir(parents=True, exist_ok=True)
-    real_state_path.write_text(_json.dumps(state, indent=2))
-
-    if work != _investigator_workdir():
-        default_state_path = _matrix_state_path()
-        default_state_path.parent.mkdir(parents=True, exist_ok=True)
-        default_state_path.write_text(_json.dumps({"redirect": str(real_state_path)}, indent=2))
-
-    click.echo(f"Workdir: {work}")
-    click.echo(f"Fixture: {paths.plugin_skill_file}")
-    click.echo(f"Cells: {len(matrix.cells)}")
 
 
 @investigate.command(name="apply")
 @click.argument("cell_id")
 def investigate_apply(*, cell_id: str) -> None:
     """Apply the rule shape for ``cell_id`` to the appropriate target file(s)."""
-    import json as _json
+    from dev10x.skills.permission_investigator import runner
 
-    from dev10x.skills.permission_investigator import fixtures
-    from dev10x.skills.permission_investigator.matrix import RuleShape
-
-    state_path = _resolve_state_path()
-    if not state_path.is_file():
-        click.echo("ERROR: state missing — run `prepare` first.", err=True)
-        sys.exit(1)
-    state = _json.loads(state_path.read_text())
-
-    cell = next((c for c in state["cells"] if c["cell_id"] == cell_id), None)
-    if cell is None:
-        click.echo(f"ERROR: unknown cell_id {cell_id}", err=True)
-        sys.exit(1)
-
-    shape = RuleShape(**cell["shape"])
-    rule = shape.render(
-        fixture_relpath=state["fixture"]["fixture_relpath"],
-        user_home=str(Path.home()),
+    sys.exit(
+        _emit_result(
+            runner.apply_cell(
+                state_path=_resolve_state_path(),
+                cell_id=cell_id,
+                user_home=Path.home(),
+            )
+        )
     )
-
-    targets: list[Path] = []
-    if cell["location"] in ("project", "both"):
-        targets.append(Path(state["fixture"]["project_settings"]))
-    if cell["location"] in ("global", "both"):
-        targets.append(Path(state["fixture"]["global_settings"]))
-
-    for target in targets:
-        fixtures.apply_rule(rule=rule, target=target)
-
-    click.echo(f"Applied rule: {rule}")
-    click.echo(f"Targets: {len(targets)}")
 
 
 @investigate.command(name="record")
@@ -774,54 +711,27 @@ def investigate_record(
     notes: str,
 ) -> None:
     """Record the outcome for one cell into the persisted matrix."""
-    import json as _json
+    from dev10x.skills.permission_investigator import runner
 
-    state_path = _resolve_state_path()
-    if not state_path.is_file():
-        click.echo("ERROR: state missing — run `prepare` first.", err=True)
-        sys.exit(1)
-    state = _json.loads(state_path.read_text())
-
-    state.setdefault("results", {})[cell_id] = {
-        "cell_id": cell_id,
-        "auto_approved": bool(auto_approved),
-        "prompted": not bool(auto_approved),
-        "error": error,
-        "notes": notes,
-    }
-    state_path.write_text(_json.dumps(state, indent=2))
-    click.echo(f"Recorded {cell_id}")
+    sys.exit(
+        _emit_result(
+            runner.record_outcome(
+                state_path=_resolve_state_path(),
+                cell_id=cell_id,
+                auto_approved=auto_approved,
+                error=error,
+                notes=notes,
+            )
+        )
+    )
 
 
 @investigate.command(name="restore")
 def investigate_restore() -> None:
     """Restore settings files from the pre-run snapshots."""
-    import json as _json
+    from dev10x.skills.permission_investigator import runner
 
-    from dev10x.skills.permission_investigator import fixtures
-
-    state_path = _resolve_state_path()
-    if not state_path.is_file():
-        click.echo("Nothing to restore — state missing.")
-        return
-    state = _json.loads(state_path.read_text())
-    snapshot_dir = Path(state["fixture"]["workdir"]) / "snapshots"
-
-    for key in ("global_settings", "project_settings"):
-        target = Path(state["fixture"][key])
-        snap = snapshot_dir / f"{target.name}.snapshot"
-        if snap.is_file():
-            fixtures.restore_settings(snapshot_path=snap, target_path=target)
-            click.echo(f"Restored {target}")
-
-    publisher_root_str = state["fixture"].get("publisher_root")
-    if publisher_root_str:
-        publisher_root = Path(publisher_root_str)
-        if publisher_root.is_dir():
-            import shutil as _shutil
-
-            _shutil.rmtree(publisher_root)
-            click.echo(f"Removed fixture publisher tree {publisher_root}")
+    sys.exit(_emit_result(runner.restore(state_path=_resolve_state_path())))
 
 
 @investigate.command(name="report")
@@ -833,41 +743,9 @@ def investigate_restore() -> None:
 )
 def investigate_report(*, output: str | None) -> None:
     """Render the populated matrix as a markdown report."""
-    import json as _json
+    from dev10x.skills.permission_investigator import runner
 
-    from dev10x.skills.permission_investigator.matrix import (
-        Matrix,
-        MatrixCell,
-        MatrixResult,
-        RuleShape,
-    )
-    from dev10x.skills.permission_investigator.report import render_markdown_report
-
-    state_path = _resolve_state_path()
-    if not state_path.is_file():
-        click.echo("ERROR: state missing — run `prepare` first.", err=True)
-        sys.exit(1)
-    state = _json.loads(state_path.read_text())
-
-    matrix = Matrix()
-    for cell_data in state.get("cells", []):
-        shape = RuleShape(**cell_data["shape"])
-        matrix.cells.append(
-            MatrixCell(
-                shape=shape,
-                location=cell_data["location"],
-                cell_id=cell_data["cell_id"],
-            )
-        )
-    for cell_id, result_data in state.get("results", {}).items():
-        matrix.add_result(MatrixResult(**result_data))
-
-    rendered = render_markdown_report(matrix)
-    if output:
-        Path(output).write_text(rendered)
-        click.echo(f"Wrote report to {output}")
-    else:
-        click.echo(rendered)
+    sys.exit(_emit_result(runner.build_report(state_path=_resolve_state_path(), output=output)))
 
 
 @investigate.command(name="delta")
@@ -962,26 +840,7 @@ def doctor_cross_contamination(*, cwd: str | None, quiet: bool) -> None:
     from dev10x.skills.permission import doctor as mod
 
     root = Path(cwd) if cwd else Path.cwd()
-    workspace = mod.detect_workspace(root)
-    settings_path = workspace.project_root / ".claude" / "settings.local.json"
-    if not settings_path.is_file():
-        click.echo(f"No settings file at {settings_path}")
-        return
-    data = json.loads(settings_path.read_text())
-    rules: list[str] = []
-    perms = data.get("permissions", {})
-    for bucket in ("allow", "deny", "ask"):
-        rules.extend(perms.get(bucket, []) or [])
-    findings = mod.detect_cross_contamination(rules, workspace=workspace)
-    if not findings:
-        click.echo(f"{settings_path} — no cross-contamination findings.")
-        return
-    click.echo(f"\n{settings_path} — {len(findings)} findings")
-    for finding in findings:
-        click.echo(f"  ! {finding.rule}")
-        if not quiet:
-            click.echo(f"      reason: {finding.reason}")
-            click.echo(f"      suggestion: {finding.suggestion}")
+    sys.exit(_emit_result(mod.cross_contamination_for_root(root=root, quiet=quiet)))
 
 
 @doctor.command(name="apply-deprecations")
@@ -1005,34 +864,11 @@ def doctor_apply_deprecations(*, dry_run: bool) -> None:
     if dry_run:
         click.echo("(dry run — no files will be modified)\n")
 
-    total_actions = 0
-    for path in sorted(settings_files):
-        data = json.loads(path.read_text())
-        perms = data.get("permissions", {})
-        changes_in_file = 0
-        for bucket in ("allow", "deny", "ask"):
-            rules = perms.get(bucket)
-            if not isinstance(rules, list):
-                continue
-            new_rules, outcomes = mod.apply_deprecations(rules, catalog=catalog)
-            if outcomes:
-                changes_in_file += len(outcomes)
-                click.echo(f"\n{path} [{bucket}] — {len(outcomes)} actions")
-                for outcome in outcomes:
-                    if outcome.action == "remove":
-                        click.echo(f"  - REMOVE: {outcome.rule}  # {outcome.reason}")
-                    elif outcome.action == "canonicalize":
-                        click.echo(f"  ~ CANON:  {outcome.rule}")
-                        click.echo(f"           → {outcome.replacement}")
-                    else:
-                        click.echo(f"  ? {outcome.action.upper()}: {outcome.rule}")
-            perms[bucket] = new_rules
-        if changes_in_file and not dry_run:
-            data["permissions"] = perms
-            path.write_text(json.dumps(data, indent=2) + "\n")
-        total_actions += changes_in_file
-    verb = "Would apply" if dry_run else "Applied"
-    click.echo(f"\n{verb} {total_actions} deprecation actions.")
+    sys.exit(
+        _emit_result(
+            mod.apply_deprecations_to_files(settings_files, catalog=catalog, dry_run=dry_run)
+        )
+    )
 
 
 @doctor.command(name="enable-group")
@@ -1059,23 +895,17 @@ def doctor_enable_group(*, group_name: str, dry_run: bool) -> None:
         return
     if dry_run:
         click.echo("(dry run — no files will be modified)\n")
-    total_added = 0
-    for path in sorted(settings_files):
-        data = json.loads(path.read_text())
-        perms = data.setdefault("permissions", {})
-        allow = perms.setdefault("allow", [])
-        added_here = [rule for rule in rules if rule not in allow]
-        if not added_here:
-            continue
-        click.echo(f"\n{path} — adding {len(added_here)} rules from {group_name!r}")
-        for rule in added_here:
-            click.echo(f"  + {rule}")
-        if not dry_run:
-            allow.extend(added_here)
-            path.write_text(json.dumps(data, indent=2) + "\n")
-        total_added += len(added_here)
-    verb = "Would add" if dry_run else "Added"
-    click.echo(f"\n{verb} {total_added} rules from group {group_name!r}.")
+
+    sys.exit(
+        _emit_result(
+            mod.enable_group_in_files(
+                settings_files,
+                rules=rules,
+                group_name=group_name,
+                dry_run=dry_run,
+            )
+        )
+    )
 
 
 @doctor.command(name="anchor-worktree-roots")

--- a/src/dev10x/skills/permission/doctor.py
+++ b/src/dev10x/skills/permission/doctor.py
@@ -29,6 +29,7 @@ import subprocess
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 import yaml
 
@@ -284,6 +285,41 @@ def _is_within(child: Path, parent: Path) -> bool:
     return True
 
 
+def cross_contamination_for_root(*, root: Path, quiet: bool = False) -> dict[str, Any]:
+    """Read a project's settings file and report cross-contamination findings.
+
+    Resolves the workspace for ``root``, reads
+    ``<project>/.claude/settings.local.json``, collects allow/deny/ask
+    rules, and runs :func:`detect_cross_contamination`. Returns a result
+    dict consumable by ``commands.permission._emit_result``.
+    """
+    workspace = detect_workspace(root)
+    settings_path = workspace.project_root / ".claude" / "settings.local.json"
+    if not settings_path.is_file():
+        return {"messages": [f"No settings file at {settings_path}"], "exit_code": 0}
+
+    data = json.loads(settings_path.read_text())
+    rules: list[str] = []
+    perms = data.get("permissions", {})
+    for bucket in ("allow", "deny", "ask"):
+        rules.extend(perms.get(bucket, []) or [])
+
+    findings = detect_cross_contamination(rules, workspace=workspace)
+    if not findings:
+        return {
+            "messages": [f"{settings_path} — no cross-contamination findings."],
+            "exit_code": 0,
+        }
+
+    messages = [f"\n{settings_path} — {len(findings)} findings"]
+    for finding in findings:
+        messages.append(f"  ! {finding.rule}")
+        if not quiet:
+            messages.append(f"      reason: {finding.reason}")
+            messages.append(f"      suggestion: {finding.suggestion}")
+    return {"messages": messages, "exit_code": 0}
+
+
 def expand_flag_overrides(flag_overrides: dict[str, list[str]]) -> list[str]:
     """Expand a ``flag_overrides`` mapping into ``Bash(<cmd> <flag>:*)`` rules.
 
@@ -417,6 +453,86 @@ def apply_deprecations(
             output.append(rule)
             seen.add(rule)
     return output, outcomes
+
+
+def apply_deprecations_to_files(
+    settings_files: Iterable[Path],
+    *,
+    catalog: Catalog,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Apply catalog deprecations across settings files, writing changes.
+
+    Reads each file, applies :func:`apply_deprecations` per
+    allow/deny/ask bucket, and (unless ``dry_run``) writes the result
+    back. Returns a result dict consumable by
+    ``commands.permission._emit_result``.
+    """
+    messages: list[str] = []
+    total_actions = 0
+    for path in sorted(settings_files):
+        data = json.loads(path.read_text())
+        perms = data.get("permissions", {})
+        changes_in_file = 0
+        for bucket in ("allow", "deny", "ask"):
+            rules = perms.get(bucket)
+            if not isinstance(rules, list):
+                continue
+            new_rules, outcomes = apply_deprecations(rules, catalog=catalog)
+            if outcomes:
+                changes_in_file += len(outcomes)
+                messages.append(f"\n{path} [{bucket}] — {len(outcomes)} actions")
+                for outcome in outcomes:
+                    if outcome.action == "remove":
+                        messages.append(f"  - REMOVE: {outcome.rule}  # {outcome.reason}")
+                    elif outcome.action == "canonicalize":
+                        messages.append(f"  ~ CANON:  {outcome.rule}")
+                        messages.append(f"           → {outcome.replacement}")
+                    else:
+                        messages.append(f"  ? {outcome.action.upper()}: {outcome.rule}")
+            perms[bucket] = new_rules
+        if changes_in_file and not dry_run:
+            data["permissions"] = perms
+            path.write_text(json.dumps(data, indent=2) + "\n")
+        total_actions += changes_in_file
+    verb = "Would apply" if dry_run else "Applied"
+    messages.append(f"\n{verb} {total_actions} deprecation actions.")
+    return {"messages": messages, "exit_code": 0}
+
+
+def enable_group_in_files(
+    settings_files: Iterable[Path],
+    *,
+    rules: Iterable[str],
+    group_name: str,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Add a catalog group's ``rules`` to each settings file's allow bucket.
+
+    Rules already present are skipped. Unless ``dry_run``, the updated
+    allow bucket is written back. Returns a result dict consumable by
+    ``commands.permission._emit_result``.
+    """
+    rule_list = list(rules)
+    messages: list[str] = []
+    total_added = 0
+    for path in sorted(settings_files):
+        data = json.loads(path.read_text())
+        perms = data.setdefault("permissions", {})
+        allow = perms.setdefault("allow", [])
+        added_here = [rule for rule in rule_list if rule not in allow]
+        if not added_here:
+            continue
+        messages.append(f"\n{path} — adding {len(added_here)} rules from {group_name!r}")
+        for rule in added_here:
+            messages.append(f"  + {rule}")
+        if not dry_run:
+            allow.extend(added_here)
+            path.write_text(json.dumps(data, indent=2) + "\n")
+        total_added += len(added_here)
+    verb = "Would add" if dry_run else "Added"
+    messages.append(f"\n{verb} {total_added} rules from group {group_name!r}.")
+    return {"messages": messages, "exit_code": 0}
 
 
 @dataclass

--- a/src/dev10x/skills/permission_investigator/runner.py
+++ b/src/dev10x/skills/permission_investigator/runner.py
@@ -1,0 +1,177 @@
+"""Domain entry points for `dev10x permission investigate` (GH-47, GH-525).
+
+The command group's bodies used to open ``matrix.json``, build the
+state envelope, and ``write_text`` inline. Per
+``.claude/rules/script-domain-boundaries.md`` (GH-246 H3/H7) that
+file read/mutate/write logic lives here instead, leaving the command
+bodies as thin arg-parse + delegate + print shims.
+
+Each function returns a result dict consumable by
+``commands.permission._emit_result`` — ``messages`` (stdout lines),
+``errors`` (stderr lines), and ``exit_code``. Path resolution (where
+``matrix.json`` lives under ``/tmp``) stays in the command layer; the
+functions below operate on explicit paths handed in by the caller.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from dev10x.skills.permission_investigator import fixtures, load_matrix_from_state
+from dev10x.skills.permission_investigator.matrix import RuleShape, generate_matrix
+from dev10x.skills.permission_investigator.report import render_markdown_report
+
+
+def _state_missing() -> dict[str, Any]:
+    return {"errors": ["ERROR: state missing — run `prepare` first."], "exit_code": 1}
+
+
+def prepare(*, workdir: Path, user_home: Path, default_workdir: Path) -> dict[str, Any]:
+    """Materialize fixtures, snapshot settings, and persist matrix state.
+
+    Writes ``matrix.json`` into ``workdir``. When ``workdir`` differs
+    from ``default_workdir``, a redirect pointer is written at the
+    default location so apply/record/report/restore can find the real
+    state without re-passing ``--workdir``.
+    """
+    paths = fixtures.materialize_fixtures(workdir=workdir, user_home=user_home)
+
+    snapshot_dir = workdir / "snapshots"
+    fixtures.snapshot_settings(settings_path=paths.global_settings, snapshot_dir=snapshot_dir)
+    fixtures.snapshot_settings(settings_path=paths.project_settings, snapshot_dir=snapshot_dir)
+
+    matrix = generate_matrix()
+    state = {
+        "fixture": {
+            "fixture_root": str(paths.fixture_root),
+            "fixture_relpath": str(paths.fixture_relpath),
+            "plugin_skill_file": str(paths.plugin_skill_file),
+            "project_settings": str(paths.project_settings),
+            "global_settings": str(paths.global_settings),
+            "workdir": str(paths.workdir),
+            "publisher_root": str(paths.publisher_root),
+        },
+        "cells": [
+            {
+                "cell_id": cell.cell_id,
+                "shape": asdict(cell.shape),
+                "location": cell.location,
+            }
+            for cell in matrix.cells
+        ],
+        "results": {},
+    }
+    real_state_path = workdir / "matrix.json"
+    real_state_path.parent.mkdir(parents=True, exist_ok=True)
+    real_state_path.write_text(json.dumps(state, indent=2))
+
+    if workdir != default_workdir:
+        default_state_path = default_workdir / "matrix.json"
+        default_state_path.parent.mkdir(parents=True, exist_ok=True)
+        default_state_path.write_text(json.dumps({"redirect": str(real_state_path)}, indent=2))
+
+    return {
+        "messages": [
+            f"Workdir: {workdir}",
+            f"Fixture: {paths.plugin_skill_file}",
+            f"Cells: {len(matrix.cells)}",
+        ],
+        "exit_code": 0,
+    }
+
+
+def apply_cell(*, state_path: Path, cell_id: str, user_home: Path) -> dict[str, Any]:
+    """Apply the rule shape for ``cell_id`` to its target settings file(s)."""
+    if not state_path.is_file():
+        return _state_missing()
+    state = json.loads(state_path.read_text())
+
+    cell = next((c for c in state["cells"] if c["cell_id"] == cell_id), None)
+    if cell is None:
+        return {"errors": [f"ERROR: unknown cell_id {cell_id}"], "exit_code": 1}
+
+    shape = RuleShape(**cell["shape"])
+    rule = shape.render(
+        fixture_relpath=state["fixture"]["fixture_relpath"],
+        user_home=str(user_home),
+    )
+
+    targets: list[Path] = []
+    if cell["location"] in ("project", "both"):
+        targets.append(Path(state["fixture"]["project_settings"]))
+    if cell["location"] in ("global", "both"):
+        targets.append(Path(state["fixture"]["global_settings"]))
+
+    for target in targets:
+        fixtures.apply_rule(rule=rule, target=target)
+
+    return {
+        "messages": [f"Applied rule: {rule}", f"Targets: {len(targets)}"],
+        "exit_code": 0,
+    }
+
+
+def record_outcome(
+    *,
+    state_path: Path,
+    cell_id: str,
+    auto_approved: bool,
+    error: str | None,
+    notes: str,
+) -> dict[str, Any]:
+    """Record the outcome for one cell into the persisted matrix."""
+    if not state_path.is_file():
+        return _state_missing()
+    state = json.loads(state_path.read_text())
+
+    state.setdefault("results", {})[cell_id] = {
+        "cell_id": cell_id,
+        "auto_approved": bool(auto_approved),
+        "prompted": not bool(auto_approved),
+        "error": error,
+        "notes": notes,
+    }
+    state_path.write_text(json.dumps(state, indent=2))
+    return {"messages": [f"Recorded {cell_id}"], "exit_code": 0}
+
+
+def restore(*, state_path: Path) -> dict[str, Any]:
+    """Restore settings files from the pre-run snapshots and drop fixtures."""
+    if not state_path.is_file():
+        return {"messages": ["Nothing to restore — state missing."], "exit_code": 0}
+    state = json.loads(state_path.read_text())
+    snapshot_dir = Path(state["fixture"]["workdir"]) / "snapshots"
+
+    messages: list[str] = []
+    for key in ("global_settings", "project_settings"):
+        target = Path(state["fixture"][key])
+        snap = snapshot_dir / f"{target.name}.snapshot"
+        if snap.is_file():
+            fixtures.restore_settings(snapshot_path=snap, target_path=target)
+            messages.append(f"Restored {target}")
+
+    publisher_root_str = state["fixture"].get("publisher_root")
+    if publisher_root_str:
+        publisher_root = Path(publisher_root_str)
+        if publisher_root.is_dir():
+            shutil.rmtree(publisher_root)
+            messages.append(f"Removed fixture publisher tree {publisher_root}")
+
+    return {"messages": messages, "exit_code": 0}
+
+
+def build_report(*, state_path: Path, output: str | None) -> dict[str, Any]:
+    """Render the populated matrix as a markdown report."""
+    if not state_path.is_file():
+        return _state_missing()
+    state = json.loads(state_path.read_text())
+
+    rendered = render_markdown_report(load_matrix_from_state(state))
+    if output:
+        Path(output).write_text(rendered)
+        return {"messages": [f"Wrote report to {output}"], "exit_code": 0}
+    return {"messages": [rendered], "exit_code": 0}

--- a/src/dev10x/subprocess_utils.py
+++ b/src/dev10x/subprocess_utils.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import functools
-import json
 import logging
 import os
 import subprocess
@@ -325,7 +324,3 @@ def parse_key_value_output(text: str) -> dict[str, str]:
         key, value = line.split("=", 1)
         result[key.strip()] = value.strip()
     return result
-
-
-def parse_json_output(text: str) -> dict[str, Any]:
-    return json.loads(text)

--- a/tests/permission/test_doctor.py
+++ b/tests/permission/test_doctor.py
@@ -485,3 +485,154 @@ class TestAnchorWorktreeRoots:
 
         skill_script_findings = [f for f in result.findings if f.scope == "skill-script"]
         assert len(skill_script_findings) == 0
+
+
+def _write_settings(path: Path, *, allow: list[str]) -> Path:
+    settings = path / ".claude" / "settings.local.json"
+    settings.parent.mkdir(parents=True, exist_ok=True)
+    settings.write_text(json.dumps({"permissions": {"allow": allow}}))
+    return settings
+
+
+class TestCrossContaminationForRoot:
+    def test_reports_missing_settings_file(self, tmp_path: Path) -> None:
+        result = doctor.cross_contamination_for_root(root=tmp_path)
+
+        assert result["exit_code"] == 0
+        assert "No settings file at" in result["messages"][0]
+
+    def test_reports_no_findings(self, tmp_path: Path) -> None:
+        _write_settings(tmp_path, allow=["Bash(git status:*)"])
+
+        result = doctor.cross_contamination_for_root(root=tmp_path)
+
+        assert result["exit_code"] == 0
+        assert "no cross-contamination findings" in result["messages"][0]
+
+    def test_reports_findings_with_detail(self, tmp_path: Path) -> None:
+        _write_settings(tmp_path, allow=["Bash(/work/other-project/script.sh:*)"])
+
+        result = doctor.cross_contamination_for_root(root=tmp_path)
+
+        joined = "\n".join(result["messages"])
+        assert "1 findings" in joined
+        assert "! Bash(/work/other-project/script.sh:*)" in joined
+        assert "reason:" in joined
+
+    def test_quiet_suppresses_detail(self, tmp_path: Path) -> None:
+        _write_settings(tmp_path, allow=["Bash(/work/other-project/script.sh:*)"])
+
+        result = doctor.cross_contamination_for_root(root=tmp_path, quiet=True)
+
+        joined = "\n".join(result["messages"])
+        assert "! Bash(/work/other-project/script.sh:*)" in joined
+        assert "reason:" not in joined
+
+
+class TestApplyDeprecationsToFiles:
+    def _catalog(self, deprecations: list[dict]) -> object:
+        return doctor.Catalog(
+            version=1,
+            last_audited="",
+            groups={},
+            deprecations=deprecations,
+            invariants=[],
+        )
+
+    def test_removes_and_writes(self, tmp_path: Path) -> None:
+        settings = _write_settings(
+            tmp_path,
+            allow=["Bash(/tmp/claude/bin/mktmp.sh:*)", "Bash(git status:*)"],
+        )
+        catalog = self._catalog([{"pattern": "mktmp", "action": "remove", "reason": "retired"}])
+
+        result = doctor.apply_deprecations_to_files([settings], catalog=catalog)
+
+        assert result["exit_code"] == 0
+        joined = "\n".join(result["messages"])
+        assert "REMOVE" in joined
+        assert "Applied 1 deprecation actions." in joined
+        data = json.loads(settings.read_text())
+        assert data["permissions"]["allow"] == ["Bash(git status:*)"]
+
+    def test_canonicalize_action(self, tmp_path: Path) -> None:
+        pinned = "Bash(/home/u/.claude/plugins/cache/Dev10x-Guru/Dev10x/0.71.0/x.sh:*)"
+        settings = _write_settings(tmp_path, allow=[pinned])
+        catalog = self._catalog(
+            [{"pattern": r"cache/.+/\d+\.\d+\.\d+/", "action": "canonicalize", "reason": "pin"}]
+        )
+
+        result = doctor.apply_deprecations_to_files([settings], catalog=catalog)
+
+        joined = "\n".join(result["messages"])
+        assert "CANON" in joined
+        data = json.loads(settings.read_text())
+        assert data["permissions"]["allow"] == [
+            "Bash(~/.claude/plugins/cache/Dev10x-Guru/Dev10x/**/x.sh:*)"
+        ]
+
+    def test_unknown_action_keeps_rule(self, tmp_path: Path) -> None:
+        settings = _write_settings(tmp_path, allow=["Bash(flagged:*)"])
+        catalog = self._catalog([{"pattern": "flagged", "action": "flag", "reason": "review"}])
+
+        result = doctor.apply_deprecations_to_files([settings], catalog=catalog)
+
+        joined = "\n".join(result["messages"])
+        assert "? FLAG:" in joined
+        data = json.loads(settings.read_text())
+        assert data["permissions"]["allow"] == ["Bash(flagged:*)"]
+
+    def test_dry_run_does_not_write(self, tmp_path: Path) -> None:
+        settings = _write_settings(tmp_path, allow=["Bash(/tmp/claude/bin/mktmp.sh:*)"])
+        catalog = self._catalog([{"pattern": "mktmp", "action": "remove", "reason": "retired"}])
+        original = settings.read_text()
+
+        result = doctor.apply_deprecations_to_files([settings], catalog=catalog, dry_run=True)
+
+        assert "Would apply 1 deprecation actions." in "\n".join(result["messages"])
+        assert settings.read_text() == original
+
+
+class TestEnableGroupInFiles:
+    def test_adds_rules_and_writes(self, tmp_path: Path) -> None:
+        settings = _write_settings(tmp_path, allow=[])
+
+        result = doctor.enable_group_in_files(
+            [settings],
+            rules=["Bash(foo:*)"],
+            group_name="g",
+        )
+
+        assert result["exit_code"] == 0
+        joined = "\n".join(result["messages"])
+        assert "adding 1 rules from 'g'" in joined
+        assert "Added 1 rules from group 'g'." in joined
+        data = json.loads(settings.read_text())
+        assert data["permissions"]["allow"] == ["Bash(foo:*)"]
+
+    def test_skips_rules_already_present(self, tmp_path: Path) -> None:
+        settings = _write_settings(tmp_path, allow=["Bash(foo:*)"])
+        original = settings.read_text()
+
+        result = doctor.enable_group_in_files(
+            [settings],
+            rules=["Bash(foo:*)"],
+            group_name="g",
+        )
+
+        assert "Added 0 rules from group 'g'." in "\n".join(result["messages"])
+        assert settings.read_text() == original
+
+    def test_dry_run_does_not_write(self, tmp_path: Path) -> None:
+        settings = _write_settings(tmp_path, allow=[])
+        original = settings.read_text()
+
+        result = doctor.enable_group_in_files(
+            [settings],
+            rules=["Bash(foo:*)"],
+            group_name="g",
+            dry_run=True,
+        )
+
+        assert "Would add 1 rules from group 'g'." in "\n".join(result["messages"])
+        assert settings.read_text() == original

--- a/tests/skills/permission-investigator/test_runner.py
+++ b/tests/skills/permission-investigator/test_runner.py
@@ -1,0 +1,59 @@
+"""Tests for dev10x.skills.permission_investigator.runner (GH-525).
+
+The investigate CLI command bodies delegate their file read/mutate/write
+logic to these domain functions. The CLI suite
+(tests/commands/test_permission_investigate.py) exercises them end-to-end;
+this module pins the apply-cell target branches that a single CLI cell
+cannot reach on its own (project vs global location).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from dev10x.skills.permission_investigator import runner
+
+
+def _prepare(tmp_path: Path) -> tuple[Path, Path]:
+    fake_home = tmp_path / "home"
+    (fake_home / ".claude").mkdir(parents=True)
+    workdir = tmp_path / "wd"
+    runner.prepare(workdir=workdir, user_home=fake_home, default_workdir=workdir)
+    return workdir / "matrix.json", fake_home
+
+
+class TestApplyCell:
+    def test_applies_every_cell_across_project_and_global_targets(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        state_path, fake_home = _prepare(tmp_path)
+        state = json.loads(state_path.read_text())
+
+        locations_seen: set[str] = set()
+        for cell in state["cells"]:
+            result = runner.apply_cell(
+                state_path=state_path,
+                cell_id=cell["cell_id"],
+                user_home=fake_home,
+            )
+            assert result["exit_code"] == 0
+            assert any(msg.startswith("Applied rule:") for msg in result["messages"])
+            locations_seen.add(cell["location"])
+
+        # The matrix must exercise both target branches for full coverage.
+        assert any(loc in ("project", "both") for loc in locations_seen)
+        assert any(loc in ("global", "both") for loc in locations_seen)
+
+    def test_errors_on_unknown_cell(self, tmp_path: Path) -> None:
+        state_path, fake_home = _prepare(tmp_path)
+
+        result = runner.apply_cell(
+            state_path=state_path,
+            cell_id="no-such-cell",
+            user_home=fake_home,
+        )
+
+        assert result["exit_code"] == 1
+        assert "unknown cell_id" in result["errors"][0]

--- a/tests/test_subprocess_utils.py
+++ b/tests/test_subprocess_utils.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import os
 import subprocess
 from pathlib import Path
@@ -12,7 +11,6 @@ import pytest
 
 from dev10x.subprocess_utils import (
     get_plugin_root,
-    parse_json_output,
     parse_key_value_output,
     resolve_script_path,
     run_script,
@@ -268,19 +266,6 @@ class TestParseKeyValueOutput:
         result = parse_key_value_output("")
 
         assert result == {}
-
-
-class TestParseJsonOutput:
-    def test_parses_valid_json(self) -> None:
-        data = {"key": "value", "count": 42}
-
-        result = parse_json_output(json.dumps(data))
-
-        assert result == data
-
-    def test_raises_on_invalid_json(self) -> None:
-        with pytest.raises(json.JSONDecodeError):
-            parse_json_output("not json")
 
 
 class TestAsyncRun:


### PR DESCRIPTION
**When** working through the PKG-M5 commands & CLI audit, **I want to** remove verified dead code and move file-mutation logic out of the permission command bodies, **so I can** keep the command layer thin and make the doctor/investigate domain logic reusable and unit-testable.

---

[`ae9a5515`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/651/commits/ae9a5515c9631b927876185c2af7b8755309a562) 🔥 GH-519 Simplify init and subprocess-utils modules
[`58a955de`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/651/commits/58a955def40593549e036974e20b5db0aa11c85d) ♻️ GH-525 Simplify permission command bodies to thin shims
Closes #525
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/519

---