### PR TITLE
✅ GH-582 Stop well-tested packages masking untested ones

### DIFF
--- a/.github/workflows/pytest-coverage-floors.yml
+++ b/.github/workflows/pytest-coverage-floors.yml
@@ -47,7 +47,11 @@ jobs:
         run: uv python install 3.12
 
       - name: Run full suite with coverage
-        run: uv run --extra dev pytest
+        # Exclude tests/benchmarks: the startup-time gates there assert
+        # absolute timing thresholds tuned for a pinned baseline and are
+        # flaky on shared CI runners. Benchmark regressions are gated
+        # separately by pytest-bench.yml against a cached baseline.
+        run: uv run --extra dev pytest --ignore=tests/benchmarks
 
       - name: Enforce commands floor
         run: uv run coverage report --include='src/dev10x/commands/*' --fail-under=60

--- a/.github/workflows/pytest-coverage-floors.yml
+++ b/.github/workflows/pytest-coverage-floors.yml
@@ -1,0 +1,56 @@
+name: Coverage Floors
+
+# Per-package coverage floors (GH-582). A single global fail_under=75
+# lets a well-tested package mask a near-zero one. These per-package
+# gates lock each package against regression.
+#
+# Floors are ratcheted: set a few points below the current measured
+# coverage so trivial additions do not flake the gate, while a real
+# drop still fails. Raise them as the coverage-debt issues land.
+#
+# Measured on develop (2026-06-15): commands 64%, mcp 99%.
+# The `session` package was folded into `domain/documents`, so it has
+# no standalone floor yet — add one once it is re-extracted.
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - "src/dev10x/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - ".github/workflows/pytest-coverage-floors.yml"
+  pull_request:
+    branches: [develop]
+    paths:
+      - "src/dev10x/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - ".github/workflows/pytest-coverage-floors.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  floors:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Run full suite with coverage
+        run: uv run --extra dev pytest
+
+      - name: Enforce commands floor
+        run: uv run coverage report --include='src/dev10x/commands/*' --fail-under=60
+
+      - name: Enforce mcp floor
+        run: uv run coverage report --include='src/dev10x/mcp/*' --fail-under=95


### PR DESCRIPTION
**When** a low-coverage package regresses under a passing global gate, **I want to** have per-package coverage floors enforced in CI, **so I can** catch a package sliding toward zero instead of a well-tested neighbour hiding it behind the 75% aggregate.

---

[`23729a82`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/652/commits/23729a82a5872ecc07a7e9c704e14daee6e02e78) ✅ GH-582 Stop well-tested packages masking untested ones
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/582

---