### PR TITLE
♻️ GH-575 Centralize paths, plugin identity, and permission config

### DIFF
--- a/src/dev10x/domain/plugin_identity.py
+++ b/src/dev10x/domain/plugin_identity.py
@@ -1,0 +1,26 @@
+"""Canonical Dev10x plugin-identity regex fragment (GH-576).
+
+A Dev10x plugin appears in cache paths as
+``plugins/cache/<publisher>/<plugin-name>/<version>/``. The
+``<plugin-name>`` segment historically had three divergent regex
+fragments across the permission modules: ``clean`` matched a bare
+``dev10x`` slug while ``doctor`` and ``update-paths`` did not. That
+divergence meant a new slug alias had to be added in three places, and
+``clean`` silently recognised paths the others rejected.
+
+``PLUGIN_NAMES`` is the single canonical fragment. It is the most
+permissive of the former three, so every consumer recognises every
+slug the others did. Compile call-site patterns from this fragment
+(combined with ``SEMVER_PATTERN`` from
+``dev10x.domain.common.plugin_version`` where a version is also
+needed) rather than re-declaring the alternation locally.
+"""
+
+from __future__ import annotations
+
+# Most permissive of the former three fragments: matches ``Dev10x``,
+# ``dev10x``, and ``dev10x-claude``. Consumers that compile with
+# ``re.IGNORECASE`` additionally match upper/mixed-case variants.
+PLUGIN_NAMES = r"(?:Dev10x|dev10x(?:-claude)?)"
+
+__all__ = ["PLUGIN_NAMES"]

--- a/src/dev10x/skills/audit/analyze_permissions.py
+++ b/src/dev10x/skills/audit/analyze_permissions.py
@@ -19,7 +19,6 @@ If output.md is omitted, writes to stdout.
 """
 
 import io
-import os
 import sys
 from pathlib import Path
 
@@ -58,6 +57,7 @@ from dev10x.audit.permissions_model import (
     propose_allow_rules,
     write_output,
 )
+from dev10x.domain.claude_paths import ClaudeDir
 from dev10x.domain.file_locks import atomic_write_text
 
 __all__ = [
@@ -107,7 +107,7 @@ def main() -> None:
     settings_path = (
         sys.argv[2]
         if len(sys.argv) >= 3 and sys.argv[2].endswith(".json")
-        else os.path.expanduser("~/.claude/settings.local.json")
+        else str(ClaudeDir.settings_local_json())
     )
     output_path = None
     if len(sys.argv) >= 3 and sys.argv[-1].endswith(".md"):
@@ -132,8 +132,8 @@ def main() -> None:
         finding.index = base_count + offset
     findings.extend(denials)
 
-    skills_dir = os.path.expanduser("~/.claude/skills")
-    tools_dir = os.path.expanduser("~/.claude/tools")
+    skills_dir = str(ClaudeDir.skills_dir())
+    tools_dir = str(ClaudeDir.tools_dir())
     hygiene = audit_script_hygiene(skills_dir=skills_dir, tools_dir=tools_dir)
 
     proposals = propose_allow_rules(findings=findings)

--- a/src/dev10x/skills/notifications/slack_notify.py
+++ b/src/dev10x/skills/notifications/slack_notify.py
@@ -13,12 +13,13 @@ from __future__ import annotations
 
 import logging
 import os
-import pathlib
 import subprocess
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from dev10x.domain.common.result import ErrorResult, Result, err, ok
+from dev10x.domain.dev10x_paths import Dev10xConfigDir
 
 if TYPE_CHECKING:
     from slack_sdk import WebClient
@@ -26,17 +27,20 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-CONFIG_PATH = pathlib.Path.home() / ".claude" / "memory" / "slack-config.yaml"
-
 _active_workspace: str | None = None
 _config: dict | None = None
 
 
+def _config_path() -> Path:
+    return Dev10xConfigDir.slack_config_yaml()
+
+
 def _load_config() -> dict:
-    if CONFIG_PATH.exists():
+    config_path = _config_path()
+    if config_path.exists():
         import yaml
 
-        return yaml.safe_load(CONFIG_PATH.read_text()) or {}
+        return yaml.safe_load(config_path.read_text()) or {}
     return {}
 
 
@@ -269,7 +273,7 @@ def send_reminder(message: str) -> str | None:
     if not self_user_id:
         print(
             "❌ self_user_id not configured. Set it in "
-            f"{CONFIG_PATH} or SLACK_SELF_USER_ID env var.",
+            f"{_config_path()} or SLACK_SELF_USER_ID env var.",
             file=sys.stderr,
         )
         return None

--- a/src/dev10x/skills/notifications/slack_review_request.py
+++ b/src/dev10x/skills/notifications/slack_review_request.py
@@ -11,8 +11,8 @@ Subcommands:
     prepare  — Resolve project config, format message, output JSON.
     send     — Post message via slack-notify.py.
 
-Config: ~/.claude/memory/Dev10x/slack-config-code-review-requests.yaml
-Slack config: ~/.claude/memory/Dev10x/slack-config.yaml
+Config: Dev10xConfigDir.slack_review_config_yaml()
+Slack config: Dev10xConfigDir.slack_config_yaml()
 """
 
 from __future__ import annotations
@@ -24,10 +24,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from dev10x.domain.dev10x_paths import Dev10xConfigDir
 from dev10x.skills.common.jtbd import extract_jtbd, md_to_slack_bold
-
-CONFIG_PATH = Path.home() / ".claude" / "memory" / "slack-config-code-review-requests.yaml"
-SLACK_CONFIG_PATH = Path.home() / ".claude" / "memory" / "slack-config.yaml"
 
 
 def load_yaml(path: Path) -> dict:
@@ -116,8 +114,8 @@ def gh_json(args: list[str]) -> Any:
 
 
 def cmd_prepare(args: argparse.Namespace) -> None:
-    config = load_yaml(path=CONFIG_PATH)
-    slack_config = load_yaml(path=SLACK_CONFIG_PATH)
+    config = load_yaml(path=Dev10xConfigDir.slack_review_config_yaml())
+    slack_config = load_yaml(path=Dev10xConfigDir.slack_config_yaml())
     repo_name = _repo_name(args.repo)
 
     project = resolve_project_config(config=config, repo_name=repo_name)

--- a/src/dev10x/skills/permission/clean_project_files.py
+++ b/src/dev10x/skills/permission/clean_project_files.py
@@ -33,6 +33,7 @@ from dev10x.domain.claude_paths import ClaudeDir
 from dev10x.domain.common.plugin_version import SEMVER_PATTERN, PluginVersion
 from dev10x.domain.common.result import Result
 from dev10x.domain.dev10x_paths import Dev10xConfigDir
+from dev10x.domain.plugin_identity import PLUGIN_NAMES
 from dev10x.skills.permission.config import parse_config, resolve_config
 
 USERSPACE_CONFIG = Dev10xConfigDir.upgrade_cleanup_projects_yaml()
@@ -41,7 +42,6 @@ PLUGIN_CONFIG = (
 )
 GLOBAL_SETTINGS = ClaudeDir.settings_json()
 
-PLUGIN_NAMES = r"(?:Dev10x|dev10x(?:-claude)?)"
 VERSION_PATTERN = re.compile(
     rf"plugins/cache/[^/]+/{PLUGIN_NAMES}/({SEMVER_PATTERN})", re.IGNORECASE
 )

--- a/src/dev10x/skills/permission/clean_project_files.py
+++ b/src/dev10x/skills/permission/clean_project_files.py
@@ -36,6 +36,7 @@ from dev10x.domain.dev10x_paths import Dev10xConfigDir
 from dev10x.domain.plugin_identity import PLUGIN_NAMES
 from dev10x.skills.permission.config import parse_config, resolve_config
 
+MEMORY_CONFIG = Dev10xConfigDir.projects_yaml()
 USERSPACE_CONFIG = Dev10xConfigDir.upgrade_cleanup_projects_yaml()
 PLUGIN_CONFIG = (
     Path(__file__).resolve().parents[4] / "skills" / "upgrade-cleanup" / "projects.yaml"
@@ -145,8 +146,8 @@ class RemovalResult:
 
 def find_config() -> Result[Path]:
     return resolve_config(
-        candidates=[USERSPACE_CONFIG, PLUGIN_CONFIG],
-        create_path=USERSPACE_CONFIG,
+        candidates=[MEMORY_CONFIG, USERSPACE_CONFIG, PLUGIN_CONFIG],
+        create_path=MEMORY_CONFIG,
     )
 
 

--- a/src/dev10x/skills/permission/doctor.py
+++ b/src/dev10x/skills/permission/doctor.py
@@ -33,8 +33,7 @@ from pathlib import Path
 import yaml
 
 from dev10x import subprocess_utils
-
-PLUGIN_NAMES = r"(?:Dev10x|dev10x-claude)"
+from dev10x.domain.plugin_identity import PLUGIN_NAMES
 
 PINNED_VERSION_RE = re.compile(
     rf"(?P<prefix>/home/[^/]+/|~/)"

--- a/src/dev10x/skills/permission/merge_worktree_permissions.py
+++ b/src/dev10x/skills/permission/merge_worktree_permissions.py
@@ -21,6 +21,7 @@ from dev10x.domain.common.ticket_id import TICKET_ID_PATTERN
 from dev10x.domain.dev10x_paths import Dev10xConfigDir
 from dev10x.skills.permission.config import parse_config, resolve_config
 
+MEMORY_CONFIG = Dev10xConfigDir.projects_yaml()
 USERSPACE_CONFIG = Dev10xConfigDir.upgrade_cleanup_projects_yaml()
 PLUGIN_CONFIG = (
     Path(__file__).resolve().parents[4] / "skills" / "upgrade-cleanup" / "projects.yaml"
@@ -79,7 +80,7 @@ def generalize_permission(entry: str) -> str:
 
 
 def find_config() -> Result[Path]:
-    return resolve_config(candidates=[USERSPACE_CONFIG, PLUGIN_CONFIG])
+    return resolve_config(candidates=[MEMORY_CONFIG, USERSPACE_CONFIG, PLUGIN_CONFIG])
 
 
 def load_config(config_path: Path) -> dict:

--- a/src/dev10x/skills/permission/update_paths.py
+++ b/src/dev10x/skills/permission/update_paths.py
@@ -35,6 +35,7 @@ from dev10x.domain.common.mktmp_path import MKTMP_GENERALIZE_PATTERN
 from dev10x.domain.common.plugin_version import SEMVER_PATTERN, PluginVersion
 from dev10x.domain.common.result import Result
 from dev10x.domain.dev10x_paths import Dev10xConfigDir
+from dev10x.domain.plugin_identity import PLUGIN_NAMES
 from dev10x.skills.permission.config import parse_config, resolve_config
 
 MEMORY_CONFIG = Dev10xConfigDir.projects_yaml()
@@ -42,7 +43,6 @@ USERSPACE_CONFIG = Dev10xConfigDir.upgrade_cleanup_projects_yaml()
 PLUGIN_CONFIG = (
     Path(__file__).resolve().parents[4] / "skills" / "upgrade-cleanup" / "projects.yaml"
 )
-PLUGIN_NAMES = r"(?:Dev10x|dev10x-claude)"
 VERSION_PATTERN = re.compile(rf"(plugins/cache/)([^/]+)(/{PLUGIN_NAMES}/)({SEMVER_PATTERN})")
 
 

--- a/src/dev10x/skills/permission/update_paths.py
+++ b/src/dev10x/skills/permission/update_paths.py
@@ -13,16 +13,13 @@ Config lookup order (post-GH-215):
 
 CLI entry point: ``dev10x permission update-paths`` (and siblings).
 
-GH-315 Bug C (deferred): ``merge-worktree`` and ``clean`` read
-``~/.config/Dev10x/upgrade-cleanup-projects.yaml`` (USERSPACE_CONFIG),
-while all other subcommands (``update-paths``, ``ensure-base``,
-``generalize``, ``ensure-reads``, ``ensure-scripts``,
-``ensure-workspace``, ``enumerate-mcp``) read
-``~/.config/Dev10x/projects.yaml`` (MEMORY_CONFIG). Both files
-contain a ``roots`` / ``plugin_cache`` section; ``merge-worktree``
-and ``clean`` do not consume ``base_permissions``, so the split is
-currently harmless. Consolidate both commands to read MEMORY_CONFIG
-in a follow-up ticket so the two files do not drift.
+GH-315 Bug C (resolved, GH-577): ``merge-worktree`` and ``clean`` now
+read ``~/.config/Dev10x/projects.yaml`` (MEMORY_CONFIG) like every
+other subcommand, falling back to the legacy
+``~/.config/Dev10x/upgrade-cleanup-projects.yaml`` (USERSPACE_CONFIG)
+only when ``projects.yaml`` is absent. ``init-userspace-config``
+migrates the legacy file into ``projects.yaml`` on first use, so the
+two no longer drift.
 """
 
 import json
@@ -1252,28 +1249,43 @@ def _detect_plugin_cache() -> str:
 
 
 def init_userspace_config() -> dict[str, object]:
-    """Create userspace config from plugin default. Returns result dict."""
+    """Create or migrate the userspace projects config (GH-577).
+
+    Consolidates on ``projects.yaml`` (MEMORY_CONFIG). When only the
+    legacy ``upgrade-cleanup-projects.yaml`` (USERSPACE_CONFIG) exists,
+    its content is migrated into ``projects.yaml`` so ``clean`` and
+    ``merge-worktree`` — which now read ``projects.yaml`` — see the same
+    roots as every other subcommand. The legacy file is left in place
+    for downgrade safety; ``upgrade-cleanup``/``plugin-doctor`` remove
+    it once parity is confirmed. Returns a result dict.
+    """
     messages: list[str] = []
     errors: list[str] = []
 
     if MEMORY_CONFIG.is_file():
         messages.append(f"Config already exists: {MEMORY_CONFIG}")
         return _result(exit_code=0, messages=messages, errors=errors)
+
+    MEMORY_CONFIG.parent.mkdir(parents=True, exist_ok=True)
+
     if USERSPACE_CONFIG.is_file():
-        messages.append(f"Config already exists: {USERSPACE_CONFIG}")
+        MEMORY_CONFIG.write_text(USERSPACE_CONFIG.read_text())
+        messages.append(f"Migrated {USERSPACE_CONFIG} -> {MEMORY_CONFIG}")
+        messages.append(f"{USERSPACE_CONFIG} is deprecated; edit {MEMORY_CONFIG} from now on.")
         return _result(exit_code=0, messages=messages, errors=errors)
+
     if not PLUGIN_CONFIG.is_file():
         errors.append(f"ERROR: Plugin default config not found: {PLUGIN_CONFIG}")
         return _result(exit_code=1, messages=messages, errors=errors)
-    USERSPACE_CONFIG.parent.mkdir(parents=True, exist_ok=True)
+
     content = PLUGIN_CONFIG.read_text()
     detected_cache = _detect_plugin_cache()
     content = content.replace(
         "~/.claude/plugins/cache/Dev10x-Guru/dev10x-claude",
         detected_cache,
     )
-    USERSPACE_CONFIG.write_text(content)
-    messages.append(f"Created: {USERSPACE_CONFIG}")
+    MEMORY_CONFIG.write_text(content)
+    messages.append(f"Created: {MEMORY_CONFIG}")
     messages.append(f"Plugin cache: {detected_cache}")
     messages.append("Edit this file to add your project roots.")
     return _result(exit_code=0, messages=messages, errors=errors)

--- a/tests/skills/upgrade-cleanup/test_update_paths.py
+++ b/tests/skills/upgrade-cleanup/test_update_paths.py
@@ -5,9 +5,11 @@ from pathlib import Path
 
 import pytest
 
+from dev10x.skills.permission import update_paths
 from dev10x.skills.permission.update_paths import (
     extract_cache_publisher,
     find_settings_files,
+    init_userspace_config,
     update_file,
 )
 
@@ -261,3 +263,63 @@ class TestFindSettingsFilesUserGlobal:
         files = find_settings_files(roots=[], include_user=False)
 
         assert files == []
+
+
+class TestInitUserspaceConfig:
+    @pytest.fixture()
+    def config_paths(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> tuple[Path, Path, Path]:
+        memory = tmp_path / "projects.yaml"
+        userspace = tmp_path / "upgrade-cleanup-projects.yaml"
+        plugin = tmp_path / "plugin-projects.yaml"
+        monkeypatch.setattr(update_paths, "MEMORY_CONFIG", memory)
+        monkeypatch.setattr(update_paths, "USERSPACE_CONFIG", userspace)
+        monkeypatch.setattr(update_paths, "PLUGIN_CONFIG", plugin)
+        return memory, userspace, plugin
+
+    def test_noop_when_projects_yaml_exists(self, config_paths: tuple[Path, Path, Path]) -> None:
+        memory, _userspace, _plugin = config_paths
+        memory.write_text("roots: [/work/existing]\n")
+
+        result = init_userspace_config()
+
+        assert result["exit_code"] == 0
+        assert memory.read_text() == "roots: [/work/existing]\n"
+        assert any("already exists" in m for m in result["messages"])
+
+    def test_migrates_legacy_userspace_into_projects_yaml(
+        self, config_paths: tuple[Path, Path, Path]
+    ) -> None:
+        memory, userspace, _plugin = config_paths
+        userspace.write_text("roots: [/work/legacy]\n")
+
+        result = init_userspace_config()
+
+        assert result["exit_code"] == 0
+        assert memory.read_text() == "roots: [/work/legacy]\n"
+        assert userspace.exists()  # left in place for downgrade safety
+        assert any("Migrated" in m for m in result["messages"])
+
+    def test_creates_from_plugin_default_when_none_exist(
+        self,
+        config_paths: tuple[Path, Path, Path],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        memory, _userspace, plugin = config_paths
+        plugin.write_text("plugin_cache: ~/.claude/plugins/cache/Dev10x-Guru/dev10x-claude\n")
+        monkeypatch.setattr(update_paths, "_detect_plugin_cache", lambda: "/detected/cache")
+
+        result = init_userspace_config()
+
+        assert result["exit_code"] == 0
+        assert "plugin_cache: /detected/cache" in memory.read_text()
+        assert any("Created" in m for m in result["messages"])
+
+    def test_errors_when_plugin_default_missing(
+        self, config_paths: tuple[Path, Path, Path]
+    ) -> None:
+        result = init_userspace_config()
+
+        assert result["exit_code"] == 1
+        assert any("Plugin default config not found" in e for e in result["errors"])


### PR DESCRIPTION
**When** auditing the skills package for the 2026-06-10 review, **I want to** route config and plugin-identity lookups through the centralized helpers instead of three hand-built variants, **so I can** trust that env overrides, lazy migration, and a single plugin-name regex apply uniformly across every permission and notification path.

---

[`38ab95dd`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/653/commits/38ab95dd6eb0b9da86e80f900a3f3ff35e15a68d) ♻️ GH-575 Honor Claude-home overrides in slack and audit helpers
[`a162ba14`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/653/commits/a162ba14209e7c94b9820136b5823cfa4ea96de2) ♻️ GH-576 Unify plugin-name regex across permission modules
[`74a008cd`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/653/commits/74a008cd798aabbbbecca63f2777e042ac619348) ♻️ GH-577 Consolidate permission config on projects.yaml
Closes #576
Closes #577
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/575

---