### PR TITLE
✨ GH-347 Surface recurring review patterns as candidates

### DIFF
--- a/.claude/rules/mcp-tools.md
+++ b/.claude/rules/mcp-tools.md
@@ -159,6 +159,7 @@ supporting each tool:
 | `audit_hook_recent` | `cli` | GH-29 | v0.69.0+ |
 | `record_upgrade` | `cli` | GH-109 | v0.72.0+ |
 | `cluster_review_comments` | `cli` | GH-346 | v0.80.0+ |
+| `candidate_rules_report` | `cli` | GH-347 | v0.80.0+ |
 | `request_sampling` | `cli` | GH-343 | v0.80.0+ |
 | `query` | `db` | PR #126 | v0.25.0+ |
 

--- a/src/dev10x/github/candidate_rules.py
+++ b/src/dev10x/github/candidate_rules.py
@@ -1,0 +1,132 @@
+"""Render a read-only candidate-rules report (GH-347).
+
+MVP visibility step for the review-bot initiative: takes the recurring
+review-comment patterns mined by
+:func:`dev10x.github.review_patterns.cluster_review_comments` (GH-346)
+and formats them into a human-readable Markdown memo.
+
+This report is intentionally **read-only**. It surfaces what reviewers
+repeat so a human can decide what deserves a rule — it does NOT generate,
+write, or apply any permission rule. Rule generation is deferred to a
+later initiative step.
+
+Internal functions return ``Result[T]`` per ADR-0009; the
+``@server.tool()`` boundary calls ``.to_dict()``.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from dev10x.domain.common.result import Result, SuccessResult, ok
+from dev10x.github import review_patterns
+
+# Max characters kept from an example comment in the memo. Examples are a
+# readability aid, not the full comment — long bodies are truncated.
+_EXAMPLE_LIMIT = 120
+
+_WHITESPACE = re.compile(r"\s+")
+
+_READ_ONLY_NOTE = (
+    "> Read-only visibility memo (MVP). These are the most frequently "
+    "recurring reviewer comments across recent merged PRs. **No rules were "
+    "generated, written, or applied** — this report only surfaces candidates "
+    "for human review."
+)
+
+
+def _summarize_example(body: str) -> str:
+    """Collapse whitespace and truncate a comment body for the memo."""
+    collapsed = _WHITESPACE.sub(" ", body).strip()
+    if len(collapsed) <= _EXAMPLE_LIMIT:
+        return collapsed
+    return collapsed[: _EXAMPLE_LIMIT - 1].rstrip() + "…"
+
+
+def _join_or_dash(values: list[str]) -> str:
+    return ", ".join(values) if values else "—"
+
+
+def render_report(*, patterns: list[dict[str, Any]], summary: dict[str, Any]) -> str:
+    """Format clustered patterns into a read-only Markdown memo.
+
+    Pure function: takes the ``patterns`` / ``summary`` payload produced by
+    :func:`review_patterns.cluster_review_comments` and returns the memo
+    text. Patterns are assumed pre-sorted (frequency desc) by the miner.
+    """
+    scanned = summary.get("repos_scanned", [])
+    lines = [
+        "# Candidate Rules Report",
+        "",
+        _READ_ONLY_NOTE,
+        "",
+        f"**Repositories scanned:** {_join_or_dash(scanned)}",
+        f"**Merged-PR review comments analyzed:** {summary.get('comments_analyzed', 0)}",
+        f"**Candidate patterns (top {summary.get('top_n', 0)}):** "
+        f"{summary.get('patterns_returned', len(patterns))}",
+        "",
+        "## Top candidate patterns",
+        "",
+    ]
+
+    if not patterns:
+        lines.append(
+            "_No recurring patterns found — every analyzed comment was unique "
+            "or contained only code/links._"
+        )
+        return "\n".join(lines)
+
+    for rank, pattern in enumerate(patterns, start=1):
+        frequency = pattern.get("frequency", 0)
+        plural = "occurrence" if frequency == 1 else "occurrences"
+        lines.append(f"### {rank}. `{pattern.get('signature', '')}` — {frequency} {plural}")
+        lines.append("")
+        lines.append(f"- **Files:** {_join_or_dash(pattern.get('files', []))}")
+        lines.append(f"- **Authors:** {_join_or_dash(pattern.get('authors', []))}")
+        examples = pattern.get("examples", [])
+        if examples:
+            lines.append(f"- **Example:** {_summarize_example(examples[0])}")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+async def candidate_rules_report(
+    *,
+    repos: list[str] | None = None,
+    limit: int = 50,
+    top_n: int = 20,
+) -> Result[dict[str, Any]]:
+    """Produce a read-only candidate-rules report for one or more repos.
+
+    Orchestrates the GH-346 miner and renders its output into a memo. No
+    rules are generated — see the module docstring.
+
+    Args:
+        repos: ``owner/name`` repositories to analyze. Defaults to the
+            current repository when omitted.
+        limit: Max merged PRs scanned per repo.
+        top_n: Number of top patterns to include in the report.
+
+    Returns:
+        ``ok({"report": str, "patterns": [...], "summary": {...}})`` or
+        ``err(...)`` when the underlying mining step fails.
+    """
+    mined = await review_patterns.cluster_review_comments(
+        repos=repos,
+        limit=limit,
+        top_n=top_n,
+    )
+    if not isinstance(mined, SuccessResult):
+        return mined
+
+    patterns = mined.value["patterns"]
+    summary = mined.value["summary"]
+    return ok(
+        {
+            "report": render_report(patterns=patterns, summary=summary),
+            "patterns": patterns,
+            "summary": summary,
+        }
+    )

--- a/src/dev10x/mcp/github_tools.py
+++ b/src/dev10x/mcp/github_tools.py
@@ -1095,3 +1095,37 @@ async def cluster_review_comments(
         limit=limit,
         top_n=top_n,
     )
+
+
+@github_tool
+async def candidate_rules_report(
+    repos: list[str] | None = None,
+    limit: int = 50,
+    top_n: int = 20,
+    cwd: str | None = None,
+) -> Result[dict]:
+    """Produce a read-only candidate-rules report (GH-347).
+
+    Mines recurring review-comment patterns via ``cluster_review_comments``
+    (GH-346) and renders them into a human-readable Markdown memo. This is
+    a read-only visibility step — it surfaces candidate patterns for human
+    review and does NOT generate, write, or apply any permission rule.
+
+    Args:
+        repos: ``owner/name`` repositories to analyze. Defaults to the
+            current repository when omitted.
+        limit: Max merged PRs scanned per repo (default 50).
+        top_n: Number of top patterns to include (default 20).
+        cwd: Effective working directory (GH-979).
+
+    Returns:
+        Dictionary with keys: report (str), patterns (list), summary
+        (dict); or error.
+    """
+    from dev10x.github import candidate_rules
+
+    return await candidate_rules.candidate_rules_report(
+        repos=repos,
+        limit=limit,
+        top_n=top_n,
+    )

--- a/tests/github/test_candidate_rules.py
+++ b/tests/github/test_candidate_rules.py
@@ -1,0 +1,140 @@
+"""Unit tests for dev10x.github.candidate_rules (GH-347).
+
+Contract class: mock
+  Rendering is a pure function tested without mocks. The orchestrator
+  patches the GH-346 miner (``cluster_review_comments``) directly so no
+  ``gh`` subprocess runs.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dev10x.domain.common.result import ErrorResult, SuccessResult, err, ok
+
+cr = pytest.importorskip("dev10x.github.candidate_rules", reason="dev10x not installed")
+
+
+def _summary(
+    *,
+    repos: list[str] | None = None,
+    analyzed: int = 8,
+    returned: int = 2,
+    top_n: int = 20,
+) -> dict:
+    return {
+        "repos_scanned": repos if repos is not None else ["o/r"],
+        "comments_analyzed": analyzed,
+        "patterns_returned": returned,
+        "top_n": top_n,
+    }
+
+
+def _pattern(
+    *,
+    signature: str = "rename pm payment_method",
+    frequency: int = 7,
+    files: list[str] | None = None,
+    authors: list[str] | None = None,
+    examples: list[str] | None = None,
+) -> dict:
+    return {
+        "signature": signature,
+        "frequency": frequency,
+        "score": frequency,
+        "files": files if files is not None else ["a.py", "b.py"],
+        "authors": authors if authors is not None else ["al", "bo"],
+        "examples": examples if examples is not None else ["rename pm to payment_method"],
+    }
+
+
+class TestSummarizeExample:
+    def test_collapses_whitespace(self) -> None:
+        assert cr._summarize_example("rename   pm\nto  payment_method") == (
+            "rename pm to payment_method"
+        )
+
+    def test_short_body_unchanged(self) -> None:
+        assert cr._summarize_example("short note") == "short note"
+
+    def test_long_body_truncated_with_ellipsis(self) -> None:
+        summarized = cr._summarize_example("x" * 200)
+        assert summarized.endswith("…")
+        assert len(summarized) <= cr._EXAMPLE_LIMIT
+
+
+class TestJoinOrDash:
+    def test_joins_values(self) -> None:
+        assert cr._join_or_dash(["a.py", "b.py"]) == "a.py, b.py"
+
+    def test_empty_yields_dash(self) -> None:
+        assert cr._join_or_dash([]) == "—"
+
+
+class TestRenderReport:
+    def test_includes_read_only_note_and_header(self) -> None:
+        report = cr.render_report(patterns=[_pattern()], summary=_summary())
+        assert report.startswith("# Candidate Rules Report")
+        assert "No rules were generated" in report
+
+    def test_includes_summary_counts(self) -> None:
+        report = cr.render_report(patterns=[_pattern()], summary=_summary(analyzed=8))
+        assert "**Repositories scanned:** o/r" in report
+        assert "**Merged-PR review comments analyzed:** 8" in report
+
+    def test_ranks_patterns_with_plural_occurrences(self) -> None:
+        report = cr.render_report(patterns=[_pattern(frequency=7)], summary=_summary())
+        assert "### 1. `rename pm payment_method` — 7 occurrences" in report
+        assert "- **Files:** a.py, b.py" in report
+        assert "- **Authors:** al, bo" in report
+        assert "- **Example:** rename pm to payment_method" in report
+
+    def test_single_occurrence_is_singular(self) -> None:
+        report = cr.render_report(patterns=[_pattern(frequency=1)], summary=_summary())
+        assert "1 occurrence" in report
+        assert "1 occurrences" not in report
+
+    def test_missing_files_authors_render_dash(self) -> None:
+        report = cr.render_report(
+            patterns=[_pattern(files=[], authors=[])],
+            summary=_summary(),
+        )
+        assert "- **Files:** —" in report
+        assert "- **Authors:** —" in report
+
+    def test_pattern_without_examples_omits_example_line(self) -> None:
+        report = cr.render_report(patterns=[_pattern(examples=[])], summary=_summary())
+        assert "**Example:**" not in report
+
+    def test_empty_patterns_shows_placeholder(self) -> None:
+        report = cr.render_report(patterns=[], summary=_summary(repos=[], returned=0))
+        assert "No recurring patterns found" in report
+        assert "**Repositories scanned:** —" in report
+
+
+class TestCandidateRulesReport:
+    @pytest.mark.asyncio
+    @patch("dev10x.github.review_patterns.cluster_review_comments", new_callable=AsyncMock)
+    async def test_happy_path_renders_and_passes_through(self, mock_cluster: AsyncMock) -> None:
+        patterns = [_pattern()]
+        summary = _summary()
+        mock_cluster.return_value = ok({"patterns": patterns, "summary": summary})
+
+        result = await cr.candidate_rules_report(repos=["o/r"])
+
+        assert isinstance(result, SuccessResult)
+        assert result.value["patterns"] == patterns
+        assert result.value["summary"] == summary
+        assert result.value["report"].startswith("# Candidate Rules Report")
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.review_patterns.cluster_review_comments", new_callable=AsyncMock)
+    async def test_propagates_mining_error(self, mock_cluster: AsyncMock) -> None:
+        mock_cluster.return_value = err("no repository specified")
+
+        result = await cr.candidate_rules_report()
+
+        assert isinstance(result, ErrorResult)
+        assert result.error == "no repository specified"

--- a/tests/mcp/test_cli_server.py
+++ b/tests/mcp/test_cli_server.py
@@ -1772,3 +1772,34 @@ class TestClusterReviewComments:
             result = await cli_server.cluster_review_comments()
 
         assert "error" in result
+
+
+class TestCandidateRulesReport:
+    """GH-347 handler delegation to the candidate-rules report builder."""
+
+    @pytest.mark.asyncio
+    async def test_delegates_to_candidate_rules(self) -> None:
+        with patch(
+            "dev10x.github.candidate_rules.candidate_rules_report",
+            new_callable=AsyncMock,
+        ) as mock_fn:
+            mock_fn.return_value = ok(
+                {"report": "# Candidate Rules Report", "patterns": [], "summary": {}}
+            )
+
+            result = await cli_server.candidate_rules_report(top_n=5)
+
+        assert result["report"] == "# Candidate Rules Report"
+        assert mock_fn.call_args.kwargs == {"repos": None, "limit": 50, "top_n": 5}
+
+    @pytest.mark.asyncio
+    async def test_propagates_error(self) -> None:
+        with patch(
+            "dev10x.github.candidate_rules.candidate_rules_report",
+            new_callable=AsyncMock,
+        ) as mock_fn:
+            mock_fn.return_value = err("no repository specified")
+
+            result = await cli_server.candidate_rules_report()
+
+        assert "error" in result


### PR DESCRIPTION
**When** the same feedback keeps recurring across merged-PR reviews, **I want to** see those patterns surfaced as a read-only memo, **so I can** judge which deserve to become rules before any are generated.

---

[`e17f2aca`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/655/commits/e17f2aca49d3c5feb4e59d86eaa2faf110f52973) ✨ GH-347 Surface recurring review patterns as candidates
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/347

---