### PR TITLE
♻️ GH-654 Adopt Catalog, Query Object, and AbstractHook archetypes

### DIFF
--- a/src/dev10x/audit/summarizer.py
+++ b/src/dev10x/audit/summarizer.py
@@ -9,71 +9,85 @@ a re-export of :func:`summarize` for the existing import path.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 from dev10x.domain.hook_telemetry import HookOutcome, HookPhase
 
 
-def summarize(*, records: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
-    """Aggregate records by hook name. Joins wrap+body via span_id when both
-    records are present.
+@dataclass(frozen=True)
+class HookStatsQuery:
+    """Query object over raw audit records → per-hook statistics (A7).
+
+    Encapsulates the read aggregation as a named query whose steps —
+    span join, per-hook accumulation, average finalization — are each
+    a private method, instead of one monolithic free function.
     """
-    by_span: dict[str, dict[str, Any]] = {}
-    body_only: list[dict[str, Any]] = []
-    wrap_only: list[dict[str, Any]] = []
 
-    for rec in records:
-        phase = rec.get("phase")
-        span_id = rec.get("span_id", "")
-        if not span_id:
-            if phase == HookPhase.BODY:
-                body_only.append(rec)
-            elif phase == HookPhase.WRAP:
-                wrap_only.append(rec)
-            continue
-        if not isinstance(phase, str):
-            continue
-        bucket = by_span.setdefault(span_id, {})
-        bucket[phase] = rec
+    records: list[dict[str, Any]]
 
-    hook_stats: dict[str, dict[str, Any]] = {}
-    for span in by_span.values():
-        body = span.get(HookPhase.BODY)
-        wrap = span.get(HookPhase.WRAP)
-        record = body or wrap
-        if record is None:
-            continue
-        hook = record.get("hook", "unknown")
-        stats = hook_stats.setdefault(
-            hook,
-            {
-                "count": 0,
-                "total_ms_sum": 0,
-                "body_ms_sum": 0,
-                "startup_ms_sum": 0,
-                "paired_count": 0,
-                "error_count": 0,
-                "block_count": 0,
-            },
-        )
-        stats["count"] += 1
-        outcome = record.get("outcome", "")
-        if outcome == HookOutcome.ERROR:
-            stats["error_count"] += 1
-        elif outcome == HookOutcome.BLOCK:
-            stats["block_count"] += 1
-        if body and wrap:
-            total = int(wrap.get("total_ms") or 0)
-            body_ms = int(body.get("body_ms") or 0)
-            stats["total_ms_sum"] += total
-            stats["body_ms_sum"] += body_ms
-            stats["startup_ms_sum"] += max(total - body_ms, 0)
-            stats["paired_count"] += 1
+    def by_hook(self) -> dict[str, dict[str, Any]]:
+        """Aggregate records by hook name, joining wrap+body via span_id."""
+        stats = self._accumulate(by_span=self._join_spans())
+        self._finalize(stats=stats)
+        return stats
 
-    for stats in hook_stats.values():
-        paired = stats["paired_count"] or 1
-        stats["total_ms_avg"] = round(stats["total_ms_sum"] / paired, 1)
-        stats["body_ms_avg"] = round(stats["body_ms_sum"] / paired, 1)
-        stats["startup_ms_avg"] = round(stats["startup_ms_sum"] / paired, 1)
+    def _join_spans(self) -> dict[str, dict[str, Any]]:
+        by_span: dict[str, dict[str, Any]] = {}
+        for rec in self.records:
+            phase = rec.get("phase")
+            span_id = rec.get("span_id", "")
+            if not span_id or not isinstance(phase, str):
+                continue
+            by_span.setdefault(span_id, {})[phase] = rec
+        return by_span
 
-    return hook_stats
+    @staticmethod
+    def _accumulate(*, by_span: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
+        hook_stats: dict[str, dict[str, Any]] = {}
+        for span in by_span.values():
+            body = span.get(HookPhase.BODY)
+            wrap = span.get(HookPhase.WRAP)
+            record = body or wrap
+            if record is None:
+                continue
+            hook = record.get("hook", "unknown")
+            stats = hook_stats.setdefault(
+                hook,
+                {
+                    "count": 0,
+                    "total_ms_sum": 0,
+                    "body_ms_sum": 0,
+                    "startup_ms_sum": 0,
+                    "paired_count": 0,
+                    "error_count": 0,
+                    "block_count": 0,
+                },
+            )
+            stats["count"] += 1
+            outcome = record.get("outcome", "")
+            if outcome == HookOutcome.ERROR:
+                stats["error_count"] += 1
+            elif outcome == HookOutcome.BLOCK:
+                stats["block_count"] += 1
+            if body and wrap:
+                total = int(wrap.get("total_ms") or 0)
+                body_ms = int(body.get("body_ms") or 0)
+                stats["total_ms_sum"] += total
+                stats["body_ms_sum"] += body_ms
+                stats["startup_ms_sum"] += max(total - body_ms, 0)
+                stats["paired_count"] += 1
+        return hook_stats
+
+    @staticmethod
+    def _finalize(*, stats: dict[str, dict[str, Any]]) -> None:
+        for hook_stats in stats.values():
+            paired = hook_stats["paired_count"] or 1
+            hook_stats["total_ms_avg"] = round(hook_stats["total_ms_sum"] / paired, 1)
+            hook_stats["body_ms_avg"] = round(hook_stats["body_ms_sum"] / paired, 1)
+            hook_stats["startup_ms_avg"] = round(hook_stats["startup_ms_sum"] / paired, 1)
+
+
+def summarize(*, records: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Aggregate records by hook name. Thin wrapper over :class:`HookStatsQuery`."""
+    return HookStatsQuery(records=records).by_hook()

--- a/src/dev10x/hooks/base.py
+++ b/src/dev10x/hooks/base.py
@@ -1,0 +1,41 @@
+"""Abstract hook base with a Template Method ``run()`` (audit finding A11).
+
+Hook feature functions share one lifecycle: resolve the input ``data``
+(use what an orchestrator passed, else read stdin once) and then act on
+it. :class:`AbstractHook` captures that invariant skeleton in ``run()``
+and defers the variable step to the abstract ``handle()``.
+
+Subclasses implement ``handle``; module-level functions stay as thin
+shims (``Hook().run(data)``) so existing ``audit_hook(...)(fn)()`` entry
+scripts and CLI command wrappers keep calling a plain function.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from abc import ABC, abstractmethod
+
+
+def load_hook_stdin() -> dict:
+    """Read a hook's JSON payload from stdin, tolerating empty/garbage input."""
+    try:
+        return json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        return {}
+
+
+class AbstractHook(ABC):
+    """Template Method base: ``run`` owns the lifecycle, ``handle`` the work."""
+
+    def run(self, data: dict | None = None) -> None:
+        """Resolve input then delegate to ``handle``.
+
+        ``data`` is what an in-process orchestrator already parsed; when
+        ``None`` (standalone invocation) the payload is read from stdin.
+        """
+        self.handle(data=data if data is not None else load_hook_stdin())
+
+    @abstractmethod
+    def handle(self, *, data: dict) -> None:
+        """Perform the hook's work against the resolved ``data``."""

--- a/src/dev10x/hooks/skill.py
+++ b/src/dev10x/hooks/skill.py
@@ -3,6 +3,12 @@
 skill_tmpdir: Creates /tmp/Dev10x/<skill-name>/ scratch directory.
 skill_metrics: Appends JSONL metric entry; prunes files older than 30 days.
 ruff_format: Auto-formats Python files with ruff after Edit/Write.
+
+Each hook is an :class:`~dev10x.hooks.base.AbstractHook` whose ``run()``
+Template Method resolves input (passed ``data`` or stdin) before
+dispatching to ``handle`` (audit finding A11). The module-level
+functions are thin shims so existing entry scripts and CLI wrappers
+keep calling a plain function.
 """
 
 from __future__ import annotations
@@ -18,6 +24,7 @@ from dev10x import subprocess_utils
 from dev10x.domain.claude_paths import ClaudeDir
 from dev10x.domain.common.skill_name import SkillName
 from dev10x.domain.git_context import GitContext
+from dev10x.hooks.base import AbstractHook
 
 
 def _get_toplevel() -> str:
@@ -27,86 +34,92 @@ def _get_toplevel() -> str:
     return GitContext().toplevel or "unknown"
 
 
-def _load_stdin() -> dict:
-    try:
-        return json.load(sys.stdin)
-    except (json.JSONDecodeError, EOFError):
-        return {}
+class SkillTmpdirHook(AbstractHook):
+    """Create /tmp/Dev10x/<skill-name>/ scratch directory (PreToolUse hook)."""
+
+    def handle(self, *, data: dict) -> None:
+        skill_name = data.get("tool_input", {}).get("skill") or ""
+        if not skill_name:
+            return
+
+        parsed = SkillName.try_parse(skill_name)
+        if parsed is None:
+            return
+        safe_name = parsed.safe_path_name
+        if safe_name:
+            Path(f"/tmp/Dev10x/{safe_name}").mkdir(parents=True, exist_ok=True)
+
+
+class SkillMetricsHook(AbstractHook):
+    """Append skill invocation metric to JSONL file (PostToolUse hook)."""
+
+    def handle(self, *, data: dict) -> None:
+        skill_name = data.get("tool_input", {}).get("skill") or ""
+        if not skill_name:
+            return
+
+        session_id = data.get("session_id") or ""
+        if not session_id:
+            return
+
+        toplevel = _get_toplevel()
+        project_hash = hashlib.md5(toplevel.encode()).hexdigest()
+
+        now = datetime.now(UTC)
+        timestamp = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+        date_tag = now.strftime("%Y-%m-%d")
+
+        metrics_dir = ClaudeDir.metrics_dir()
+        metrics_dir.mkdir(parents=True, exist_ok=True)
+
+        metrics_file = metrics_dir / f"{project_hash}_{date_tag}.jsonl"
+        entry = json.dumps({"skill": skill_name, "session": session_id, "timestamp": timestamp})
+        # GH-548: single os.write to an O_APPEND fd so concurrent hook
+        # processes never interleave partial JSON lines. TextIOWrapper may
+        # split one logical record across multiple syscalls, breaking the
+        # POSIX atomic-append guarantee. Mirrors audit/log_reader.append_record.
+        line = (entry + "\n").encode("utf-8")
+        fd = os.open(str(metrics_file), os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o644)
+        try:
+            os.write(fd, line)
+        finally:
+            os.close(fd)
+
+        cutoff = now - timedelta(days=30)
+        for old_file in metrics_dir.glob("*.jsonl"):
+            try:
+                if datetime.fromtimestamp(old_file.stat().st_mtime, tz=UTC) < cutoff:
+                    old_file.unlink()
+            except OSError:
+                pass
+
+
+class RuffFormatHook(AbstractHook):
+    """Auto-format Python files with ruff after Edit/Write (PostToolUse hook)."""
+
+    def handle(self, *, data: dict) -> None:
+        file_path = data.get("tool_input", {}).get("file_path") or ""
+        if not file_path:
+            return
+
+        path = Path(file_path)
+        if path.suffix != ".py" or not path.is_file():
+            sys.exit(0)
+
+        subprocess_utils.run(["ruff", "format", file_path], check=False)
+        subprocess_utils.run(["ruff", "check", "--fix", file_path], check=False)
 
 
 def skill_tmpdir(data: dict | None = None) -> None:
-    """Create /tmp/Dev10x/<skill-name>/ scratch directory (PreToolUse hook)."""
-    if data is None:
-        data = _load_stdin()
-    skill_name = data.get("tool_input", {}).get("skill") or ""
-    if not skill_name:
-        return
-
-    parsed = SkillName.try_parse(skill_name)
-    if parsed is None:
-        return
-    safe_name = parsed.safe_path_name
-    if safe_name:
-        Path(f"/tmp/Dev10x/{safe_name}").mkdir(parents=True, exist_ok=True)
+    """Shim: dispatch to :class:`SkillTmpdirHook`."""
+    SkillTmpdirHook().run(data)
 
 
 def skill_metrics(data: dict | None = None) -> None:
-    """Append skill invocation metric to JSONL file (PostToolUse hook)."""
-    if data is None:
-        data = _load_stdin()
-
-    skill_name = data.get("tool_input", {}).get("skill") or ""
-    if not skill_name:
-        return
-
-    session_id = data.get("session_id") or ""
-    if not session_id:
-        return
-
-    toplevel = _get_toplevel()
-    project_hash = hashlib.md5(toplevel.encode()).hexdigest()
-
-    now = datetime.now(UTC)
-    timestamp = now.strftime("%Y-%m-%dT%H:%M:%SZ")
-    date_tag = now.strftime("%Y-%m-%d")
-
-    metrics_dir = ClaudeDir.metrics_dir()
-    metrics_dir.mkdir(parents=True, exist_ok=True)
-
-    metrics_file = metrics_dir / f"{project_hash}_{date_tag}.jsonl"
-    entry = json.dumps({"skill": skill_name, "session": session_id, "timestamp": timestamp})
-    # GH-548: single os.write to an O_APPEND fd so concurrent hook
-    # processes never interleave partial JSON lines. TextIOWrapper may
-    # split one logical record across multiple syscalls, breaking the
-    # POSIX atomic-append guarantee. Mirrors audit/log_reader.append_record.
-    line = (entry + "\n").encode("utf-8")
-    fd = os.open(str(metrics_file), os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o644)
-    try:
-        os.write(fd, line)
-    finally:
-        os.close(fd)
-
-    cutoff = now - timedelta(days=30)
-    for old_file in metrics_dir.glob("*.jsonl"):
-        try:
-            if datetime.fromtimestamp(old_file.stat().st_mtime, tz=UTC) < cutoff:
-                old_file.unlink()
-        except OSError:
-            pass
+    """Shim: dispatch to :class:`SkillMetricsHook`."""
+    SkillMetricsHook().run(data)
 
 
 def ruff_format(data: dict | None = None) -> None:
-    """Auto-format Python files with ruff after Edit/Write (PostToolUse hook)."""
-    if data is None:
-        data = _load_stdin()
-
-    file_path = data.get("tool_input", {}).get("file_path") or ""
-    if not file_path:
-        return
-
-    path = Path(file_path)
-    if path.suffix != ".py" or not path.is_file():
-        sys.exit(0)
-
-    subprocess_utils.run(["ruff", "format", file_path], check=False)
-    subprocess_utils.run(["ruff", "check", "--fix", file_path], check=False)
+    """Shim: dispatch to :class:`RuffFormatHook`."""
+    RuffFormatHook().run(data)

--- a/src/dev10x/skill_index/__init__.py
+++ b/src/dev10x/skill_index/__init__.py
@@ -9,7 +9,11 @@ from __future__ import annotations
 from typing import Any
 
 from dev10x.domain.common.result import Result, err, ok
+from dev10x.skill_index.builder import SkillEntry, scan_skill_dirs
+from dev10x.skill_index.catalog import SkillCatalog
 from dev10x.subprocess_utils import async_run_script
+
+__all__ = ["SkillCatalog", "SkillEntry", "generate_all", "scan_skill_dirs"]
 
 
 async def generate_all(

--- a/src/dev10x/skill_index/catalog.py
+++ b/src/dev10x/skill_index/catalog.py
@@ -1,0 +1,50 @@
+"""Skill catalog aggregate (audit finding D7).
+
+Wraps the front-matter builder (:mod:`dev10x.skill_index.builder`) in a
+queryable aggregate so callers can list entries or look one up by name
+without re-scanning the skill directories or re-implementing the
+key/name match. ``scan_skill_dirs`` returns a flat sorted list; this
+aggregate adds the ``lookup`` capability that a bare list lacked.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+from dev10x.skill_index.builder import SkillEntry, scan_skill_dirs
+
+
+@dataclass(frozen=True)
+class SkillCatalog:
+    """An immutable, queryable collection of parsed skill entries."""
+
+    entries: tuple[SkillEntry, ...] = ()
+
+    @classmethod
+    def from_dirs(cls, *, skill_dirs: Iterable[Path]) -> SkillCatalog:
+        """Build a catalog by scanning ``skill_dirs`` for ``SKILL.md`` files."""
+        return cls(entries=tuple(scan_skill_dirs(skill_dirs=skill_dirs)))
+
+    def list(self) -> list[SkillEntry]:
+        """Return all entries (sorted by key, as the builder produced them)."""
+        return list(self.entries)
+
+    def lookup(self, *, name: str) -> SkillEntry | None:
+        """Find an entry by its menu key, falling back to its raw name.
+
+        Returns ``None`` when ``name`` is blank or matches nothing. Key
+        matches win over name matches so the invocation-name a caller
+        types resolves before an internal ``name:`` collision.
+        """
+        needle = name.strip()
+        if not needle:
+            return None
+        for entry in self.entries:
+            if entry.key == needle:
+                return entry
+        for entry in self.entries:
+            if entry.name == needle:
+                return entry
+        return None

--- a/src/dev10x/skills/permission_investigator/matrix.py
+++ b/src/dev10x/skills/permission_investigator/matrix.py
@@ -100,6 +100,42 @@ class Matrix:
         return f"{seen}/{total}"
 
 
+@dataclass(frozen=True)
+class MatrixQuery:
+    """Query object over a populated :class:`Matrix` (audit finding A7).
+
+    Groups the read-only queries that report rendering and delta
+    computation run against a matrix's recorded results, so they live
+    with the matrix definition instead of as free functions in the
+    report module.
+    """
+
+    matrix: Matrix
+
+    def aggregate(self) -> dict[str, list[MatrixResult]]:
+        """Group recorded results by status (works / prompts / error / unknown)."""
+        grouped: dict[str, list[MatrixResult]] = {
+            "works": [],
+            "prompts": [],
+            "error": [],
+            "unknown": [],
+        }
+        known = {cell.cell_id for cell in self.matrix.cells}
+        for cell_id, result in self.matrix.results.items():
+            if cell_id not in known:
+                continue
+            grouped.setdefault(result.status, []).append(result)
+        return grouped
+
+    def shapes_for_status(self, *, status: str) -> set[tuple[PathPrefix, WildcardShape]]:
+        """Return the (prefix, wildcard) shapes whose cells recorded ``status``."""
+        return {
+            (cell.shape.prefix, cell.shape.wildcard)
+            for cell in self.matrix.cells
+            if (result := self.matrix.results.get(cell.cell_id)) and result.status == status
+        }
+
+
 def _tilde_prefix(*, user_home: str) -> str:
     del user_home
     return "~"

--- a/src/dev10x/skills/permission_investigator/report.py
+++ b/src/dev10x/skills/permission_investigator/report.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from dev10x.domain.common.allow_rule import AllowRule
 from dev10x.skills.permission_investigator.matrix import (
     Matrix,
+    MatrixQuery,
     MatrixResult,
     PathPrefix,
     WildcardShape,
@@ -31,18 +32,7 @@ class Delta:
 
 def aggregate_results(matrix: Matrix) -> dict[str, list[MatrixResult]]:
     """Group results by status (works / prompts / error / unknown)."""
-    grouped: dict[str, list[MatrixResult]] = {
-        "works": [],
-        "prompts": [],
-        "error": [],
-        "unknown": [],
-    }
-    cell_index = {cell.cell_id: cell for cell in matrix.cells}
-    for cell_id, result in matrix.results.items():
-        if cell_id not in cell_index:
-            continue
-        grouped.setdefault(result.status, []).append(result)
-    return grouped
+    return MatrixQuery(matrix=matrix).aggregate()
 
 
 def render_markdown_report(matrix: Matrix) -> str:
@@ -111,11 +101,7 @@ def _shapes_for_status(
     matrix: Matrix,
     status: str,
 ) -> set[tuple[PathPrefix, WildcardShape]]:
-    return {
-        (cell.shape.prefix, cell.shape.wildcard)
-        for cell in matrix.cells
-        if (result := matrix.results.get(cell.cell_id)) and result.status == status
-    }
+    return MatrixQuery(matrix=matrix).shapes_for_status(status=status)
 
 
 def _classify_rule(rule: str) -> tuple[PathPrefix | None, WildcardShape | None]:

--- a/tests/audit/test_log_reader.py
+++ b/tests/audit/test_log_reader.py
@@ -23,6 +23,7 @@ from dev10x.audit.log_reader import (
     prune,
     summarize,
 )
+from dev10x.audit.summarizer import HookStatsQuery
 from dev10x.domain.hook_telemetry import HookOutcome, HookPhase
 
 
@@ -432,6 +433,40 @@ class TestSummarize:
         ]
         result = summarize(records=records)
         assert result == {}
+
+
+class TestHookStatsQuery:
+    def test_by_hook_matches_summarize_wrapper(self) -> None:
+        records = [
+            {
+                "phase": HookPhase.WRAP,
+                "span_id": "s1",
+                "hook": "session-start",
+                "total_ms": 120,
+                "outcome": HookOutcome.OK,
+            },
+            {
+                "phase": HookPhase.BODY,
+                "span_id": "s1",
+                "hook": "session-start",
+                "body_ms": 40,
+                "outcome": HookOutcome.OK,
+            },
+        ]
+        assert HookStatsQuery(records=records).by_hook() == summarize(records=records)
+
+    def test_query_object_aggregates_paired_span(self) -> None:
+        records = [
+            {"phase": HookPhase.WRAP, "span_id": "s1", "hook": "h", "total_ms": 100},
+            {"phase": HookPhase.BODY, "span_id": "s1", "hook": "h", "body_ms": 60},
+        ]
+        stats = HookStatsQuery(records=records).by_hook()["h"]
+        assert stats["paired_count"] == 1
+        assert stats["startup_ms_avg"] == 40.0
+
+    def test_span_with_only_unknown_phase_is_skipped(self) -> None:
+        records = [{"phase": "warmup", "span_id": "s1", "hook": "h"}]
+        assert HookStatsQuery(records=records).by_hook() == {}
 
 
 class TestPrune:

--- a/tests/hooks/test_base.py
+++ b/tests/hooks/test_base.py
@@ -1,0 +1,52 @@
+"""Tests for the AbstractHook Template Method base (audit finding A11)."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from dev10x.hooks.base import AbstractHook, load_hook_stdin
+
+
+class _RecordingHook(AbstractHook):
+    def __init__(self) -> None:
+        self.seen: dict | None = None
+
+    def handle(self, *, data: dict) -> None:
+        self.seen = data
+
+
+class TestRun:
+    def test_passes_explicit_data_through_without_reading_stdin(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _boom() -> dict:
+            raise AssertionError("stdin must not be read when data is provided")
+
+        monkeypatch.setattr("dev10x.hooks.base.load_hook_stdin", _boom)
+        hook = _RecordingHook()
+
+        hook.run({"tool_input": {"skill": "Dev10x:x"}})
+
+        assert hook.seen == {"tool_input": {"skill": "Dev10x:x"}}
+
+    def test_reads_stdin_when_data_is_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("dev10x.hooks.base.load_hook_stdin", lambda: {"from": "stdin"})
+        hook = _RecordingHook()
+
+        hook.run(None)
+
+        assert hook.seen == {"from": "stdin"}
+
+
+class TestLoadHookStdin:
+    def test_parses_valid_json(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("sys.stdin", io.StringIO('{"a": 1}'))
+
+        assert load_hook_stdin() == {"a": 1}
+
+    def test_returns_empty_dict_on_invalid_json(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("sys.stdin", io.StringIO("not json"))
+
+        assert load_hook_stdin() == {}

--- a/tests/skill_index/test_catalog.py
+++ b/tests/skill_index/test_catalog.py
@@ -1,0 +1,77 @@
+"""Tests for the SkillCatalog aggregate (audit finding D7)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dev10x.skill_index.builder import SkillEntry
+from dev10x.skill_index.catalog import SkillCatalog
+
+
+def _skill_md(*, name: str, invocation: str | None = None) -> str:
+    lines = ["---", f"name: {name}"]
+    if invocation is not None:
+        lines.append(f"invocation-name: {invocation}")
+    lines += ["description: x", "---", "", "Overview"]
+    return "\n".join(lines)
+
+
+def _make_skill(root: Path, dirname: str, text: str) -> None:
+    skill_dir = root / dirname
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(text, encoding="utf-8")
+
+
+class TestFromDirs:
+    def test_scans_and_sorts_entries(self, tmp_path: Path) -> None:
+        _make_skill(tmp_path, "zebra", _skill_md(name="Dev10x:zebra"))
+        _make_skill(tmp_path, "alpha", _skill_md(name="Dev10x:alpha"))
+
+        catalog = SkillCatalog.from_dirs(skill_dirs=[tmp_path])
+
+        assert [entry.key for entry in catalog.list()] == ["Dev10x:alpha", "Dev10x:zebra"]
+
+    def test_empty_when_no_skills(self, tmp_path: Path) -> None:
+        assert SkillCatalog.from_dirs(skill_dirs=[tmp_path]).list() == []
+
+
+class TestList:
+    def test_returns_a_copy_not_the_internal_tuple(self) -> None:
+        entry = SkillEntry(key="Dev10x:x", name="Dev10x:x")
+        catalog = SkillCatalog(entries=(entry,))
+
+        listed = catalog.list()
+        listed.append(SkillEntry(key="Dev10x:y", name="Dev10x:y"))
+
+        assert catalog.list() == [entry]
+
+
+class TestLookup:
+    def test_finds_by_key(self) -> None:
+        entry = SkillEntry(key="Dev10x:public", name="internal-name")
+        catalog = SkillCatalog(entries=(entry,))
+
+        assert catalog.lookup(name="Dev10x:public") == entry
+
+    def test_falls_back_to_name_when_no_key_match(self) -> None:
+        entry = SkillEntry(key="Dev10x:public", name="internal-name")
+        catalog = SkillCatalog(entries=(entry,))
+
+        assert catalog.lookup(name="internal-name") == entry
+
+    def test_key_match_wins_over_name_match(self) -> None:
+        by_key = SkillEntry(key="shared", name="other")
+        by_name = SkillEntry(key="Dev10x:other", name="shared")
+        catalog = SkillCatalog(entries=(by_key, by_name))
+
+        assert catalog.lookup(name="shared") == by_key
+
+    def test_unknown_name_returns_none(self) -> None:
+        catalog = SkillCatalog(entries=(SkillEntry(key="Dev10x:x", name="Dev10x:x"),))
+
+        assert catalog.lookup(name="Dev10x:missing") is None
+
+    def test_blank_name_returns_none(self) -> None:
+        catalog = SkillCatalog(entries=(SkillEntry(key="Dev10x:x", name="Dev10x:x"),))
+
+        assert catalog.lookup(name="   ") is None

--- a/tests/skills/permission-investigator/test_matrix.py
+++ b/tests/skills/permission-investigator/test_matrix.py
@@ -10,6 +10,8 @@ from dev10x.skills.permission_investigator.matrix import (
     DEFAULT_TOOLS,
     DEFAULT_WILDCARDS,
     Matrix,
+    MatrixCell,
+    MatrixQuery,
     MatrixResult,
     RuleShape,
     generate_matrix,
@@ -168,6 +170,57 @@ class TestMatrixResultStatus:
         )
 
         assert result.status == "error"
+
+
+class TestMatrixQuery:
+    def _matrix_with(self, *, status_by_shape: dict[tuple[str, str], str]) -> Matrix:
+        matrix = Matrix()
+        for index, ((prefix, wildcard), status) in enumerate(status_by_shape.items()):
+            shape = RuleShape(tool="Read", prefix=prefix, wildcard=wildcard)
+            cell = MatrixCell(shape=shape, location="project", cell_id=f"c{index}")
+            matrix.cells.append(cell)
+            matrix.add_result(
+                MatrixResult(
+                    cell_id=cell.cell_id,
+                    auto_approved=status == "works",
+                    prompted=status == "prompts",
+                )
+            )
+        return matrix
+
+    def test_aggregate_groups_results_by_status(self) -> None:
+        matrix = self._matrix_with(
+            status_by_shape={
+                ("tilde", "literal"): "works",
+                ("home_user", "single_star"): "prompts",
+            }
+        )
+
+        grouped = MatrixQuery(matrix=matrix).aggregate()
+
+        assert len(grouped["works"]) == 1
+        assert len(grouped["prompts"]) == 1
+        assert grouped["error"] == []
+
+    def test_aggregate_ignores_results_without_a_cell(self) -> None:
+        matrix = Matrix()
+        matrix.add_result(MatrixResult(cell_id="ghost", auto_approved=True, prompted=False))
+
+        grouped = MatrixQuery(matrix=matrix).aggregate()
+
+        assert all(results == [] for results in grouped.values())
+
+    def test_shapes_for_status_returns_matching_shapes(self) -> None:
+        matrix = self._matrix_with(
+            status_by_shape={
+                ("tilde", "literal"): "works",
+                ("home_user", "single_star"): "prompts",
+            }
+        )
+
+        shapes = MatrixQuery(matrix=matrix).shapes_for_status(status="works")
+
+        assert shapes == {("tilde", "literal")}
 
 
 class TestMatrixCoverage:


### PR DESCRIPTION
**When** extending the Dev10x package — reaching for the skill index, an audit summary, or a hook entry point, **I want to** query a named aggregate and reuse one lifecycle skeleton, **so I can** add a lookup, a new query, or a new hook without re-deriving scan / aggregation / stdin boilerplate each time.

---

[`869db508`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/657/commits/869db508d7459cfa33c4c76df2d4c9703dc7beb5) ♻️ GH-654 Adopt Catalog, Query Object, and AbstractHook archetypes
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/654

---