### PR TITLE
♻️ GH-586 Harden the validators package (PKG-M3 audit)

### DIFF
--- a/.claude/rules/hook-patterns.md
+++ b/.claude/rules/hook-patterns.md
@@ -196,15 +196,27 @@ active-by-default should ship as `experimental=True`. Users opt
 in via `DEV10X_HOOK_EXPERIMENTAL=1`. Once the validator is proven
 stable, flip the flag to `False` and bump the tier appropriately.
 
-Register the tier in `src/dev10x/validators/__init__.py`:
+Register the tier by appending a `ValidatorSpec` to `_SPECS` in
+`src/dev10x/validators/__init__.py` (the typed dataclass replaced the
+old `_VALIDATOR_SPECS` 5-tuple — see
+`dev10x.validators.registry.ValidatorSpec`):
 
 ```python
-_VALIDATOR_SPECS: list[tuple[str, str, str, str, bool]] = [
-    # (module_path, class_name, rule_id, profile, experimental)
+_SPECS: list[ValidatorSpec] = [
     ...
-    ("dev10x.validators.new_rule", "NewRuleValidator", "DX009", "standard", True),
+    ValidatorSpec(
+        module_path="dev10x.validators.new_rule",
+        class_name="NewRuleValidator",
+        rule_id="DX009",
+        profile=ProfileTier.STANDARD,
+        experimental=True,
+    ),
 ]
 ```
+
+Each validator class declares the same `rule_id`/`profile`/
+`experimental` metadata as `ValidatorBase` class attributes; the
+registry asserts the two agree at registration time.
 
 ### Reviewer Expectations
 

--- a/src/dev10x/hooks/edit_validator.py
+++ b/src/dev10x/hooks/edit_validator.py
@@ -13,6 +13,7 @@ Two validation passes:
 
 from __future__ import annotations
 
+import functools
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -25,12 +26,37 @@ if TYPE_CHECKING:
 _YAML_PATH = Path(__file__).parent.parent / "validators" / "command-skill-map.yaml"
 
 
-def _build_engine(*, yaml_path: Path) -> RuleEngine:
+@functools.cache
+def _cached_engine(yaml_path_str: str, mtime_ns: int) -> RuleEngine:
+    """Build a RuleEngine for one (path, mtime) pair.
+
+    GH-586: ``_build_engine`` previously re-parsed the YAML config on
+    every ``Edit``/``Write`` hook invocation. Keying the cache on the
+    file's mtime parses an unchanged config once per process while an
+    edit to the YAML (new mtime) transparently yields a fresh engine.
+    Mirrors the ``_cached_registry`` pattern in
+    ``dev10x.validators.__init__``.
+    """
     from dev10x.config.loader import load_config
     from dev10x.domain.rules.rule_engine import RuleEngine
 
-    config = load_config(yaml_path=yaml_path)
+    config = load_config(yaml_path=Path(yaml_path_str))
     return RuleEngine.from_config(config=config)
+
+
+def _build_engine(*, yaml_path: Path) -> RuleEngine:
+    try:
+        mtime_ns = yaml_path.stat().st_mtime_ns
+    except OSError:
+        # Missing/unreadable config: bypass the cache with a sentinel
+        # mtime and let load_config surface the error as before.
+        mtime_ns = -1
+    return _cached_engine(str(yaml_path), mtime_ns)
+
+
+def reset_engine_cache() -> None:
+    """Clear cached RuleEngine instances — used by tests."""
+    _cached_engine.cache_clear()
 
 
 def _run_python_validators(*, data: dict[str, Any], debug: bool = False) -> None:

--- a/src/dev10x/validators/base.py
+++ b/src/dev10x/validators/base.py
@@ -42,10 +42,6 @@ class Validator(Protocol):
         """Return HookResult to block, HookAllow to auto-approve, None for no opinion."""
         ...
 
-    def run(self, inp: HookInput) -> HookResult | HookAllow | None:
-        """Template: ``should_run`` gate followed by ``validate``."""
-        ...
-
 
 @runtime_checkable
 class Corrector(Protocol):
@@ -86,13 +82,3 @@ class ValidatorBase:
     def validate(self, inp: HookInput) -> HookResult | HookAllow | None:
         """Block/allow/abstain decision — overridden by concrete validators."""
         raise NotImplementedError  # pragma: no cover
-
-    def run(self, inp: HookInput) -> HookResult | HookAllow | None:
-        """Template method: skip when ``should_run`` is False, else ``validate``.
-
-        Consolidates the ``should_run`` → ``validate`` sequencing that the
-        dispatcher previously open-coded per call site.
-        """
-        if not self.should_run(inp=inp):
-            return None
-        return self.validate(inp=inp)

--- a/src/dev10x/validators/registry.py
+++ b/src/dev10x/validators/registry.py
@@ -19,9 +19,7 @@ the registry verifies the two agree at registration time.
 from __future__ import annotations
 
 import importlib
-import os
-import sys
-import traceback
+import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol
 
@@ -32,7 +30,7 @@ if TYPE_CHECKING:
     from dev10x.domain import HookAllow, HookInput, HookResult, HookRetry
     from dev10x.validators.base import Validator
 
-_DEBUG = os.environ.get("HOOK_DEBUG", "") != ""
+log = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -211,9 +209,13 @@ class ValidatorChain:
       :meth:`correct` — for PermissionDenied: short-circuits at the
         first validator returning a :class:`HookRetry`.
 
-    Validators raising during ``should_run``/``validate``/``correct``
-    are swallowed (logged when ``HOOK_DEBUG`` is set) so a single
-    misbehaving validator cannot block the hook.
+    A validator raising during ``should_run``/``validate``/``correct``
+    is always logged (GH-494 — previously silent unless ``HOOK_DEBUG``).
+    For non-safety tiers the exception is then swallowed so one
+    misbehaving validator cannot block the hook. A **safety-critical**
+    (``ProfileTier.MINIMAL``) validator instead fails CLOSED: ``run``
+    emits a blocking :class:`HookResult` rather than letting the command
+    through unchecked.
     """
 
     registry: ValidatorRegistry
@@ -222,7 +224,8 @@ class ValidatorChain:
         """Invoke ``validate()`` on every applicable validator.
 
         Returns the list of non-None results in registration order;
-        callers emit each in turn.
+        callers emit each in turn. When a safety-critical validator
+        raises, a fail-closed block is appended in its place (GH-494).
         """
         results: list[HookResult | HookAllow] = []
         for validator in self.registry.active():
@@ -230,6 +233,9 @@ class ValidatorChain:
                 result = validator.run(inp=inp)
             except Exception:
                 _log_validator_error(validator=validator, method="validate")
+                blocked = _safety_fail_closed(validator=validator)
+                if blocked is not None:
+                    results.append(blocked)
                 continue
             if result is not None:
                 results.append(result)
@@ -255,13 +261,44 @@ class ValidatorChain:
 
 
 def _log_validator_error(*, validator: Validator, method: str) -> None:
-    if not _DEBUG:
-        return
-    print(
-        f"[HOOK_DEBUG] {validator.name} {method}() raised:",
-        file=sys.stderr,
+    """Always surface a validator failure (GH-494).
+
+    Previously gated on ``HOOK_DEBUG``, which silenced exceptions in
+    production and let the chain fail open with no diagnostic. Emitting
+    at ERROR keeps the traceback visible on stderr even when no logging
+    handler is configured (the stdlib last-resort handler covers it).
+    """
+    log.error(
+        "validator %s %s() raised",
+        getattr(validator, "name", "?"),
+        method,
+        exc_info=True,
     )
-    traceback.print_exc(file=sys.stderr)
+
+
+def _safety_fail_closed(*, validator: Validator) -> HookResult | None:
+    """Return a blocking result when a safety-critical validator raised.
+
+    Safety-critical validators (``ProfileTier.MINIMAL`` — DX001–DX005,
+    DX012) guard against destructive or unsafe commands. If one raises
+    we cannot know whether the command is safe, so we fail CLOSED and
+    block rather than letting it through (GH-494). Non-safety tiers
+    return None here and remain fail-open.
+    """
+    if getattr(validator, "profile", None) is not ProfileTier.MINIMAL:
+        return None
+    from dev10x.domain import HookResult
+
+    rule_id = getattr(validator, "rule_id", "?")
+    name = getattr(validator, "name", "?")
+    return HookResult(
+        message=(
+            f"🛡️ Safety validator {name} ({rule_id}) raised an exception and "
+            "could not evaluate this command. Blocking as a precaution "
+            "(fail-closed). Re-run with HOOK_DEBUG=1 for the traceback, or set "
+            f"DEV10X_HOOK_DISABLE={rule_id} if this validator is misbehaving."
+        )
+    )
 
 
 __all__ = [

--- a/src/dev10x/validators/registry.py
+++ b/src/dev10x/validators/registry.py
@@ -230,7 +230,9 @@ class ValidatorChain:
         results: list[HookResult | HookAllow] = []
         for validator in self.registry.active():
             try:
-                result = validator.run(inp=inp)
+                if not validator.should_run(inp=inp):
+                    continue
+                result = validator.validate(inp=inp)
             except Exception:
                 _log_validator_error(validator=validator, method="validate")
                 blocked = _safety_fail_closed(validator=validator)

--- a/src/dev10x/validators/spec_drift.py
+++ b/src/dev10x/validators/spec_drift.py
@@ -32,6 +32,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import ClassVar
 
+from dev10x import subprocess_utils
 from dev10x.domain import HookInput, HookResult
 from dev10x.domain.common.ticket_id import TicketId
 from dev10x.domain.profile_tier import ProfileTier
@@ -62,14 +63,16 @@ See ``.claude/rules/hook-patterns.md`` — DX015 / spec-drift — for details.
 def _branch_ticket_id(*, cwd: str) -> str | None:
     """Return the first ticket-id found in the current branch name, or None."""
     try:
-        branch = subprocess.check_output(
+        result = subprocess_utils.run(
             ["git", "rev-parse", "--abbrev-ref", "HEAD"],
-            stderr=subprocess.DEVNULL,
-            text=True,
             cwd=cwd or None,
-        ).strip()
+            capture_output=True,
+            text=True,
+            check=True,
+        )
     except (subprocess.CalledProcessError, FileNotFoundError, OSError):
         return None
+    branch = result.stdout.strip()
     ticket = TicketId.find_first_in_branch_name(branch)
     return str(ticket) if ticket is not None else None
 
@@ -77,14 +80,16 @@ def _branch_ticket_id(*, cwd: str) -> str | None:
 def _repo_toplevel(*, cwd: str) -> str | None:
     """Return the git repository toplevel, or None if not a git repo."""
     try:
-        return subprocess.check_output(
+        result = subprocess_utils.run(
             ["git", "rev-parse", "--show-toplevel"],
-            stderr=subprocess.DEVNULL,
-            text=True,
             cwd=cwd or None,
-        ).strip()
+            capture_output=True,
+            text=True,
+            check=True,
+        )
     except (subprocess.CalledProcessError, FileNotFoundError, OSError):
         return None
+    return result.stdout.strip()
 
 
 def _working_set_paths(*, cwd: str) -> set[str]:
@@ -95,14 +100,16 @@ def _working_set_paths(*, cwd: str) -> set[str]:
     Returns an empty set on any git error.
     """
     try:
-        output = subprocess.check_output(
+        result = subprocess_utils.run(
             ["git", "status", "--porcelain"],
-            stderr=subprocess.DEVNULL,
-            text=True,
             cwd=cwd or None,
+            capture_output=True,
+            text=True,
+            check=True,
         )
     except (subprocess.CalledProcessError, FileNotFoundError, OSError):
         return set()
+    output = result.stdout
     paths: set[str] = set()
     for line in output.splitlines():
         # porcelain format: "XY filename" or "XY old -> new" for renames

--- a/tests/hooks/test_edit_validator.py
+++ b/tests/hooks/test_edit_validator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -9,6 +10,7 @@ import yaml
 
 from dev10x.domain.rules.rule_engine import RuleEngine
 from dev10x.domain.rules.validation_rule import Rule
+from dev10x.hooks.edit_validator import _build_engine, reset_engine_cache
 
 
 @pytest.fixture()
@@ -186,3 +188,53 @@ class TestLoadRules:
         engine = RuleEngine.from_yaml(path=yaml_path)
 
         assert len(engine.edit_rules) == 0
+
+
+class TestBuildEngineCache:
+    """GH-586: _build_engine caches by (path, mtime) to avoid re-parsing
+    the YAML config on every Edit/Write hook invocation."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        reset_engine_cache()
+        yield
+        reset_engine_cache()
+
+    def _write_yaml(self, path: Path, rule_name: str) -> None:
+        path.write_text(
+            yaml.dump(
+                {
+                    "rules": [
+                        {
+                            "name": rule_name,
+                            "matcher": "Edit|Write",
+                            "hook_block": True,
+                            "file_names": [".env"],
+                        }
+                    ]
+                }
+            )
+        )
+
+    def test_same_file_returns_cached_engine(self, tmp_path: Path) -> None:
+        yaml_path = tmp_path / "rules.yaml"
+        self._write_yaml(yaml_path, "block-env")
+        first = _build_engine(yaml_path=yaml_path)
+        second = _build_engine(yaml_path=yaml_path)
+        assert first is second
+
+    def test_changed_mtime_rebuilds_engine(self, tmp_path: Path) -> None:
+        yaml_path = tmp_path / "rules.yaml"
+        self._write_yaml(yaml_path, "block-env")
+        first = _build_engine(yaml_path=yaml_path)
+        # Simulate an edit by bumping the file's mtime forward.
+        st = yaml_path.stat()
+        os.utime(yaml_path, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000_000))
+        second = _build_engine(yaml_path=yaml_path)
+        assert first is not second
+
+    def test_missing_config_bypasses_cache_and_raises(self, tmp_path: Path) -> None:
+        # stat() on a missing file raises OSError → sentinel mtime branch;
+        # load_config then surfaces the error as before (no silent cache).
+        with pytest.raises(Exception):
+            _build_engine(yaml_path=tmp_path / "does-not-exist.yaml")

--- a/tests/validators/test_registry.py
+++ b/tests/validators/test_registry.py
@@ -365,13 +365,13 @@ class TestValidatorChain:
         assert chain.correct(inp=stub_input) is None
 
 
-class TestValidatorBaseTemplate:
-    def test_run_validates_when_should_run_true(self, stub_input: HookInput) -> None:
-        result = _StubValidator().run(inp=stub_input)
-        assert isinstance(result, HookResult)
-        assert result.message == "stub-blocked"
+class TestValidatorChainGate:
+    """The ``should_run`` gate is enforced by the chain, not a
+    validator-level ``run()`` template (GH-586). Removing ``run()`` from
+    the Protocol means a validator cannot override the gate to bypass it.
+    """
 
-    def test_run_skips_when_should_run_false(self, stub_input: HookInput) -> None:
+    def test_run_skips_validator_when_should_run_false(self, stub_input: HookInput) -> None:
         @dataclass
         class _Skipper(ValidatorBase):
             name: ClassVar[str] = "skipper"
@@ -384,4 +384,16 @@ class TestValidatorBaseTemplate:
             def validate(self, inp: HookInput) -> HookResult | None:
                 raise AssertionError("validate must not run when should_run is False")
 
-        assert _Skipper().run(inp=stub_input) is None
+        registry = ValidatorRegistry()
+        registry._instances = [_Skipper()]  # type: ignore[attr-defined]
+        chain = ValidatorChain(registry=registry)
+        assert chain.run(inp=stub_input) == []
+
+    def test_run_invokes_validate_when_should_run_true(self, stub_input: HookInput) -> None:
+        registry = ValidatorRegistry()
+        registry._instances = [_StubValidator()]  # type: ignore[attr-defined]
+        chain = ValidatorChain(registry=registry)
+        results = chain.run(inp=stub_input)
+        assert len(results) == 1
+        assert isinstance(results[0], HookResult)
+        assert results[0].message == "stub-blocked"

--- a/tests/validators/test_registry.py
+++ b/tests/validators/test_registry.py
@@ -240,12 +240,12 @@ class TestValidatorChain:
         assert isinstance(results[0], HookResult)
         assert results[0].message == "stub-blocked"
 
-    def test_run_swallows_validator_exceptions(self, stub_input: HookInput) -> None:
+    def test_run_swallows_non_safety_validator_exceptions(self, stub_input: HookInput) -> None:
         @dataclass
         class _Raiser(ValidatorBase):
             name: ClassVar[str] = "raiser"
             rule_id: ClassVar[str] = "DX900"
-            profile: ClassVar[ProfileTier] = ProfileTier.MINIMAL
+            profile: ClassVar[ProfileTier] = ProfileTier.STANDARD
 
             def should_run(self, inp: HookInput) -> bool:
                 return True
@@ -256,7 +256,56 @@ class TestValidatorChain:
         registry = ValidatorRegistry()
         registry._instances = [_Raiser()]  # type: ignore[attr-defined]
         chain = ValidatorChain(registry=registry)
+        # Non-safety tiers remain fail-open: one buggy validator must not
+        # block every command.
         assert chain.run(inp=stub_input) == []
+
+    def test_run_fails_closed_on_safety_validator_exception(self, stub_input: HookInput) -> None:
+        @dataclass
+        class _SafetyRaiser(ValidatorBase):
+            name: ClassVar[str] = "safety-raiser"
+            rule_id: ClassVar[str] = "DX903"
+            profile: ClassVar[ProfileTier] = ProfileTier.MINIMAL
+
+            def should_run(self, inp: HookInput) -> bool:
+                return True
+
+            def validate(self, inp: HookInput) -> HookResult | None:
+                raise RuntimeError("boom")
+
+        registry = ValidatorRegistry()
+        registry._instances = [_SafetyRaiser()]  # type: ignore[attr-defined]
+        chain = ValidatorChain(registry=registry)
+        # Safety-critical (MINIMAL) validators fail CLOSED: a blocking
+        # result is emitted in place of the swallowed exception (GH-494).
+        results = chain.run(inp=stub_input)
+        assert len(results) == 1
+        assert isinstance(results[0], HookResult)
+        assert "fail-closed" in results[0].message
+        assert "DX903" in results[0].message
+
+    def test_run_logs_validator_exception(
+        self, stub_input: HookInput, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        @dataclass
+        class _Raiser(ValidatorBase):
+            name: ClassVar[str] = "noisy-raiser"
+            rule_id: ClassVar[str] = "DX904"
+            profile: ClassVar[ProfileTier] = ProfileTier.STANDARD
+
+            def should_run(self, inp: HookInput) -> bool:
+                return True
+
+            def validate(self, inp: HookInput) -> HookResult | None:
+                raise RuntimeError("boom")
+
+        registry = ValidatorRegistry()
+        registry._instances = [_Raiser()]  # type: ignore[attr-defined]
+        chain = ValidatorChain(registry=registry)
+        with caplog.at_level("ERROR"):
+            chain.run(inp=stub_input)
+        # GH-494: failures are always logged, not only under HOOK_DEBUG.
+        assert any("noisy-raiser" in rec.message for rec in caplog.records)
 
     def test_correct_dispatches_only_to_capable(self, stub_input: HookInput) -> None:
         registry = ValidatorRegistry(

--- a/tests/validators/test_spec_drift.py
+++ b/tests/validators/test_spec_drift.py
@@ -34,6 +34,15 @@ from dev10x.validators.spec_drift import (
 # Helpers
 # ---------------------------------------------------------------------------
 
+# GH-495: spec_drift now routes git calls through subprocess_utils.run
+# (CWD-discipline). Patch that seam instead of subprocess.check_output.
+_RUN = "dev10x.validators.spec_drift.subprocess_utils.run"
+
+
+def _completed(stdout: str) -> subprocess.CompletedProcess[str]:
+    """Build a successful CompletedProcess mirroring subprocess_utils.run."""
+    return subprocess.CompletedProcess(args=["git"], returncode=0, stdout=stdout, stderr="")
+
 
 def _edit_inp(
     *,
@@ -108,35 +117,35 @@ class TestShouldRun:
 
 class TestBranchTicketId:
     def test_extracts_gh_ticket(self) -> None:
-        with patch("subprocess.check_output", return_value="janusz/GH-434/feature\n"):
+        with patch(_RUN, return_value=_completed("janusz/GH-434/feature\n")):
             result = _branch_ticket_id(cwd="/work/repo")
         assert result == "GH-434"
 
     def test_extracts_feat_ticket(self) -> None:
-        with patch("subprocess.check_output", return_value="user/FEAT-123/something\n"):
+        with patch(_RUN, return_value=_completed("user/FEAT-123/something\n")):
             result = _branch_ticket_id(cwd="/work/repo")
         assert result == "FEAT-123"
 
     def test_returns_none_for_no_ticket(self) -> None:
-        with patch("subprocess.check_output", return_value="main\n"):
+        with patch(_RUN, return_value=_completed("main\n")):
             result = _branch_ticket_id(cwd="/work/repo")
         assert result is None
 
     def test_returns_none_on_git_error(self) -> None:
         with patch(
-            "subprocess.check_output",
+            _RUN,
             side_effect=subprocess.CalledProcessError(128, "git"),
         ):
             result = _branch_ticket_id(cwd="/work/repo")
         assert result is None
 
     def test_returns_none_when_git_missing(self) -> None:
-        with patch("subprocess.check_output", side_effect=FileNotFoundError()):
+        with patch(_RUN, side_effect=FileNotFoundError()):
             result = _branch_ticket_id(cwd="/work/repo")
         assert result is None
 
     def test_uppercases_ticket_id(self) -> None:
-        with patch("subprocess.check_output", return_value="user/gh-434/feature\n"):
+        with patch(_RUN, return_value=_completed("user/gh-434/feature\n")):
             result = _branch_ticket_id(cwd="/work/repo")
         assert result == "GH-434"
 
@@ -148,13 +157,13 @@ class TestBranchTicketId:
 
 class TestRepoToplevel:
     def test_returns_toplevel(self) -> None:
-        with patch("subprocess.check_output", return_value="/work/repo\n"):
+        with patch(_RUN, return_value=_completed("/work/repo\n")):
             result = _repo_toplevel(cwd="/work/repo")
         assert result == "/work/repo"
 
     def test_returns_none_on_error(self) -> None:
         with patch(
-            "subprocess.check_output",
+            _RUN,
             side_effect=subprocess.CalledProcessError(128, "git"),
         ):
             result = _repo_toplevel(cwd="/some/path")
@@ -168,33 +177,33 @@ class TestRepoToplevel:
 
 class TestWorkingSetPaths:
     def test_parses_modified_file(self) -> None:
-        with patch("subprocess.check_output", return_value=" M docs/specs/GH-434.md\n"):
+        with patch(_RUN, return_value=_completed(" M docs/specs/GH-434.md\n")):
             paths = _working_set_paths(cwd="/work/repo")
         assert "docs/specs/GH-434.md" in paths
 
     def test_parses_added_file(self) -> None:
-        with patch("subprocess.check_output", return_value="A  docs/specs/NEW-1.md\n"):
+        with patch(_RUN, return_value=_completed("A  docs/specs/NEW-1.md\n")):
             paths = _working_set_paths(cwd="/work/repo")
         assert "docs/specs/NEW-1.md" in paths
 
     def test_parses_rename(self) -> None:
         with patch(
-            "subprocess.check_output",
-            return_value="R  old/path.md -> new/path.md\n",
+            _RUN,
+            return_value=_completed("R  old/path.md -> new/path.md\n"),
         ):
             paths = _working_set_paths(cwd="/work/repo")
         assert "new/path.md" in paths
 
     def test_returns_empty_on_git_error(self) -> None:
         with patch(
-            "subprocess.check_output",
+            _RUN,
             side_effect=subprocess.CalledProcessError(128, "git"),
         ):
             paths = _working_set_paths(cwd="/work/repo")
         assert paths == set()
 
     def test_returns_empty_when_git_missing(self) -> None:
-        with patch("subprocess.check_output", side_effect=FileNotFoundError()):
+        with patch(_RUN, side_effect=FileNotFoundError()):
             paths = _working_set_paths(cwd="/work/repo")
         assert paths == set()
 


### PR DESCRIPTION
**When** the validators package gates every Bash and Edit/Write hook call, **I want to** close the PKG-M3 audit findings — enforce the should_run gate centrally, fail closed on safety-validator errors, route spec-drift git calls through subprocess_utils, cache the rule engine, and correct the stale registry docs — **so I can** trust the hook layer to block unsafe commands without silent failures or per-call parsing overhead.

---

[`55361e05`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/659/commits/55361e05c5fd010857fb75dc6bca76a21f2080a1) 📝 GH-497 Align hook-patterns registry doc with ValidatorSpec
[`56d22cdb`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/659/commits/56d22cdbd9a9a83b4151202857327447c3486637) ♻️ GH-495 Honor effective CWD in spec-drift git lookups
[`b3fa81f3`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/659/commits/b3fa81f3f1f11e360cc9978404002aaa255a59dd) 🐛 GH-494 Fail closed when safety validators raise
[`0ebb25e3`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/659/commits/0ebb25e3597182fa4432f3e3fb425233e510909c) ♻️ GH-586 Enforce should_run gate centrally and cache rules
Closes #497
Closes #495
Closes #494
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/586

---