### PR TITLE
🔥 GH-504 Clean up the domain package per the PKG-M4 audit

### DIFF
--- a/src/dev10x/commands/hook.py
+++ b/src/dev10x/commands/hook.py
@@ -32,17 +32,17 @@ def validate_bash() -> None:
 
 
 def _validate_bash_body() -> None:
-    from dev10x.domain import HookInput
+    from dev10x.hooks.hook_transport import emit, read_hook_input
     from dev10x.validators import get_chain
 
-    inp = HookInput.from_stdin()
+    inp = read_hook_input()
     if inp.tool_name != "Bash":
         sys.exit(0)
     if not inp.command:
         sys.exit(0)
 
     for result in get_chain().run(inp=inp):
-        result.emit()
+        emit(result)
 
     sys.exit(0)
 
@@ -97,15 +97,15 @@ def permission_denied() -> None:
     tool was prompted (settings override semantics, missing rules).
     Exit codes: 0 always (retry decision is in JSON output).
     """
-    from dev10x.domain import HookInput
+    from dev10x.hooks.hook_transport import emit, read_hook_input
     from dev10x.validators import get_chain
 
-    inp = HookInput.from_stdin()
+    inp = read_hook_input()
 
     if inp.command:
         result = get_chain().correct(inp=inp)
         if result is not None:
-            result.emit()
+            emit(result)
 
     _run_permission_diagnostics(raw=inp.raw, cwd=inp.cwd)
     sys.exit(0)

--- a/src/dev10x/domain/claude_paths.py
+++ b/src/dev10x/domain/claude_paths.py
@@ -85,10 +85,6 @@ class ClaudeDir:
         return cls._resolve("projects", "_metrics")
 
     @classmethod
-    def memory_dir(cls) -> Path:
-        return cls._resolve("memory")
-
-    @classmethod
     def memory_dev10x_dir(cls) -> Path:
         return cls._resolve("memory", "Dev10x")
 

--- a/src/dev10x/domain/common/branch_name.py
+++ b/src/dev10x/domain/common/branch_name.py
@@ -84,10 +84,3 @@ class BranchName:
             return cls.parse(value)
         except (TypeError, ValueError):
             return None
-
-    def validate_convention(self) -> None:
-        if not self.follows_convention:
-            raise ValueError(
-                f"Branch {self.raw!r} does not follow the "
-                f"'username/TICKET-ID/[worktree/]slug' convention."
-            )

--- a/src/dev10x/domain/common/ticket_id.py
+++ b/src/dev10x/domain/common/ticket_id.py
@@ -13,7 +13,6 @@ from dataclasses import dataclass
 
 TICKET_ID_PATTERN = r"[A-Z]+-\d+"
 _FULL_RE = re.compile(rf"^{TICKET_ID_PATTERN}$")
-_SEARCH_RE = re.compile(TICKET_ID_PATTERN)
 # A ticket occupying a whole branch-path segment, e.g. ``user/GH-12/slug``.
 # Case-insensitive so lowercase branch names (``gh-12``) still resolve; the
 # ``GH-`` prefix needs no special case — it is already a ``[A-Z]+`` project.
@@ -44,21 +43,6 @@ class TicketId:
             return cls.parse(value)
         except (TypeError, ValueError):
             return None
-
-    @classmethod
-    def find_first(cls, text: str) -> TicketId | None:
-        match = _SEARCH_RE.search(text)
-        if not match:
-            return None
-        return cls.try_parse(match.group(0))
-
-    @classmethod
-    def find_all(cls, text: str) -> list[TicketId]:
-        return [
-            ticket
-            for match in _SEARCH_RE.finditer(text)
-            if (ticket := cls.try_parse(match.group(0))) is not None
-        ]
 
     @classmethod
     def find_first_in_branch_name(cls, branch: str) -> TicketId | None:

--- a/src/dev10x/domain/dev10x_paths.py
+++ b/src/dev10x/domain/dev10x_paths.py
@@ -143,10 +143,6 @@ class Dev10xConfigDir:
         )
 
     @classmethod
-    def playbooks_dir(cls) -> Path:
-        return _with_lazy_migration(cls._resolve("playbooks"), _legacy_playbooks_dir)
-
-    @classmethod
     def gitmoji_yaml(cls) -> Path:
         return _with_lazy_migration(cls._resolve("gitmoji.yaml"), _legacy_gitmoji_yaml)
 
@@ -162,13 +158,6 @@ class Dev10xConfigDir:
         return _with_lazy_migration(
             cls._resolve("settings-pr-merge.yaml"),
             _legacy_settings_pr_merge_yaml,
-        )
-
-    @classmethod
-    def plugin_maintenance_prefs_yaml(cls) -> Path:
-        return _with_lazy_migration(
-            cls._resolve("plugin-maintenance-prefs.yaml"),
-            _legacy_plugin_maintenance_prefs_yaml,
         )
 
 

--- a/src/dev10x/domain/documents/plan.py
+++ b/src/dev10x/domain/documents/plan.py
@@ -55,7 +55,6 @@ def get_plan_path(*, toplevel: str) -> Path:
 
 @dataclass(frozen=True)
 class TaskTransition:
-    timestamp_field: str | None
     allowed_from: frozenset[TaskStatus | None]
     removes: bool = False
 
@@ -66,15 +65,12 @@ class TaskTransition:
 # from any state because the operation removes the task entirely.
 TASK_TRANSITIONS: dict[TaskStatus, TaskTransition] = {
     TaskStatus.PENDING: TaskTransition(
-        timestamp_field=None,
         allowed_from=frozenset({None, TaskStatus.PENDING, TaskStatus.IN_PROGRESS}),
     ),
     TaskStatus.IN_PROGRESS: TaskTransition(
-        timestamp_field="started_at",
         allowed_from=frozenset({None, TaskStatus.PENDING, TaskStatus.IN_PROGRESS}),
     ),
     TaskStatus.COMPLETED: TaskTransition(
-        timestamp_field="completed_at",
         allowed_from=frozenset(
             {
                 None,
@@ -85,7 +81,6 @@ TASK_TRANSITIONS: dict[TaskStatus, TaskTransition] = {
         ),
     ),
     TaskStatus.DELETED: TaskTransition(
-        timestamp_field=None,
         allowed_from=frozenset(
             {
                 None,

--- a/src/dev10x/domain/documents/task.py
+++ b/src/dev10x/domain/documents/task.py
@@ -90,7 +90,3 @@ class Task:
             else:
                 merged[k] = v
         return replace(self, metadata=merged)
-
-    @property
-    def is_active(self) -> bool:
-        return self.status in (TaskStatus.PENDING, TaskStatus.IN_PROGRESS)

--- a/src/dev10x/domain/events/hook_input.py
+++ b/src/dev10x/domain/events/hook_input.py
@@ -1,13 +1,7 @@
 from __future__ import annotations
 
-import json
-import os
-import sys
 from dataclasses import dataclass
-from typing import Any, NoReturn
-
-from dev10x.domain.events.hook_event import HookEventName
-from dev10x.subprocess_utils import effective_cwd
+from typing import Any
 
 
 @dataclass(frozen=True)
@@ -18,24 +12,12 @@ class HookInput:
     cwd: str = ""
 
     @classmethod
-    def from_stdin(cls) -> HookInput:
-        try:
-            data = json.load(sys.stdin)
-        except (json.JSONDecodeError, EOFError):
-            data = {}
+    def from_dict(cls, data: dict[str, Any], *, cwd: str = "") -> HookInput:
         return cls(
             tool_name=data.get("tool_name", ""),
             command=data.get("tool_input", {}).get("command", ""),
             raw=data,
-            cwd=effective_cwd() or os.getcwd(),
-        )
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> HookInput:
-        return cls(
-            tool_name=data.get("tool_name", ""),
-            command=data.get("tool_input", {}).get("command", ""),
-            raw=data,
+            cwd=cwd,
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -51,14 +33,6 @@ class HookInput:
 class HookResult:
     message: str
 
-    def emit(self) -> NoReturn:
-        result = {
-            "hookSpecificOutput": {"permissionDecision": "deny"},
-            "systemMessage": self.message,
-        }
-        print(json.dumps(result), file=sys.stderr)
-        sys.exit(2)
-
     def to_dict(self) -> dict[str, str]:
         return {"message": self.message, "decision": "deny"}
 
@@ -67,15 +41,6 @@ class HookResult:
 class HookAllow:
     message: str = ""
 
-    def emit(self) -> NoReturn:
-        result: dict[str, Any] = {
-            "hookSpecificOutput": {"permissionDecision": "allow"},
-        }
-        if self.message:
-            result["systemMessage"] = self.message
-        print(json.dumps(result), file=sys.stderr)
-        sys.exit(0)
-
     def to_dict(self) -> dict[str, str]:
         return {"message": self.message, "decision": "allow"}
 
@@ -83,18 +48,6 @@ class HookAllow:
 @dataclass(frozen=True)
 class HookRetry:
     message: str
-
-    def emit(self) -> NoReturn:
-        result: dict[str, Any] = {
-            "hookSpecificOutput": {
-                "hookEventName": HookEventName.PERMISSION_DENIED,
-                "retry": True,
-            },
-        }
-        if self.message:
-            result["systemMessage"] = self.message
-        print(json.dumps(result), file=sys.stderr)
-        sys.exit(0)
 
     def to_dict(self) -> dict[str, str]:
         return {"message": self.message, "decision": "retry"}

--- a/src/dev10x/domain/rules/rule_engine.py
+++ b/src/dev10x/domain/rules/rule_engine.py
@@ -66,16 +66,6 @@ class RuleEngine:
             )
         return None
 
-    def evaluate_file(self, *, file_path: str) -> RuleMatch | None:
-        for rule in self.edit_rules:
-            if not rule.matches_file(file_path=file_path):
-                continue
-            return RuleMatch(
-                rule_name=rule.name,
-                message=rule.format_message(file_path=file_path),
-            )
-        return None
-
     def evaluate_command(self, *, command: str) -> Rule | None:
         for rule in self.command_rules:
             if rule.matches_command(command=command):

--- a/src/dev10x/domain/sensitivity.py
+++ b/src/dev10x/domain/sensitivity.py
@@ -291,20 +291,6 @@ class SensitivityClassifier:
                 )
         return results
 
-    def is_sensitive(self, *, command: str) -> bool:
-        """Return True if *command* triggers any sensitivity rule."""
-        return bool(self.classify(command=command))
-
-    def highest_label(self, *, command: str) -> SensitivityLabel | None:
-        """Return the first matched label, or None if no match.
-
-        When multiple labels match, returns the first match in wordlist
-        order (which preserves the declaration order of
-        ``_DEFAULT_PATTERNS``).
-        """
-        matches = self.classify(command=command)
-        return matches[0].label if matches else None
-
 
 __all__ = [
     "SensitivityClassifier",

--- a/src/dev10x/hooks/edit_validator.py
+++ b/src/dev10x/hooks/edit_validator.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from dev10x.domain.events.hook_input import HookInput, HookResult
+from dev10x.hooks.hook_transport import emit
 
 if TYPE_CHECKING:
     from dev10x.domain.rules.rule_engine import RuleEngine
@@ -78,7 +79,7 @@ def _run_python_validators(*, data: dict[str, Any], debug: bool = False) -> None
                 f"[DEBUG] Python validator blocked: {result}",
                 file=_sys.stderr,
             )
-        result.emit()
+        emit(result)
 
 
 def validate_edit_write(
@@ -108,7 +109,7 @@ def validate_edit_write(
                 f"[DEBUG] Rule '{match.rule_name}' matched: {file_path}",
                 file=sys.stderr,
             )
-        HookResult(message=match.message).emit()
+        emit(HookResult(message=match.message))
 
     _run_python_validators(data=data, debug=debug)
 

--- a/src/dev10x/hooks/hook_transport.py
+++ b/src/dev10x/hooks/hook_transport.py
@@ -1,0 +1,70 @@
+"""Hook transport adapter — owns stdin reads and the wire response.
+
+GH-511: the Claude Code hook envelope (``hookSpecificOutput`` +
+``sys.exit``) and stdin parsing are process-boundary concerns. They
+live here in the ``dev10x.hooks`` adapter layer rather than on the
+``dev10x.domain.events`` value objects, per
+``.claude/rules/script-domain-boundaries.md`` (GH-246 H3/H7): domain
+objects keep their data shape and ``to_dict()``; this thin adapter
+translates a domain decision into the wire response and owns the
+exit code.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import NoReturn
+
+from dev10x.domain.events.hook_event import HookEventName
+from dev10x.domain.events.hook_input import HookAllow, HookInput, HookResult, HookRetry
+from dev10x.subprocess_utils import effective_cwd
+
+
+def read_hook_input() -> HookInput:
+    """Parse the hook JSON envelope from stdin into a ``HookInput``.
+
+    Resolves the effective working directory (bound worktree wins,
+    process CWD is the fallback) so downstream git/gh subprocesses
+    target the caller's root — the transport-layer counterpart to the
+    GH-979 CWD discipline.
+    """
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        data = {}
+    return HookInput.from_dict(data=data, cwd=effective_cwd() or os.getcwd())
+
+
+def emit(result: HookResult | HookAllow | HookRetry) -> NoReturn:
+    """Write the Claude Code hook envelope for ``result`` and exit.
+
+    ``HookResult`` denies the tool call (exit 2); ``HookAllow`` and
+    ``HookRetry`` both exit 0 with their decision-specific envelope.
+    """
+    if isinstance(result, HookResult):
+        payload: dict[str, object] = {
+            "hookSpecificOutput": {"permissionDecision": "deny"},
+            "systemMessage": result.message,
+        }
+        print(json.dumps(payload), file=sys.stderr)
+        sys.exit(2)
+
+    if isinstance(result, HookAllow):
+        payload = {"hookSpecificOutput": {"permissionDecision": "allow"}}
+        if result.message:
+            payload["systemMessage"] = result.message
+        print(json.dumps(payload), file=sys.stderr)
+        sys.exit(0)
+
+    payload = {
+        "hookSpecificOutput": {
+            "hookEventName": HookEventName.PERMISSION_DENIED,
+            "retry": True,
+        },
+    }
+    if result.message:
+        payload["systemMessage"] = result.message
+    print(json.dumps(payload), file=sys.stderr)
+    sys.exit(0)

--- a/tests/domain/common/test_branch_name.py
+++ b/tests/domain/common/test_branch_name.py
@@ -59,12 +59,3 @@ class TestParseRejection:
 
     def test_try_parse_returns_none_for_empty(self) -> None:
         assert BranchName.try_parse("") is None
-
-
-class TestValidateConvention:
-    def test_passes_for_conforming(self) -> None:
-        BranchName.parse("janusz/GH-1/slug").validate_convention()
-
-    def test_raises_for_non_conforming(self) -> None:
-        with pytest.raises(ValueError):
-            BranchName.parse("develop").validate_convention()

--- a/tests/domain/common/test_ticket_id.py
+++ b/tests/domain/common/test_ticket_id.py
@@ -45,26 +45,6 @@ class TestTryParse:
         assert TicketId.try_parse("invalid") is None
 
 
-class TestFindFirst:
-    def test_finds_embedded_ticket(self) -> None:
-        ticket = TicketId.find_first("Fixes GH-42 today")
-
-        assert ticket == TicketId(project="GH", number=42)
-
-    def test_returns_none_when_absent(self) -> None:
-        assert TicketId.find_first("no ticket here") is None
-
-
-class TestFindAll:
-    def test_returns_all_tickets(self) -> None:
-        tickets = TicketId.find_all("GH-1 and TEAM-2 and PAY-3")
-
-        assert [str(t) for t in tickets] == ["GH-1", "TEAM-2", "PAY-3"]
-
-    def test_returns_empty_list_when_none(self) -> None:
-        assert TicketId.find_all("nothing") == []
-
-
 class TestFindFirstInBranchName:
     @pytest.mark.parametrize(
         "branch,expected",

--- a/tests/domain/documents/test_task.py
+++ b/tests/domain/documents/test_task.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import pytest
-
 from dev10x.domain.documents.task import Task, TaskStatus
 
 
@@ -117,17 +115,3 @@ class TestTaskMerge:
         merged = task.with_metadata_merged(updates={"old": None})
 
         assert merged.metadata == {"type": "epic"}
-
-
-class TestTaskIsActive:
-    @pytest.mark.parametrize(
-        "status,expected",
-        [
-            (TaskStatus.PENDING, True),
-            (TaskStatus.IN_PROGRESS, True),
-            (TaskStatus.COMPLETED, False),
-            (TaskStatus.DELETED, False),
-        ],
-    )
-    def test_is_active(self, status: TaskStatus, expected: bool) -> None:
-        assert Task(id="1", status=status).is_active is expected

--- a/tests/domain/test_claude_paths.py
+++ b/tests/domain/test_claude_paths.py
@@ -30,7 +30,6 @@ def no_override(monkeypatch: pytest.MonkeyPatch) -> None:
         ("projects_dir", "projects"),
         ("session_state_dir", "projects/_session_state"),
         ("metrics_dir", "projects/_metrics"),
-        ("memory_dir", "memory"),
         ("memory_dev10x_dir", "memory/Dev10x"),
         ("memory_projects_yaml", "memory/Dev10x/projects.yaml"),
         ("dev10x_config_dir", "Dev10x"),

--- a/tests/domain/test_dev10x_paths.py
+++ b/tests/domain/test_dev10x_paths.py
@@ -41,11 +41,9 @@ def isolated_dirs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> tuple[Path
         ("upgrade_cleanup_projects_yaml", "upgrade-cleanup-projects.yaml"),
         ("github_bot_dir", "github-bot"),
         ("github_app_yaml", "github-bot/github-app.yaml"),
-        ("playbooks_dir", "playbooks"),
         ("gitmoji_yaml", "gitmoji.yaml"),
         ("github_reviewers_config_yaml", "github-reviewers-config.yaml"),
         ("settings_pr_merge_yaml", "settings-pr-merge.yaml"),
-        ("plugin_maintenance_prefs_yaml", "plugin-maintenance-prefs.yaml"),
     ],
 )
 def test_accessors_resolve_under_override(
@@ -212,19 +210,6 @@ def test_migrate_all_includes_memory_dev10x_files(
     assert "gitmoji.yaml" in migrated_names
     assert "github-reviewers-config.yaml" in migrated_names
     assert "settings-pr-merge.yaml" in migrated_names
-
-
-def test_plugin_maintenance_prefs_migrates_from_memory_dev10x(
-    isolated_dirs: tuple[Path, Path],
-) -> None:
-    legacy_root, new_root = isolated_dirs
-    legacy = legacy_root / "memory" / "Dev10x" / "plugin-maintenance-prefs.yaml"
-    legacy.parent.mkdir(parents=True)
-    legacy.write_text("update_preference: skip\n")
-    current = Dev10xConfigDir.plugin_maintenance_prefs_yaml()
-    assert current == new_root / "plugin-maintenance-prefs.yaml"
-    assert current.read_text() == "update_preference: skip\n"
-    assert legacy.exists(), "legacy file must remain for downgrade safety"
 
 
 def test_migrate_all_is_idempotent(isolated_dirs: tuple[Path, Path]) -> None:

--- a/tests/domain/test_plan.py
+++ b/tests/domain/test_plan.py
@@ -7,7 +7,6 @@ import pytest
 import yaml
 
 from dev10x.domain.documents.plan import (
-    TASK_TRANSITIONS,
     Plan,
     TaskStatus,
     _extract_task_id,
@@ -401,15 +400,6 @@ class TestPlanContextKeys:
 
 
 class TestTaskTransitions:
-    def test_pending_has_no_timestamp(self) -> None:
-        assert TASK_TRANSITIONS[TaskStatus.PENDING].timestamp_field is None
-
-    def test_in_progress_writes_started_at(self) -> None:
-        assert TASK_TRANSITIONS[TaskStatus.IN_PROGRESS].timestamp_field == "started_at"
-
-    def test_completed_writes_completed_at(self) -> None:
-        assert TASK_TRANSITIONS[TaskStatus.COMPLETED].timestamp_field == "completed_at"
-
     def test_completed_to_in_progress_rejected(self) -> None:
         plan = Plan(
             metadata={"status": "in_progress"},

--- a/tests/domain/test_rule_engine.py
+++ b/tests/domain/test_rule_engine.py
@@ -173,41 +173,6 @@ class TestRuleEngineEvaluate:
         assert result.rule_name == "block-env"
 
 
-class TestRuleEngineEvaluateFile:
-    def test_matches_by_file_only(self) -> None:
-        engine = RuleEngine(
-            edit_rules=[
-                Rule(
-                    name="block-env",
-                    matcher="Edit|Write",
-                    file_names=[".env"],
-                    message="BLOCKED",
-                ),
-            ],
-        )
-
-        result = engine.evaluate_file(file_path="/app/.env")
-
-        assert result is not None
-        assert result.rule_name == "block-env"
-
-    def test_returns_none_for_unmatched(self) -> None:
-        engine = RuleEngine(
-            edit_rules=[
-                Rule(
-                    name="block-env",
-                    matcher="Edit|Write",
-                    file_names=[".env"],
-                    message="BLOCKED",
-                ),
-            ],
-        )
-
-        result = engine.evaluate_file(file_path="/app/main.py")
-
-        assert result is None
-
-
 class TestRuleEngineEvaluateCommand:
     @pytest.fixture()
     def engine(self) -> RuleEngine:

--- a/tests/domain/test_sensitivity.py
+++ b/tests/domain/test_sensitivity.py
@@ -260,21 +260,6 @@ class TestClassifierHelpers:
     def classifier(self) -> SensitivityClassifier:
         return SensitivityClassifier()
 
-    def test_is_sensitive_true_for_gh_secret(self, classifier: SensitivityClassifier) -> None:
-        assert classifier.is_sensitive(command="gh secret list") is True
-
-    def test_is_sensitive_false_for_benign(self, classifier: SensitivityClassifier) -> None:
-        assert classifier.is_sensitive(command="git status") is False
-
-    def test_highest_label_returns_none_for_clean(self, classifier: SensitivityClassifier) -> None:
-        assert classifier.highest_label(command="ls /tmp") is None
-
-    def test_highest_label_returns_label_for_sensitive(
-        self, classifier: SensitivityClassifier
-    ) -> None:
-        label = classifier.highest_label(command="gh secret list")
-        assert label == SensitivityLabel.SECRET
-
     def test_multiple_labels_can_match(self, classifier: SensitivityClassifier) -> None:
         # A command that rg-searches ~/.config for credentials hitting both
         # CREDENTIAL wordlist entries

--- a/tests/hooks/test_hook_transport.py
+++ b/tests/hooks/test_hook_transport.py
@@ -1,0 +1,66 @@
+"""Tests for the hooks transport adapter (GH-511).
+
+emit()/read_hook_input() own the Claude Code wire envelope and stdin
+read that used to live on the domain value objects. HookRetry's
+envelope is covered in test_permission_denied.py; the cwd-resolution
+path is covered in test_cwd_discipline_sweep.py.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+
+from dev10x.domain.events.hook_input import HookAllow, HookResult
+from dev10x.hooks.hook_transport import emit, read_hook_input
+
+
+class TestEmitHookResult:
+    def test_exits_with_code_2(self) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            emit(HookResult(message="blocked"))
+        assert exc_info.value.code == 2
+
+    def test_writes_deny_envelope(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with pytest.raises(SystemExit):
+            emit(HookResult(message="blocked"))
+        output = json.loads(capsys.readouterr().err)
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+        assert output["systemMessage"] == "blocked"
+
+
+class TestEmitHookAllow:
+    def test_exits_with_code_0(self) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            emit(HookAllow())
+        assert exc_info.value.code == 0
+
+    def test_writes_allow_envelope(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with pytest.raises(SystemExit):
+            emit(HookAllow(message="auto-approved"))
+        output = json.loads(capsys.readouterr().err)
+        assert output["hookSpecificOutput"]["permissionDecision"] == "allow"
+        assert output["systemMessage"] == "auto-approved"
+
+    def test_omits_system_message_when_empty(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with pytest.raises(SystemExit):
+            emit(HookAllow())
+        output = json.loads(capsys.readouterr().err)
+        assert "systemMessage" not in output
+
+
+class TestReadHookInput:
+    def test_parses_tool_name_and_command(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        payload = json.dumps({"tool_name": "Bash", "tool_input": {"command": "git status"}})
+        monkeypatch.setattr("sys.stdin", io.StringIO(payload))
+        inp = read_hook_input()
+        assert inp.tool_name == "Bash"
+        assert inp.command == "git status"
+
+    def test_empty_stdin_yields_blank_fields(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("sys.stdin", io.StringIO(""))
+        inp = read_hook_input()
+        assert inp.tool_name == ""
+        assert inp.command == ""

--- a/tests/hooks/test_permission_denied.py
+++ b/tests/hooks/test_permission_denied.py
@@ -7,6 +7,7 @@ import json
 import pytest
 
 from dev10x.domain.events.hook_input import HookRetry
+from dev10x.hooks.hook_transport import emit
 from tests.fakers import BashHookInputFaker
 
 
@@ -23,7 +24,7 @@ class TestHookRetry:
 
     def test_emit_exits_zero(self, hook_retry: HookRetry) -> None:
         with pytest.raises(SystemExit) as exc_info:
-            hook_retry.emit()
+            emit(hook_retry)
         assert exc_info.value.code == 0
 
     def test_emit_writes_json_to_stderr(
@@ -32,7 +33,7 @@ class TestHookRetry:
         capsys: pytest.CaptureFixture[str],
     ) -> None:
         with pytest.raises(SystemExit):
-            hook_retry.emit()
+            emit(hook_retry)
         output = json.loads(capsys.readouterr().err)
         assert output["hookSpecificOutput"]["hookEventName"] == "PermissionDenied"
         assert output["hookSpecificOutput"]["retry"] is True
@@ -44,7 +45,7 @@ class TestHookRetry:
     ) -> None:
         retry = HookRetry(message="")
         with pytest.raises(SystemExit):
-            retry.emit()
+            emit(retry)
         output = json.loads(capsys.readouterr().err)
         assert "systemMessage" not in output
 

--- a/tests/test_cwd_discipline_sweep.py
+++ b/tests/test_cwd_discipline_sweep.py
@@ -19,30 +19,30 @@ from dev10x.subprocess_utils import use_cwd
 
 
 class TestHookInputCwd:
-    """domain/events/hook_input.py:27 — H6."""
+    """hooks/hook_transport.py:read_hook_input — H6 (moved from domain in GH-511)."""
 
-    def test_from_stdin_honors_bound_cwd(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        from dev10x.domain.events.hook_input import HookInput
+    def test_read_hook_input_honors_bound_cwd(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from dev10x.hooks.hook_transport import read_hook_input
 
         payload = json.dumps({"tool_name": "Bash", "tool_input": {"command": "ls"}})
         monkeypatch.setattr(sys, "stdin", io.StringIO(payload))
 
         with use_cwd("/bound/worktree"):
-            inp = HookInput.from_stdin()
+            inp = read_hook_input()
 
         assert inp.cwd == "/bound/worktree"
 
-    def test_from_stdin_falls_back_to_process_cwd(
+    def test_read_hook_input_falls_back_to_process_cwd(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        from dev10x.domain.events.hook_input import HookInput
+        from dev10x.hooks.hook_transport import read_hook_input
 
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps({})))
 
-        inp = HookInput.from_stdin()
+        inp = read_hook_input()
 
         assert inp.cwd == os.getcwd()
 

--- a/tests/validators/test_types.py
+++ b/tests/validators/test_types.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from dev10x.domain import HookInput, HookResult
+from dev10x.domain import HookAllow, HookInput, HookResult
 
 
 class TestHookInputFromDict:
@@ -40,26 +40,19 @@ class TestHookInputFromEmptyDict:
 
 
 class TestHookResult:
-    def test_emit_exits_with_code_2(self) -> None:
-        result = HookResult(message="blocked")
-        with pytest.raises(SystemExit) as exc_info:
-            result.emit()
-        assert exc_info.value.code == 2
+    def test_to_dict_decision_deny(self) -> None:
+        assert HookResult(message="blocked").to_dict()["decision"] == "deny"
+
+    def test_to_dict_message(self) -> None:
+        assert HookResult(message="blocked").to_dict()["message"] == "blocked"
 
 
 class TestHookAllow:
-    def test_emit_exits_with_code_0(self) -> None:
-        from dev10x.domain import HookAllow
+    def test_to_dict_decision_allow(self) -> None:
+        assert HookAllow().to_dict()["decision"] == "allow"
 
-        allow = HookAllow()
-        with pytest.raises(SystemExit) as exc_info:
-            allow.emit()
-        assert exc_info.value.code == 0
+    def test_to_dict_message_defaults_empty(self) -> None:
+        assert HookAllow().to_dict()["message"] == ""
 
-    def test_emit_with_message_exits_0(self) -> None:
-        from dev10x.domain import HookAllow
-
-        allow = HookAllow(message="auto-approved")
-        with pytest.raises(SystemExit) as exc_info:
-            allow.emit()
-        assert exc_info.value.code == 0
+    def test_to_dict_message_preserved(self) -> None:
+        assert HookAllow(message="auto-approved").to_dict()["message"] == "auto-approved"


### PR DESCRIPTION
**When** running the PKG-M4 per-package audit on `src/dev10x/domain`, **I want to** drop verified-dead members and lift hook transport I/O out of the domain core, **so I can** keep the domain surface lean and free of process-boundary concerns.

---

[`28ab3180`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/660/commits/28ab318004a1ddddaf08d667991a44f06c0a2b9a) 🔥 GH-504 Clean up the domain package per the PKG-M4 audit
Closes #504
Closes #511
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/504

---