### PR TITLE
♻️ GH-512 Streamline runtime hooks and tighten audit/config reads

### DIFF
--- a/src/dev10x/hooks/audit_emit.py
+++ b/src/dev10x/hooks/audit_emit.py
@@ -68,7 +68,6 @@ def audit_hook(name: str, *, event: HookEventName | str = "") -> Callable[[F], F
                 return func(*args, **kwargs)
 
             span_id = writer.current_span_id()
-            session_id = ""
             start = time.perf_counter()
             exit_code = 0
             error: BaseException | None = None
@@ -97,7 +96,6 @@ def audit_hook(name: str, *, event: HookEventName | str = "") -> Callable[[F], F
                     "hook": name,
                     "event": event,
                     "span_id": span_id,
-                    "session_id": session_id,
                     "body_ms": body_ms,
                     "outcome": writer.classify_outcome(exit_code=exit_code),
                 }

--- a/src/dev10x/hooks/permission_diagnostics.py
+++ b/src/dev10x/hooks/permission_diagnostics.py
@@ -60,9 +60,6 @@ class DiagnosticResult:
     def matched(self) -> list[RuleMatch]:
         return [m for m in self.matches if m.is_matched()]
 
-    def has_any_match(self) -> bool:
-        return any(m.is_matched() for m in self.matches)
-
 
 SETTINGS_PRECEDENCE: list[SettingsFile] = [
     SettingsFile(

--- a/src/dev10x/hooks/session_policy.py
+++ b/src/dev10x/hooks/session_policy.py
@@ -17,6 +17,8 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 
+import yaml
+
 from dev10x.domain.documents.settings_document import (
     SettingsDocument,
     _deduplicate_rules,
@@ -90,11 +92,8 @@ class BuildAutonomyReassuranceRule(PolicyRule[str]):
         if not session_yaml.exists():
             return ""
         try:
-            import yaml
-
-            with open(session_yaml) as f:
-                data = yaml.safe_load(f) or {}
-        except Exception:
+            data = yaml.safe_load(session_yaml.read_text()) or {}
+        except (OSError, yaml.YAMLError):
             return ""
 
         level = FrictionLevel.from_yaml(data.get("friction_level"))

--- a/src/dev10x/hooks/task_plan_sync.py
+++ b/src/dev10x/hooks/task_plan_sync.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import json
 import sys
 from collections.abc import Callable
-from pathlib import Path
 from typing import Any
 
 from dev10x.domain.documents.plan import Plan, get_plan_path, get_toplevel
@@ -25,11 +24,6 @@ from dev10x.plan.service import (
     plan_summary,
     set_plan_context,
 )
-
-
-def read_plan(*, plan_path: Path) -> dict[str, Any]:
-    """Load plan YAML into a dict. Consumed by `dev10x.hooks.session`."""
-    return Plan.load(path=plan_path).to_dict()
 
 
 def cmd_set_context(*, args: list[str]) -> None:


### PR DESCRIPTION
**When** maintaining the runtime & infra hook packages flagged in the 2026-06-10 per-package audit (PKG-M7, milestone 33), **I want to** remove verified-dead code and tighten the audit-record and session-policy error paths, **so I can** keep the hooks package lean and its telemetry and config-read handling honest.

---

[`692ea315`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/661/commits/692ea315d184a03ece32ec618a5273c438e8c372) 🔥 GH-512 Streamline runtime hooks by dropping dead code
[`00903c67`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/661/commits/00903c6773670f2d20446ec804215ba49ba0024f) ♻️ GH-517 Tighten audit records and session-policy reads
Closes #517
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/512

---