### PR TITLE
♻️ GH-496 Surface github-package failures instead of swallowing them

### DIFF
--- a/src/dev10x/github/__init__.py
+++ b/src/dev10x/github/__init__.py
@@ -324,7 +324,10 @@ async def _list_unresolved_threads(
     result = await _gh_api_raw("graphql", fields={"query": query})
     if result.returncode != 0:
         return err(result.stderr.strip())
-    data = json.loads(result.stdout)
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return err(f"Invalid JSON from GitHub API: {result.stdout[:200]}")
     threads = (
         data.get("data", {})
         .get("repository", {})
@@ -480,7 +483,10 @@ async def _pr_comment_resolve(
     if query_result.returncode != 0:
         return err(query_result.stderr.strip())
 
-    query_data = json.loads(query_result.stdout)
+    try:
+        query_data = json.loads(query_result.stdout)
+    except json.JSONDecodeError:
+        return err(f"Invalid JSON from GitHub API: {query_result.stdout[:200]}")
     thread_ids: list[str] = []
     errors: list[str] = []
     for i, cid in enumerate(ids_to_resolve):
@@ -525,7 +531,10 @@ async def _pr_comment_resolve(
     if result.returncode != 0:
         return err(result.stderr.strip())
 
-    response: dict[str, Any] = json.loads(result.stdout)
+    try:
+        response: dict[str, Any] = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return err(f"Invalid JSON from GitHub API: {result.stdout[:200]}")
     if errors:
         response["warnings"] = errors
     return ok(response)
@@ -572,7 +581,10 @@ async def minimize_comments(
     )
     if result.returncode != 0:
         return err(result.stderr.strip())
-    return ok(json.loads(result.stdout))
+    try:
+        return ok(json.loads(result.stdout))
+    except json.JSONDecodeError:
+        return err(f"Invalid JSON from GitHub API: {result.stdout[:200]}")
 
 
 async def resolve_review_thread(
@@ -599,7 +611,10 @@ async def resolve_review_thread(
         )
         if result.returncode != 0:
             return err(result.stderr.strip())
-        return ok(json.loads(result.stdout))
+        try:
+            return ok(json.loads(result.stdout))
+        except json.JSONDecodeError:
+            return err(f"Invalid JSON from GitHub API: {result.stdout[:200]}")
 
     if comment_ids:
         repo_result = await _resolve_repo(repo)
@@ -1018,7 +1033,10 @@ async def milestone_create(
     )
     if result.returncode != 0:
         return err(result.stderr.strip())
-    data = json.loads(result.stdout) if result.stdout.strip() else {}
+    try:
+        data = json.loads(result.stdout) if result.stdout.strip() else {}
+    except json.JSONDecodeError:
+        return err(f"Invalid JSON from GitHub API: {result.stdout[:200]}")
     number = int(data.get("number", 0))
     return ok(
         {

--- a/src/dev10x/github/app_auth.py
+++ b/src/dev10x/github/app_auth.py
@@ -15,6 +15,7 @@ to the engineer's ``gh auth`` token without raising.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import time
 from dataclasses import dataclass
@@ -25,6 +26,13 @@ import yaml
 
 from dev10x.domain.dev10x_paths import Dev10xConfigDir
 from dev10x.subprocess_utils import async_run
+
+try:  # PyJWT is an optional dependency; its absence surfaces as ImportError
+    from jwt.exceptions import PyJWTError as _PyJWTError
+except ImportError:  # pragma: no cover - exercised only without PyJWT installed
+    _PyJWTError = ()  # type: ignore[assignment, misc]
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_CONFIG_PATH = Dev10xConfigDir.github_app_yaml()
 
@@ -171,12 +179,22 @@ async def get_bot_token(
 
     try:
         private_key = cfg.private_key_path.read_text()
-    except OSError:
+    except OSError as exc:
+        logger.warning(
+            "GitHub App private key unreadable at %s: %s",
+            cfg.private_key_path,
+            exc,
+        )
         return None
 
     try:
         app_jwt = _create_app_jwt(app_id=cfg.app_id, private_key=private_key)
-    except Exception:
+    except (_PyJWTError, ImportError, ValueError, TypeError) as exc:
+        logger.warning(
+            "GitHub App JWT creation failed for app_id=%s: %s",
+            cfg.app_id,
+            exc,
+        )
         return None
 
     installation_id = cfg.installation_id or await _resolve_installation_id(
@@ -184,6 +202,11 @@ async def get_bot_token(
         app_jwt=app_jwt,
     )
     if installation_id is None:
+        logger.warning(
+            "GitHub App installation-id resolution failed for repo=%s app_id=%s",
+            repo,
+            cfg.app_id,
+        )
         return None
 
     exchanged = await _exchange_for_installation_token(
@@ -191,6 +214,11 @@ async def get_bot_token(
         app_jwt=app_jwt,
     )
     if exchanged is None:
+        logger.warning(
+            "GitHub App token exchange failed for repo=%s installation_id=%s",
+            repo,
+            installation_id,
+        )
         return None
 
     token, expires_at = exchanged

--- a/src/dev10x/github/app_auth.py
+++ b/src/dev10x/github/app_auth.py
@@ -106,6 +106,11 @@ async def _resolve_installation_id(
     repo: str,
     app_jwt: str,
 ) -> str | None:
+    # NOTE (GH-499): the App JWT is passed via `-H` in argv, which is
+    # world-visible through `ps` / `/proc/<pid>/cmdline` for the gh child's
+    # lifetime. gh offers no argv-free path for a Bearer header (it has no
+    # `-H @file`, and GH_TOKEN forces the `token` scheme the App endpoints
+    # reject), so this exposure is accepted pending a dedicated fix.
     result = await async_run(
         args=[
             "gh",
@@ -131,6 +136,7 @@ async def _exchange_for_installation_token(
     installation_id: str,
     app_jwt: str,
 ) -> tuple[str, float] | None:
+    # NOTE (GH-499): App JWT passed via argv — see _resolve_installation_id.
     result = await async_run(
         args=[
             "gh",

--- a/src/dev10x/github/app_auth.py
+++ b/src/dev10x/github/app_auth.py
@@ -68,10 +68,6 @@ class _CachedToken:
 _TOKEN_CACHE: dict[str, _CachedToken] = {}
 
 
-def _clear_cache() -> None:
-    _TOKEN_CACHE.clear()
-
-
 def _create_app_jwt(*, app_id: str, private_key: str) -> str:
     import jwt
 

--- a/tests/github/test_app_auth.py
+++ b/tests/github/test_app_auth.py
@@ -13,9 +13,9 @@ from dev10x.github import app_auth as auth
 
 @pytest.fixture(autouse=True)
 def clear_token_cache():
-    auth._clear_cache()
+    auth._TOKEN_CACHE.clear()
     yield
-    auth._clear_cache()
+    auth._TOKEN_CACHE.clear()
 
 
 def _completed(

--- a/tests/github/test_app_auth.py
+++ b/tests/github/test_app_auth.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import subprocess
 import time
 from pathlib import Path
@@ -257,3 +258,39 @@ class TestGetBotToken:
         ):
             result = await auth.get_bot_token(repo="owner/repo", config=app_config)
         assert result is None
+
+    @pytest.mark.asyncio
+    async def test_logs_warning_when_jwt_creation_fails(
+        self,
+        app_config: auth.AppConfig,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        with (
+            patch.object(auth, "_create_app_jwt", side_effect=ValueError("bad key")),
+            caplog.at_level(logging.WARNING),
+        ):
+            result = await auth.get_bot_token(repo="owner/repo", config=app_config)
+        assert result is None
+        assert "JWT creation failed" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_logs_warning_when_installation_id_unresolvable(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        key_path = tmp_path / "bot.pem"
+        key_path.write_text("KEY")
+        config = auth.AppConfig(app_id="1", private_key_path=key_path)
+        with (
+            patch.object(auth, "_create_app_jwt", return_value="jwt"),
+            patch(
+                "dev10x.github.app_auth.async_run",
+                new_callable=AsyncMock,
+                return_value=_completed(returncode=1, stderr="nope"),
+            ),
+            caplog.at_level(logging.WARNING),
+        ):
+            result = await auth.get_bot_token(repo="owner/repo", config=config)
+        assert result is None
+        assert "installation-id resolution failed" in caplog.text

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -2454,3 +2454,100 @@ class TestIssueCommentBodyFile:
         result = await gh.issue_comment_edit(comment_id=9, repo="o/r")
         assert isinstance(result, ErrorResult)
         mock_run.assert_not_awaited()
+
+
+class TestMalformedJsonGuards:
+    """GH-496: a zero exit code does not guarantee JSON on stdout.
+
+    Each guarded call site must return ``err(...)`` rather than raising
+    ``json.JSONDecodeError`` across the domain boundary when gh exits 0
+    with a non-JSON body (empty response, HTML error page, partial output).
+    """
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github._gh_api_raw", new_callable=AsyncMock)
+    async def test_unresolved_threads_guards_malformed_json(
+        self,
+        mock_api: AsyncMock,
+        mock_resolve_repo: AsyncMock,
+    ) -> None:
+        mock_api.return_value = _completed(stdout="<html>502 Bad Gateway</html>")
+
+        result = await gh.pr_comments(action="list", pr_number=42, unresolved_only=True)
+
+        assert isinstance(result, ErrorResult)
+        assert "Invalid JSON" in result.error
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github._gh_api_raw", new_callable=AsyncMock)
+    async def test_resolve_query_guards_malformed_json(
+        self,
+        mock_api: AsyncMock,
+        mock_resolve_repo: AsyncMock,
+    ) -> None:
+        mock_api.return_value = _completed(stdout="not json")
+
+        result = await gh.pr_comments(action="resolve", comment_id="PRRC_x")
+
+        assert isinstance(result, ErrorResult)
+        assert "Invalid JSON" in result.error
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github._gh_api_raw", new_callable=AsyncMock)
+    async def test_resolve_mutation_guards_malformed_json(
+        self,
+        mock_api: AsyncMock,
+        mock_resolve_repo: AsyncMock,
+    ) -> None:
+        mock_api.side_effect = [
+            _completed(
+                stdout=json.dumps(_thread_lookup_response("n0", db_id=5, thread_id="PRRT_t1"))
+            ),
+            _completed(stdout="not json"),
+        ]
+
+        result = await gh.pr_comments(action="resolve", comment_id="PRRC_x")
+
+        assert isinstance(result, ErrorResult)
+        assert "Invalid JSON" in result.error
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github._gh_api_raw", new_callable=AsyncMock)
+    async def test_minimize_comments_guards_malformed_json(
+        self,
+        mock_api: AsyncMock,
+        mock_resolve_repo: AsyncMock,
+    ) -> None:
+        mock_api.return_value = _completed(stdout="not json")
+
+        result = await gh.minimize_comments(node_ids=["PRRC_a"])
+
+        assert isinstance(result, ErrorResult)
+        assert "Invalid JSON" in result.error
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github._gh_api_raw", new_callable=AsyncMock)
+    async def test_resolve_review_thread_guards_malformed_json(
+        self,
+        mock_api: AsyncMock,
+    ) -> None:
+        mock_api.return_value = _completed(stdout="not json")
+
+        result = await gh.resolve_review_thread(thread_ids=["PRRT_t1"])
+
+        assert isinstance(result, ErrorResult)
+        assert "Invalid JSON" in result.error
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github._gh_api_raw", new_callable=AsyncMock)
+    async def test_milestone_create_guards_malformed_json(
+        self,
+        mock_api: AsyncMock,
+        mock_resolve_repo: AsyncMock,
+    ) -> None:
+        mock_api.return_value = _completed(stdout="not json")
+
+        result = await gh.milestone_create(title="M1")
+
+        assert isinstance(result, ErrorResult)
+        assert "Invalid JSON" in result.error


### PR DESCRIPTION
**When** I maintain the `github` package and its GitHub-API or App-auth calls hit malformed output or a broken App config, **I want to** see failures surfaced as logged warnings and `Result` errors instead of silent `None` returns or uncaught `JSONDecodeError`s, **so I can** diagnose a misconfigured setup and rely on the package's error contract.

PKG-M6 github-package audit bundle. GH-499 (App JWT visible in the `gh` argv) is documented in-code and deferred to its own security-reviewed PR — no clean `gh`-native fix exists (no `-H @file`; `GH_TOKEN` forces the `token` scheme the App endpoints reject), so the real fix is a direct HTTP client.

Note: this PR targets `develop`, so the `Fixes:`/`Closes` keywords will not auto-close on merge — the constituent issues are closed manually post-merge.

---

[`0666b9be`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/662/commits/0666b9bec62b5af424050c1b097f4e80550c6a8b) ♻️ GH-500 Simplify app_auth by dropping test-only cache helper
[`9ae3e5d8`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/662/commits/9ae3e5d87fb1b29d62c4460361b14dae6aa46f57) ♻️ GH-503 Make GitHub App auth failures observable
[`a35b04e1`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/662/commits/a35b04e19aa1e825b3fbf14285bf949600343ee8) ♻️ GH-496 Keep GitHub API parsing within the Result contract
[`aa530a22`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/662/commits/aa530a22ddc302a18753b6422097331e7280045a) 📝 GH-499 Document accepted App JWT argv exposure
Closes #500
Closes #503
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/496

---