### PR TITLE
♻️ GH-509 Enforce the Result contract at the MCP boundary

### DIFF
--- a/.claude/rules/mcp-tools.md
+++ b/.claude/rules/mcp-tools.md
@@ -29,7 +29,9 @@ registration:
 All MCP tools follow a two-layer pattern: internal functions return a
 typed `Result[T]` (`SuccessResult` or `ErrorResult` from
 `dev10x.domain.common.result`), and the `@server.tool()` handler at the
-MCP boundary calls `.to_dict()` to produce the wire-format dict.
+MCP boundary routes the result through `to_wire()` — which asserts
+`isinstance(result, ResultProtocol)` then calls `.to_dict()` — to
+produce the wire-format dict (ADR-0009).
 
 ```python
 # Internal module (audit/release/monitor/permission/plan/skill_index/
@@ -41,12 +43,15 @@ async def collect_prs(...) -> Result[dict[str, Any]]:
         return err("descriptive message")
     return ok({tool-specific fields})
 
-# MCP server boundary (src/dev10x/mcp/server_cli.py): unwrap via
-# .to_dict() so external consumers see the uniform wire format.
+# MCP server boundary (src/dev10x/mcp/server_cli.py): route through
+# to_wire() so external consumers see the uniform wire format and a
+# handler that forgot to return a Result fails loud at the boundary.
+from dev10x.domain.common.result import to_wire
+
 @server.tool()
 async def collect_prs(...) -> dict:
     """Brief description of what the tool does."""
-    return (await rel.collect_prs(...)).to_dict()
+    return to_wire(await rel.collect_prs(...))
 ```
 
 **Wire format** (what callers see):
@@ -58,8 +63,8 @@ async def collect_prs(...) -> dict:
 **Why two layers**: internal callers branch on `isinstance(result,
 SuccessResult)` for type-safe error handling; the MCP boundary keeps
 the legacy dict shape so existing tool consumers don't break. New
-modules MUST mirror the pattern — return `Result[T]` internally, call
-`.to_dict()` at the `@server.tool()` boundary.
+modules MUST mirror the pattern — return `Result[T]` internally, route
+through `to_wire()` at the `@server.tool()` boundary.
 
 **Tool-specific success payloads**:
 - `mktmp`: returns `{"path": "/tmp/file"}`

--- a/src/dev10x/domain/common/result.py
+++ b/src/dev10x/domain/common/result.py
@@ -10,9 +10,10 @@ class ResultProtocol(Protocol):
     """Contract every value crossing the MCP boundary must satisfy.
 
     Both ``SuccessResult`` and ``ErrorResult`` implement ``to_dict``.
-    The ``@server.tool()`` boundary asserts ``isinstance(x,
-    ResultProtocol)`` to catch a handler that forgot ``.to_dict()``
-    before the wire-encode step (ADR-0009).
+    The ``@server.tool()`` boundary routes its result through
+    :func:`to_wire`, which asserts ``isinstance(x, ResultProtocol)``
+    to catch a handler that forgot to return a ``Result`` before the
+    wire-encode step (ADR-0009).
     """
 
     def to_dict(self) -> dict[str, Any]: ...
@@ -52,3 +53,21 @@ def err(
     **details: Any,
 ) -> ErrorResult:
     return ErrorResult(error=error, details=details)
+
+
+def to_wire(result: ResultProtocol) -> dict[str, Any]:
+    """Assert the ADR-0009 boundary contract, then wire-encode.
+
+    Every ``@server.tool()`` handler routes its ``Result`` through
+    here so a handler that forgot to build a ``Result`` (returning a
+    bare value, a ``CompletedProcess``, a raw ``dict``, etc.) fails at
+    the boundary with a clear ``TypeError`` instead of at JSON-encode
+    time, far from the cause. ``@runtime_checkable`` only verifies the
+    ``to_dict`` method is present — the documented scope of the guard.
+    """
+    if not isinstance(result, ResultProtocol):
+        raise TypeError(
+            f"MCP boundary expected a Result (got {type(result).__name__}); "
+            "a @server.tool() handler likely forgot to return ok()/err()."
+        )
+    return result.to_dict()

--- a/src/dev10x/mcp/audit_tools.py
+++ b/src/dev10x/mcp/audit_tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dev10x.domain.common.result import to_wire
 from dev10x.mcp._app import server
 
 
@@ -21,12 +22,12 @@ async def audit_extract_session(
     """
     from dev10x import audit
 
-    return (
+    return to_wire(
         await audit.extract_session(
             jsonl_path=jsonl_path,
             output_path=output_path,
         )
-    ).to_dict()
+    )
 
 
 @server.tool()
@@ -45,12 +46,12 @@ async def audit_analyze_actions(
     """
     from dev10x import audit
 
-    return (
+    return to_wire(
         await audit.analyze_actions(
             transcript_path=transcript_path,
             output_path=output_path,
         )
-    ).to_dict()
+    )
 
 
 @server.tool()
@@ -71,13 +72,13 @@ async def audit_analyze_permissions(
     """
     from dev10x import audit
 
-    return (
+    return to_wire(
         await audit.analyze_permissions(
             transcript_path=transcript_path,
             settings_path=settings_path,
             output_path=output_path,
         )
-    ).to_dict()
+    )
 
 
 @server.tool()
@@ -93,7 +94,7 @@ async def audit_hook_log_path() -> dict:
     """
     from dev10x import audit
 
-    return (await audit.hook_log_path()).to_dict()
+    return to_wire(await audit.hook_log_path())
 
 
 @server.tool()
@@ -116,11 +117,11 @@ async def audit_hook_recent(
     """
     from dev10x import audit
 
-    return (
+    return to_wire(
         await audit.hook_recent(
             limit=limit,
             hook_name=hook_name,
             span_id=span_id,
             log_path=log_path,
         )
-    ).to_dict()
+    )

--- a/src/dev10x/mcp/git_tools.py
+++ b/src/dev10x/mcp/git_tools.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 # `from __future__ import annotations`.
 from mcp.server.fastmcp import Context  # noqa: F401
 
+from dev10x.domain.common.result import to_wire
 from dev10x.mcp._app import server
 
 
@@ -42,9 +43,7 @@ async def push_safe(
     from dev10x.subprocess_utils import use_cwd
 
     with use_cwd(cwd):
-        return (
-            await git_tools.push_safe(args=args, protected_branches=protected_branches)
-        ).to_dict()
+        return to_wire(await git_tools.push_safe(args=args, protected_branches=protected_branches))
 
 
 @server.tool()
@@ -75,7 +74,7 @@ async def rebase_groom(
         await ctx.info(f"rebase_groom: rebasing onto {base_ref} using {seq_path}")
 
     with use_cwd(cwd):
-        result = (await git_tools.rebase_groom(seq_path=seq_path, base_ref=base_ref)).to_dict()
+        result = to_wire(await git_tools.rebase_groom(seq_path=seq_path, base_ref=base_ref))
 
     if ctx is not None:
         if "error" in result:
@@ -118,7 +117,7 @@ async def create_worktree(
     from dev10x.subprocess_utils import use_cwd
 
     with use_cwd(cwd):
-        return (await git_tools.create_worktree(branch=branch, base=base, path=path)).to_dict()
+        return to_wire(await git_tools.create_worktree(branch=branch, base=base, path=path))
 
 
 @server.tool()
@@ -145,7 +144,7 @@ async def mass_rewrite(
         await ctx.info(f"mass_rewrite: running unattended rebase from {config_path}")
 
     with use_cwd(cwd):
-        result = (await git_tools.mass_rewrite(config_path=config_path)).to_dict()
+        result = to_wire(await git_tools.mass_rewrite(config_path=config_path))
 
     if ctx is not None:
         if "error" in result:
@@ -180,9 +179,9 @@ async def start_split_rebase(
     from dev10x.subprocess_utils import use_cwd
 
     with use_cwd(cwd):
-        return (
+        return to_wire(
             await git_tools.start_split_rebase(commit_hash=commit_hash, base_branch=base_branch)
-        ).to_dict()
+        )
 
 
 @server.tool()
@@ -201,7 +200,7 @@ async def next_worktree_name(base_dir: str | None = None, cwd: str | None = None
     from dev10x.subprocess_utils import use_cwd
 
     with use_cwd(cwd):
-        return (await git_tools.next_worktree_name(base_dir=base_dir)).to_dict()
+        return to_wire(await git_tools.next_worktree_name(base_dir=base_dir))
 
 
 @server.tool()
@@ -213,4 +212,4 @@ async def setup_aliases() -> dict:
     """
     from dev10x import git as git_tools
 
-    return (await git_tools.setup_aliases()).to_dict()
+    return to_wire(await git_tools.setup_aliases())

--- a/src/dev10x/mcp/github_tools.py
+++ b/src/dev10x/mcp/github_tools.py
@@ -12,7 +12,7 @@ from mcp.server.fastmcp import Context  # noqa: F401
 
 from dev10x import github as gh
 from dev10x import subprocess_utils
-from dev10x.domain.common.result import Result
+from dev10x.domain.common.result import Result, to_wire
 from dev10x.mcp._app import server
 
 
@@ -20,7 +20,7 @@ def github_tool(fn):
     """Wrap a GitHub handler with cwd binding + Result→dict unwrapping.
 
     The inner ``fn`` returns a ``Result``; this decorator enters
-    ``use_cwd(kwargs["cwd"])`` and calls ``.to_dict()`` at the MCP
+    ``use_cwd(kwargs["cwd"])`` and calls ``to_wire()`` at the MCP
     boundary. ``functools.wraps`` preserves the inner signature so
     FastMCP builds the correct tool schema.
     """
@@ -30,7 +30,7 @@ def github_tool(fn):
     async def wrapper(*args, **kwargs):
         with subprocess_utils.use_cwd(kwargs.get("cwd")):
             result = await fn(*args, **kwargs)
-        return result.to_dict()
+        return to_wire(result)
 
     return wrapper
 
@@ -447,7 +447,7 @@ async def create_pr(
         await ctx.info(f"create_pr: opening PR for {issue_id} (draft={draft})")
 
     with use_cwd(cwd):
-        result = (
+        result = to_wire(
             await gh.create_pr(
                 title=title,
                 job_story=job_story,
@@ -458,7 +458,7 @@ async def create_pr(
                 draft=draft,
                 head_repo=head_repo,
             )
-        ).to_dict()
+        )
 
     if ctx is not None:
         if "error" in result:

--- a/src/dev10x/mcp/misc_tools.py
+++ b/src/dev10x/mcp/misc_tools.py
@@ -10,6 +10,7 @@ from typing import Literal, cast
 # `from __future__ import annotations`.
 from mcp.server.fastmcp import Context  # noqa: F401
 
+from dev10x.domain.common.result import to_wire
 from dev10x.mcp._app import server
 
 
@@ -48,7 +49,7 @@ async def mktmp(
     from dev10x.subprocess_utils import use_cwd
 
     with use_cwd(cwd):
-        return (
+        return to_wire(
             await util.mktmp(
                 namespace=namespace,
                 prefix=prefix,
@@ -57,7 +58,7 @@ async def mktmp(
                 create=create,
                 cwd=cwd,
             )
-        ).to_dict()
+        )
 
 
 @server.tool()
@@ -92,12 +93,12 @@ async def slack_thread_is_forward(
     """
     from dev10x.utilities import slack as slack_helper
 
-    return (
+    return to_wire(
         await slack_helper.slack_thread_is_forward(
             parent_body=parent_body,
             reply_count=reply_count,
         )
-    ).to_dict()
+    )
 
 
 @server.tool()
@@ -128,7 +129,7 @@ async def update_paths(
     """
     from dev10x import permission as perm
 
-    return (
+    return to_wire(
         await perm.update_paths(
             version=version,
             dry_run=dry_run,
@@ -139,7 +140,7 @@ async def update_paths(
             init=init,
             quiet=quiet,
         )
-    ).to_dict()
+    )
 
 
 @server.tool()
@@ -156,7 +157,7 @@ async def generate_skill_index(
     """
     from dev10x import skill_index as idx
 
-    return (await idx.generate_all(force=force)).to_dict()
+    return to_wire(await idx.generate_all(force=force))
 
 
 @server.tool()
@@ -176,7 +177,7 @@ async def record_upgrade(version: str | None = None) -> dict:
     """
     from dev10x.domain.install_version import record_upgrade as _record_upgrade
 
-    return _record_upgrade(version=version).to_dict()
+    return to_wire(_record_upgrade(version=version))
 
 
 @server.tool()
@@ -222,7 +223,7 @@ async def run_tests(
         await ctx.info(f"run_tests: launching pytest ({extra_desc})")
 
     with use_cwd(cwd):
-        result = (await runner.run_tests(args=args, coverage=coverage, timeout=timeout)).to_dict()
+        result = to_wire(await runner.run_tests(args=args, coverage=coverage, timeout=timeout))
 
     if ctx is not None:
         summary = result.get("summary", "")

--- a/src/dev10x/mcp/monitor_tools.py
+++ b/src/dev10x/mcp/monitor_tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dev10x.domain.common.result import to_wire
 from dev10x.mcp._app import server
 
 
@@ -35,7 +36,7 @@ async def ci_check_status(
     from dev10x.subprocess_utils import use_cwd
 
     with use_cwd(cwd):
-        return (
+        return to_wire(
             await mon.ci_check_status(
                 pr_number=pr_number,
                 repo=repo,
@@ -45,4 +46,4 @@ async def ci_check_status(
                 initial_wait=initial_wait,
                 max_polls=max_polls,
             )
-        ).to_dict()
+        )

--- a/src/dev10x/mcp/plan_tools.py
+++ b/src/dev10x/mcp/plan_tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dev10x.domain.common.result import to_wire
 from dev10x.mcp._app import server
 
 
@@ -24,7 +25,7 @@ async def plan_sync_set_context(
     from dev10x.subprocess_utils import use_cwd
 
     with use_cwd(cwd):
-        return (await plan_tools.set_context(args=args)).to_dict()
+        return to_wire(await plan_tools.set_context(args=args))
 
 
 @server.tool()
@@ -43,7 +44,7 @@ async def plan_sync_json_summary(cwd: str | None = None) -> dict:
     from dev10x.subprocess_utils import use_cwd
 
     with use_cwd(cwd):
-        return (await plan_tools.json_summary()).to_dict()
+        return to_wire(await plan_tools.json_summary())
 
 
 @server.tool()
@@ -60,4 +61,4 @@ async def plan_sync_archive(cwd: str | None = None) -> dict:
     from dev10x.subprocess_utils import use_cwd
 
     with use_cwd(cwd):
-        return (await plan_tools.archive()).to_dict()
+        return to_wire(await plan_tools.archive())

--- a/src/dev10x/mcp/release_tools.py
+++ b/src/dev10x/mcp/release_tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dev10x.domain.common.result import to_wire
 from dev10x.mcp._app import server
 
 
@@ -25,11 +26,11 @@ async def collect_prs(
     """
     from dev10x import release as rel
 
-    return (
+    return to_wire(
         await rel.collect_prs(
             repo_path=repo_path,
             from_tag=from_tag,
             to_tag=to_tag,
             ticket_pattern=ticket_pattern,
         )
-    ).to_dict()
+    )

--- a/src/dev10x/mcp/roots_manager.py
+++ b/src/dev10x/mcp/roots_manager.py
@@ -232,7 +232,7 @@ def list_roots() -> Result[dict[str, Any]]:
 
     Backing domain function for the ``list_client_roots`` MCP tool. Returns
     a :class:`~dev10x.domain.common.result.Result` so the handler can unwrap
-    it via ``.to_dict()`` like every other tool at the MCP boundary
+    it via ``to_wire()`` like every other tool at the MCP boundary
     (ADR-0009). There is no error path today — the payload is always a
     success — but the two-layer shape keeps the tool consistent and leaves
     room for a future failure mode without changing the wire contract.

--- a/src/dev10x/mcp/roots_tools.py
+++ b/src/dev10x/mcp/roots_tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dev10x.domain.common.result import to_wire
 from dev10x.mcp._app import server
 
 
@@ -30,4 +31,4 @@ async def list_client_roots() -> dict:
     """
     from dev10x.mcp.roots_manager import list_roots
 
-    return list_roots().to_dict()
+    return to_wire(list_roots())

--- a/src/dev10x/mcp/sampling_manager.py
+++ b/src/dev10x/mcp/sampling_manager.py
@@ -18,7 +18,7 @@ session so a later tool call can issue a ``sampling/createMessage`` request.
 ``request_sampling`` is the backing domain function for the
 ``request_sampling`` MCP tool.  It returns a
 :class:`~dev10x.domain.common.result.Result` so the handler unwraps it via
-``.to_dict()`` at the MCP boundary like every other tool (ADR-0009).
+``to_wire()`` at the MCP boundary like every other tool (ADR-0009).
 
 Environment variables
 ---------------------

--- a/src/dev10x/mcp/sampling_tools.py
+++ b/src/dev10x/mcp/sampling_tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dev10x.domain.common.result import to_wire
 from dev10x.mcp._app import server
 
 
@@ -42,10 +43,11 @@ async def request_sampling(
     """
     from dev10x.mcp.sampling_manager import request_sampling as _request_sampling
 
-    result = await _request_sampling(
-        prompt=prompt,
-        system_prompt=system_prompt,
-        max_tokens=max_tokens,
-        temperature=temperature,
+    return to_wire(
+        await _request_sampling(
+            prompt=prompt,
+            system_prompt=system_prompt,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
     )
-    return result.to_dict()

--- a/src/dev10x/mcp/server_db.py
+++ b/src/dev10x/mcp/server_db.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from mcp.server.fastmcp import FastMCP
 
+from dev10x.domain.common.result import to_wire
+
 server = FastMCP(name="Dev10x-db")
 
 
@@ -28,7 +30,7 @@ async def query(
     """
     from dev10x import db as db_tools
 
-    return db_tools.query(database=database, sql=sql).to_dict()
+    return to_wire(db_tools.query(database=database, sql=sql))
 
 
 def main() -> None:

--- a/tests/domain/test_result.py
+++ b/tests/domain/test_result.py
@@ -1,6 +1,13 @@
 import pytest
 
-from dev10x.domain.common.result import ErrorResult, ResultProtocol, SuccessResult, err, ok
+from dev10x.domain.common.result import (
+    ErrorResult,
+    ResultProtocol,
+    SuccessResult,
+    err,
+    ok,
+    to_wire,
+)
 
 
 class TestOk:
@@ -78,3 +85,24 @@ class TestResultProtocol:
 
     def test_object_without_to_dict_does_not_satisfy(self) -> None:
         assert not isinstance(object(), ResultProtocol)
+
+
+class TestToWire:
+    """ADR-0009: the @server.tool() boundary routes its Result through to_wire."""
+
+    def test_success_encodes_to_dict(self) -> None:
+        assert to_wire(ok({"a": 1})) == {"a": 1}
+
+    def test_error_encodes_to_dict(self) -> None:
+        assert to_wire(err("boom", code=2)) == {"error": "boom", "code": 2}
+
+    def test_raises_on_raw_dict(self) -> None:
+        # A handler that forgot to return ok()/err() yields a bare dict,
+        # which lacks to_dict() and must fail loud at the boundary rather
+        # than at JSON-encode time.
+        with pytest.raises(TypeError):
+            to_wire({"already": "encoded"})  # type: ignore[arg-type]
+
+    def test_raises_on_object_without_to_dict(self) -> None:
+        with pytest.raises(TypeError):
+            to_wire(object())  # type: ignore[arg-type]


### PR DESCRIPTION
**When** I write or change an MCP `@server.tool()` handler, **I want to** have the boundary reject any value that isn't a `Result` before it reaches the wire, **so I can** catch a forgotten `.to_dict()` immediately at the boundary instead of debugging an opaque JSON-serialization failure far from the cause.

---

[`c7f7ec35`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/663/commits/c7f7ec354150d7bcff25c2f7ae4562fb3285532c) ♻️ GH-509 Enforce the Result contract at the MCP boundary
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/509

---