### PR TITLE
✨ GH-348 Enable evidence-based rule synthesis from review patterns

### DIFF
--- a/.claude/rules/mcp-tools.md
+++ b/.claude/rules/mcp-tools.md
@@ -161,6 +161,7 @@ supporting each tool:
 | `cluster_review_comments` | `cli` | GH-346 | v0.80.0+ |
 | `candidate_rules_report` | `cli` | GH-347 | v0.80.0+ |
 | `validate_candidate_patterns` | `cli` | GH-348 | v0.80.0+ |
+| `author_reference_rules` | `cli` | GH-349 | v0.80.0+ |
 | `request_sampling` | `cli` | GH-343 | v0.80.0+ |
 | `query` | `db` | PR #126 | v0.25.0+ |
 

--- a/.claude/rules/mcp-tools.md
+++ b/.claude/rules/mcp-tools.md
@@ -162,6 +162,8 @@ supporting each tool:
 | `candidate_rules_report` | `cli` | GH-347 | v0.80.0+ |
 | `validate_candidate_patterns` | `cli` | GH-348 | v0.80.0+ |
 | `author_reference_rules` | `cli` | GH-349 | v0.80.0+ |
+| `rule_confidence_report` | `cli` | GH-350 | v0.80.0+ |
+| `record_rule_feedback` | `cli` | GH-350 | v0.80.0+ |
 | `request_sampling` | `cli` | GH-343 | v0.80.0+ |
 | `query` | `db` | PR #126 | v0.25.0+ |
 

--- a/.claude/rules/mcp-tools.md
+++ b/.claude/rules/mcp-tools.md
@@ -160,6 +160,7 @@ supporting each tool:
 | `record_upgrade` | `cli` | GH-109 | v0.72.0+ |
 | `cluster_review_comments` | `cli` | GH-346 | v0.80.0+ |
 | `candidate_rules_report` | `cli` | GH-347 | v0.80.0+ |
+| `validate_candidate_patterns` | `cli` | GH-348 | v0.80.0+ |
 | `request_sampling` | `cli` | GH-343 | v0.80.0+ |
 | `query` | `db` | PR #126 | v0.25.0+ |
 

--- a/src/dev10x/github/pattern_validation.py
+++ b/src/dev10x/github/pattern_validation.py
@@ -1,0 +1,284 @@
+"""Validate candidate review-comment patterns against recent diffs (GH-348).
+
+Milestone-5 step for the review-bot initiative. Takes the recurring
+review-comment patterns mined by
+:func:`dev10x.github.review_patterns.cluster_review_comments` (GH-346)
+and estimates, for each pattern, how often it would fire on recent code
+changes — a heuristic false-positive proxy used to decide which patterns
+are worth turning into reference rules (GH-349).
+
+The false-positive rate here is a **heuristic estimate, not a measured
+ground truth**: it assumes that a pattern firing on many more diffs than
+the number of review comments that formed it is likely to over-trigger
+as a rule. Treat the ``validated`` flag and ranking as guidance for
+human rule authoring, not as a precise metric.
+
+Like :mod:`dev10x.github.review_patterns`, this module is intentionally
+self-contained — it fetches its own diffs via ``gh`` rather than
+reaching into the miner's private helpers. It is wired as the
+``validate_candidate_patterns`` MCP tool in ``github_tools.py``.
+
+Internal functions return ``Result[T]`` per ADR-0009; the
+``@server.tool()`` boundary calls ``.to_dict()``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from dev10x.domain.common.result import Result, SuccessResult, err, ok
+from dev10x.github import review_patterns
+from dev10x.subprocess_utils import async_run
+
+logger = logging.getLogger(__name__)
+
+# A pattern fires on a diff when at least this fraction of its signature
+# tokens appear among the diff's added-line tokens. Kept below 1.0 so a
+# 6-token signature still matches when most (not all) tokens are present.
+_MATCH_THRESHOLD = 0.6
+
+# Defaults for the validated / rejected decision. A pattern is validated
+# when reviewers raised it at least ``_DEFAULT_MIN_FREQUENCY`` times and
+# its estimated false-positive rate stays at or below
+# ``_DEFAULT_MAX_FP_RATE``.
+_DEFAULT_MIN_FREQUENCY = 2
+_DEFAULT_MAX_FP_RATE = 0.5
+
+# Recent merged PRs sampled for diff matching when not overridden.
+_DEFAULT_DIFF_LIMIT = 20
+
+_NON_WORD = re.compile(r"[^a-z0-9_\s]")
+
+
+def _added_line_tokens(diff_text: str) -> set[str]:
+    """Collect lowercased word tokens from a unified diff's added lines.
+
+    Only ``+`` hunk lines (excluding the ``+++`` file header) contribute,
+    so the token set reflects newly written code rather than context or
+    removals.
+    """
+    tokens: set[str] = set()
+    for line in diff_text.splitlines():
+        if line.startswith("+") and not line.startswith("+++"):
+            cleaned = _NON_WORD.sub(" ", line[1:].lower())
+            tokens.update(token for token in cleaned.split() if token)
+    return tokens
+
+
+def pattern_fires(
+    *,
+    signature: str,
+    diff_tokens: set[str],
+    threshold: float = _MATCH_THRESHOLD,
+) -> bool:
+    """Return whether a pattern signature fires on a diff's added tokens.
+
+    The signature is already stopword-free (the GH-346 miner strips
+    stopwords before building it), so a plain intersection ratio against
+    the diff's added-line tokens is enough. An empty signature never
+    fires.
+    """
+    signature_tokens = {token for token in signature.split() if token}
+    if not signature_tokens:
+        return False
+    overlap = len(signature_tokens & diff_tokens)
+    return overlap / len(signature_tokens) >= threshold
+
+
+def estimate_false_positive_rate(*, frequency: int, diff_matches: int) -> float:
+    """Heuristic FP proxy: surplus diff matches beyond reviewer frequency.
+
+    A pattern that fires on many more diffs than the number of review
+    comments that formed it is likely to over-trigger as a rule, so the
+    surplus is treated as the probable false-positive surface. When the
+    pattern fires on no diffs we cannot estimate a rate and return
+    ``0.0`` — but such a pattern is also a weak rule candidate, which
+    :func:`validate_patterns` reflects via its ``diff_matches`` count.
+    """
+    if diff_matches <= 0:
+        return 0.0
+    surplus = max(0, diff_matches - frequency)
+    return surplus / diff_matches
+
+
+@dataclass(frozen=True)
+class ValidatedPattern:
+    """A candidate pattern scored against recent diffs."""
+
+    signature: str
+    frequency: int
+    diff_matches: int
+    false_positive_rate: float
+    validated: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "signature": self.signature,
+            "frequency": self.frequency,
+            "diff_matches": self.diff_matches,
+            "false_positive_rate": round(self.false_positive_rate, 4),
+            "validated": self.validated,
+        }
+
+
+def validate_patterns(
+    *,
+    patterns: list[dict[str, Any]],
+    diffs: list[str],
+    min_frequency: int = _DEFAULT_MIN_FREQUENCY,
+    max_fp_rate: float = _DEFAULT_MAX_FP_RATE,
+    threshold: float = _MATCH_THRESHOLD,
+) -> list[ValidatedPattern]:
+    """Score each candidate pattern against a corpus of recent diffs.
+
+    Pure function: takes the ``patterns`` payload from
+    :func:`review_patterns.cluster_review_comments` and a list of unified
+    diff texts, and returns a per-pattern verdict. Ordering is
+    deterministic: validated patterns first, then false-positive rate
+    ascending, then frequency descending, then signature ascending.
+    """
+    diff_token_sets = [_added_line_tokens(diff) for diff in diffs]
+    results: list[ValidatedPattern] = []
+    for pattern in patterns:
+        signature = pattern.get("signature", "")
+        frequency = pattern.get("frequency", 0)
+        diff_matches = sum(
+            1
+            for tokens in diff_token_sets
+            if pattern_fires(signature=signature, diff_tokens=tokens, threshold=threshold)
+        )
+        fp_rate = estimate_false_positive_rate(frequency=frequency, diff_matches=diff_matches)
+        validated = frequency >= min_frequency and fp_rate <= max_fp_rate
+        results.append(
+            ValidatedPattern(
+                signature=signature,
+                frequency=frequency,
+                diff_matches=diff_matches,
+                false_positive_rate=fp_rate,
+                validated=validated,
+            )
+        )
+    results.sort(key=lambda v: (not v.validated, v.false_positive_rate, -v.frequency, v.signature))
+    return results
+
+
+async def _merged_pr_numbers(*, repo: str, limit: int) -> Result[list[int]]:
+    result = await async_run(
+        args=[
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "merged",
+            "--limit",
+            str(limit),
+            "--json",
+            "number",
+        ],
+        timeout=60,
+    )
+    if result.returncode != 0:
+        return err(result.stderr.strip() or "gh pr list failed")
+    try:
+        payload = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError:
+        return err("could not parse gh pr list output")
+    return ok([int(item["number"]) for item in payload])
+
+
+async def _pr_diff(*, repo: str, pr_number: int) -> str | None:
+    result = await async_run(
+        args=["gh", "pr", "diff", str(pr_number), "--repo", repo],
+        timeout=60,
+    )
+    if result.returncode != 0:
+        logger.warning(
+            "skipping PR diff",
+            extra={"repo": repo, "pr_number": pr_number, "stderr": result.stderr.strip()},
+        )
+        return None
+    return result.stdout or ""
+
+
+async def _recent_diffs(*, repo: str, limit: int) -> list[str]:
+    numbers_result = await _merged_pr_numbers(repo=repo, limit=limit)
+    if not isinstance(numbers_result, SuccessResult):
+        logger.warning("skipping repo diffs", extra={"repo": repo, "error": numbers_result.error})
+        return []
+    diffs: list[str] = []
+    for pr_number in numbers_result.value:
+        diff = await _pr_diff(repo=repo, pr_number=pr_number)
+        if diff:
+            diffs.append(diff)
+    return diffs
+
+
+async def validate_candidate_patterns(
+    *,
+    repos: list[str] | None = None,
+    limit: int = 50,
+    top_n: int = 20,
+    diff_limit: int = _DEFAULT_DIFF_LIMIT,
+    min_frequency: int = _DEFAULT_MIN_FREQUENCY,
+    max_fp_rate: float = _DEFAULT_MAX_FP_RATE,
+) -> Result[dict[str, Any]]:
+    """Validate mined patterns against recent merged-PR diffs.
+
+    Orchestrates the GH-346 miner, fetches recent merged-PR diffs from
+    the same repositories, and scores each pattern. No rules are
+    generated — that is GH-349's job.
+
+    Args:
+        repos: ``owner/name`` repositories to analyze. Defaults to the
+            current repository when omitted.
+        limit: Max merged PRs scanned for review comments (miner input).
+        top_n: Number of top candidate patterns to validate.
+        diff_limit: Max recent merged PRs sampled for diff matching.
+        min_frequency: Minimum reviewer frequency for a validated pattern.
+        max_fp_rate: Maximum estimated false-positive rate for a
+            validated pattern.
+
+    Returns:
+        ``ok({"validated": [...], "summary": {...}})`` or ``err(...)``
+        when the underlying mining step fails.
+    """
+    mined = await review_patterns.cluster_review_comments(
+        repos=repos,
+        limit=limit,
+        top_n=top_n,
+    )
+    if not isinstance(mined, SuccessResult):
+        return mined
+
+    patterns = mined.value["patterns"]
+    summary = mined.value["summary"]
+    scanned = summary.get("repos_scanned", [])
+
+    diffs: list[str] = []
+    for repo in scanned:
+        diffs.extend(await _recent_diffs(repo=repo, limit=diff_limit))
+
+    validated = validate_patterns(
+        patterns=patterns,
+        diffs=diffs,
+        min_frequency=min_frequency,
+        max_fp_rate=max_fp_rate,
+    )
+    return ok(
+        {
+            "validated": [pattern.to_dict() for pattern in validated],
+            "summary": {
+                **summary,
+                "diffs_analyzed": len(diffs),
+                "validated_count": sum(1 for pattern in validated if pattern.validated),
+                "min_frequency": min_frequency,
+                "max_fp_rate": max_fp_rate,
+            },
+        }
+    )

--- a/src/dev10x/github/rule_authoring.py
+++ b/src/dev10x/github/rule_authoring.py
@@ -1,0 +1,219 @@
+"""Author reference-rule docs from validated review patterns (GH-349).
+
+Milestone-5 step for the review-bot initiative. Takes the patterns that
+:func:`dev10x.github.pattern_validation.validate_candidate_patterns`
+(GH-348) marked ``validated`` and renders one reference-rule Markdown
+doc per pattern, plus an INDEX-style routing fragment that wires the
+generated docs to the review agents.
+
+Like its siblings, this module is **dry-run by default**: the
+orchestrator returns the generated doc content and routing fragment for
+human review rather than rewriting the canonical
+``.claude/rules/INDEX.md`` in place. The optional
+:func:`write_rule_docs` helper materializes docs under an explicit base
+directory when a caller opts in, keeping file I/O out of the analysis
+path and free of hidden CWD coupling.
+
+Internal functions return ``Result[T]`` per ADR-0009; the
+``@server.tool()`` boundary calls ``.to_dict()``.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from dev10x.domain.common.result import Result, SuccessResult, ok
+from dev10x.github import pattern_validation
+
+# Generated rule docs live under the review-checks reference tree so the
+# review agents (reviewer-generic and friends) pick them up via routing.
+GENERATED_RULES_DIR = "references/review-checks/generated"
+
+# Reviewer agent the generated routing rows point at. Review-comment
+# patterns are general-purpose checks, so the catch-all reviewer owns
+# them until a human re-routes a doc to a more specific agent.
+_DEFAULT_REVIEWER = "reviewer-generic"
+
+_SLUG_NON_WORD = re.compile(r"[^a-z0-9]+")
+
+
+def _rule_slug(signature: str) -> str:
+    """Turn a pattern signature into a filename-safe slug."""
+    slug = _SLUG_NON_WORD.sub("-", signature.lower()).strip("-")
+    return slug or "unnamed-pattern"
+
+
+def _rule_title(signature: str) -> str:
+    cleaned = signature.strip()
+    return cleaned[:1].upper() + cleaned[1:] if cleaned else "Unnamed pattern"
+
+
+@dataclass(frozen=True)
+class RuleDoc:
+    """A generated reference-rule document for one validated pattern."""
+
+    slug: str
+    title: str
+    path: str
+    content: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "slug": self.slug,
+            "title": self.title,
+            "path": self.path,
+            "content": self.content,
+        }
+
+
+def render_rule_doc(*, pattern: dict[str, Any]) -> str:
+    """Render a single validated pattern into a reference-rule Markdown doc.
+
+    Pure function: takes one entry from
+    :func:`pattern_validation.validate_candidate_patterns`' ``validated``
+    list and returns the doc body. The confidence note records the
+    heuristic provenance so readers do not mistake the frequency/FP
+    figures for measured precision.
+    """
+    signature = pattern.get("signature", "")
+    frequency = pattern.get("frequency", 0)
+    fp_rate = pattern.get("false_positive_rate", 0.0)
+    title = _rule_title(signature)
+    tokens = ", ".join(f"`{token}`" for token in signature.split()) or "—"
+    return "\n".join(
+        [
+            f"# {title}",
+            "",
+            "> Generated from a validated reviewer-comment pattern "
+            "(GH-349). The frequency and false-positive rate are "
+            "heuristic estimates from recent merged PRs — confirm "
+            "against the codebase before enforcing.",
+            "",
+            "## When this applies",
+            "",
+            f"Reviewers raised this point **{frequency}** time(s) across "
+            "recent merged PRs. Watch for changes whose added lines "
+            "match the signal tokens below.",
+            "",
+            f"**Signal tokens:** {tokens}",
+            "",
+            "## Confidence",
+            "",
+            f"- Reviewer frequency: {frequency}",
+            f"- Estimated false-positive rate: {fp_rate}",
+            "",
+            "_Confidence is refined over time via feedback tracking (GH-350)._",
+            "",
+        ]
+    )
+
+
+def author_rule_docs(*, patterns: list[dict[str, Any]]) -> list[RuleDoc]:
+    """Build one :class:`RuleDoc` per validated pattern.
+
+    Pure function: only patterns flagged ``validated`` produce a doc.
+    Ordering follows the input (already ranked by the validator).
+    """
+    docs: list[RuleDoc] = []
+    for pattern in patterns:
+        if not pattern.get("validated"):
+            continue
+        signature = pattern.get("signature", "")
+        slug = _rule_slug(signature)
+        docs.append(
+            RuleDoc(
+                slug=slug,
+                title=_rule_title(signature),
+                path=f"{GENERATED_RULES_DIR}/{slug}.md",
+                content=render_rule_doc(pattern=pattern),
+            )
+        )
+    return docs
+
+
+def render_routing_fragment(*, docs: list[RuleDoc]) -> str:
+    """Render an INDEX-style routing table fragment for generated docs.
+
+    The fragment is meant to be pasted into ``.claude/rules/INDEX.md`` by
+    a human — it is never written in place.
+    """
+    if not docs:
+        return "_No validated patterns — no routing rows generated._"
+    rows = ["| Generated rule | Reviewer agent |", "|---|---|"]
+    rows.extend(f"| `{doc.path}` | `{_DEFAULT_REVIEWER}` |" for doc in docs)
+    return "\n".join(rows)
+
+
+def write_rule_docs(*, docs: list[RuleDoc], base_dir: Path) -> list[str]:
+    """Materialize generated docs under ``base_dir``; return written paths.
+
+    File I/O is isolated here behind an explicit ``base_dir`` so the
+    analysis path stays side-effect free and no hidden CWD coupling
+    leaks in (GH-979). Each doc's ``path`` is repo-relative; it is
+    joined onto ``base_dir`` to form the absolute target.
+    """
+    written: list[str] = []
+    for doc in docs:
+        target = base_dir / doc.path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(doc.content, encoding="utf-8")
+        written.append(str(target))
+    return written
+
+
+async def author_reference_rules(
+    *,
+    repos: list[str] | None = None,
+    limit: int = 50,
+    top_n: int = 20,
+    diff_limit: int = 20,
+    min_frequency: int = 2,
+    max_fp_rate: float = 0.5,
+) -> Result[dict[str, Any]]:
+    """Author reference-rule docs from validated review patterns.
+
+    Orchestrates GH-348 validation, generates a doc per validated
+    pattern, and returns the docs plus an INDEX routing fragment. This is
+    a dry run — no files are written and no routing table is edited.
+
+    Args:
+        repos: ``owner/name`` repositories to analyze. Defaults to the
+            current repository when omitted.
+        limit: Max merged PRs scanned for review comments.
+        top_n: Number of top candidate patterns to consider.
+        diff_limit: Max recent merged PRs sampled for diff matching.
+        min_frequency: Minimum reviewer frequency for a validated pattern.
+        max_fp_rate: Maximum estimated false-positive rate for a
+            validated pattern.
+
+    Returns:
+        ``ok({"rules": [...], "routing_fragment": str, "summary": {...}})``
+        or ``err(...)`` when the upstream validation step fails.
+    """
+    validated = await pattern_validation.validate_candidate_patterns(
+        repos=repos,
+        limit=limit,
+        top_n=top_n,
+        diff_limit=diff_limit,
+        min_frequency=min_frequency,
+        max_fp_rate=max_fp_rate,
+    )
+    if not isinstance(validated, SuccessResult):
+        return validated
+
+    patterns = validated.value["validated"]
+    docs = author_rule_docs(patterns=patterns)
+    return ok(
+        {
+            "rules": [doc.to_dict() for doc in docs],
+            "routing_fragment": render_routing_fragment(docs=docs),
+            "summary": {
+                **validated.value["summary"],
+                "rules_authored": len(docs),
+                "generated_rules_dir": GENERATED_RULES_DIR,
+            },
+        }
+    )

--- a/src/dev10x/github/rule_confidence.py
+++ b/src/dev10x/github/rule_confidence.py
@@ -1,0 +1,217 @@
+"""Confidence weighting & feedback tracking for review rules (GH-350).
+
+Final milestone-5 step for the review-bot initiative. Records, per rule,
+how often it caught a real issue versus fired as a false positive, then
+ranks rules by a Wilson-score confidence so the highest-precision rules
+surface first and noisy ones sink.
+
+The Wilson lower bound rewards evidence: a rule with 5 catches / 0 false
+positives outranks one with 1 catch / 0 false positives even though both
+have raw precision 1.0. A rule with no feedback yet scores 0.0.
+
+Feedback persists as a small JSON store. Low-level helpers take an
+explicit ``store_path`` so file I/O carries no hidden CWD coupling
+(GH-979); the orchestrators resolve a default under the Dev10x config
+home when no path is given.
+
+Internal functions return ``Result[T]`` per ADR-0009; the
+``@server.tool()`` boundary calls ``.to_dict()``.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from dev10x.domain.common.result import Result, err, ok
+from dev10x.domain.dev10x_paths import Dev10xConfigDir
+
+_FEEDBACK_FILENAME = "rule-feedback.json"
+
+# z-score for a 95% Wilson score interval.
+_WILSON_Z = 1.96
+
+CATCH = "catch"
+FALSE_POSITIVE = "false_positive"
+_OUTCOMES = frozenset({CATCH, FALSE_POSITIVE})
+
+
+@dataclass(frozen=True)
+class RuleFeedback:
+    """Catch/false-positive tallies for one rule."""
+
+    rule_id: str
+    catches: int = 0
+    false_positives: int = 0
+
+    @property
+    def total(self) -> int:
+        return self.catches + self.false_positives
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "rule_id": self.rule_id,
+            "catches": self.catches,
+            "false_positives": self.false_positives,
+        }
+
+
+def confidence_score(*, catches: int, false_positives: int) -> float:
+    """Wilson lower bound of precision (catches / total) at 95%.
+
+    Returns ``0.0`` when there is no feedback yet.
+    """
+    total = catches + false_positives
+    if total <= 0:
+        return 0.0
+    phat = catches / total
+    z = _WILSON_Z
+    denominator = 1 + z * z / total
+    centre = phat + z * z / (2 * total)
+    margin = z * math.sqrt((phat * (1 - phat) + z * z / (4 * total)) / total)
+    return max(0.0, (centre - margin) / denominator)
+
+
+@dataclass(frozen=True)
+class ScoredRule:
+    """A rule with its confidence score, ready for ranking."""
+
+    rule_id: str
+    catches: int
+    false_positives: int
+    confidence: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "rule_id": self.rule_id,
+            "catches": self.catches,
+            "false_positives": self.false_positives,
+            "confidence": round(self.confidence, 4),
+        }
+
+
+def rank_rules(*, feedback: list[RuleFeedback]) -> list[ScoredRule]:
+    """Score each rule and rank by confidence desc, catches desc, id asc."""
+    scored = [
+        ScoredRule(
+            rule_id=item.rule_id,
+            catches=item.catches,
+            false_positives=item.false_positives,
+            confidence=confidence_score(
+                catches=item.catches,
+                false_positives=item.false_positives,
+            ),
+        )
+        for item in feedback
+    ]
+    scored.sort(key=lambda rule: (-rule.confidence, -rule.catches, rule.rule_id))
+    return scored
+
+
+def load_feedback(*, store_path: Path) -> dict[str, RuleFeedback]:
+    """Load the feedback store; an absent file is an empty store."""
+    if not store_path.exists():
+        return {}
+    raw = json.loads(store_path.read_text(encoding="utf-8"))
+    return {
+        rule_id: RuleFeedback(
+            rule_id=rule_id,
+            catches=int(entry.get("catches", 0)),
+            false_positives=int(entry.get("false_positives", 0)),
+        )
+        for rule_id, entry in raw.items()
+    }
+
+
+def save_feedback(*, feedback: dict[str, RuleFeedback], store_path: Path) -> None:
+    """Persist the feedback store as sorted, indented JSON."""
+    store_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        rule_id: {"catches": item.catches, "false_positives": item.false_positives}
+        for rule_id, item in feedback.items()
+    }
+    store_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def record_feedback(*, rule_id: str, outcome: str, store_path: Path) -> RuleFeedback:
+    """Increment a rule's catch or false-positive tally and persist it.
+
+    Raises ``ValueError`` on an unknown outcome so direct callers fail
+    loud; the MCP orchestrator validates first and returns an error
+    result instead.
+    """
+    if outcome not in _OUTCOMES:
+        raise ValueError(f"unknown outcome {outcome!r}; expected one of {sorted(_OUTCOMES)}")
+    feedback = load_feedback(store_path=store_path)
+    current = feedback.get(rule_id, RuleFeedback(rule_id=rule_id))
+    if outcome == CATCH:
+        updated = RuleFeedback(
+            rule_id=rule_id,
+            catches=current.catches + 1,
+            false_positives=current.false_positives,
+        )
+    else:
+        updated = RuleFeedback(
+            rule_id=rule_id,
+            catches=current.catches,
+            false_positives=current.false_positives + 1,
+        )
+    feedback[rule_id] = updated
+    save_feedback(feedback=feedback, store_path=store_path)
+    return updated
+
+
+def _default_store_path() -> Path:
+    return Dev10xConfigDir.home() / _FEEDBACK_FILENAME
+
+
+def _resolve_store_path(store_path: str | None) -> Path:
+    return Path(store_path) if store_path else _default_store_path()
+
+
+async def rule_confidence_report(*, store_path: str | None = None) -> Result[dict[str, Any]]:
+    """Rank tracked rules by confidence.
+
+    Args:
+        store_path: Feedback JSON store. Defaults to the Dev10x config
+            home when omitted.
+
+    Returns:
+        ``ok({"ranked": [...], "summary": {...}})``.
+    """
+    path = _resolve_store_path(store_path)
+    feedback = load_feedback(store_path=path)
+    ranked = rank_rules(feedback=list(feedback.values()))
+    return ok(
+        {
+            "ranked": [rule.to_dict() for rule in ranked],
+            "summary": {"rules_tracked": len(ranked), "store_path": str(path)},
+        }
+    )
+
+
+async def record_rule_feedback(
+    *,
+    rule_id: str,
+    outcome: str,
+    store_path: str | None = None,
+) -> Result[dict[str, Any]]:
+    """Record one catch or false-positive for a rule.
+
+    Args:
+        rule_id: Identifier of the rule that fired.
+        outcome: ``"catch"`` (real issue) or ``"false_positive"``.
+        store_path: Feedback JSON store. Defaults to the Dev10x config
+            home when omitted.
+
+    Returns:
+        ``ok({"feedback": {...}})`` or ``err(...)`` on an unknown outcome.
+    """
+    if outcome not in _OUTCOMES:
+        return err(f"unknown outcome {outcome!r}; expected one of {sorted(_OUTCOMES)}")
+    path = _resolve_store_path(store_path)
+    updated = record_feedback(rule_id=rule_id, outcome=outcome, store_path=path)
+    return ok({"feedback": updated.to_dict()})

--- a/src/dev10x/mcp/github_tools.py
+++ b/src/dev10x/mcp/github_tools.py
@@ -1129,3 +1129,49 @@ async def candidate_rules_report(
         limit=limit,
         top_n=top_n,
     )
+
+
+@github_tool
+async def validate_candidate_patterns(
+    repos: list[str] | None = None,
+    limit: int = 50,
+    top_n: int = 20,
+    diff_limit: int = 20,
+    min_frequency: int = 2,
+    max_fp_rate: float = 0.5,
+    cwd: str | None = None,
+) -> Result[dict]:
+    """Validate candidate review-comment patterns against recent diffs (GH-348).
+
+    Mines recurring review-comment patterns via ``cluster_review_comments``
+    (GH-346), fetches recent merged-PR diffs, and estimates a heuristic
+    false-positive rate for each pattern so the validated subset can feed
+    reference-rule authoring (GH-349). The false-positive rate is a
+    heuristic estimate, not a measured ground truth.
+
+    Args:
+        repos: ``owner/name`` repositories to analyze. Defaults to the
+            current repository when omitted.
+        limit: Max merged PRs scanned for review comments (default 50).
+        top_n: Number of top candidate patterns to validate (default 20).
+        diff_limit: Max recent merged PRs sampled for diff matching
+            (default 20).
+        min_frequency: Minimum reviewer frequency for a validated pattern
+            (default 2).
+        max_fp_rate: Maximum estimated false-positive rate for a
+            validated pattern (default 0.5).
+        cwd: Effective working directory (GH-979).
+
+    Returns:
+        Dictionary with keys: validated (list), summary (dict); or error.
+    """
+    from dev10x.github import pattern_validation
+
+    return await pattern_validation.validate_candidate_patterns(
+        repos=repos,
+        limit=limit,
+        top_n=top_n,
+        diff_limit=diff_limit,
+        min_frequency=min_frequency,
+        max_fp_rate=max_fp_rate,
+    )

--- a/src/dev10x/mcp/github_tools.py
+++ b/src/dev10x/mcp/github_tools.py
@@ -1175,3 +1175,49 @@ async def validate_candidate_patterns(
         min_frequency=min_frequency,
         max_fp_rate=max_fp_rate,
     )
+
+
+@github_tool
+async def author_reference_rules(
+    repos: list[str] | None = None,
+    limit: int = 50,
+    top_n: int = 20,
+    diff_limit: int = 20,
+    min_frequency: int = 2,
+    max_fp_rate: float = 0.5,
+    cwd: str | None = None,
+) -> Result[dict]:
+    """Author reference-rule docs from validated review patterns (GH-349).
+
+    Validates candidate patterns (GH-348), then renders one
+    reference-rule Markdown doc per validated pattern plus an INDEX-style
+    routing fragment. Dry run: no files are written and no routing table
+    is edited — the docs and fragment are returned for human review.
+
+    Args:
+        repos: ``owner/name`` repositories to analyze. Defaults to the
+            current repository when omitted.
+        limit: Max merged PRs scanned for review comments (default 50).
+        top_n: Number of top candidate patterns to consider (default 20).
+        diff_limit: Max recent merged PRs sampled for diff matching
+            (default 20).
+        min_frequency: Minimum reviewer frequency for a validated pattern
+            (default 2).
+        max_fp_rate: Maximum estimated false-positive rate for a
+            validated pattern (default 0.5).
+        cwd: Effective working directory (GH-979).
+
+    Returns:
+        Dictionary with keys: rules (list), routing_fragment (str),
+        summary (dict); or error.
+    """
+    from dev10x.github import rule_authoring
+
+    return await rule_authoring.author_reference_rules(
+        repos=repos,
+        limit=limit,
+        top_n=top_n,
+        diff_limit=diff_limit,
+        min_frequency=min_frequency,
+        max_fp_rate=max_fp_rate,
+    )

--- a/src/dev10x/mcp/github_tools.py
+++ b/src/dev10x/mcp/github_tools.py
@@ -1221,3 +1221,55 @@ async def author_reference_rules(
         min_frequency=min_frequency,
         max_fp_rate=max_fp_rate,
     )
+
+
+@github_tool
+async def rule_confidence_report(
+    store_path: str | None = None,
+    cwd: str | None = None,
+) -> Result[dict]:
+    """Rank review rules by feedback-weighted confidence (GH-350).
+
+    Reads the catch/false-positive feedback store and ranks rules by a
+    95% Wilson-score lower bound on precision, so high-precision rules
+    surface first and noisy ones sink.
+
+    Args:
+        store_path: Feedback JSON store. Defaults to the Dev10x config
+            home when omitted.
+        cwd: Effective working directory (GH-979).
+
+    Returns:
+        Dictionary with keys: ranked (list), summary (dict).
+    """
+    from dev10x.github import rule_confidence
+
+    return await rule_confidence.rule_confidence_report(store_path=store_path)
+
+
+@github_tool
+async def record_rule_feedback(
+    rule_id: str,
+    outcome: str,
+    store_path: str | None = None,
+    cwd: str | None = None,
+) -> Result[dict]:
+    """Record one catch or false-positive for a review rule (GH-350).
+
+    Args:
+        rule_id: Identifier of the rule that fired.
+        outcome: ``"catch"`` (real issue) or ``"false_positive"``.
+        store_path: Feedback JSON store. Defaults to the Dev10x config
+            home when omitted.
+        cwd: Effective working directory (GH-979).
+
+    Returns:
+        Dictionary with key: feedback (dict); or error on bad outcome.
+    """
+    from dev10x.github import rule_confidence
+
+    return await rule_confidence.record_rule_feedback(
+        rule_id=rule_id,
+        outcome=outcome,
+        store_path=store_path,
+    )

--- a/tests/github/test_pattern_validation.py
+++ b/tests/github/test_pattern_validation.py
@@ -1,0 +1,243 @@
+"""Unit tests for dev10x.github.pattern_validation (GH-348).
+
+Contract class: mock
+  Token matching and FP estimation are pure functions tested without
+  mocks. The orchestrator patches the GH-346 miner and the diff helpers
+  directly so no ``gh`` subprocess runs.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dev10x.domain.common.result import ErrorResult, SuccessResult, err, ok
+
+pv = pytest.importorskip("dev10x.github.pattern_validation", reason="dev10x not installed")
+
+
+def _completed(
+    *,
+    returncode: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def _pattern(*, signature: str = "rename pm payment_method", frequency: int = 7) -> dict:
+    return {"signature": signature, "frequency": frequency}
+
+
+class TestAddedLineTokens:
+    def test_only_added_lines_contribute(self) -> None:
+        diff = "+++ b/a.py\n+def rename_payment_method():\n-old_line\n unchanged"
+        tokens = pv._added_line_tokens(diff)
+        assert "rename_payment_method" in tokens
+        assert "old_line" not in tokens
+        assert "unchanged" not in tokens
+
+    def test_file_header_excluded(self) -> None:
+        assert pv._added_line_tokens("+++ b/payment.py\n") == set()
+
+    def test_punctuation_stripped_and_lowercased(self) -> None:
+        assert pv._added_line_tokens("+  Payment_Method, pm = X()") == {
+            "payment_method",
+            "pm",
+            "x",
+        }
+
+
+class TestPatternFires:
+    def test_full_overlap_fires(self) -> None:
+        assert pv.pattern_fires(signature="named parameters", diff_tokens={"named", "parameters"})
+
+    def test_partial_overlap_above_threshold_fires(self) -> None:
+        assert pv.pattern_fires(
+            signature="a b c d e",
+            diff_tokens={"a", "b", "c"},
+            threshold=0.6,
+        )
+
+    def test_partial_overlap_below_threshold_does_not_fire(self) -> None:
+        assert not pv.pattern_fires(
+            signature="a b c d e",
+            diff_tokens={"a"},
+            threshold=0.6,
+        )
+
+    def test_empty_signature_never_fires(self) -> None:
+        assert not pv.pattern_fires(signature="   ", diff_tokens={"a", "b"})
+
+
+class TestEstimateFalsePositiveRate:
+    def test_no_matches_is_zero(self) -> None:
+        assert pv.estimate_false_positive_rate(frequency=5, diff_matches=0) == 0.0
+
+    def test_matches_within_frequency_is_zero(self) -> None:
+        assert pv.estimate_false_positive_rate(frequency=10, diff_matches=4) == 0.0
+
+    def test_surplus_matches_yield_rate(self) -> None:
+        assert pv.estimate_false_positive_rate(frequency=2, diff_matches=10) == 0.8
+
+
+class TestValidatePatterns:
+    def test_validated_when_frequent_and_low_fp(self) -> None:
+        diffs = ["+ rename pm payment_method"]
+        result = pv.validate_patterns(
+            patterns=[_pattern(frequency=5)],
+            diffs=diffs,
+            min_frequency=2,
+            max_fp_rate=0.5,
+        )
+        assert result[0].validated is True
+        assert result[0].diff_matches == 1
+        assert result[0].false_positive_rate == 0.0
+
+    def test_rejected_when_below_min_frequency(self) -> None:
+        result = pv.validate_patterns(
+            patterns=[_pattern(frequency=1)],
+            diffs=[],
+            min_frequency=2,
+            max_fp_rate=0.5,
+        )
+        assert result[0].validated is False
+
+    def test_rejected_when_fp_rate_too_high(self) -> None:
+        diffs = ["+ rename pm payment_method"] * 10
+        result = pv.validate_patterns(
+            patterns=[_pattern(frequency=1)],
+            diffs=diffs,
+            min_frequency=1,
+            max_fp_rate=0.5,
+        )
+        assert result[0].false_positive_rate == 0.9
+        assert result[0].validated is False
+
+    def test_ordering_validated_first_then_fp_then_frequency(self) -> None:
+        diffs = ["+ rename pm payment_method"]
+        patterns = [
+            {"signature": "unmatched signature here", "frequency": 1},
+            _pattern(signature="rename pm payment_method", frequency=5),
+        ]
+        result = pv.validate_patterns(
+            patterns=patterns,
+            diffs=diffs,
+            min_frequency=2,
+            max_fp_rate=0.5,
+        )
+        assert result[0].validated is True
+        assert result[0].signature == "rename pm payment_method"
+
+    def test_to_dict_rounds_rate(self) -> None:
+        diffs = ["+ rename pm payment_method"] * 3
+        result = pv.validate_patterns(
+            patterns=[_pattern(frequency=1)],
+            diffs=diffs,
+            min_frequency=1,
+            max_fp_rate=1.0,
+        )
+        payload = result[0].to_dict()
+        assert payload["false_positive_rate"] == 0.6667
+        assert payload["diff_matches"] == 3
+        assert payload["validated"] is True
+
+
+class TestValidateCandidatePatterns:
+    @pytest.mark.asyncio
+    @patch("dev10x.github.pattern_validation._recent_diffs", new_callable=AsyncMock)
+    @patch("dev10x.github.review_patterns.cluster_review_comments", new_callable=AsyncMock)
+    async def test_happy_path_validates_and_summarizes(
+        self, mock_cluster: AsyncMock, mock_diffs: AsyncMock
+    ) -> None:
+        mock_cluster.return_value = ok(
+            {
+                "patterns": [_pattern(frequency=5)],
+                "summary": {"repos_scanned": ["o/r"], "comments_analyzed": 8},
+            }
+        )
+        mock_diffs.return_value = ["+ rename pm payment_method"]
+
+        result = await pv.validate_candidate_patterns(repos=["o/r"])
+
+        assert isinstance(result, SuccessResult)
+        assert result.value["validated"][0]["validated"] is True
+        assert result.value["summary"]["diffs_analyzed"] == 1
+        assert result.value["summary"]["validated_count"] == 1
+        mock_diffs.assert_awaited_once_with(repo="o/r", limit=20)
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.review_patterns.cluster_review_comments", new_callable=AsyncMock)
+    async def test_propagates_mining_error(self, mock_cluster: AsyncMock) -> None:
+        mock_cluster.return_value = err("no repository specified")
+
+        result = await pv.validate_candidate_patterns()
+
+        assert isinstance(result, ErrorResult)
+        assert result.error == "no repository specified"
+
+
+class TestRecentDiffs:
+    @pytest.mark.asyncio
+    @patch("dev10x.github.pattern_validation._pr_diff", new_callable=AsyncMock)
+    @patch("dev10x.github.pattern_validation._merged_pr_numbers", new_callable=AsyncMock)
+    async def test_collects_non_empty_diffs(
+        self, mock_numbers: AsyncMock, mock_diff: AsyncMock
+    ) -> None:
+        mock_numbers.return_value = ok([1, 2])
+        mock_diff.side_effect = ["+ added one", None]
+
+        diffs = await pv._recent_diffs(repo="o/r", limit=20)
+
+        assert diffs == ["+ added one"]
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.pattern_validation._merged_pr_numbers", new_callable=AsyncMock)
+    async def test_returns_empty_on_number_lookup_error(self, mock_numbers: AsyncMock) -> None:
+        mock_numbers.return_value = err("gh pr list failed")
+
+        assert await pv._recent_diffs(repo="o/r", limit=20) == []
+
+
+class TestMergedPrNumbers:
+    @pytest.mark.asyncio
+    @patch("dev10x.github.pattern_validation.async_run", new_callable=AsyncMock)
+    async def test_parses_numbers(self, mock_run: AsyncMock) -> None:
+        mock_run.return_value = _completed(stdout=json.dumps([{"number": 7}, {"number": 9}]))
+        result = await pv._merged_pr_numbers(repo="o/r", limit=50)
+        assert isinstance(result, SuccessResult)
+        assert result.value == [7, 9]
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.pattern_validation.async_run", new_callable=AsyncMock)
+    async def test_error_on_nonzero_returncode(self, mock_run: AsyncMock) -> None:
+        mock_run.return_value = _completed(returncode=1, stderr="boom")
+        result = await pv._merged_pr_numbers(repo="o/r", limit=50)
+        assert isinstance(result, ErrorResult)
+        assert result.error == "boom"
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.pattern_validation.async_run", new_callable=AsyncMock)
+    async def test_error_on_unparseable_json(self, mock_run: AsyncMock) -> None:
+        mock_run.return_value = _completed(stdout="not json")
+        result = await pv._merged_pr_numbers(repo="o/r", limit=50)
+        assert isinstance(result, ErrorResult)
+
+
+class TestPrDiff:
+    @pytest.mark.asyncio
+    @patch("dev10x.github.pattern_validation.async_run", new_callable=AsyncMock)
+    async def test_returns_diff_text(self, mock_run: AsyncMock) -> None:
+        mock_run.return_value = _completed(stdout="+ added line")
+        assert await pv._pr_diff(repo="o/r", pr_number=3) == "+ added line"
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.pattern_validation.async_run", new_callable=AsyncMock)
+    async def test_returns_none_on_failure(self, mock_run: AsyncMock) -> None:
+        mock_run.return_value = _completed(returncode=1, stderr="404")
+        assert await pv._pr_diff(repo="o/r", pr_number=3) is None

--- a/tests/github/test_rule_authoring.py
+++ b/tests/github/test_rule_authoring.py
@@ -1,0 +1,136 @@
+"""Unit tests for dev10x.github.rule_authoring (GH-349).
+
+Contract class: mock
+  Doc rendering and routing are pure functions tested without mocks. The
+  orchestrator patches the GH-348 validator directly so no ``gh``
+  subprocess runs. The write helper uses tmp_path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dev10x.domain.common.result import ErrorResult, SuccessResult, err, ok
+
+ra = pytest.importorskip("dev10x.github.rule_authoring", reason="dev10x not installed")
+
+
+def _validated(
+    *,
+    signature: str = "block chaining",
+    frequency: int = 5,
+    fp_rate: float = 0.1,
+    validated: bool = True,
+) -> dict:
+    return {
+        "signature": signature,
+        "frequency": frequency,
+        "diff_matches": 1,
+        "false_positive_rate": fp_rate,
+        "validated": validated,
+    }
+
+
+class TestRuleSlug:
+    def test_spaces_and_punctuation_become_hyphens(self) -> None:
+        assert ra._rule_slug("block chaining, no &&") == "block-chaining-no"
+
+    def test_empty_signature_falls_back(self) -> None:
+        assert ra._rule_slug("   ") == "unnamed-pattern"
+
+
+class TestRuleTitle:
+    def test_capitalizes_first_letter_only(self) -> None:
+        assert ra._rule_title("block chaining") == "Block chaining"
+
+    def test_empty_signature_falls_back(self) -> None:
+        assert ra._rule_title("") == "Unnamed pattern"
+
+
+class TestRenderRuleDoc:
+    def test_includes_title_tokens_and_confidence(self) -> None:
+        doc = ra.render_rule_doc(pattern=_validated(frequency=7, fp_rate=0.2))
+        assert doc.startswith("# Block chaining")
+        assert "heuristic estimates" in doc
+        assert "**Signal tokens:** `block`, `chaining`" in doc
+        assert "Reviewer frequency: 7" in doc
+        assert "Estimated false-positive rate: 0.2" in doc
+
+    def test_empty_signature_tokens_render_dash(self) -> None:
+        doc = ra.render_rule_doc(pattern=_validated(signature=""))
+        assert "**Signal tokens:** —" in doc
+
+
+class TestAuthorRuleDocs:
+    def test_only_validated_patterns_produce_docs(self) -> None:
+        patterns = [
+            _validated(signature="block chaining", validated=True),
+            _validated(signature="rejected one", validated=False),
+        ]
+        docs = ra.author_rule_docs(patterns=patterns)
+        assert len(docs) == 1
+        assert docs[0].slug == "block-chaining"
+        assert docs[0].path == "references/review-checks/generated/block-chaining.md"
+
+    def test_empty_when_none_validated(self) -> None:
+        assert ra.author_rule_docs(patterns=[_validated(validated=False)]) == []
+
+
+class TestRenderRoutingFragment:
+    def test_table_rows_for_each_doc(self) -> None:
+        docs = ra.author_rule_docs(patterns=[_validated()])
+        fragment = ra.render_routing_fragment(docs=docs)
+        assert "| Generated rule | Reviewer agent |" in fragment
+        assert "`references/review-checks/generated/block-chaining.md`" in fragment
+        assert "`reviewer-generic`" in fragment
+
+    def test_no_docs_yields_placeholder(self) -> None:
+        assert "No validated patterns" in ra.render_routing_fragment(docs=[])
+
+
+class TestWriteRuleDocs:
+    def test_materializes_files_under_base_dir(self, tmp_path: Path) -> None:
+        docs = ra.author_rule_docs(patterns=[_validated()])
+        written = ra.write_rule_docs(docs=docs, base_dir=tmp_path)
+        target = tmp_path / "references/review-checks/generated/block-chaining.md"
+        assert written == [str(target)]
+        assert target.read_text(encoding="utf-8").startswith("# Block chaining")
+
+
+class TestAuthorReferenceRules:
+    @pytest.mark.asyncio
+    @patch(
+        "dev10x.github.pattern_validation.validate_candidate_patterns",
+        new_callable=AsyncMock,
+    )
+    async def test_happy_path_authors_and_summarizes(self, mock_validate: AsyncMock) -> None:
+        mock_validate.return_value = ok(
+            {
+                "validated": [_validated(), _validated(signature="skip me", validated=False)],
+                "summary": {"repos_scanned": ["o/r"], "diffs_analyzed": 3},
+            }
+        )
+
+        result = await ra.author_reference_rules(repos=["o/r"])
+
+        assert isinstance(result, SuccessResult)
+        assert len(result.value["rules"]) == 1
+        assert result.value["summary"]["rules_authored"] == 1
+        assert result.value["summary"]["generated_rules_dir"] == ra.GENERATED_RULES_DIR
+        assert "block-chaining" in result.value["routing_fragment"]
+
+    @pytest.mark.asyncio
+    @patch(
+        "dev10x.github.pattern_validation.validate_candidate_patterns",
+        new_callable=AsyncMock,
+    )
+    async def test_propagates_validation_error(self, mock_validate: AsyncMock) -> None:
+        mock_validate.return_value = err("no repository specified")
+
+        result = await ra.author_reference_rules()
+
+        assert isinstance(result, ErrorResult)
+        assert result.error == "no repository specified"

--- a/tests/github/test_rule_confidence.py
+++ b/tests/github/test_rule_confidence.py
@@ -1,0 +1,128 @@
+"""Unit tests for dev10x.github.rule_confidence (GH-350).
+
+Contract class: real
+  Scoring and ranking are pure functions; the feedback store uses
+  tmp_path real files. The default-path orchestrators patch
+  Dev10xConfigDir.home to a tmp dir so no real config home is touched.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from dev10x.domain.common.result import ErrorResult, SuccessResult
+
+rc = pytest.importorskip("dev10x.github.rule_confidence", reason="dev10x not installed")
+
+
+class TestConfidenceScore:
+    def test_no_feedback_is_zero(self) -> None:
+        assert rc.confidence_score(catches=0, false_positives=0) == 0.0
+
+    def test_more_evidence_outranks_less_at_same_precision(self) -> None:
+        few = rc.confidence_score(catches=1, false_positives=0)
+        many = rc.confidence_score(catches=5, false_positives=0)
+        assert many > few
+
+    def test_false_positives_lower_score(self) -> None:
+        clean = rc.confidence_score(catches=5, false_positives=0)
+        noisy = rc.confidence_score(catches=5, false_positives=5)
+        assert noisy < clean
+
+
+class TestRankRules:
+    def test_orders_by_confidence_then_catches_then_id(self) -> None:
+        feedback = [
+            rc.RuleFeedback(rule_id="noisy", catches=2, false_positives=8),
+            rc.RuleFeedback(rule_id="clean", catches=8, false_positives=0),
+        ]
+        ranked = rc.rank_rules(feedback=feedback)
+        assert [rule.rule_id for rule in ranked] == ["clean", "noisy"]
+        assert ranked[0].confidence > ranked[1].confidence
+
+    def test_to_dict_rounds_confidence(self) -> None:
+        ranked = rc.rank_rules(
+            feedback=[rc.RuleFeedback(rule_id="r", catches=3, false_positives=1)]
+        )
+        payload = ranked[0].to_dict()
+        assert payload["rule_id"] == "r"
+        assert isinstance(payload["confidence"], float)
+        assert len(str(payload["confidence"]).split(".")[-1]) <= 4
+
+
+class TestRuleFeedback:
+    def test_total_sums_tallies(self) -> None:
+        assert rc.RuleFeedback(rule_id="r", catches=3, false_positives=2).total == 5
+
+
+class TestFeedbackStore:
+    def test_load_missing_file_is_empty(self, tmp_path: Path) -> None:
+        assert rc.load_feedback(store_path=tmp_path / "missing.json") == {}
+
+    def test_save_then_load_round_trips(self, tmp_path: Path) -> None:
+        store = tmp_path / "fb.json"
+        rc.save_feedback(
+            feedback={"r": rc.RuleFeedback(rule_id="r", catches=2, false_positives=1)},
+            store_path=store,
+        )
+        loaded = rc.load_feedback(store_path=store)
+        assert loaded["r"].catches == 2
+        assert loaded["r"].false_positives == 1
+
+    def test_record_catch_increments_and_persists(self, tmp_path: Path) -> None:
+        store = tmp_path / "fb.json"
+        rc.record_feedback(rule_id="r", outcome=rc.CATCH, store_path=store)
+        updated = rc.record_feedback(rule_id="r", outcome=rc.CATCH, store_path=store)
+        assert updated.catches == 2
+        assert json.loads(store.read_text())["r"]["catches"] == 2
+
+    def test_record_false_positive_increments(self, tmp_path: Path) -> None:
+        store = tmp_path / "fb.json"
+        updated = rc.record_feedback(rule_id="r", outcome=rc.FALSE_POSITIVE, store_path=store)
+        assert updated.false_positives == 1
+
+    def test_record_unknown_outcome_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="unknown outcome"):
+            rc.record_feedback(rule_id="r", outcome="maybe", store_path=tmp_path / "fb.json")
+
+
+class TestRuleConfidenceReport:
+    @pytest.mark.asyncio
+    async def test_explicit_path_ranks_tracked_rules(self, tmp_path: Path) -> None:
+        store = tmp_path / "fb.json"
+        rc.save_feedback(
+            feedback={"clean": rc.RuleFeedback(rule_id="clean", catches=5, false_positives=0)},
+            store_path=store,
+        )
+        result = await rc.rule_confidence_report(store_path=str(store))
+        assert isinstance(result, SuccessResult)
+        assert result.value["summary"]["rules_tracked"] == 1
+        assert result.value["ranked"][0]["rule_id"] == "clean"
+
+    @pytest.mark.asyncio
+    async def test_default_path_uses_config_home(self, tmp_path: Path) -> None:
+        with patch.object(rc.Dev10xConfigDir, "home", return_value=tmp_path):
+            result = await rc.rule_confidence_report()
+        assert isinstance(result, SuccessResult)
+        assert result.value["summary"]["store_path"] == str(tmp_path / rc._FEEDBACK_FILENAME)
+
+
+class TestRecordRuleFeedback:
+    @pytest.mark.asyncio
+    async def test_records_catch(self, tmp_path: Path) -> None:
+        store = tmp_path / "fb.json"
+        result = await rc.record_rule_feedback(rule_id="r", outcome="catch", store_path=str(store))
+        assert isinstance(result, SuccessResult)
+        assert result.value["feedback"]["catches"] == 1
+
+    @pytest.mark.asyncio
+    async def test_unknown_outcome_returns_error(self, tmp_path: Path) -> None:
+        result = await rc.record_rule_feedback(
+            rule_id="r", outcome="maybe", store_path=str(tmp_path / "fb.json")
+        )
+        assert isinstance(result, ErrorResult)
+        assert "unknown outcome" in result.error


### PR DESCRIPTION
**When** the review-bot has mined recurring reviewer comments into ranked candidate patterns (GH-346/347), **I want to** validate those candidates against real diffs, turn the trustworthy ones into reference rules wired to the review agents, and weight each rule by how often it catches real issues versus false positives, **so I can** grow the review ruleset from evidence rather than guesswork.

---

[`bfcb2b55`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/664/commits/bfcb2b554f9b9717a7295fffc8294ed2252d3d22) ✨ GH-348 Enable false-positive estimation for review patterns
[`fed45fea`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/664/commits/fed45feabea21ad1440b6e457c282eca97f18b3d) ✨ GH-349 Enable reference-rule authoring from validated patterns
[`45ae00eb`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/664/commits/45ae00eb60c2fa99cab589aaeb6d9ed54911e631) ✨ GH-350 Enable confidence weighting for review rules
Closes #349
Closes #350
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/348

---