### PR TITLE
✨ GH-600 Enable source-derived permission catalog and proactive seed

### DIFF
--- a/src/dev10x/commands/permission.py
+++ b/src/dev10x/commands/permission.py
@@ -499,14 +499,20 @@ def enumerate_mcp(*, dry_run: bool, quiet: bool) -> None:
     is_flag=True,
     help="With --apply: show what would be written without modifying files.",
 )
+@click.option(
+    "--proactive",
+    is_flag=True,
+    help="Seed the curated default-safe surface (GH-601) without a prior approval (GH-603).",
+)
 def promote_plan(
     *,
     quiet: bool,
     apply_changes: bool,
     include_sensitive: bool,
     dry_run: bool,
+    proactive: bool,
 ) -> None:
-    """Promote read-only MCP tools + research domains to global settings (GH-470/GH-480).
+    """Promote read-only MCP tools + research domains to global settings (GH-470/GH-480/GH-603).
 
     Without ``--apply`` this reports a DRY-RUN plan and makes NO changes:
     read-only tools and project-local research WebFetch domains are classified
@@ -518,24 +524,35 @@ def promote_plan(
     idempotent. Sensitivity-flagged reads are promoted only with the explicit
     ``--include-sensitive`` opt-in; writes are never promoted. Combine
     ``--apply --dry-run`` to preview exactly which rules the write would add.
+
+    ``--proactive`` (GH-603) ignores project-local approvals and instead seeds
+    the curated default-safe catalog surface (tier-2 ``benign`` groups, GH-601)
+    directly — so a fresh project never pays the first-prompt toll. PII/secret
+    groups (tier 3) are never proactively seeded.
     """
     from dev10x.skills.permission import promote as mod
     from dev10x.skills.permission import update_paths as paths_mod
 
-    config_path = _require_config(paths_mod)
-    if not quiet:
-        click.echo(f"Config: {config_path}")
-    config = paths_mod.load_config(config_path)
-
-    settings_files = paths_mod.find_settings_files(
-        roots=config.get("roots", []),
-        include_user=False,
-    )
     global_settings = Path.home() / ".claude" / "settings.json"
-    plan = mod.build_promotion_plan(
-        project_settings_paths=settings_files,
-        global_settings_path=global_settings,
-    )
+    if proactive:
+        catalog = Path(mod.__file__).parent / "baseline-permissions.yaml"
+        plan = mod.build_proactive_seed_plan(
+            catalog_path=catalog,
+            global_settings_path=global_settings,
+        )
+    else:
+        config_path = _require_config(paths_mod)
+        if not quiet:
+            click.echo(f"Config: {config_path}")
+        config = paths_mod.load_config(config_path)
+        settings_files = paths_mod.find_settings_files(
+            roots=config.get("roots", []),
+            include_user=False,
+        )
+        plan = mod.build_promotion_plan(
+            project_settings_paths=settings_files,
+            global_settings_path=global_settings,
+        )
     if not apply_changes:
         click.echo(mod.render_promotion_plan(plan))
         return

--- a/src/dev10x/skills/permission/baseline-permissions.yaml
+++ b/src/dev10x/skills/permission/baseline-permissions.yaml
@@ -599,6 +599,88 @@ groups:
       - WebFetch(domain:docs.sentry.io)
       - WebFetch(domain:resend.com)
 
+  # ─── Curated read-only third-party surfaces (GH-601, S1) ────────────
+  # Default-safe reads across MCP + CLI + skills. Split from the opt-in
+  # sensitive groups in tier 3 by the manifest's sensitivity axis (GH-600,
+  # S3): only `sensitivity: benign` reads are seeded by default. Write
+  # tools are deliberately absent (write-precedence) so they keep prompting.
+
+  mcp-sentry-readonly:
+    tier: 2
+    sensitivity: benign
+    description: >
+      Sentry read-only MCP tools (evidence #1). Issue/event/resource
+      reads and tool discovery — default-safe. Write tools
+      (``update_issue``, ``execute_sentry_tool``) are absent so they keep
+      prompting; ``analyze_issue_with_seer`` is also excluded because it
+      triggers a cost-bearing Seer analysis (same doctrine as
+      ``gh workflow run``).
+    rules:
+      - mcp__claude_ai_Sentry__find_organizations
+      - mcp__claude_ai_Sentry__find_projects
+      - mcp__claude_ai_Sentry__get_sentry_resource
+      - mcp__claude_ai_Sentry__search_events
+      - mcp__claude_ai_Sentry__search_issues
+      - mcp__claude_ai_Sentry__search_sentry_tools
+
+  mcp-atlassian-readonly:
+    tier: 2
+    sensitivity: benign
+    description: >
+      Atlassian / JIRA read-only MCP tools (evidence #6). Issue and
+      project reads plus JQL search — default-safe. Write tools
+      (``createJiraIssue``, ``editJiraIssue``, ``addCommentToJiraIssue``,
+      ``transitionJiraIssue``, ``createIssueLink``, ``addWorklogToJiraIssue``)
+      are absent (write-precedence catches the camelCase verbs via GH-593).
+    rules:
+      - mcp__claude_ai_Atlassian__atlassianUserInfo
+      - mcp__claude_ai_Atlassian__getAccessibleAtlassianResources
+      - mcp__claude_ai_Atlassian__getIssueLinkTypes
+      - mcp__claude_ai_Atlassian__getJiraIssue
+      - mcp__claude_ai_Atlassian__getJiraIssueRemoteIssueLinks
+      - mcp__claude_ai_Atlassian__getJiraIssueTypeMetaWithFields
+      - mcp__claude_ai_Atlassian__getJiraProjectIssueTypesMetadata
+      - mcp__claude_ai_Atlassian__getTransitionsForJiraIssue
+      - mcp__claude_ai_Atlassian__getVisibleJiraProjects
+      - mcp__claude_ai_Atlassian__lookupJiraAccountId
+      - mcp__claude_ai_Atlassian__searchJiraIssuesUsingJql
+      - mcp__claude_ai_Atlassian__fetch
+      - mcp__claude_ai_Atlassian__search
+
+  vercel-cli-readonly:
+    tier: 2
+    sensitivity: benign
+    description: >
+      Vercel CLI read-only subcommands (evidence #24). Enumerated
+      per-subcommand — never ``Bash(vercel:*)`` — because the vercel verb
+      surface mixes reads with deploys / promotes / removes. Inspect, list,
+      and logs only. ``vercel env`` listings expose secret NAMES and live
+      in the opt-in ``secrets-listing-readonly`` group, not here.
+    rules:
+      - Bash(vercel ls:*)
+      - Bash(vercel list:*)
+      - Bash(vercel inspect:*)
+      - Bash(vercel logs:*)
+      - Bash(vercel whoami:*)
+      - Bash(vercel teams ls:*)
+      - Bash(vercel projects ls:*)
+      - Bash(vercel domains ls:*)
+      - Bash(vercel certs ls:*)
+      - Bash(vercel dns ls:*)
+      - Bash(vercel git ls:*)
+
+  readonly-skills:
+    tier: 2
+    sensitivity: benign
+    description: >
+      Read-only analysis skills that inspect and report without mutating
+      the workspace (evidence #20). Mutating skills are intentionally
+      absent — they ship through their own delegation paths.
+    rules:
+      - Skill(code-review)
+      - Skill(security-review)
+      - Skill(review)
+
   obsidian-cli:
     tier: 3
     description: >
@@ -672,6 +754,49 @@ groups:
       - Bash(obsidian wordcount:*)
       - Bash(obsidian recents:*)
       - Skill(obsidian-cli:*)
+
+  # ─── Opt-in sensitive read surfaces (GH-601, S1; D7) ────────────────
+  # These reads use benign verbs (read/get/list/search) but touch
+  # sensitive TARGETS, so the manifest's sensitivity axis (GH-600) flags
+  # them non-default-safe. They are tier 3 / opt-in — enable per project
+  # with `dev10x permission doctor --enable-group=<name>`. The proactive
+  # seed (GH-603) never auto-promotes a non-benign group.
+
+  mcp-google-workspace-readonly:
+    tier: 3
+    sensitivity: pii
+    description: >
+      Google Drive / Gmail / Calendar read-only MCP tools (evidence #5).
+      The verbs are benign but the data is personal (PII), so this group
+      is OPT-IN — never seeded by default. Write tools (create/update/
+      delete/label/send) are absent regardless.
+    rules:
+      - mcp__claude_ai_Google_Drive__search_files
+      - mcp__claude_ai_Google_Drive__read_file_content
+      - mcp__claude_ai_Google_Drive__get_file_metadata
+      - mcp__claude_ai_Google_Drive__get_file_permissions
+      - mcp__claude_ai_Google_Drive__list_recent_files
+      - mcp__claude_ai_Google_Drive__download_file_content
+      - mcp__claude_ai_Gmail__search_threads
+      - mcp__claude_ai_Gmail__get_thread
+      - mcp__claude_ai_Gmail__list_labels
+      - mcp__claude_ai_Gmail__list_drafts
+      - mcp__claude_ai_Google_Calendar__list_calendars
+      - mcp__claude_ai_Google_Calendar__list_events
+      - mcp__claude_ai_Google_Calendar__get_event
+      - mcp__claude_ai_Google_Calendar__suggest_time
+
+  secrets-listing-readonly:
+    tier: 3
+    sensitivity: secret
+    description: >
+      Secret / env-var NAME listings (D7). Enumerating which secrets exist
+      is a reconnaissance step (see domain/sensitivity.py SECRET), so these
+      reads are OPT-IN even though a bare list never prints values.
+    rules:
+      - Bash(vercel env ls:*)
+      - Bash(gh secret list:*)
+      - Bash(gh variable list:*)
 
 # ─── DEPRECATIONS ─────────────────────────────────────────────────────
 # Rules the doctor should rewrite or remove on sweep.

--- a/src/dev10x/skills/permission/manifest.py
+++ b/src/dev10x/skills/permission/manifest.py
@@ -1,0 +1,272 @@
+"""Source-derived two-axis permission manifest (GH-600).
+
+Every pre-approval decision needs to know two things about a surface
+(an MCP tool, a CLI command, or a skill): does it **read or write**, and
+how **sensitive** is the data it touches. Before this module those two
+axes lived apart — read/write was a token heuristic buried in
+``promote.py`` and sensitivity was a command-string classifier in
+``domain/sensitivity.py`` — and the curated catalog was hand-maintained,
+so it rotted (camelCase tools, new CLI subcommands, own-CLI gaps).
+
+This module is the single source for both axes. Entries are *derived*
+from live sources — the MCP tool list, the ``dev10x`` Click tree, and
+skill frontmatter — never hand-typed, so the manifest cannot drift
+behind what the plugin actually exposes. A CI drift-check
+(:func:`find_manifest_drift`) fails when a discovered surface yields no
+manifest entry, extending GH-595's ``dev10x-cli`` check to every surface.
+
+The read/write axis reuses GH-593's camelCase-aware tokenizer via
+:func:`dev10x.skills.permission.promote.classify_tokens`, so a write
+tool can never be misclassified as a promotable read.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+import yaml
+
+from dev10x.skills.permission.cli_catalog import (
+    INTERNAL_GROUPS,
+    enumerate_leaf_commands,
+)
+from dev10x.skills.permission.promote import classify_tokens, is_sensitivity_flagged
+
+
+class Surface(StrEnum):
+    """The kind of thing a permission rule pre-approves."""
+
+    MCP = "mcp"
+    CLI = "cli"
+    SKILL = "skill"
+
+
+class Access(StrEnum):
+    """Read/write axis — whether the surface mutates state."""
+
+    READ = "read"
+    WRITE = "write"
+    UNKNOWN = "unknown"
+
+
+class Sensitivity(StrEnum):
+    """Data-sensitivity axis — what the surface touches.
+
+    ``BENIGN`` reads are safe to seed by default; everything else is
+    opt-in. ``MUTATING`` is the write counterpart (a side-effecting
+    surface is sensitive by virtue of changing state); ``PII`` /
+    ``INFRA`` / ``SECRET`` mark reads whose *target* is sensitive even
+    when the verb is harmless.
+    """
+
+    BENIGN = "benign"
+    PII = "pii"
+    INFRA = "infra"
+    SECRET = "secret"
+    MUTATING = "mutating"
+
+
+# Skill frontmatter tools that mutate the workspace directly. A skill whose
+# ``allowed-tools`` lists any of these is a write surface regardless of its
+# name (the name heuristic alone would miss e.g. a "polish" skill that edits).
+_WRITE_SKILL_TOOLS = frozenset({"Write", "Edit", "MultiEdit", "NotebookEdit"})
+
+
+@dataclass(frozen=True)
+class ManifestEntry:
+    """One surface classified on both axes.
+
+    ``name`` is the stable identifier used for drift matching: the
+    fully-qualified MCP tool name, the ``uvx dev10x …`` command string,
+    or the skill directory name.
+    """
+
+    surface: Surface
+    name: str
+    access: Access
+    sensitivity: Sensitivity
+
+    @property
+    def key(self) -> tuple[str, str]:
+        return (str(self.surface), self.name)
+
+    @property
+    def default_safe(self) -> bool:
+        """True when this surface is safe to seed without an opt-in.
+
+        A surface is default-safe only when it is a benign read — a write
+        (``MUTATING``) or a sensitive-target read (``PII``/``INFRA``/
+        ``SECRET``) always requires an explicit opt-in.
+        """
+        return self.access is Access.READ and self.sensitivity is Sensitivity.BENIGN
+
+
+def _sensitivity_for(access: Access, name: str) -> Sensitivity:
+    """Derive the sensitivity axis from what is knowable from the name.
+
+    A write is ``MUTATING``; a read whose name carries a private/DM/secret
+    token is ``SECRET``; everything else is ``BENIGN``. ``PII`` and
+    ``INFRA`` cannot be inferred from a verb-name alone (they depend on the
+    target), so they arrive only via curated overrides in
+    :func:`build_manifest`.
+    """
+    if access is Access.WRITE:
+        return Sensitivity.MUTATING
+    if is_sensitivity_flagged(name):
+        return Sensitivity.SECRET
+    return Sensitivity.BENIGN
+
+
+def _entry(surface: Surface, name: str) -> ManifestEntry:
+    access = Access(classify_tokens(name))
+    return ManifestEntry(surface, name, access, _sensitivity_for(access, name))
+
+
+def manifest_from_mcp_tools(tool_names: Iterable[str]) -> list[ManifestEntry]:
+    """Classify each fully-qualified MCP tool name on both axes."""
+    return [_entry(Surface.MCP, name) for name in tool_names]
+
+
+def manifest_from_cli(cli_group, *, prog: str = "uvx dev10x") -> list[ManifestEntry]:
+    """Classify every agent-facing leaf command of a Click CLI tree.
+
+    Internal command groups (hook entry points, the validator surface)
+    are excluded — they are deliberately absent from the agent allow-list
+    (see :data:`cli_catalog.INTERNAL_GROUPS`).
+    """
+    entries: list[ManifestEntry] = []
+    for path in enumerate_leaf_commands(cli_group):
+        if path[0] in INTERNAL_GROUPS:
+            continue
+        entries.append(_entry(Surface.CLI, f"{prog} " + " ".join(path)))
+    return entries
+
+
+def _parse_frontmatter(text: str) -> dict | None:
+    """Return the YAML frontmatter block of a SKILL.md, or None if absent/invalid."""
+    if not text.startswith("---"):
+        return None
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return None
+    try:
+        data = yaml.safe_load(parts[1])
+    except yaml.YAMLError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _skill_access(allowed_tools: Iterable[str]) -> Access:
+    """Classify a skill as read/write from its ``allowed-tools`` list.
+
+    A skill is a write surface when it can edit files directly
+    (Write/Edit/…) or when any ``Bash(...)`` rule names a write verb
+    (``git commit``, ``gh pr create``, ``push`` …). Otherwise it reads.
+    """
+    for tool in allowed_tools:
+        head = tool.split("(", 1)[0]
+        if head in _WRITE_SKILL_TOOLS:
+            return Access.WRITE
+        if head == "Bash":
+            inner = tool[tool.find("(") + 1 : tool.rfind(")")]
+            if classify_tokens(inner) == "write":
+                return Access.WRITE
+    return Access.READ
+
+
+def manifest_from_skills(skills_dir: Path) -> list[ManifestEntry]:
+    """Classify every skill under *skills_dir* from its SKILL.md frontmatter.
+
+    A SKILL.md whose frontmatter is missing, unparseable, or carries a
+    non-list ``allowed-tools`` is intentionally SKIPPED so the drift-check
+    (:func:`find_manifest_drift`) reports it — a malformed skill must not
+    silently fall out of the manifest. A skill with valid frontmatter and
+    *no* ``allowed-tools`` is a read-only orchestration skill (no external
+    surface to mutate), classified ``READ`` — not a skip.
+    """
+    entries: list[ManifestEntry] = []
+    for skill_md in sorted(Path(skills_dir).glob("*/SKILL.md")):
+        front = _parse_frontmatter(skill_md.read_text())
+        if front is None:
+            continue
+        allowed = front.get("allowed-tools", [])
+        if not isinstance(allowed, list):
+            continue
+        access = _skill_access(t for t in allowed if isinstance(t, str))
+        name = skill_md.parent.name
+        entries.append(ManifestEntry(Surface.SKILL, name, access, _sensitivity_for(access, name)))
+    return entries
+
+
+def build_manifest(
+    *,
+    mcp_tools: Iterable[str],
+    cli_group,
+    skills_dir: Path,
+    sensitivity_overrides: Mapping[str, Sensitivity] | None = None,
+) -> list[ManifestEntry]:
+    """Build the full two-axis manifest from all live sources.
+
+    ``sensitivity_overrides`` maps an entry ``name`` to a curated
+    sensitivity label for cases the name heuristic cannot infer — e.g.
+    Google Drive/Gmail reads are ``PII`` even though ``read``/``get`` are
+    benign verbs (GH-601). Overrides apply across every surface.
+    """
+    overrides = sensitivity_overrides or {}
+    entries = [
+        *manifest_from_mcp_tools(mcp_tools),
+        *manifest_from_cli(cli_group),
+        *manifest_from_skills(skills_dir),
+    ]
+    if not overrides:
+        return entries
+    return [
+        ManifestEntry(e.surface, e.name, e.access, overrides[e.name]) if e.name in overrides else e
+        for e in entries
+    ]
+
+
+def discovered_surface_keys(
+    *,
+    mcp_tools: Iterable[str],
+    cli_group,
+    skills_dir: Path,
+) -> set[tuple[str, str]]:
+    """Enumerate every surface that the manifest is expected to cover.
+
+    Independent of :func:`build_manifest` so the drift-check has a second
+    witness: a surface a generator silently drops (e.g. a skill with
+    malformed frontmatter) appears here but not in the manifest.
+    """
+    keys: set[tuple[str, str]] = {(str(Surface.MCP), name) for name in mcp_tools}
+    for path in enumerate_leaf_commands(cli_group):
+        if path[0] in INTERNAL_GROUPS:
+            continue
+        keys.add((str(Surface.CLI), "uvx dev10x " + " ".join(path)))
+    for skill_md in Path(skills_dir).glob("*/SKILL.md"):
+        keys.add((str(Surface.SKILL), skill_md.parent.name))
+    return keys
+
+
+def find_manifest_drift(
+    *,
+    mcp_tools: Iterable[str],
+    cli_group,
+    skills_dir: Path,
+) -> list[str]:
+    """Return discovered surfaces that produced no manifest entry (CI gate).
+
+    Empty means every live MCP tool, CLI command, and skill is classified.
+    A non-empty result is a drift: the manifest fell behind a surface the
+    plugin actually exposes.
+    """
+    mcp_tools = list(mcp_tools)
+    manifest = build_manifest(mcp_tools=mcp_tools, cli_group=cli_group, skills_dir=skills_dir)
+    covered = {entry.key for entry in manifest}
+    discovered = discovered_surface_keys(
+        mcp_tools=mcp_tools, cli_group=cli_group, skills_dir=skills_dir
+    )
+    return sorted(f"{surface}:{name}" for surface, name in discovered - covered)

--- a/src/dev10x/skills/permission/promote.py
+++ b/src/dev10x/skills/permission/promote.py
@@ -37,6 +37,8 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 
+import yaml
+
 from dev10x.domain.common.mcp_tool_name import McpToolName
 from dev10x.skills.permission.enumerate_mcp import (
     _server_prefix_from_tool,
@@ -426,3 +428,92 @@ def render_promotion_result(result: PromotionResult, *, dry_run: bool = False) -
     elif not dry_run and result.total_added == 0:
         lines.append("No changes — global settings already contained every promotable rule.")
     return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Proactive seed (GH-603, Increment 2)
+#
+# The reactive plan above acts only on tools a project already approved. The
+# proactive seed emits the curated default-safe surface (GH-601) directly,
+# without waiting for a first approval, so a fresh project never pays the
+# first-prompt toll. It reads ONLY tier-2 / ``sensitivity: benign`` catalog
+# groups — opt-in PII/secret groups (tier 3) are never proactively seeded —
+# and re-applies write-precedence + sensitivity flagging as a second gate
+# (the GH-600 manifest classifier) so a mis-tagged group cannot leak a write
+# or a sensitive read into the auto-seeded set.
+# ---------------------------------------------------------------------------
+
+
+def catalog_default_safe_surface(catalog_path: Path) -> tuple[list[str], list[str]]:
+    """Return ``(mcp_tools, webfetch_domains)`` from default-safe catalog groups.
+
+    A group qualifies when it is ``tier: 2`` AND ``sensitivity: benign`` — the
+    proactive surface. Opt-in groups (tier 3, ``pii``/``secret``) and untagged
+    groups are skipped. Only MCP-tool and ``WebFetch(domain:…)`` rules are
+    returned; ``Bash``/``Skill`` rules are seeded into project settings by
+    ``ensure_base``, not promoted to global here.
+    """
+    try:
+        data = yaml.safe_load(Path(catalog_path).read_text())
+    except (OSError, yaml.YAMLError):
+        return [], []
+    tools: list[str] = []
+    domains: list[str] = []
+    for group in (data or {}).get("groups", {}).values():
+        if group.get("tier") != 2 or group.get("sensitivity") != "benign":
+            continue
+        for rule in group.get("rules", []):
+            if not isinstance(rule, str):
+                continue
+            if McpToolName.is_mcp(rule) and not rule.endswith("*"):
+                tools.append(rule)
+            else:
+                match = _WEBFETCH_RE.match(rule)
+                if match:
+                    domains.append(match.group("domain"))
+    return tools, domains
+
+
+def build_proactive_seed_plan(
+    *,
+    catalog_path: Path,
+    global_settings_path: Path,
+) -> PromotionPlan:
+    """Build a promotion plan from the curated default-safe surface (GH-603).
+
+    Unlike :func:`build_promotion_plan`, this needs no project-local approval:
+    the candidate set is the catalog's tier-2 benign groups (GH-601). Each
+    candidate is re-classified through the manifest's write-precedence +
+    sensitivity gate, so a write or sensitive read that slipped into a benign
+    group is excluded rather than seeded. Candidates already in the global
+    allow list are counted, not re-added (idempotent).
+    """
+    tools, domains = catalog_default_safe_surface(catalog_path)
+    global_allow = set(_read_allow_rules(global_settings_path))
+    global_domains = collect_webfetch_domains(global_settings_path)
+
+    plan = PromotionPlan()
+    seen: set[str] = set()
+    for rule in tools:
+        if rule in seen:
+            continue
+        seen.add(rule)
+        if rule in global_allow:
+            plan.already_global_tools += 1
+            continue
+        kind = classify_mcp_tool(rule)
+        if kind == "write":
+            plan.writes_excluded.append(rule)
+        elif is_sensitivity_flagged(rule):
+            plan.sensitive_opt_in.append(rule)
+        else:
+            plan.read_promotable.append(rule)
+
+    domain_set = set(domains)
+    plan.already_global_domains = len(domain_set & global_domains)
+    plan.domains_promotable = sorted(domain_set - global_domains)
+
+    plan.read_promotable.sort()
+    plan.sensitive_opt_in.sort()
+    plan.writes_excluded.sort()
+    return plan

--- a/src/dev10x/skills/permission/promote.py
+++ b/src/dev10x/skills/permission/promote.py
@@ -155,18 +155,30 @@ def _tokens(full_tool_name: str) -> set[str]:
     }
 
 
+def classify_tokens(name: str) -> str:
+    """Classify any verb-bearing name (CLI command, skill, tool) as read/write/unknown.
+
+    Splits *name* into tokens (camelCase + snake_case + digits, GH-593) and
+    applies write-precedence: any write token wins, so a write is never
+    misclassified as promotable. Used by both :func:`classify_mcp_tool` and the
+    source-derived manifest generators (GH-600), so every surface — MCP, CLI,
+    skill — shares one classifier.
+    """
+    tokens = _tokens(name)
+    if tokens & WRITE_TOKENS:
+        return "write"
+    if tokens & READ_TOKENS:
+        return "read"
+    return "unknown"
+
+
 def classify_mcp_tool(full_tool_name: str) -> str:
     """Classify a fully-qualified MCP tool name as read/write/unknown.
 
     Write-precedence: any write token wins, so a write is never
     misclassified as promotable.
     """
-    tokens = _tokens(full_tool_name)
-    if tokens & WRITE_TOKENS:
-        return "write"
-    if tokens & READ_TOKENS:
-        return "read"
-    return "unknown"
+    return classify_tokens(full_tool_name)
 
 
 def is_sensitivity_flagged(full_tool_name: str) -> bool:

--- a/tests/commands/test_permission_promote.py
+++ b/tests/commands/test_permission_promote.py
@@ -66,3 +66,22 @@ def test_config_line_printed_without_quiet(env: Path) -> None:
     result = CliRunner().invoke(promote_plan, [])
     assert result.exit_code == 0
     assert "Config:" in result.output
+
+
+def test_proactive_dry_run_lists_curated_surface(env: Path) -> None:
+    # --proactive ignores project settings and reads the shipped catalog.
+    result = CliRunner().invoke(promote_plan, ["--proactive", "--quiet"])
+    assert result.exit_code == 0
+    assert "DRY RUN — no files modified" in result.output
+    assert "mcp__claude_ai_Sentry__search_issues" in result.output
+    assert json.loads(env.read_text())["permissions"]["allow"] == []
+
+
+def test_proactive_apply_seeds_default_safe_not_pii(env: Path) -> None:
+    result = CliRunner().invoke(promote_plan, ["--proactive", "--apply", "--quiet"])
+    assert result.exit_code == 0
+    allow = json.loads(env.read_text())["permissions"]["allow"]
+    assert "mcp__claude_ai_Sentry__search_issues" in allow
+    assert "mcp__claude_ai_Atlassian__getJiraIssue" in allow
+    # PII/secret opt-in groups are never proactively seeded.
+    assert "mcp__claude_ai_Google_Drive__read_file_content" not in allow

--- a/tests/skills/permission/test_baseline_curation.py
+++ b/tests/skills/permission/test_baseline_curation.py
@@ -1,0 +1,134 @@
+"""Tests for the curated read-only safe-default catalog (GH-601).
+
+Validates the sensitivity split (default-safe vs opt-in), the absence
+of any verb-blind broad CLI entry, and — cross-checking the GH-600
+classifier — that no write tool leaked into a read-only group.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+import dev10x.skills.permission as permission_pkg
+from dev10x.skills.permission.manifest import Access, Sensitivity
+from dev10x.skills.permission.promote import classify_mcp_tool
+
+CATALOG = Path(permission_pkg.__file__).parent / "baseline-permissions.yaml"
+
+DEFAULT_SAFE_GROUPS = (
+    "mcp-sentry-readonly",
+    "mcp-atlassian-readonly",
+    "vercel-cli-readonly",
+    "readonly-skills",
+)
+OPT_IN_GROUPS = {
+    "mcp-google-workspace-readonly": Sensitivity.PII,
+    "secrets-listing-readonly": Sensitivity.SECRET,
+}
+
+
+@pytest.fixture(scope="module")
+def groups() -> dict:
+    return yaml.safe_load(CATALOG.read_text())["groups"]
+
+
+def _mcp_rules(group: dict) -> list[str]:
+    return [r for r in group["rules"] if r.startswith("mcp__")]
+
+
+class TestDefaultSafeGroups:
+    @pytest.mark.parametrize("name", DEFAULT_SAFE_GROUPS)
+    def test_tier_2_and_benign(self, groups: dict, name: str) -> None:
+        group = groups[name]
+        assert group["tier"] == 2
+        assert group["sensitivity"] == Sensitivity.BENIGN
+
+    @pytest.mark.parametrize("name", ["mcp-sentry-readonly", "mcp-atlassian-readonly"])
+    def test_no_write_tool_leaked(self, groups: dict, name: str) -> None:
+        # Cross-check against the GH-600/GH-593 classifier: a default-safe
+        # group must contain zero write tools (write-precedence).
+        writes = [r for r in _mcp_rules(groups[name]) if classify_mcp_tool(r) == "write"]
+        assert writes == []
+
+    def test_sentry_excludes_known_writes(self, groups: dict) -> None:
+        rules = set(groups["mcp-sentry-readonly"]["rules"])
+        assert "mcp__claude_ai_Sentry__update_issue" not in rules
+        assert "mcp__claude_ai_Sentry__execute_sentry_tool" not in rules
+
+    def test_atlassian_excludes_known_writes(self, groups: dict) -> None:
+        rules = set(groups["mcp-atlassian-readonly"]["rules"])
+        assert "mcp__claude_ai_Atlassian__createJiraIssue" not in rules
+        assert "mcp__claude_ai_Atlassian__editJiraIssue" not in rules
+        assert "mcp__claude_ai_Atlassian__addCommentToJiraIssue" not in rules
+
+
+class TestOptInGroups:
+    @pytest.mark.parametrize("name,sensitivity", OPT_IN_GROUPS.items())
+    def test_tier_3_and_sensitive(self, groups: dict, name: str, sensitivity: Sensitivity) -> None:
+        group = groups[name]
+        assert group["tier"] == 3
+        assert group["sensitivity"] == sensitivity
+
+    def test_google_workspace_not_default_safe(self, groups: dict) -> None:
+        # Drive/Gmail/Calendar reads must NOT appear in any tier-2 group.
+        tier2_rules = {
+            r for g in groups.values() if g.get("tier") == 2 for r in g.get("rules", [])
+        }
+        google_tools = [
+            r for r in groups["mcp-google-workspace-readonly"]["rules"] if r.startswith("mcp__")
+        ]
+        assert google_tools  # sanity: the group is non-empty
+        assert not (set(google_tools) & tier2_rules)
+
+    def test_secret_listings_are_opt_in(self, groups: dict) -> None:
+        rules = set(groups["secrets-listing-readonly"]["rules"])
+        assert "Bash(vercel env ls:*)" in rules
+        assert "Bash(gh secret list:*)" in rules
+
+
+class TestNoVerbBlindBroadEntry:
+    """Acceptance: no `vercel:*` / `aws-vault exec:*`-style broad entry."""
+
+    def test_no_bare_vercel_wildcard(self, groups: dict) -> None:
+        all_rules = [r for g in groups.values() for r in g.get("rules", [])]
+        forbidden = {"Bash(vercel:*)", "Bash(vercel *)", "Bash(vercel)"}
+        assert not (set(all_rules) & forbidden)
+
+    def test_every_vercel_rule_is_per_subcommand(self, groups: dict) -> None:
+        # Each vercel Bash rule must name a subcommand: `Bash(vercel <sub>...`.
+        for group in groups.values():
+            for rule in group.get("rules", []):
+                if rule.startswith("Bash(vercel"):
+                    inner = rule[len("Bash(") : rule.rfind(")")]
+                    head = inner.split(":", 1)[0].strip()
+                    assert head != "vercel", f"verb-blind broad vercel entry: {rule}"
+                    assert head.startswith("vercel ")
+
+
+class TestManifestAlignment:
+    """The catalog agrees with the GH-600 manifest classifier.
+
+    A default-safe MCP tool must never classify as WRITE. READ or UNKNOWN
+    are both acceptable: a verb-less name like ``atlassianUserInfo`` is a
+    genuine read the token heuristic cannot label, which is precisely why
+    GH-601 curates it by hand rather than relying on auto-promotion.
+    """
+
+    def test_default_safe_mcp_tools_are_never_write(self, groups: dict) -> None:
+        for name in ("mcp-sentry-readonly", "mcp-atlassian-readonly"):
+            for rule in _mcp_rules(groups[name]):
+                assert Access(classify_mcp_tool(rule)) is not Access.WRITE
+
+    def test_search_and_get_tools_classify_read(self, groups: dict) -> None:
+        # Where the heuristic CAN see a verb, it must agree with curation.
+        reads = [
+            r
+            for name in ("mcp-sentry-readonly", "mcp-atlassian-readonly")
+            for r in _mcp_rules(groups[name])
+            if any(verb in r.lower() for verb in ("search", "get", "find", "lookup"))
+        ]
+        assert reads
+        assert all(Access(classify_mcp_tool(r)) is Access.READ for r in reads)

--- a/tests/skills/permission/test_manifest.py
+++ b/tests/skills/permission/test_manifest.py
@@ -1,0 +1,267 @@
+"""Tests for the source-derived two-axis permission manifest (GH-600)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+import pytest
+
+import dev10x.skills.permission as permission_pkg
+from dev10x.cli import cli
+from dev10x.skills.permission.enumerate_mcp import discover_mcp_tools, plugin_root
+from dev10x.skills.permission.manifest import (
+    Access,
+    ManifestEntry,
+    Sensitivity,
+    Surface,
+    build_manifest,
+    discovered_surface_keys,
+    find_manifest_drift,
+    manifest_from_cli,
+    manifest_from_mcp_tools,
+    manifest_from_skills,
+)
+
+PLUGIN_SKILLS = plugin_root() / "skills"
+
+
+@pytest.fixture
+def cli_group() -> click.Group:
+    @click.group()
+    def root() -> None: ...
+
+    @root.group()
+    def permission() -> None: ...
+
+    @permission.command(name="list-rules")
+    def list_rules() -> None: ...  # read verb
+
+    @permission.command(name="delete-rule")
+    def delete_rule() -> None: ...  # write verb
+
+    @permission.command()
+    def frobnicate() -> None: ...  # no read/write verb → unknown
+
+    @root.group()
+    def hook() -> None: ...
+
+    @hook.command(name="validate-bash")
+    def validate_bash() -> None: ...  # internal — excluded
+
+    return root
+
+
+def _write_skill(skills_dir: Path, name: str, body: str) -> Path:
+    skill_dir = skills_dir / name
+    skill_dir.mkdir(parents=True)
+    md = skill_dir / "SKILL.md"
+    md.write_text(body)
+    return md
+
+
+class TestManifestEntry:
+    def test_key_is_surface_and_name(self) -> None:
+        entry = ManifestEntry(Surface.MCP, "mcp__x__get_y", Access.READ, Sensitivity.BENIGN)
+        assert entry.key == ("mcp", "mcp__x__get_y")
+
+    def test_benign_read_is_default_safe(self) -> None:
+        entry = ManifestEntry(Surface.MCP, "mcp__x__get_y", Access.READ, Sensitivity.BENIGN)
+        assert entry.default_safe is True
+
+    @pytest.mark.parametrize(
+        "access,sensitivity",
+        [
+            (Access.WRITE, Sensitivity.MUTATING),
+            (Access.READ, Sensitivity.PII),
+            (Access.READ, Sensitivity.SECRET),
+            (Access.UNKNOWN, Sensitivity.BENIGN),
+        ],
+    )
+    def test_non_benign_read_is_not_default_safe(
+        self, access: Access, sensitivity: Sensitivity
+    ) -> None:
+        entry = ManifestEntry(Surface.MCP, "tool", access, sensitivity)
+        assert entry.default_safe is False
+
+
+class TestManifestFromMcpTools:
+    def test_read_tool_is_benign(self) -> None:
+        (entry,) = manifest_from_mcp_tools(["mcp__claude_ai_Sentry__search_issues"])
+        assert (entry.surface, entry.access, entry.sensitivity) == (
+            Surface.MCP,
+            Access.READ,
+            Sensitivity.BENIGN,
+        )
+
+    def test_write_tool_is_mutating(self) -> None:
+        (entry,) = manifest_from_mcp_tools(["mcp__claude_ai_Atlassian__createJiraIssue"])
+        assert entry.access is Access.WRITE
+        assert entry.sensitivity is Sensitivity.MUTATING
+
+    def test_sensitive_read_is_secret(self) -> None:
+        (entry,) = manifest_from_mcp_tools(["mcp__claude_ai_Slack__read_dm"])
+        assert entry.access is Access.READ
+        assert entry.sensitivity is Sensitivity.SECRET
+
+
+class TestManifestFromCli:
+    def test_classifies_and_excludes_internal(self, cli_group: click.Group) -> None:
+        entries = manifest_from_cli(cli_group)
+        by_name = {e.name: e for e in entries}
+        assert by_name["uvx dev10x permission list-rules"].access is Access.READ
+        assert by_name["uvx dev10x permission delete-rule"].access is Access.WRITE
+        assert by_name["uvx dev10x permission frobnicate"].access is Access.UNKNOWN
+        # internal `hook` group excluded
+        assert not any(name.startswith("uvx dev10x hook") for name in by_name)
+
+    def test_custom_prog_prefix(self, cli_group: click.Group) -> None:
+        entries = manifest_from_cli(cli_group, prog="aws")
+        assert all(e.name.startswith("aws ") for e in entries)
+
+
+class TestManifestFromSkills:
+    def test_read_skill(self, tmp_path: Path) -> None:
+        _write_skill(
+            tmp_path,
+            "viewer",
+            "---\nname: Dev10x:viewer\nallowed-tools:\n  - Read\n  - Bash(git log:*)\n---\nBody",
+        )
+        (entry,) = manifest_from_skills(tmp_path)
+        assert (entry.surface, entry.name, entry.access) == (Surface.SKILL, "viewer", Access.READ)
+        assert entry.sensitivity is Sensitivity.BENIGN
+
+    def test_write_skill_via_edit_tool(self, tmp_path: Path) -> None:
+        _write_skill(
+            tmp_path,
+            "editor",
+            "---\nname: Dev10x:editor\nallowed-tools:\n  - Read\n  - Edit\n---\nBody",
+        )
+        (entry,) = manifest_from_skills(tmp_path)
+        assert entry.access is Access.WRITE
+        assert entry.sensitivity is Sensitivity.MUTATING
+
+    def test_write_skill_via_bash_write_verb(self, tmp_path: Path) -> None:
+        _write_skill(
+            tmp_path,
+            "creator",
+            "---\nname: Dev10x:creator\nallowed-tools:\n  - Bash(gh pr create:*)\n---\nBody",
+        )
+        (entry,) = manifest_from_skills(tmp_path)
+        assert entry.access is Access.WRITE
+
+    def test_malformed_frontmatter_skipped(self, tmp_path: Path) -> None:
+        _write_skill(tmp_path, "broken", "no frontmatter here\n")
+        assert manifest_from_skills(tmp_path) == []
+
+    def test_unterminated_frontmatter_skipped(self, tmp_path: Path) -> None:
+        _write_skill(tmp_path, "halfbroken", "---\nname: x\nno closing fence\n")
+        assert manifest_from_skills(tmp_path) == []
+
+    def test_invalid_yaml_skipped(self, tmp_path: Path) -> None:
+        _write_skill(tmp_path, "badyaml", "---\n: : :\nbad\n---\nBody")
+        assert manifest_from_skills(tmp_path) == []
+
+    def test_non_dict_frontmatter_skipped(self, tmp_path: Path) -> None:
+        _write_skill(tmp_path, "listfront", "---\n- just\n- a\n- list\n---\nBody")
+        assert manifest_from_skills(tmp_path) == []
+
+    def test_missing_allowed_tools_is_read(self, tmp_path: Path) -> None:
+        # Valid frontmatter, no external tools → read-only orchestration skill.
+        _write_skill(tmp_path, "notools", "---\nname: Dev10x:notools\n---\nBody")
+        (entry,) = manifest_from_skills(tmp_path)
+        assert entry.access is Access.READ
+
+    def test_non_list_allowed_tools_skipped(self, tmp_path: Path) -> None:
+        # Malformed allowed-tools (a string, not a list) → drift signal.
+        _write_skill(tmp_path, "strtools", "---\nname: x\nallowed-tools: Read\n---\nBody")
+        assert manifest_from_skills(tmp_path) == []
+
+    def test_non_string_tools_ignored(self, tmp_path: Path) -> None:
+        _write_skill(
+            tmp_path,
+            "mixed",
+            "---\nname: x\nallowed-tools:\n  - 42\n  - Read\n---\nBody",
+        )
+        (entry,) = manifest_from_skills(tmp_path)
+        assert entry.access is Access.READ
+
+
+class TestBuildManifest:
+    def test_aggregates_all_surfaces(self, tmp_path: Path, cli_group: click.Group) -> None:
+        _write_skill(tmp_path, "viewer", "---\nallowed-tools:\n  - Read\n---\nB")
+        manifest = build_manifest(
+            mcp_tools=["mcp__claude_ai_Sentry__search_issues"],
+            cli_group=cli_group,
+            skills_dir=tmp_path,
+        )
+        surfaces = {e.surface for e in manifest}
+        assert surfaces == {Surface.MCP, Surface.CLI, Surface.SKILL}
+
+    def test_sensitivity_override_applied(self, tmp_path: Path, cli_group: click.Group) -> None:
+        manifest = build_manifest(
+            mcp_tools=["mcp__claude_ai_Google_Drive__read_file_content"],
+            cli_group=cli_group,
+            skills_dir=tmp_path,
+            sensitivity_overrides={
+                "mcp__claude_ai_Google_Drive__read_file_content": Sensitivity.PII
+            },
+        )
+        drive = next(e for e in manifest if e.surface is Surface.MCP)
+        assert drive.sensitivity is Sensitivity.PII
+        assert drive.default_safe is False
+
+    def test_no_overrides_returns_derived(self, tmp_path: Path, cli_group: click.Group) -> None:
+        manifest = build_manifest(
+            mcp_tools=["mcp__claude_ai_Sentry__search_issues"],
+            cli_group=cli_group,
+            skills_dir=tmp_path,
+        )
+        sentry = next(e for e in manifest if e.surface is Surface.MCP)
+        assert sentry.sensitivity is Sensitivity.BENIGN
+
+
+class TestDrift:
+    def test_no_drift_when_all_covered(self, tmp_path: Path, cli_group: click.Group) -> None:
+        _write_skill(tmp_path, "viewer", "---\nallowed-tools:\n  - Read\n---\nB")
+        drift = find_manifest_drift(
+            mcp_tools=["mcp__claude_ai_Sentry__search_issues"],
+            cli_group=cli_group,
+            skills_dir=tmp_path,
+        )
+        assert drift == []
+
+    def test_drift_when_skill_dropped(self, tmp_path: Path, cli_group: click.Group) -> None:
+        # Malformed frontmatter: discovered but not classified → drift.
+        _write_skill(tmp_path, "broken", "no frontmatter\n")
+        drift = find_manifest_drift(mcp_tools=[], cli_group=cli_group, skills_dir=tmp_path)
+        assert drift == ["skill:broken"]
+
+    def test_discovered_keys_cover_all_surfaces(
+        self, tmp_path: Path, cli_group: click.Group
+    ) -> None:
+        _write_skill(tmp_path, "viewer", "---\nallowed-tools:\n  - Read\n---\nB")
+        keys = discovered_surface_keys(
+            mcp_tools=["mcp__x__get_y"], cli_group=cli_group, skills_dir=tmp_path
+        )
+        assert ("mcp", "mcp__x__get_y") in keys
+        assert ("skill", "viewer") in keys
+        assert ("cli", "uvx dev10x permission list-rules") in keys
+        assert not any(surface == "cli" and "hook" in name for surface, name in keys)
+
+
+class TestLiveManifestHasNoDrift:
+    """CI gate: every live plugin surface must classify into the manifest."""
+
+    def test_no_drift_across_all_surfaces(self) -> None:
+        mcp_tools = [tool for tools in discover_mcp_tools().values() for tool in tools]
+        drift = find_manifest_drift(
+            mcp_tools=mcp_tools,
+            cli_group=cli,
+            skills_dir=PLUGIN_SKILLS,
+        )
+        assert drift == [], f"Surfaces missing from the manifest: {drift}"
+
+    def test_catalog_path_exists(self) -> None:
+        # The manifest lives beside the curated catalog it validates.
+        assert (Path(permission_pkg.__file__).parent / "baseline-permissions.yaml").is_file()

--- a/tests/skills/permission/test_proactive_seed.py
+++ b/tests/skills/permission/test_proactive_seed.py
@@ -1,0 +1,175 @@
+"""Tests for proactive default-safe seeding (GH-603)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+import dev10x.skills.permission as permission_pkg
+from dev10x.skills.permission.promote import (
+    apply_promotion_plan,
+    build_proactive_seed_plan,
+    catalog_default_safe_surface,
+)
+
+CATALOG = Path(permission_pkg.__file__).parent / "baseline-permissions.yaml"
+
+_SYNTHETIC = {
+    "groups": {
+        "benign-mcp": {
+            "tier": 2,
+            "sensitivity": "benign",
+            "rules": [
+                "mcp__claude_ai_Acme__search_widgets",  # read → promotable
+                "mcp__claude_ai_Acme__get_widget",  # read → promotable
+                "mcp__claude_ai_Acme__create_widget",  # write → excluded
+                "mcp__claude_ai_Acme__read_dm",  # sensitive → opt-in
+                "WebFetch(domain:docs.acme.dev)",  # domain → promotable
+                "Bash(acme ls:*)",  # not MCP/webfetch → skipped
+                42,  # non-string → skipped
+            ],
+        },
+        "opt-in-pii": {  # tier 3 → never seeded
+            "tier": 3,
+            "sensitivity": "pii",
+            "rules": ["mcp__claude_ai_Acme__get_person"],
+        },
+        "untagged-tier2": {  # tier 2 but no sensitivity → not default-safe
+            "tier": 2,
+            "rules": ["mcp__claude_ai_Other__search_things"],
+        },
+    }
+}
+
+
+def _write_catalog(path: Path, data: dict) -> Path:
+    path.write_text(yaml.safe_dump(data))
+    return path
+
+
+def _write_global(path: Path, allow: list[str]) -> Path:
+    path.write_text(json.dumps({"permissions": {"allow": allow}}))
+    return path
+
+
+class TestCatalogDefaultSafeSurface:
+    def test_collects_only_benign_tier2_mcp_and_domains(self, tmp_path: Path) -> None:
+        catalog = _write_catalog(tmp_path / "c.yaml", _SYNTHETIC)
+        tools, domains = catalog_default_safe_surface(catalog)
+        assert tools == [
+            "mcp__claude_ai_Acme__search_widgets",
+            "mcp__claude_ai_Acme__get_widget",
+            "mcp__claude_ai_Acme__create_widget",
+            "mcp__claude_ai_Acme__read_dm",
+        ]
+        assert domains == ["docs.acme.dev"]
+
+    def test_excludes_opt_in_and_untagged(self, tmp_path: Path) -> None:
+        catalog = _write_catalog(tmp_path / "c.yaml", _SYNTHETIC)
+        tools, _ = catalog_default_safe_surface(catalog)
+        assert "mcp__claude_ai_Acme__get_person" not in tools  # tier-3 PII
+        assert "mcp__claude_ai_Other__search_things" not in tools  # untagged
+
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        assert catalog_default_safe_surface(tmp_path / "nope.yaml") == ([], [])
+
+    def test_invalid_yaml_returns_empty(self, tmp_path: Path) -> None:
+        bad = tmp_path / "bad.yaml"
+        bad.write_text("groups: [: : :\n")
+        assert catalog_default_safe_surface(bad) == ([], [])
+
+    def test_empty_document_returns_empty(self, tmp_path: Path) -> None:
+        empty = tmp_path / "empty.yaml"
+        empty.write_text("")
+        assert catalog_default_safe_surface(empty) == ([], [])
+
+
+class TestBuildProactiveSeedPlan:
+    def test_classifies_curated_surface(self, tmp_path: Path) -> None:
+        catalog = _write_catalog(tmp_path / "c.yaml", _SYNTHETIC)
+        global_settings = _write_global(tmp_path / "g.json", [])
+        plan = build_proactive_seed_plan(
+            catalog_path=catalog, global_settings_path=global_settings
+        )
+        assert plan.read_promotable == [
+            "mcp__claude_ai_Acme__get_widget",
+            "mcp__claude_ai_Acme__search_widgets",
+        ]
+        assert plan.writes_excluded == ["mcp__claude_ai_Acme__create_widget"]
+        assert plan.sensitive_opt_in == ["mcp__claude_ai_Acme__read_dm"]
+        assert plan.domains_promotable == ["docs.acme.dev"]
+
+    def test_dedups_against_global(self, tmp_path: Path) -> None:
+        catalog = _write_catalog(tmp_path / "c.yaml", _SYNTHETIC)
+        global_settings = _write_global(
+            tmp_path / "g.json",
+            ["mcp__claude_ai_Acme__get_widget", "WebFetch(domain:docs.acme.dev)"],
+        )
+        plan = build_proactive_seed_plan(
+            catalog_path=catalog, global_settings_path=global_settings
+        )
+        assert plan.read_promotable == ["mcp__claude_ai_Acme__search_widgets"]
+        assert plan.already_global_tools == 1
+        assert plan.already_global_domains == 1
+        assert plan.domains_promotable == []
+
+    def test_dedups_tool_listed_in_two_groups(self, tmp_path: Path) -> None:
+        # Same tool curated in two benign groups → seeded once.
+        dup = {
+            "groups": {
+                "benign-a": {
+                    "tier": 2,
+                    "sensitivity": "benign",
+                    "rules": ["mcp__claude_ai_Acme__search_widgets"],
+                },
+                "benign-b": {
+                    "tier": 2,
+                    "sensitivity": "benign",
+                    "rules": ["mcp__claude_ai_Acme__search_widgets"],
+                },
+            }
+        }
+        catalog = _write_catalog(tmp_path / "c.yaml", dup)
+        global_settings = _write_global(tmp_path / "g.json", [])
+        plan = build_proactive_seed_plan(
+            catalog_path=catalog, global_settings_path=global_settings
+        )
+        assert plan.read_promotable == ["mcp__claude_ai_Acme__search_widgets"]
+
+    def test_apply_writes_curated_reads(self, tmp_path: Path) -> None:
+        catalog = _write_catalog(tmp_path / "c.yaml", _SYNTHETIC)
+        global_settings = _write_global(tmp_path / "g.json", [])
+        plan = build_proactive_seed_plan(
+            catalog_path=catalog, global_settings_path=global_settings
+        )
+        result = apply_promotion_plan(plan=plan, global_settings_path=global_settings)
+        written = set(json.loads(global_settings.read_text())["permissions"]["allow"])
+        assert "mcp__claude_ai_Acme__search_widgets" in written
+        assert "mcp__claude_ai_Acme__get_widget" in written
+        # write + sensitive never auto-seeded
+        assert "mcp__claude_ai_Acme__create_widget" not in written
+        assert "mcp__claude_ai_Acme__read_dm" not in written
+        assert result.backup_path is not None
+
+
+class TestRealCatalogSeed:
+    """Integration: the shipped catalog seeds reads, never PII/secret."""
+
+    def test_seeds_sentry_and_atlassian_reads(self, tmp_path: Path) -> None:
+        global_settings = _write_global(tmp_path / "g.json", [])
+        plan = build_proactive_seed_plan(
+            catalog_path=CATALOG, global_settings_path=global_settings
+        )
+        assert "mcp__claude_ai_Sentry__search_issues" in plan.read_promotable
+        assert "mcp__claude_ai_Atlassian__getJiraIssue" in plan.read_promotable
+
+    def test_never_seeds_pii_or_secret(self, tmp_path: Path) -> None:
+        global_settings = _write_global(tmp_path / "g.json", [])
+        plan = build_proactive_seed_plan(
+            catalog_path=CATALOG, global_settings_path=global_settings
+        )
+        seeded = set(plan.read_promotable)
+        assert "mcp__claude_ai_Google_Drive__read_file_content" not in seeded
+        assert "mcp__claude_ai_Gmail__get_thread" not in seeded


### PR DESCRIPTION
**When** I use read-only tools, CLIs, and skills across many projects, **I want** them classified by one source-derived manifest and pre-approved when safe — clearly opt-in when they touch PII or secrets — **so** I stop re-approving the same safe surfaces in every project.

---

[`1e0c0d45`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/665/commits/1e0c0d457f57a3330029f4ed683285167592f980) ✨ GH-600 Enable source-derived two-axis permission manifest
[`0fa11813`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/665/commits/0fa11813746089fc0fd3710c646ae802e460f4c3) ✨ GH-601 Enable default-safe reads for Sentry, JIRA, Vercel
[`6eb74971`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/665/commits/6eb749712c397057088e73f0c8e0856de8c24cf6) ✨ GH-603 Enable proactive seeding of default-safe surfaces
Closes #600
Closes #601
Closes #603
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/600

---