### PR TITLE
✨ GH-351 Enable installable PR review as a GitHub Action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,115 @@
+# Dev10x PR Review — installable GitHub Action (GH-351).
+#
+# Scaffold for the "Installable GitHub bot/Action" milestone (M6). This
+# composite action lets ANY repository adopt Dev10x automated PR review by
+# referencing it from a workflow:
+#
+#     uses: Dev10x-Guru/dev10x-claude@v1
+#
+# The install + permissions flow is documented in
+# docs/github-action-install.md; a copy-paste consumer workflow lives at
+# docs/install/dev10x-review.yml.
+#
+# Scope note: this ticket (GH-351) ships the runnable skeleton and the
+# install/permissions contract only. The two extension points are tracked
+# separately and marked inline below:
+#   - GH-352: review from learned rules (replaces the generic review prompt)
+#   - GH-353: continuous learning loop (fills in the `learn` mode stub)
+name: "Dev10x PR Review"
+description: >-
+  Automated, supervisor-style PR review powered by Claude Code. Reviews
+  pull requests on open and harvests review patterns on close.
+author: "Dev10x"
+
+branding:
+  icon: "check-circle"
+  color: "blue"
+
+inputs:
+  anthropic_api_key:
+    description: "Anthropic API key. Store as a repository secret and pass via secrets.ANTHROPIC_API_KEY."
+    required: true
+  github_token:
+    description: "Token used to read the PR and post review comments. Defaults to the job token."
+    required: false
+    default: ${{ github.token }}
+  model:
+    description: "Claude model id for the review (e.g. haiku, sonnet, opus)."
+    required: false
+    default: "haiku"
+  mode:
+    description: >-
+      review | learn | auto. `auto` reviews on opened/synchronize/ready_for_review
+      and harvests learnings on closed.
+    required: false
+    default: "auto"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Resolve run mode
+      id: resolve
+      shell: bash
+      env:
+        REQUESTED_MODE: ${{ inputs.mode }}
+        EVENT_ACTION: ${{ github.event.action }}
+      run: |
+        mode="$REQUESTED_MODE"
+        if [ "$mode" = "auto" ]; then
+          if [ "$EVENT_ACTION" = "closed" ]; then
+            mode="learn"
+          else
+            mode="review"
+          fi
+        fi
+        echo "mode=$mode" >> "$GITHUB_OUTPUT"
+        echo "::notice::Dev10x PR Review resolved mode=$mode (event=${EVENT_ACTION:-none})"
+
+    - name: Checkout repository
+      if: steps.resolve.outputs.mode == 'review'
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+
+    - name: Run Dev10x review
+      if: steps.resolve.outputs.mode == 'review'
+      uses: anthropics/claude-code-action@v1
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      with:
+        anthropic_api_key: ${{ inputs.anthropic_api_key }}
+        github_token: ${{ inputs.github_token }}
+        # GH-352: replace this self-contained prompt with the packaged
+        # reviewer agents + learned rules so review quality matches the
+        # internal multi-agent pipeline (see .github/workflows/claude-code-review.yml).
+        prompt: |
+          REPO: ${{ github.repository }}
+          PR NUMBER: ${{ github.event.pull_request.number }}
+
+          You are performing an automated code review. Be brief but thorough.
+
+          1. Run `gh pr diff ${{ github.event.pull_request.number }} --stat`
+             then `gh pr diff ${{ github.event.pull_request.number }}` to read
+             the changes. Review ONLY the changed lines — pre-existing issues
+             are out of scope.
+          2. Look for correctness bugs, security issues (injected secrets,
+             unsafe input handling), missing error handling, and obvious
+             maintainability problems.
+          3. Before claiming an error, read the surrounding file to confirm it
+             is real. Avoid false positives.
+          4. Post specific findings as inline review comments and ONE summary
+             comment. If the PR is clean, say so plainly.
+
+          Be constructive and helpful.
+        claude_args: >-
+          --model ${{ inputs.model }}
+          --allowed-tools "Read,Grep,Glob,mcp__github_inline_comment__create_inline_comment,mcp__github__get_pull_request_review_comments,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api:*)"
+
+    - name: Harvest review learnings (scaffold)
+      if: steps.resolve.outputs.mode == 'learn'
+      shell: bash
+      run: |
+        # GH-353: harvest new patterns from this closed PR's review threads
+        # and open a rules-update PR for human approval. Stubbed until the
+        # continuous-learning loop lands.
+        echo "::notice::Dev10x learning loop is not enabled yet (tracked in GH-353). No action taken on closed PR."

--- a/docs/github-action-install.md
+++ b/docs/github-action-install.md
@@ -1,0 +1,96 @@
+# Dev10x PR Review — GitHub Action install
+
+Run Dev10x automated PR review on **any** repository by installing the
+Dev10x GitHub Action. This is independent of the Claude Code plugin
+install ([installation.md](installation.md)) — you do not need the
+plugin to use the Action.
+
+> **Scaffold status (M6).** This is the foundational install flow
+> (GH-351). The review currently runs a self-contained generic prompt.
+> Review-from-learned-rules (GH-352) and the continuous learning loop
+> (GH-353) extend this scaffold and are tracked separately.
+
+## What it does
+
+| PR event | Mode | Behavior |
+|----------|------|----------|
+| `opened`, `synchronize`, `ready_for_review` | `review` | Reviews the diff and posts inline + summary comments |
+| `closed` | `learn` | Harvests review patterns (scaffolded — no-op until GH-353) |
+
+## Prerequisites
+
+- An **Anthropic API key** with access to the model you select
+  (default `haiku`). Create one at
+  [console.anthropic.com](https://console.anthropic.com/).
+- Admin access to the target repository (to add a secret and a
+  workflow file).
+
+## Step 1 — Add the API key secret
+
+In the target repository:
+
+**Settings → Secrets and variables → Actions → New repository secret**
+
+| Name | Value |
+|------|-------|
+| `ANTHROPIC_API_KEY` | your Anthropic API key |
+
+The key is never written to logs and is only passed to
+[`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action).
+
+## Step 2 — Add the workflow
+
+Copy [`install/dev10x-review.yml`](install/dev10x-review.yml) to
+`.github/workflows/dev10x-review.yml` in the target repository.
+
+The workflow references the Action by tag:
+
+```yaml
+- uses: Dev10x-Guru/dev10x-claude@v1
+  with:
+    anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+Pin to a released tag (`@v1`) for stability, or a commit SHA for
+maximum reproducibility.
+
+## Step 3 — Permissions
+
+The workflow job must grant these permissions so the Action can read the
+PR and post review feedback:
+
+```yaml
+permissions:
+  contents: read         # check out the PR head
+  pull-requests: write   # post inline + summary review comments
+  issues: write          # post issue-style comments / labels
+  id-token: write        # OIDC for the Claude Code action
+```
+
+These are **job-level** permissions in the consumer workflow — the
+Action does not request additional scopes. No GitHub App installation is
+required for the Action route.
+
+## Action inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `anthropic_api_key` | yes | — | Anthropic API key (pass via secret) |
+| `github_token` | no | `${{ github.token }}` | Token for PR read + comment writes |
+| `model` | no | `haiku` | Claude model id (`haiku`, `sonnet`, `opus`) |
+| `mode` | no | `auto` | `review`, `learn`, or `auto` (event-driven) |
+
+## GitHub App route (deferred)
+
+A hosted **GitHub App** — central install, webhook-driven, no per-repo
+workflow file — is the heavier alternative to the Action. It is out of
+scope for this scaffold and tracked under the M6 milestone. The Action
+route above requires no hosting and works today.
+
+## Verify
+
+Open a pull request in the target repository. The **Dev10x PR Review**
+check appears in the PR's Checks tab; review comments post on completion.
+If nothing runs, confirm the workflow file path
+(`.github/workflows/dev10x-review.yml`), the `ANTHROPIC_API_KEY` secret,
+and that the PR is not a draft (draft PRs are skipped on the review path).

--- a/docs/install/dev10x-review.yml
+++ b/docs/install/dev10x-review.yml
@@ -1,0 +1,38 @@
+# Dev10x PR Review — consumer workflow template (GH-351).
+#
+# Copy this file into your repository at .github/workflows/dev10x-review.yml
+# and add an ANTHROPIC_API_KEY repository secret. See
+# docs/github-action-install.md for the full install + permissions flow.
+#
+# This template is stored under docs/install/ on purpose: GitHub only runs
+# workflows located in .github/workflows/, so it will not execute from here.
+name: Dev10x PR Review
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, closed]
+
+jobs:
+  dev10x-review:
+    # Skip drafts on the review path; closed events still run for the
+    # (scaffolded) learning loop.
+    if: >-
+      github.event.action == 'closed' || !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Dev10x PR Review
+        uses: Dev10x-Guru/dev10x-claude@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Optional overrides:
+          # model: haiku
+          # mode: auto

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -91,6 +91,15 @@ cd ~/.claude/plugins/Dev10x && git pull
 claude plugin marketplace update Dev10x-Guru
 ```
 
+## Option C: GitHub Action (automated PR review)
+
+To run Dev10x automated PR review on a repository — independent of the
+Claude Code plugin — install the **Dev10x PR Review** GitHub Action.
+Add an `ANTHROPIC_API_KEY` secret and a workflow that references
+`Dev10x-Guru/dev10x-claude@v1`. See
+[GitHub Action install](github-action-install.md) for the full install
+and permissions flow.
+
 ## Verify the installation
 
 Start a new Claude Code session and check that skills are loaded:


### PR DESCRIPTION
**When** my team wants Dev10x-style automated PR review on a repository that does not run the Claude Code plugin, **I want to** install a ready-made GitHub Action with a documented permissions and secret flow, **so I can** get reviews on every pull request without wiring the pipeline by hand.

---

[`94d6a21f`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/666/commits/94d6a21f274fc73f79125decd306d28ee8fd5595) ✨ GH-351 Enable installable PR review as a GitHub Action
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/351

---