### PR TITLE
🐛 GH-574 Restore audit-report fidelity across audit entry points

### DIFF
--- a/src/dev10x/audit/__init__.py
+++ b/src/dev10x/audit/__init__.py
@@ -18,7 +18,7 @@ from datetime import date
 from pathlib import Path
 from typing import Any
 
-from dev10x.audit.log_reader import iter_records, prune
+from dev10x.audit.log_reader import audit_dir, iter_records, prune
 from dev10x.audit.summarizer import summarize
 from dev10x.domain.claude_paths import ClaudeDir
 from dev10x.domain.common.result import Result, err, ok
@@ -36,15 +36,9 @@ __all__ = [
     "hook_recent",
 ]
 
-_DEFAULT_HOOK_AUDIT_DIR = "/tmp/Dev10x/hook-audit"
 
-
-def _resolve_audit_dir() -> Path:
-    return Path(os.environ.get("DEV10X_HOOK_AUDIT_DIR", _DEFAULT_HOOK_AUDIT_DIR))
-
-
-def _today_log_path(audit_dir: Path) -> Path:
-    return audit_dir / f"hooks-{date.today().isoformat()}.jsonl"
+def _today_log_path(log_dir: Path) -> Path:
+    return log_dir / f"hooks-{date.today().isoformat()}.jsonl"
 
 
 async def extract_session(
@@ -126,19 +120,19 @@ async def analyze_permissions(
 
 
 async def hook_log_path() -> Result[dict[str, Any]]:
-    audit_dir = _resolve_audit_dir()
-    today_log = _today_log_path(audit_dir)
+    log_dir = audit_dir()
+    today_log = _today_log_path(log_dir)
 
     available = []
-    if audit_dir.exists():
-        available = sorted(p.name for p in audit_dir.glob("hooks-*.jsonl"))
+    if log_dir.exists():
+        available = sorted(p.name for p in log_dir.glob("hooks-*.jsonl"))
 
     return ok(
         {
-            "audit_dir": str(audit_dir),
+            "audit_dir": str(log_dir),
             "today_log": str(today_log),
             "today_log_exists": today_log.exists(),
-            "audit_dir_exists": audit_dir.exists(),
+            "audit_dir_exists": log_dir.exists(),
             "available_logs": available,
             "audit_disabled": os.environ.get("DEV10X_HOOK_AUDIT", "1").lower()
             in {"0", "false", "no", "off"},
@@ -153,8 +147,8 @@ async def hook_recent(
     span_id: str | None = None,
     log_path: str | None = None,
 ) -> Result[dict[str, Any]]:
-    audit_dir = _resolve_audit_dir()
-    target = Path(log_path) if log_path else _today_log_path(audit_dir)
+    log_dir = audit_dir()
+    target = Path(log_path) if log_path else _today_log_path(log_dir)
 
     if not target.exists():
         return err(
@@ -167,7 +161,7 @@ async def hook_recent(
     if log_path:
         records = iter_records(paths=[target])
     else:
-        records = iter_records(base_dir=audit_dir)
+        records = iter_records(base_dir=log_dir)
 
     if hook_name:
         records = [rec for rec in records if rec.get("hook") == hook_name]

--- a/src/dev10x/audit/analyze.py
+++ b/src/dev10x/audit/analyze.py
@@ -24,6 +24,7 @@ from dev10x.audit.permissions_model import (
     HygieneFinding,
     audit_script_hygiene,
     count_nuisance_patterns,
+    detect_hook_denials,
     detect_known_friction,
     parse_additional_directories,
     parse_allow_rules,
@@ -92,6 +93,15 @@ def build_audit_report(
     for offset, finding in enumerate(extra, start=1):
         finding.index = base_count + offset
     findings.extend(extra)
+
+    # GH-507: surface PreToolUse hook denials hidden in tool-result blocks
+    # so MCP callers see HOOK_DENIAL findings, matching the standalone CLI
+    # path in dev10x.skills.audit.analyze_permissions.main.
+    denials = detect_hook_denials(text=transcript)
+    base_count = len(findings)
+    for offset, finding in enumerate(denials, start=1):
+        finding.index = base_count + offset
+    findings.extend(denials)
 
     skills_root = str(skills_dir) if skills_dir else str(ClaudeDir.skills_dir())
     tools_root = str(tools_dir) if tools_dir else str(ClaudeDir.tools_dir())

--- a/src/dev10x/audit/permissions_model.py
+++ b/src/dev10x/audit/permissions_model.py
@@ -19,22 +19,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TextIO
 
+from dev10x.audit.transcript_grammar import TOOL_INPUT_BLOCK_RE, TOOL_RE, TURN_RE
 from dev10x.domain.common.allow_rule import AllowRule, AllowRuleLoader
 from dev10x.domain.common.mcp_tool_name import McpToolName
 from dev10x.domain.common.mktmp_path import MktmpPath
 from dev10x.subprocess_utils import effective_cwd
-
-TURN_RE = re.compile(
-    r"^## Turn (\d+) \[([^\]]+)\] (USER|ASSISTANT)",
-    re.MULTILINE,
-)
-
-TOOL_INPUT_BLOCK_RE = re.compile(
-    r"^\*\*Tool: `([^`]+)`\*\*\n```\n(.*?)```",
-    re.MULTILINE | re.DOTALL,
-)
-
-TOOL_RE = re.compile(r"^\*\*Tool: `([^`]+)`\*\*", re.MULTILINE)
 
 PERMISSION_TOOLS = {"Bash", "Read", "Write", "Edit"}
 

--- a/src/dev10x/audit/transcript_grammar.py
+++ b/src/dev10x/audit/transcript_grammar.py
@@ -1,0 +1,37 @@
+"""Single source of truth for the skill-audit transcript grammar (GH-588).
+
+The normalized audit transcript (produced by ``extract_session.py``) is
+parsed by two places that each used to define their own copy of these
+regexes:
+
+- ``dev10x.audit.permissions_model`` (Phase 4 permission friction)
+- ``dev10x.skills.audit.analyze_actions`` (Phase 1 action inventory)
+
+The copies drifted — the actions parser captured a trailing group on
+``TURN_RE`` that the permissions parser discarded — so the same transcript
+could be read two subtly different ways. This module owns the grammar.
+``permissions_model`` imports it directly. ``analyze_actions`` is a PEP 723
+standalone uv-script that keeps an inlined mirror (it must not import
+``dev10x`` at module scope); ``tests/audit/test_transcript_grammar.py``
+asserts the mirror stays identical to this source of truth.
+
+``TURN_RE`` exposes four groups: turn number, timestamp, role, and the
+trailing remainder of the heading line (used to detect ``[CORRECTION]``
+markers). Callers that need only the first three groups ignore the fourth.
+"""
+
+from __future__ import annotations
+
+import re
+
+TURN_RE = re.compile(
+    r"^## Turn (\d+) \[([^\]]+)\] (USER|ASSISTANT)(.*)",
+    re.MULTILINE,
+)
+
+TOOL_RE = re.compile(r"^\*\*Tool: `([^`]+)`\*\*", re.MULTILINE)
+
+TOOL_INPUT_BLOCK_RE = re.compile(
+    r"^\*\*Tool: `([^`]+)`\*\*\n```\n(.*?)```",
+    re.MULTILINE | re.DOTALL,
+)

--- a/src/dev10x/skills/audit/analyze_actions.py
+++ b/src/dev10x/skills/audit/analyze_actions.py
@@ -55,6 +55,10 @@ def _atomic_write_text(output_path: str, content: str) -> None:
         raise
 
 
+# Transcript grammar (GH-588). The single source of truth lives in
+# dev10x.audit.transcript_grammar. This PEP 723 standalone uv-script cannot
+# import dev10x at module scope, so it mirrors the patterns inline;
+# tests/audit/test_transcript_grammar.py asserts the mirror stays identical.
 TURN_RE = re.compile(
     r"^## Turn (\d+) \[([^\]]+)\] (USER|ASSISTANT)(.*)",
     re.MULTILINE,

--- a/tests/audit/test_analyze.py
+++ b/tests/audit/test_analyze.py
@@ -7,6 +7,13 @@ import pytest
 analyze = pytest.importorskip("dev10x.audit.analyze", reason="dev10x not installed")
 
 
+def _result_block(*, tool_id: str, content: str) -> str:
+    return (
+        f"<details><summary>Tool result ({tool_id}...)</summary>\n\n"
+        f"```\n{content}\n```\n</details>\n\n"
+    )
+
+
 class TestBuildAuditReport:
     def test_returns_audit_report_dataclass(self, tmp_path) -> None:
         settings = tmp_path / "settings.json"
@@ -61,6 +68,46 @@ class TestBuildAuditReport:
         )
 
         assert report.hygiene == []
+
+
+class TestBuildAuditReportHookDenials:
+    """GH-507: build_audit_report must surface hook-denial findings so MCP
+    callers see the same HOOK_DENIAL findings as the standalone CLI path."""
+
+    def test_includes_hook_denial_finding(self, tmp_path) -> None:
+        settings = tmp_path / "settings.json"
+        settings.write_text('{"permissions": {"allow": []}}')
+        transcript = (
+            "## Turn 5 [12:00:00] ASSISTANT\n\n"
+            "**Tool: `Bash`**\n```\ncommand=psql -h localhost\n```\n\n"
+            "## Turn 6 [12:00:01] USER\n\n"
+            + _result_block(
+                tool_id="toolu_abc12",
+                content="BLOCKED: Direct psql calls are not allowed.",
+            )
+        )
+
+        report = analyze.build_audit_report(
+            transcript=transcript,
+            settings_path=settings,
+        )
+
+        classifications = [f.classification for f in report.findings]
+        assert "HOOK_DENIAL" in classifications
+
+    def test_no_denial_in_clean_transcript(self, tmp_path) -> None:
+        settings = tmp_path / "settings.json"
+        settings.write_text('{"permissions": {"allow": []}}')
+        transcript = "## Turn 3 [09:00:00] USER\n\n" + _result_block(
+            tool_id="toolu_ok000", content="SELECT 1\n 1"
+        )
+
+        report = analyze.build_audit_report(
+            transcript=transcript,
+            settings_path=settings,
+        )
+
+        assert all(f.classification != "HOOK_DENIAL" for f in report.findings)
 
 
 class TestAuditReportRender:

--- a/tests/audit/test_audit.py
+++ b/tests/audit/test_audit.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 audit_mod = pytest.importorskip("dev10x.audit", reason="dev10x not installed")
+from dev10x.audit.log_reader import audit_dir as writer_audit_dir  # noqa: E402
 from dev10x.domain.common.result import ErrorResult, SuccessResult  # noqa: E402
 
 
@@ -167,8 +168,22 @@ class TestHookLogPath:
         monkeypatch.delenv("DEV10X_HOOK_AUDIT", raising=False)
         result = await audit_mod.hook_log_path()
         assert isinstance(result, SuccessResult)
-        assert result.value["audit_dir"] == "/tmp/Dev10x/hook-audit"
+        # GH-574: the reader default must match the writer's default. The
+        # reader previously defaulted to /tmp/Dev10x/hook-audit while the
+        # writer (log_reader.audit_dir) used /tmp/Dev10x/logs, so a default
+        # install wrote records the reader never found.
+        assert result.value["audit_dir"] == "/tmp/Dev10x/logs"
+        assert result.value["audit_dir"] == str(writer_audit_dir())
         assert result.value["audit_disabled"] is False
+
+    @pytest.mark.asyncio
+    async def test_reader_matches_writer_when_env_set(self, tmp_path, monkeypatch) -> None:
+        # GH-574: both reader and writer resolve through the same accessor,
+        # so an explicit override lands on a single shared directory.
+        monkeypatch.setenv("DEV10X_HOOK_AUDIT_DIR", str(tmp_path))
+        result = await audit_mod.hook_log_path()
+        assert isinstance(result, SuccessResult)
+        assert result.value["audit_dir"] == str(writer_audit_dir())
 
     @pytest.mark.asyncio
     async def test_honors_env_override(self, tmp_path, monkeypatch) -> None:

--- a/tests/audit/test_transcript_grammar.py
+++ b/tests/audit/test_transcript_grammar.py
@@ -1,0 +1,41 @@
+"""GH-588: the transcript grammar has one source of truth.
+
+``dev10x.audit.transcript_grammar`` owns the regexes. ``permissions_model``
+imports them (identity check). ``analyze_actions`` is a PEP 723 standalone
+uv-script that mirrors them inline; these tests assert the mirror never
+drifts from the source of truth.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+grammar = pytest.importorskip("dev10x.audit.transcript_grammar", reason="dev10x not installed")
+from dev10x.audit import permissions_model  # noqa: E402
+from dev10x.skills.audit import analyze_actions  # noqa: E402
+
+NAMES = ["TURN_RE", "TOOL_RE", "TOOL_INPUT_BLOCK_RE"]
+
+
+@pytest.mark.parametrize("name", NAMES)
+def test_permissions_model_reuses_source_of_truth(name: str) -> None:
+    # Imported, not redefined — same compiled object, so it cannot diverge.
+    assert getattr(permissions_model, name) is getattr(grammar, name)
+
+
+@pytest.mark.parametrize("name", NAMES)
+def test_analyze_actions_mirror_matches_source(name: str) -> None:
+    mirror = getattr(analyze_actions, name)
+    canonical = getattr(grammar, name)
+    assert mirror.pattern == canonical.pattern
+    assert mirror.flags == canonical.flags
+
+
+def test_turn_re_exposes_trailing_group() -> None:
+    # The unified TURN_RE keeps the trailing group analyze_actions relies on
+    # for [CORRECTION] detection; permissions_model simply ignores it.
+    match = grammar.TURN_RE.search("## Turn 7 [12:00:00] USER **[CORRECTION]**")
+    assert match is not None
+    assert match.group(1) == "7"
+    assert match.group(3) == "USER"
+    assert "[CORRECTION]" in match.group(4)


### PR DESCRIPTION
**When** I run the skill-audit pipeline on a default install or through the MCP tools, **I want to** read the same hook-audit records the writer produced, see hook-denial findings in the report, and parse transcripts one consistent way, **so I can** trust the audit report reflects the real session friction regardless of entry point.

---

[`fee27eb4`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/667/commits/fee27eb46a234e79c11ed60593256f6678fec90a) 🐛 GH-574 Surface hook-audit records in default installs
[`52df80e6`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/667/commits/52df80e68e773619706de5523ea6fafdf61a2c28) 🐛 GH-507 Surface hook-denial findings to MCP audit callers
[`4cffa714`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/667/commits/4cffa714e05d3f932850fa0510f72d0adcd2a08f) ♻️ GH-588 Unify transcript grammar across audit parsers
Closes #507
Closes #588
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/574

---