### PR TITLE
✨ GH-602 Enable fleet-wide seeding and rule provenance for worktrees

### DIFF
--- a/src/dev10x/commands/permission.py
+++ b/src/dev10x/commands/permission.py
@@ -566,6 +566,61 @@ def promote_plan(
     click.echo(mod.render_promotion_result(result, dry_run=dry_run))
 
 
+@permission.command(name="provenance")
+@click.option(
+    "--path",
+    "settings_path",
+    default=None,
+    help="Settings file to inspect (default: ./.claude/settings.local.json).",
+)
+def provenance(*, settings_path: str | None) -> None:
+    """Report where each permission rule came from (GH-602).
+
+    Classifies every allow/deny rule in a settings file as ``default`` (Dev10x
+    base catalog), ``user`` (user-global settings), or ``project`` (local only).
+    """
+    from dev10x.skills.permission import provenance as mod
+    from dev10x.skills.permission import update_paths as paths_mod
+
+    config = paths_mod.load_config(_require_config(paths_mod))
+    target = (
+        Path(settings_path) if settings_path else Path.cwd() / ".claude" / "settings.local.json"
+    )
+    result = mod.build_provenance(settings_path=target, config=config)
+    if isinstance(result, ErrorResult):
+        click.echo(f"ERROR: {result.error}", err=True)
+        sys.exit(1)
+    counts = result.value["counts"]
+    click.echo(f"{result.value['path']}")
+    click.echo(
+        f"  default: {counts['default']}  user: {counts['user']}  project: {counts['project']}"
+    )
+    for entry in result.value["rules"]:
+        click.echo(f"  [{entry['provenance']}] {entry['kind']}: {entry['rule']}")
+
+
+@permission.command(name="seed-worktree")
+@click.argument("worktree_path")
+@click.option("--dry-run", is_flag=True, help="Show what would be seeded without writing.")
+def seed_worktree(*, worktree_path: str, dry_run: bool) -> None:
+    """Pre-seed a worktree's settings with curated safe defaults (GH-602).
+
+    Used at worktree creation so a curated read-only surface is honored in the
+    new worktree without a first prompt.
+    """
+    from dev10x.skills.permission import update_paths as paths_mod
+
+    config = paths_mod.load_config(_require_config(paths_mod))
+    result = paths_mod.seed_worktree(
+        worktree_root=Path(worktree_path), config=config, dry_run=dry_run
+    )
+    if isinstance(result, ErrorResult):
+        click.echo(f"ERROR: {result.error}", err=True)
+        sys.exit(1)
+    verb = "Would seed" if dry_run else "Seeded"
+    click.echo(f"{verb} {result.value['added']} rule(s) → {result.value['path']}")
+
+
 @permission.command(name="merge-worktree")
 @click.option("--dry-run", is_flag=True, help="Show changes without modifying files")
 @click.option("--restore", is_flag=True, help="Restore settings from most recent backups")

--- a/src/dev10x/mcp/git_tools.py
+++ b/src/dev10x/mcp/git_tools.py
@@ -117,7 +117,40 @@ async def create_worktree(
     from dev10x.subprocess_utils import use_cwd
 
     with use_cwd(cwd):
-        return to_wire(await git_tools.create_worktree(branch=branch, base=base, path=path))
+        result = to_wire(await git_tools.create_worktree(branch=branch, base=base, path=path))
+
+    _seed_worktree_defaults(result)
+    return result
+
+
+def _seed_worktree_defaults(result: dict) -> None:
+    """Pre-seed curated safe defaults into a freshly created worktree (GH-602).
+
+    Best-effort: a seeding failure must never fail worktree creation, but it
+    is recorded under ``seed_error`` (not silently swallowed) so the caller
+    can see why the new worktree did not get its defaults.
+    """
+    from pathlib import Path
+
+    worktree_path = result.get("worktree_path")
+    if "error" in result or not worktree_path:
+        return
+
+    from dev10x.domain.common.result import SuccessResult
+    from dev10x.skills.permission import update_paths as paths_mod
+
+    try:
+        config_path = paths_mod.find_config()
+        if not isinstance(config_path, SuccessResult):
+            return
+        config = paths_mod.load_config(config_path.value)
+        seeded = paths_mod.seed_worktree(worktree_root=Path(worktree_path), config=config)
+        if isinstance(seeded, SuccessResult):
+            result["seeded_permissions"] = seeded.value["added"]
+        else:
+            result["seed_error"] = seeded.error
+    except OSError as error:
+        result["seed_error"] = str(error)
 
 
 @server.tool()

--- a/src/dev10x/skills/permission/provenance.py
+++ b/src/dev10x/skills/permission/provenance.py
@@ -1,0 +1,98 @@
+"""Queryable rule provenance for seeded permission settings (GH-602).
+
+Once safe defaults are seeded fleet-wide, a settings file mixes three
+origins: rules from the Dev10x base catalog (``default``), rules a user
+promoted to their global ``~/.claude/settings.json`` (``user``), and
+rules local to this one project/worktree (``project``). Provenance makes
+that origin queryable so a maintainer can tell which rules a re-seed
+would re-establish and which are bespoke to a single directory.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import Counter
+from enum import StrEnum
+from pathlib import Path
+
+from dev10x.domain.common.result import Result, err, ok
+from dev10x.skills.permission.update_paths import _load_global_allow_rules
+
+log = logging.getLogger(__name__)
+
+
+class RuleProvenance(StrEnum):
+    """Where a permission rule in a settings file came from."""
+
+    DEFAULT = "default"  # shipped in the Dev10x base catalog (projects.yaml)
+    USER = "user"  # present in the user-global ~/.claude/settings.json
+    PROJECT = "project"  # local to this settings file only
+
+
+def classify_provenance(
+    rule: str,
+    *,
+    base_rules: set[str],
+    global_rules: set[str],
+) -> RuleProvenance:
+    """Resolve a rule's origin (catalog default → user-global → project-local)."""
+    if rule in base_rules:
+        return RuleProvenance.DEFAULT
+    if rule in global_rules:
+        return RuleProvenance.USER
+    return RuleProvenance.PROJECT
+
+
+def build_provenance(
+    *,
+    settings_path: Path,
+    config: dict,
+    global_rules: set[str] | None = None,
+) -> Result[dict]:
+    """Tag every allow/deny rule in a settings file with its provenance.
+
+    ``global_rules`` is injectable for testing; when omitted it is read from
+    the live user-global settings. Denies are classified against the base
+    deny catalog only — Claude Code does not inherit denies globally.
+    """
+    if not settings_path.is_file():
+        return err("settings file not found", path=str(settings_path))
+    try:
+        data = json.loads(settings_path.read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        return err(f"cannot read settings file: {error}", path=str(settings_path))
+
+    base_allow = set(config.get("base_permissions", []))
+    base_deny = set(config.get("base_denies", []))
+    user_rules = global_rules if global_rules is not None else _load_global_allow_rules()[0]
+
+    permissions = data.get("permissions", {})
+    rules: list[dict[str, str]] = []
+    for rule in permissions.get("allow", []):
+        if isinstance(rule, str):
+            rules.append(
+                {
+                    "rule": rule,
+                    "kind": "allow",
+                    "provenance": classify_provenance(
+                        rule, base_rules=base_allow, global_rules=user_rules
+                    ).value,
+                }
+            )
+    for rule in permissions.get("deny", []):
+        if isinstance(rule, str):
+            # Denies are not inherited globally: catalog-default or project-local.
+            origin = RuleProvenance.DEFAULT if rule in base_deny else RuleProvenance.PROJECT
+            rules.append({"rule": rule, "kind": "deny", "provenance": origin.value})
+
+    counts = Counter(entry["provenance"] for entry in rules)
+    return ok(
+        {
+            "path": str(settings_path),
+            "rules": rules,
+            "counts": {
+                provenance.value: counts.get(provenance.value, 0) for provenance in RuleProvenance
+            },
+        }
+    )

--- a/src/dev10x/skills/permission/update_paths.py
+++ b/src/dev10x/skills/permission/update_paths.py
@@ -30,7 +30,7 @@ from dev10x.domain.claude_paths import ClaudeDir
 from dev10x.domain.common.allow_rule import AllowRule
 from dev10x.domain.common.mktmp_path import MKTMP_GENERALIZE_PATTERN
 from dev10x.domain.common.plugin_version import SEMVER_PATTERN, PluginVersion
-from dev10x.domain.common.result import Result
+from dev10x.domain.common.result import Result, err, ok
 from dev10x.domain.dev10x_paths import Dev10xConfigDir
 from dev10x.domain.plugin_identity import PLUGIN_NAMES
 from dev10x.skills.permission.config import parse_config, resolve_config
@@ -1015,6 +1015,60 @@ def ensure_base(
         errors=errors,
         total_added=total_added,
         files_changed=files_changed,
+    )
+
+
+def seed_worktree(
+    *,
+    worktree_root: Path,
+    config: dict,
+    dry_run: bool = False,
+) -> Result[dict[str, object]]:
+    """Pre-seed a single worktree's settings.local.json with base defaults (GH-602).
+
+    A read-only surface curated once should be honored in a freshly created
+    worktree without a first prompt. This seeds the worktree's
+    ``.claude/settings.local.json`` (creating it when absent) with the base
+    catalog, deduped against the user-global allow list. Returns the count
+    added so the worktree-creation caller can report it.
+    """
+    base_permissions = config.get("base_permissions", [])
+    base_denies = config.get("base_denies", [])
+    settings = Path(worktree_root) / ".claude" / "settings.local.json"
+
+    created_fresh = not settings.exists()
+    if dry_run:
+        return ok(
+            {
+                "path": str(settings),
+                "added": 0,
+                "would_create": created_fresh,
+                "dry_run": True,
+            }
+        )
+
+    if created_fresh:
+        try:
+            settings.parent.mkdir(parents=True, exist_ok=True)
+            settings.write_text("{}\n")
+        except OSError as error:
+            return err(f"cannot create worktree settings: {error}", path=str(settings))
+
+    global_rules, _ = _load_global_allow_rules()
+    filtered = [rule for rule in base_permissions if rule not in global_rules]
+
+    from dev10x.skills.permission.enumerate_mcp import discover_mcp_tools
+
+    mcp_catalog = discover_mcp_tools()
+    added_allow, _ = ensure_base_permissions(settings, filtered, mcp_catalog=mcp_catalog)
+    added_deny, _ = ensure_base_denies(settings, base_denies)
+
+    return ok(
+        {
+            "path": str(settings),
+            "added": added_allow + added_deny,
+            "created_fresh": created_fresh,
+        }
     )
 
 

--- a/tests/commands/test_permission_provenance.py
+++ b/tests/commands/test_permission_provenance.py
@@ -1,0 +1,84 @@
+"""Tests for `dev10x permission provenance` and `seed-worktree` (GH-602)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from dev10x.commands.permission import provenance as provenance_cmd
+from dev10x.commands.permission import seed_worktree as seed_worktree_cmd
+from dev10x.domain.common.result import err, ok
+
+
+@pytest.fixture(autouse=True)
+def _config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from dev10x.skills.permission import update_paths as paths_mod
+
+    monkeypatch.setattr(paths_mod, "find_config", lambda: ok(tmp_path / "config.yaml"))
+    monkeypatch.setattr(paths_mod, "load_config", lambda _path: {"base_permissions": []})
+
+
+def test_provenance_prints_counts(monkeypatch: pytest.MonkeyPatch) -> None:
+    from dev10x.skills.permission import provenance as mod
+
+    monkeypatch.setattr(
+        mod,
+        "build_provenance",
+        lambda **_kw: ok(
+            {
+                "path": "/p/.claude/settings.local.json",
+                "rules": [{"rule": "Bash(ls:*)", "kind": "allow", "provenance": "default"}],
+                "counts": {"default": 1, "user": 0, "project": 0},
+            }
+        ),
+    )
+    result = CliRunner().invoke(provenance_cmd, [])
+    assert result.exit_code == 0
+    assert "default: 1" in result.output
+    assert "[default] allow: Bash(ls:*)" in result.output
+
+
+def test_provenance_error_exits_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
+    from dev10x.skills.permission import provenance as mod
+
+    monkeypatch.setattr(mod, "build_provenance", lambda **_kw: err("settings file not found"))
+    result = CliRunner().invoke(provenance_cmd, ["--path", "/nope.json"])
+    assert result.exit_code == 1
+    assert "not found" in result.output
+
+
+def test_seed_worktree_reports_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    from dev10x.skills.permission import update_paths as paths_mod
+
+    monkeypatch.setattr(
+        paths_mod,
+        "seed_worktree",
+        lambda **_kw: ok({"path": "/wt/.claude/settings.local.json", "added": 5}),
+    )
+    result = CliRunner().invoke(seed_worktree_cmd, ["/wt"])
+    assert result.exit_code == 0
+    assert "Seeded 5 rule(s)" in result.output
+
+
+def test_seed_worktree_dry_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    from dev10x.skills.permission import update_paths as paths_mod
+
+    monkeypatch.setattr(
+        paths_mod,
+        "seed_worktree",
+        lambda **_kw: ok({"path": "/wt/.claude/settings.local.json", "added": 0}),
+    )
+    result = CliRunner().invoke(seed_worktree_cmd, ["/wt", "--dry-run"])
+    assert result.exit_code == 0
+    assert "Would seed 0 rule(s)" in result.output
+
+
+def test_seed_worktree_error_exits_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
+    from dev10x.skills.permission import update_paths as paths_mod
+
+    monkeypatch.setattr(paths_mod, "seed_worktree", lambda **_kw: err("cannot create"))
+    result = CliRunner().invoke(seed_worktree_cmd, ["/wt"])
+    assert result.exit_code == 1
+    assert "cannot create" in result.output

--- a/tests/mcp/test_git_tools_seed.py
+++ b/tests/mcp/test_git_tools_seed.py
@@ -1,0 +1,62 @@
+"""Tests for worktree-creation seeding at the MCP boundary (GH-602)."""
+
+from __future__ import annotations
+
+import pytest
+
+from dev10x.domain.common.result import err, ok
+from dev10x.mcp.git_tools import _seed_worktree_defaults
+
+
+@pytest.fixture
+def wired(monkeypatch: pytest.MonkeyPatch):
+    """Wire find_config/load_config to succeed; caller sets seed_worktree."""
+    from dev10x.skills.permission import update_paths as paths_mod
+
+    monkeypatch.setattr(paths_mod, "find_config", lambda: ok("/cfg.yaml"))
+    monkeypatch.setattr(paths_mod, "load_config", lambda _path: {"base_permissions": []})
+    return paths_mod
+
+
+def test_skips_on_error_result(wired):
+    result = {"error": "boom"}
+    _seed_worktree_defaults(result)
+    assert "seeded_permissions" not in result
+
+
+def test_skips_without_worktree_path(wired):
+    result = {"created": True}
+    _seed_worktree_defaults(result)
+    assert "seeded_permissions" not in result
+
+
+def test_records_seeded_count(wired, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(wired, "seed_worktree", lambda **_kw: ok({"added": 9}))
+    result = {"worktree_path": "/wt", "created": True}
+    _seed_worktree_defaults(result)
+    assert result["seeded_permissions"] == 9
+
+
+def test_records_seed_error(wired, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(wired, "seed_worktree", lambda **_kw: err("cannot create"))
+    result = {"worktree_path": "/wt"}
+    _seed_worktree_defaults(result)
+    assert result["seed_error"] == "cannot create"
+
+
+def test_skips_when_config_missing(wired, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(wired, "find_config", lambda: err("no config"))
+    result = {"worktree_path": "/wt"}
+    _seed_worktree_defaults(result)
+    assert "seeded_permissions" not in result
+    assert "seed_error" not in result
+
+
+def test_oserror_is_recorded(wired, monkeypatch: pytest.MonkeyPatch):
+    def _boom(**_kw):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(wired, "seed_worktree", _boom)
+    result = {"worktree_path": "/wt"}
+    _seed_worktree_defaults(result)
+    assert "disk full" in result["seed_error"]

--- a/tests/skills/permission/test_provenance.py
+++ b/tests/skills/permission/test_provenance.py
@@ -1,0 +1,87 @@
+"""Tests for queryable rule provenance (GH-602)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dev10x.domain.common.result import ErrorResult, SuccessResult
+from dev10x.skills.permission.provenance import (
+    RuleProvenance,
+    build_provenance,
+    classify_provenance,
+)
+
+
+class TestClassifyProvenance:
+    def test_default(self):
+        assert (
+            classify_provenance("a", base_rules={"a"}, global_rules=set())
+            == RuleProvenance.DEFAULT
+        )
+
+    def test_user(self):
+        assert (
+            classify_provenance("b", base_rules=set(), global_rules={"b"}) == RuleProvenance.USER
+        )
+
+    def test_project(self):
+        assert (
+            classify_provenance("c", base_rules=set(), global_rules=set())
+            == RuleProvenance.PROJECT
+        )
+
+
+class TestBuildProvenance:
+    def _settings(self, tmp_path: Path) -> Path:
+        path = tmp_path / "settings.local.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "permissions": {
+                        "allow": ["Bash(ls:*)", "Bash(local:*)", "User(x)", 123],
+                        "deny": ["Bash(sudo:*)", "Bash(localdeny:*)"],
+                    }
+                }
+            )
+        )
+        return path
+
+    def test_tags_each_origin(self, tmp_path: Path):
+        config = {"base_permissions": ["Bash(ls:*)"], "base_denies": ["Bash(sudo:*)"]}
+        result = build_provenance(
+            settings_path=self._settings(tmp_path), config=config, global_rules={"User(x)"}
+        )
+        assert isinstance(result, SuccessResult)
+        counts = result.value["counts"]
+        assert counts["default"] == 2  # Bash(ls:*) allow + Bash(sudo:*) deny
+        assert counts["user"] == 1  # User(x)
+        assert counts["project"] == 2  # Bash(local:*) + Bash(localdeny:*)
+        # The non-string allow entry (123) is dropped, not classified.
+        assert all(isinstance(entry["rule"], str) for entry in result.value["rules"])
+
+    def test_reads_global_when_not_injected(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(
+            "dev10x.skills.permission.provenance._load_global_allow_rules",
+            lambda: ({"User(x)"}, []),
+        )
+        result = build_provenance(
+            settings_path=self._settings(tmp_path),
+            config={"base_permissions": [], "base_denies": []},
+        )
+        assert isinstance(result, SuccessResult)
+        assert result.value["counts"]["user"] == 1
+
+    def test_missing_file(self, tmp_path: Path):
+        result = build_provenance(settings_path=tmp_path / "absent.json", config={})
+        assert isinstance(result, ErrorResult)
+        assert "not found" in result.error
+
+    def test_bad_json(self, tmp_path: Path):
+        path = tmp_path / "settings.local.json"
+        path.write_text("{not json")
+        result = build_provenance(settings_path=path, config={})
+        assert isinstance(result, ErrorResult)
+        assert "cannot read" in result.error

--- a/tests/skills/permission/test_seed_worktree.py
+++ b/tests/skills/permission/test_seed_worktree.py
@@ -1,0 +1,72 @@
+"""Tests for seed-at-worktree-creation (GH-602)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dev10x.domain.common.result import ErrorResult, SuccessResult
+from dev10x.skills.permission import enumerate_mcp
+from dev10x.skills.permission import update_paths as mod
+
+
+@pytest.fixture
+def config() -> dict:
+    return {
+        "base_permissions": ["Bash(ls:*)", "Skill(Dev10x:foo)"],
+        "base_denies": ["Bash(sudo:*)"],
+    }
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(mod, "_load_global_allow_rules", lambda: (set(), []))
+    monkeypatch.setattr(enumerate_mcp, "discover_mcp_tools", lambda **_kw: {})
+
+
+def _allow(worktree: Path) -> list[str]:
+    data = json.loads((worktree / ".claude" / "settings.local.json").read_text())
+    return data["permissions"]["allow"]
+
+
+def test_seeds_fresh_worktree(tmp_path: Path, config: dict):
+    result = mod.seed_worktree(worktree_root=tmp_path, config=config)
+    assert isinstance(result, SuccessResult)
+    assert result.value["created_fresh"] is True
+    assert result.value["added"] == 3
+    settings = tmp_path / ".claude" / "settings.local.json"
+    data = json.loads(settings.read_text())
+    assert "Bash(ls:*)" in data["permissions"]["allow"]
+    assert "Bash(sudo:*)" in data["permissions"]["deny"]
+
+
+def test_dry_run_writes_nothing(tmp_path: Path, config: dict):
+    result = mod.seed_worktree(worktree_root=tmp_path, config=config, dry_run=True)
+    assert isinstance(result, SuccessResult)
+    assert result.value["would_create"] is True
+    assert not (tmp_path / ".claude" / "settings.local.json").exists()
+
+
+def test_idempotent(tmp_path: Path, config: dict):
+    mod.seed_worktree(worktree_root=tmp_path, config=config)
+    second = mod.seed_worktree(worktree_root=tmp_path, config=config)
+    assert second.value["added"] == 0
+    assert second.value["created_fresh"] is False
+
+
+def test_dedupes_against_global(tmp_path: Path, config: dict, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(mod, "_load_global_allow_rules", lambda: ({"Bash(ls:*)"}, []))
+    mod.seed_worktree(worktree_root=tmp_path, config=config)
+    allow = _allow(tmp_path)
+    assert "Bash(ls:*)" not in allow  # already global — skipped
+    assert "Skill(Dev10x:foo)" in allow
+
+
+def test_create_error_is_reported(tmp_path: Path, config: dict):
+    blocker = tmp_path / "afile"
+    blocker.write_text("x")  # a file where the worktree dir should be
+    result = mod.seed_worktree(worktree_root=blocker, config=config)
+    assert isinstance(result, ErrorResult)
+    assert "cannot create" in result.error


### PR DESCRIPTION
**When** I curate a read-only permission surface once but keep re-approving it in every fresh worktree and sibling project, and I can't tell which of a project's rules are catalog defaults versus local additions, **I want to** seed the curated safe defaults at worktree creation and query each rule's provenance, **so I can** stop re-approving known-safe surfaces across the fleet and audit where every rule came from.

---

[`6e10e149`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/672/commits/6e10e1494cce26232b6331cf9d3425cd08fa8c29) ✨ GH-602 Enable fleet-wide seeding and rule provenance for worktrees
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/602

---