### PR TITLE
✨ GH-352 Enable learned-rule review in the installable Action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,10 +10,11 @@
 # docs/github-action-install.md; a copy-paste consumer workflow lives at
 # docs/install/dev10x-review.yml.
 #
-# Scope note: this ticket (GH-351) ships the runnable skeleton and the
-# install/permissions contract only. The two extension points are tracked
-# separately and marked inline below:
-#   - GH-352: review from learned rules (replaces the generic review prompt)
+# Scope note: GH-351 shipped the runnable skeleton + install/permissions
+# contract. GH-352 implements the `review` path — packaged reviewer
+# checklist + learned rules mined from the consumer repo (see the
+# "Prepare review context" and "Run Dev10x review" steps). One extension
+# point remains:
 #   - GH-353: continuous learning loop (fills in the `learn` mode stub)
 name: "Dev10x PR Review"
 description: >-
@@ -71,6 +72,39 @@ runs:
       with:
         fetch-depth: 1
 
+    - name: Set up uv
+      if: steps.resolve.outputs.mode == 'review'
+      uses: astral-sh/setup-uv@v5
+
+    - name: Prepare review context
+      # GH-352: assemble the two review inputs into the workspace so the
+      # review step reads workspace-local files instead of depending on
+      # internal repo paths the consumer does not have:
+      #   - checklist.md      — the bundled, repo-agnostic reviewer checklist
+      #                         shipped inside this Action ($GITHUB_ACTION_PATH).
+      #   - learned-rules.md  — rules mined from the CONSUMER repo's own
+      #                         merged-PR history via `dev10x github review-rules`.
+      # Mining degrades gracefully: on failure the review still runs against
+      # the bundled checklist alone.
+      if: steps.resolve.outputs.mode == 'review'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+      run: |
+        set -e
+        review_dir="$GITHUB_WORKSPACE/.dev10x-review"
+        mkdir -p "$review_dir"
+        cp "$GITHUB_ACTION_PATH/references/review-bundle/checklist.md" \
+          "$review_dir/checklist.md"
+        if uvx --from "$GITHUB_ACTION_PATH" dev10x github review-rules \
+            --repo "$GITHUB_REPOSITORY" > "$review_dir/learned-rules.md"; then
+          echo "::notice::Dev10x learned-rules digest generated for $GITHUB_REPOSITORY."
+        else
+          echo "::notice::Dev10x learned-rule mining unavailable — reviewing with the bundled checklist only."
+          printf '# Learned review rules\n\n_Learned-rule mining was unavailable for this run. Reviewing with the bundled checklist only._\n' \
+            > "$review_dir/learned-rules.md"
+        fi
+
     - name: Run Dev10x review
       if: steps.resolve.outputs.mode == 'review'
       uses: anthropics/claude-code-action@v1
@@ -79,31 +113,59 @@ runs:
       with:
         anthropic_api_key: ${{ inputs.anthropic_api_key }}
         github_token: ${{ inputs.github_token }}
-        # GH-352: replace this self-contained prompt with the packaged
-        # reviewer agents + learned rules so review quality matches the
-        # internal multi-agent pipeline (see .github/workflows/claude-code-review.yml).
+        # GH-352: review with the packaged reviewer logic + learned rules so
+        # external repos get review quality close to the internal multi-agent
+        # pipeline (see .github/workflows/claude-code-review.yml). Both inputs
+        # are staged into .dev10x-review/ by the "Prepare review context" step.
         prompt: |
           REPO: ${{ github.repository }}
           PR NUMBER: ${{ github.event.pull_request.number }}
 
-          You are performing an automated code review. Be brief but thorough.
+          You are performing an automated, supervisor-style code review.
+          Be brief but thorough.
 
-          1. Run `gh pr diff ${{ github.event.pull_request.number }} --stat`
-             then `gh pr diff ${{ github.event.pull_request.number }}` to read
-             the changes. Review ONLY the changed lines — pre-existing issues
-             are out of scope.
-          2. Look for correctness bugs, security issues (injected secrets,
-             unsafe input handling), missing error handling, and obvious
-             maintainability problems.
-          3. Before claiming an error, read the surrounding file to confirm it
-             is real. Avoid false positives.
-          4. Post specific findings as inline review comments and ONE summary
-             comment. If the PR is clean, say so plainly.
+          STEP 1 — LOAD REVIEW GUIDANCE (already staged in the workspace):
+          - .dev10x-review/checklist.md — the bundled, repo-agnostic reviewer
+            checklist: scope rules, the false-positive gate, severity levels,
+            per-domain and cross-cutting checks, and the output format.
+          - .dev10x-review/learned-rules.md — rules mined from THIS
+            repository's own merged-PR review history. Treat them as
+            heuristic signals, not hard rules.
+
+          STEP 2 — READ THE DIFF:
+          Run `gh pr diff ${{ github.event.pull_request.number }} --stat`
+          then `gh pr diff ${{ github.event.pull_request.number }}`. Review
+          ONLY the changed lines — pre-existing issues are out of scope.
+          Classify changed files by domain and apply the matching domain
+          checklist from checklist.md plus the cross-cutting checks.
+
+          STEP 3 — APPLY LEARNED RULES:
+          For each learned rule whose signal tokens appear in the changed
+          lines, check whether this PR repeats the issue reviewers
+          historically raised.
+
+          STEP 4 — VERIFY BEFORE POSTING:
+          Read the surrounding code in the actual file (not just the diff)
+          and quote the real code. Pass every finding through the
+          false-positive gate in checklist.md. Skip anything that fails.
+
+          STEP 5 — PRODUCE OUTPUT:
+          Check existing comments to avoid duplicates. Post specific issues
+          as inline review comments and exactly ONE summary comment. If the
+          PR is clean, say so plainly and validate the good work.
+
+          STEP 6 — CONVERT TO DRAFT IF ISSUES FOUND:
+          Read the real inline-comment count — do NOT rely on recollection:
+            `gh pr view ${{ github.event.pull_request.number }} --json reviewComments --jq '.reviewComments | length'`
+          If the count is greater than 0, convert the PR to draft so the
+          author can batch fixes without re-triggering a review per push:
+            `gh pr ready --undo ${{ github.event.pull_request.number }}`
+          If the count is 0, do not convert.
 
           Be constructive and helpful.
         claude_args: >-
           --model ${{ inputs.model }}
-          --allowed-tools "Read,Grep,Glob,mcp__github_inline_comment__create_inline_comment,mcp__github__get_pull_request_review_comments,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api:*)"
+          --allowed-tools "Read,Grep,Glob,mcp__github_inline_comment__create_inline_comment,mcp__github__get_pull_request_review_comments,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh pr ready:*),Bash(gh api:*)"
 
     - name: Harvest review learnings (scaffold)
       if: steps.resolve.outputs.mode == 'learn'

--- a/docs/github-action-install.md
+++ b/docs/github-action-install.md
@@ -5,17 +5,36 @@ Dev10x GitHub Action. This is independent of the Claude Code plugin
 install ([installation.md](installation.md)) — you do not need the
 plugin to use the Action.
 
-> **Scaffold status (M6).** This is the foundational install flow
-> (GH-351). The review currently runs a self-contained generic prompt.
-> Review-from-learned-rules (GH-352) and the continuous learning loop
-> (GH-353) extend this scaffold and are tracked separately.
+> **Status (M6).** The install flow (GH-351) and the learned-rules
+> review path (GH-352) are live. The continuous learning loop (GH-353,
+> the `learn` mode) extends this and is tracked separately.
 
 ## What it does
 
 | PR event | Mode | Behavior |
 |----------|------|----------|
-| `opened`, `synchronize`, `ready_for_review` | `review` | Reviews the diff and posts inline + summary comments |
+| `opened`, `synchronize`, `ready_for_review` | `review` | Reviews the diff with the packaged reviewer checklist + learned rules, posts inline + summary comments |
 | `closed` | `learn` | Harvests review patterns (scaffolded — no-op until GH-353) |
+
+### How the review works (GH-352)
+
+On the `review` path the Action assembles two inputs into the consumer
+workspace under `.dev10x-review/` before invoking the model:
+
+- **`checklist.md`** — a bundled, repo-agnostic reviewer checklist that
+  ships inside the Action. It distills the internal multi-agent review
+  pipeline (scope rules, false-positive gate, severity levels, per-domain
+  and cross-cutting checks) so an external repo gets comparable review
+  quality without any Dev10x internal files checked out.
+- **`learned-rules.md`** — review rules mined from **your own**
+  repository's merged-PR review history via
+  `dev10x github review-rules`. These are heuristic signals weighted
+  during review, not hard rules. Mining degrades gracefully: if it is
+  unavailable, the review proceeds on the bundled checklist alone.
+
+When the review finds issues it converts the PR to draft so you can
+batch fixes without re-triggering a review on each push; mark it
+*Ready for review* when done.
 
 ## Prerequisites
 

--- a/references/review-bundle/checklist.md
+++ b/references/review-bundle/checklist.md
@@ -1,0 +1,127 @@
+# Bundled PR Review Checklist (repo-agnostic)
+
+Self-contained reviewer guidance for the installable Dev10x review
+Action (GH-352). It distills the internal multi-agent pipeline
+(`.github/workflows/claude-code-review.yml` + `.claude/agents/reviewer-*`
++ `references/review-checks-common.md`) into a single file that ships
+**inside the Action**, because consumer repositories do not have those
+internal files checked out.
+
+Apply it together with the mined learned-rules digest (when present).
+The learned rules are heuristic signals from the consumer repo's own
+review history — weigh them, do not enforce them blindly.
+
+## Scope (read first)
+
+- Review **only the lines changed in this PR's diff**. Pre-existing
+  issues outside the diff are out of scope — do not flag them.
+- PR metadata (title, body, commit messages, branch name) is handled by
+  separate hygiene tooling. Do not comment on it.
+- Be brief but thorough. Prefer a small number of high-confidence,
+  actionable findings over a long list of preferences.
+
+## False-positive prevention gate
+
+Before posting **any** inline comment, all must hold:
+
+1. **In diff** — the line is actually part of this PR's changes
+   (`gh pr diff --name-only` to confirm the file changed).
+2. **Verified in the file** — you read the surrounding code in the
+   actual file, not just the diff snippet, and quoted the real code.
+3. **Rule or pattern backs it** — it violates a documented project
+   convention or contradicts an established pattern (5+ existing uses),
+   not merely your preference.
+4. **Real, not stale** — the issue still exists at current HEAD (not
+   fixed in a later commit of the same PR).
+
+If any check fails, do not post.
+
+## Severity
+
+- **CRITICAL / REQUIRED** — correctness bug, security hole, data loss,
+  or a violation enforced by CI/merge protection. Blocks merge.
+- **WARNING** — likely defect or maintainability risk; author should
+  address or justify.
+- **INFO / RECOMMENDED** — advisory; never blocks merge. Do not
+  re-raise once the author has consciously declined it.
+
+Only label REQUIRED when a real enforcement mechanism exists.
+
+## Cross-cutting checks (all files)
+
+- **Correctness** — logic errors, off-by-one, wrong conditionals,
+  unhandled None/empty, incorrect error propagation.
+- **Security** — no hardcoded secrets/tokens, no `eval`/`exec` of
+  untrusted input, safe handling of user input, proper quoting in shell.
+- **Error handling** — failures are surfaced, not silently swallowed
+  (`except: pass`, `|| true`, `2>/dev/null` on a command whose output
+  drives branching). `except E: side_effect(); raise` is NOT swallowing.
+- **Dead code** — for a new class/function/constant, confirm it is
+  referenced outside its definition file (exclude tests, ABCs, exports).
+- **Parameter changes** — when a signature changes, all call sites must
+  be updated; check beyond the diff.
+- **Naming** — only flag genuinely misleading names; respect existing
+  conventions (5+ uses), version suffixes, and domain prefixes.
+
+## Architecture checks (new / substantially modified code)
+
+Apply on PRs adding or significantly changing endpoint/view/service
+code; skip for docs-only, config-only, or test-only PRs.
+
+- New endpoints/views delegate business logic to a service layer rather
+  than calling repositories/ORM directly (WARNING).
+- Functions/methods over ~50 lines, or one function doing
+  validation + business logic + persistence + formatting, likely
+  violate SRP (WARNING).
+- Inline dicts with 4+ keys crossing module boundaries should be typed
+  DTOs (INFO). Validate inputs early via serializer/DTO (WARNING when
+  raw `request.data[...]` parsing is unvalidated).
+
+## Domain quick-checklists
+
+Load only the domains with changed files.
+
+- **Python / shell code** — type hints on signatures; named args for
+  3+ params; `set -e` and meaningful exit codes in shell; check the
+  shebang before flagging shell syntax (bash vs sh vs fish); a new
+  production `.py` module with logic should have a matching test
+  (WARNING when absent; exempt pure DTOs/ABCs/config).
+- **Infrastructure (CI workflows, Makefiles, scripts)** — no hardcoded
+  branch names (use the PR's base ref); idempotent branch creation
+  (`checkout -B`); never expose secrets in logs; quote expansions.
+- **Documentation** — referenced commands/files/dirs must exist; mark
+  not-yet-implemented features `[PLANNED]`; unverified references in
+  user-facing docs are WARNING.
+- **Migrations / schema** — guard against data loss and tenant-scope
+  leaks; prefer backward-compatible, low-lock changes.
+- **Async tasks / event handlers** — idempotency, retry/timeout
+  semantics, no swallowed exceptions, correct registration.
+- **Frontend** — accessibility, SSR safety, auth/i18n correctness,
+  fragile locators avoided.
+
+## Shell anti-patterns
+
+- No hardcoded temp paths; create temp files via the project's helper.
+- A shell command-parsing check must inspect **all** segments — both
+  pipe (`|`) and `&&`/`;` chained sub-commands.
+- Flag implicit defaults (`jq '.field // ""'`) when the default value
+  silently drives branching; validate explicitly instead.
+
+## Producing the review
+
+1. Check existing review comments and summaries first to avoid
+   duplicates; determine the correct round number (highest + 1).
+2. Post specific issues as **inline comments** on the changed lines.
+3. Post **one** summary comment per review cycle. If the PR is clean,
+   say so plainly and validate the good work.
+4. After the author pushes fixes, acknowledge them and focus only on
+   new issues — do not re-raise resolved or consciously-declined items.
+
+## Convert to draft when issues are found
+
+After reviewing, read the real inline-comment count from the API
+(`gh pr view <N> --json reviewComments --jq '.reviewComments | length'`)
+— do not rely on recollection. If the count is greater than 0, convert
+the PR to draft (`gh pr ready --undo <N>`) so the author can batch fixes
+without re-triggering a review on every push. If the count is 0, leave
+the PR as-is.

--- a/src/dev10x/cli.py
+++ b/src/dev10x/cli.py
@@ -41,6 +41,7 @@ class LazyGroup(click.Group):
     cls=LazyGroup,
     lazy_subcommands={
         "config": "dev10x.commands.config.config",
+        "github": "dev10x.commands.github.github",
         "github-app": "dev10x.commands.github_app.github_app",
         "hook": "dev10x.commands.hook.hook",
         "init": "dev10x.commands.init.init",

--- a/src/dev10x/commands/github.py
+++ b/src/dev10x/commands/github.py
@@ -1,0 +1,138 @@
+"""``dev10x github`` — GitHub review helpers usable from CI (GH-352).
+
+The installable PR-review Action (``action.yml``) shells out to
+``dev10x github review-rules`` to mine the consumer repository's own
+merged-PR review history into a learned-rules Markdown digest. That
+digest is fed into the review prompt alongside the bundled,
+repo-agnostic reviewer checklist so an external repo gets review quality
+close to the internal multi-agent pipeline.
+
+This command is the CLI seam over
+:func:`dev10x.github.rule_authoring.author_reference_rules`, which was
+previously reachable only through the MCP boundary. Per ADR-0010 the
+domain function returns ``Result[T]`` and stays side-effect free; this
+entry point owns stdout and the process exit code.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from typing import Any
+
+import click
+
+_RULE_SEPARATOR = "\n\n---\n\n"
+
+_NO_RULES_DIGEST = "\n".join(
+    [
+        "# Learned review rules",
+        "",
+        "_No validated review-comment patterns were found in this "
+        "repository's recent merged PRs. Review proceeds with the bundled "
+        "reviewer checklist only._",
+        "",
+    ]
+)
+
+
+@click.group()
+def github() -> None:
+    """GitHub review helpers (learned-rule mining for the review Action)."""
+
+
+def _render_digest(*, rules: list[dict[str, Any]], routing_fragment: str) -> str:
+    """Compose the learned-rules Markdown digest from authored rule docs.
+
+    Pure string assembly so the rendering is unit-testable without
+    touching ``gh``. Each rule doc already carries its own heuristic
+    confidence caveat, so the digest only adds a short preamble.
+    """
+    if not rules:
+        return _NO_RULES_DIGEST
+
+    bodies = [str(rule.get("content", "")).rstrip() for rule in rules]
+    return "\n".join(
+        [
+            "# Learned review rules",
+            "",
+            f"> Mined from this repository's merged-PR review history "
+            f"({len(rules)} validated pattern(s)). Frequencies and "
+            "false-positive rates are heuristic estimates — treat them as "
+            "signals, not measured precision.",
+            "",
+            _RULE_SEPARATOR.join(bodies),
+            "",
+            "## Routing",
+            "",
+            routing_fragment,
+            "",
+        ]
+    )
+
+
+@github.command(name="review-rules")
+@click.option(
+    "--repo",
+    default=None,
+    help="owner/name to mine. Defaults to the current repository.",
+)
+@click.option(
+    "--limit",
+    type=int,
+    default=50,
+    show_default=True,
+    help="Max merged PRs scanned for review comments.",
+)
+@click.option(
+    "--min-frequency",
+    type=int,
+    default=2,
+    show_default=True,
+    help="Minimum reviewer frequency for a validated pattern.",
+)
+@click.option(
+    "--max-fp-rate",
+    type=float,
+    default=0.5,
+    show_default=True,
+    help="Maximum estimated false-positive rate for a validated pattern.",
+)
+def review_rules(
+    *,
+    repo: str | None,
+    limit: int,
+    min_frequency: int,
+    max_fp_rate: float,
+) -> None:
+    """Print a learned-rules Markdown digest from validated review patterns.
+
+    Wraps :func:`dev10x.github.rule_authoring.author_reference_rules` and
+    emits a self-contained Markdown document on stdout. When no pattern
+    validates, a clear placeholder digest is emitted (exit 0) so the
+    Action always has a readable file to feed the review prompt. A genuine
+    mining failure (e.g. ``gh`` auth error) prints the message to stderr
+    and exits non-zero so the Action can degrade gracefully.
+    """
+    from dev10x.domain.common.result import SuccessResult
+    from dev10x.github import rule_authoring
+
+    result = asyncio.run(
+        rule_authoring.author_reference_rules(
+            repos=[repo] if repo else None,
+            limit=limit,
+            min_frequency=min_frequency,
+            max_fp_rate=max_fp_rate,
+        )
+    )
+
+    if not isinstance(result, SuccessResult):
+        click.echo(f"[ERROR] {result.error}", err=True)
+        sys.exit(1)
+
+    click.echo(
+        _render_digest(
+            rules=result.value["rules"],
+            routing_fragment=result.value["routing_fragment"],
+        )
+    )

--- a/tests/commands/test_github_review_rules.py
+++ b/tests/commands/test_github_review_rules.py
@@ -1,0 +1,123 @@
+"""Tests for `dev10x github review-rules` (GH-352).
+
+Contract class: mock
+  The pure digest renderer is tested directly; the command path patches
+  the GH-349 author so no ``gh`` subprocess runs.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from dev10x.cli import cli
+from dev10x.commands.github import _render_digest
+from dev10x.domain.common.result import err, ok
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _rule(*, slug: str = "block-chaining", content: str = "# Block chaining\n\nbody") -> dict:
+    return {"slug": slug, "title": "Block chaining", "path": f"p/{slug}.md", "content": content}
+
+
+class TestGithubGroupRegistration:
+    def test_group_exposed(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["github", "--help"])
+
+        assert result.exit_code == 0
+        assert "review-rules" in result.output
+
+    def test_review_rules_help_lists_options(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["github", "review-rules", "--help"])
+
+        assert result.exit_code == 0
+        assert "--repo" in result.output
+        assert "--min-frequency" in result.output
+        assert "--max-fp-rate" in result.output
+
+
+class TestRenderDigest:
+    def test_includes_rule_bodies_and_routing(self) -> None:
+        digest = _render_digest(
+            rules=[_rule(content="# A\n\naaa"), _rule(slug="b", content="# B\n\nbbb")],
+            routing_fragment="| Generated rule | Reviewer agent |",
+        )
+        assert digest.startswith("# Learned review rules")
+        assert "2 validated pattern(s)" in digest
+        assert "# A" in digest and "# B" in digest
+        assert "---" in digest  # separator between rule bodies
+        assert "## Routing" in digest
+        assert "| Generated rule | Reviewer agent |" in digest
+
+    def test_empty_rules_yield_placeholder(self) -> None:
+        digest = _render_digest(rules=[], routing_fragment="ignored")
+        assert "# Learned review rules" in digest
+        assert "No validated review-comment patterns" in digest
+        assert "## Routing" not in digest
+
+
+class TestReviewRulesCommand:
+    @patch(
+        "dev10x.github.rule_authoring.author_reference_rules",
+        new_callable=AsyncMock,
+    )
+    def test_happy_path_prints_digest(
+        self,
+        mock_author: AsyncMock,
+        runner: CliRunner,
+    ) -> None:
+        mock_author.return_value = ok(
+            {
+                "rules": [_rule(content="# Block chaining\n\navoid && chaining")],
+                "routing_fragment": "| `p/block-chaining.md` | `reviewer-generic` |",
+                "summary": {"rules_authored": 1},
+            }
+        )
+
+        result = runner.invoke(cli, ["github", "review-rules", "--repo", "o/r"])
+
+        assert result.exit_code == 0, result.output
+        assert "Learned review rules" in result.output
+        assert "avoid && chaining" in result.output
+        assert "reviewer-generic" in result.output
+        mock_author.assert_awaited_once()
+        assert mock_author.await_args.kwargs["repos"] == ["o/r"]
+
+    @patch(
+        "dev10x.github.rule_authoring.author_reference_rules",
+        new_callable=AsyncMock,
+    )
+    def test_no_repo_passes_none(
+        self,
+        mock_author: AsyncMock,
+        runner: CliRunner,
+    ) -> None:
+        mock_author.return_value = ok({"rules": [], "routing_fragment": "x", "summary": {}})
+
+        result = runner.invoke(cli, ["github", "review-rules"])
+
+        assert result.exit_code == 0, result.output
+        assert "No validated review-comment patterns" in result.output
+        assert mock_author.await_args.kwargs["repos"] is None
+
+    @patch(
+        "dev10x.github.rule_authoring.author_reference_rules",
+        new_callable=AsyncMock,
+    )
+    def test_mining_error_exits_nonzero(
+        self,
+        mock_author: AsyncMock,
+        runner: CliRunner,
+    ) -> None:
+        mock_author.return_value = err("no repository specified")
+
+        result = runner.invoke(cli, ["github", "review-rules"])
+
+        assert result.exit_code == 1
+        assert "no repository specified" in result.output

--- a/tests/mcp/test_misc_tools.py
+++ b/tests/mcp/test_misc_tools.py
@@ -188,9 +188,7 @@ class TestRecordUpgrade:
 
         import asyncio
 
-        result = asyncio.get_event_loop().run_until_complete(
-            cli_server.record_upgrade(version="1.2.3")
-        )
+        result = asyncio.run(cli_server.record_upgrade(version="1.2.3"))
 
         assert result == {"version": "1.2.3", "path": "/home/user/.config/dev10x"}
         assert mock_fn.call_args.kwargs["version"] == "1.2.3"
@@ -201,7 +199,7 @@ class TestRecordUpgrade:
 
         import asyncio
 
-        asyncio.get_event_loop().run_until_complete(cli_server.record_upgrade())
+        asyncio.run(cli_server.record_upgrade())
 
         assert mock_fn.call_args.kwargs["version"] is None
 
@@ -211,7 +209,7 @@ class TestRecordUpgrade:
 
         import asyncio
 
-        result = asyncio.get_event_loop().run_until_complete(cli_server.record_upgrade())
+        result = asyncio.run(cli_server.record_upgrade())
 
         assert "error" in result
 

--- a/tests/test_cli_lazy.py
+++ b/tests/test_cli_lazy.py
@@ -16,6 +16,7 @@ from dev10x.cli import cli
 
 EXPECTED_SUBCOMMANDS = {
     "config",
+    "github",
     "github-app",
     "hook",
     "init",


### PR DESCRIPTION
**When** I install the Dev10x PR-review Action on one of my repositories, **I want to** have new PRs reviewed with the same checklist the internal multi-agent pipeline uses plus rules learned from my own merged PRs, **so I can** get comparable review quality without checking any Dev10x internals into my repo.

---

[`fe71c5b3`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/677/commits/fe71c5b3d289450db5c9ad81181e6c8b905c842c) ✨ GH-352 Enable learned-rule review in the installable Action
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/352

---