### PR TITLE
✨ GH-607 Unify sensitivity classification across surfaces

### DIFF
--- a/src/dev10x/domain/sensitivity.py
+++ b/src/dev10x/domain/sensitivity.py
@@ -128,6 +128,28 @@ _DEFAULT_PATTERNS: list[SensitivityPattern] = [
         r"(?:^|\s)\.env\b",
         ".env file reference",
     ),
+    # Credentialed-CLI secret-exfil reads (GH-605). These verbs READ but
+    # the value they return is a live secret — a broad "allow read
+    # subcommands" grant on a credentialed wrapper must never cover them,
+    # so DX014's sensitivity axis elevates them to ask even when the
+    # surrounding wrapper (aws-vault exec, vercel) is otherwise pre-approved.
+    _compile(
+        SensitivityLabel.SECRET,
+        r"\bsecretsmanager\s+get-secret-value\b",
+        "aws secretsmanager get-secret-value",
+    ),
+    _compile(
+        SensitivityLabel.SECRET,
+        r"\bssm\s+get-parameters?\b.*--with-decryption\b",
+        "aws ssm get-parameter --with-decryption",
+    ),
+    # `vercel env pull` / `vercel pull` write decrypted secrets to disk
+    # (GH-605 evidence #24).
+    _compile(
+        SensitivityLabel.SECRET,
+        r"\bvercel\s+(?:env\s+)?pull\b",
+        "vercel env pull (decrypted secrets to disk)",
+    ),
     # ── CREDENTIAL ──────────────────────────────────────────────────────────
     # GH-271 #269: rg for *_PRODUCTION_RW
     _compile(
@@ -292,9 +314,69 @@ class SensitivityClassifier:
         return results
 
 
+# ---------------------------------------------------------------------------
+# Identifier sensitivity — the NAME axis (GH-607)
+#
+# This module is the single source of the sensitivity vocabulary for every
+# PAP surface. ``SensitivityClassifier`` above matches *command strings*
+# (shell-shaped regexes, used by DX014); the helpers below match *identifier
+# names* — MCP tool, CLI command, and skill names — by word token.
+#
+# Both wordlists live here so the four surfaces — DX014, MCP promotion
+# (``promote.py``), the credentialed-CLI allowlist (GH-605), and skill
+# curation (GH-608) — share one source and cannot drift apart. Previously
+# the name-token set and its tokenizer lived in
+# ``skills/permission/promote.py``, duplicating the sensitivity notion the
+# regex wordlist already encodes (GH-607). The skills layer now imports
+# these from the domain layer rather than re-declaring them.
+# ---------------------------------------------------------------------------
+
+# Splits an identifier into word tokens: an acronym run before a CamelWord
+# (``HTTPSConnection`` → ``HTTPS`` + ``Connection``), a Capitalized or
+# lowercase word, a bare acronym, or a digit run. Combined with splitting on
+# ``_`` this tokenizes camelCase MCP tools (``getJiraIssue`` →
+# ``{get, jira, issue}``) instead of collapsing them into one token (GH-593).
+_IDENTIFIER_TOKEN_RE = re.compile(r"[A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+|[0-9]+")
+
+# Read identifiers whose target is private/DM/secret/credential data — a read
+# verb against one of these is promotable only on an explicit opt-in.
+SENSITIVE_NAME_TOKENS: frozenset[str] = frozenset(
+    {"private", "secret", "secrets", "credential", "credentials", "password", "dm"}
+)
+
+
+def tokenize_identifier(name: str) -> set[str]:
+    """Split a surface identifier into lowercase word tokens.
+
+    Strips any ``server__tool`` MCP prefix (keeps the final segment), then
+    splits on ``_`` and camelCase boundaries (GH-593). Shared by the
+    read/write classifier (``promote.classify_tokens``) and the name-based
+    sensitivity check so every surface tokenizes identically (GH-607).
+    """
+    short = name.rsplit("__", 1)[-1]
+    return {
+        match.group(0).lower()
+        for chunk in short.split("_")
+        for match in _IDENTIFIER_TOKEN_RE.finditer(chunk)
+    }
+
+
+def name_is_sensitive(name: str, *, tokens: frozenset[str] = SENSITIVE_NAME_TOKENS) -> bool:
+    """Return True when an identifier names a private/DM/secret/credential read.
+
+    Distinct from :class:`SensitivityClassifier`, which matches shell-command
+    *shapes*: this matches identifier *tokens* (tool / skill / command names).
+    Both share this module as their single source (GH-607).
+    """
+    return bool(tokenize_identifier(name) & tokens)
+
+
 __all__ = [
+    "SENSITIVE_NAME_TOKENS",
     "SensitivityClassifier",
     "SensitivityLabel",
     "SensitivityMatch",
     "SensitivityPattern",
+    "name_is_sensitive",
+    "tokenize_identifier",
 ]

--- a/src/dev10x/skills/permission/manifest.py
+++ b/src/dev10x/skills/permission/manifest.py
@@ -177,6 +177,38 @@ def _skill_access(allowed_tools: Iterable[str]) -> Access:
     return Access.READ
 
 
+def classify_skill_access(
+    *,
+    name: str,
+    description: str = "",
+    allowed_tools: Iterable[str] = (),
+) -> Access:
+    """Classify a skill read-only vs mutating for the S15 curation surface (GH-608).
+
+    Composes three signals under write-precedence — a skill is ``WRITE`` if
+    ANY signal says write, ``READ`` only when none does:
+
+    1. ``allowed-tools`` declares Edit/Write or a write-verb ``Bash`` rule
+       (the strongest signal; shared with :func:`_skill_access`).
+    2. the skill NAME's verb (``git-commit`` → write) via the unified
+       :func:`classify_tokens`.
+    3. the frontmatter DESCRIPTION's leading verb (``Create…``/``Apply…``)
+       via the same unified read/write vocabulary (GH-607).
+
+    Read-only skills are default-safe to seed; mutating skills are opt-in.
+    This reuses the single GH-607 classifier so the skill surface cannot
+    drift from the MCP/CLI surfaces. *Which* non-Dev10x families to
+    pre-approve at all is a separate policy decision (D13).
+    """
+    if _skill_access(allowed_tools) is Access.WRITE:
+        return Access.WRITE
+    if classify_tokens(name) == "write":
+        return Access.WRITE
+    if description and classify_tokens(description) == "write":
+        return Access.WRITE
+    return Access.READ
+
+
 def manifest_from_skills(skills_dir: Path) -> list[ManifestEntry]:
     """Classify every skill under *skills_dir* from its SKILL.md frontmatter.
 

--- a/src/dev10x/skills/permission/promote.py
+++ b/src/dev10x/skills/permission/promote.py
@@ -40,6 +40,7 @@ from pathlib import Path
 import yaml
 
 from dev10x.domain.common.mcp_tool_name import McpToolName
+from dev10x.domain.sensitivity import name_is_sensitive, tokenize_identifier
 from dev10x.skills.permission.enumerate_mcp import (
     _server_prefix_from_tool,
     _source_type_from_prefix,
@@ -118,55 +119,20 @@ WRITE_TOKENS = frozenset(
         "authorize",
     }
 )
-# Read tools whose target is private/DM/secret — promotable only on opt-in.
-SENSITIVE_TOKENS = frozenset(
-    {"private", "secret", "secrets", "credential", "credentials", "password", "dm"}
-)
-
 _WEBFETCH_RE = re.compile(r"^WebFetch\(domain:(?P<domain>.+)\)$")
-
-# Token boundaries: an acronym run before a CamelWord (``HTTPSConnection`` →
-# ``HTTPS`` + ``Connection``), a Capitalized-or-lowercase word, a bare acronym,
-# or a digit run. Splitting on this AND ``_`` lets camelCase MCP tools
-# (``getJiraIssue``, ``createJiraIssue``) tokenize by verb instead of
-# collapsing into one unsplittable ``unknown`` token (GH-593).
-_TOKEN_RE = re.compile(r"[A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+|[0-9]+")
-
-
-def _short_name(full_tool_name: str) -> str:
-    """Return the tool name after the final ``__`` separator (original case).
-
-    Case is preserved so :func:`_tokens` can detect camelCase boundaries;
-    callers that need a verb set get lowercased tokens from ``_tokens``.
-    """
-    return full_tool_name.rsplit("__", 1)[-1]
-
-
-def _tokens(full_tool_name: str) -> set[str]:
-    """Split a tool's short name into lowercase verb tokens.
-
-    Splits on both ``_`` and camelCase boundaries (GH-593) so a camelCase
-    server such as ``getJiraIssue`` yields ``{get, jira, issue}`` — and its
-    ``get``/``create`` verb drives classification — rather than collapsing
-    to a single ``unknown`` token.
-    """
-    return {
-        match.group(0).lower()
-        for chunk in _short_name(full_tool_name).split("_")
-        for match in _TOKEN_RE.finditer(chunk)
-    }
 
 
 def classify_tokens(name: str) -> str:
     """Classify any verb-bearing name (CLI command, skill, tool) as read/write/unknown.
 
-    Splits *name* into tokens (camelCase + snake_case + digits, GH-593) and
-    applies write-precedence: any write token wins, so a write is never
-    misclassified as promotable. Used by both :func:`classify_mcp_tool` and the
-    source-derived manifest generators (GH-600), so every surface — MCP, CLI,
-    skill — shares one classifier.
+    Tokenizes *name* via the shared
+    :func:`dev10x.domain.sensitivity.tokenize_identifier` (camelCase +
+    snake_case + digits, GH-593) and applies write-precedence: any write token
+    wins, so a write is never misclassified as promotable. Used by both
+    :func:`classify_mcp_tool` and the source-derived manifest generators
+    (GH-600), so every surface — MCP, CLI, skill — shares one classifier.
     """
-    tokens = _tokens(name)
+    tokens = tokenize_identifier(name)
     if tokens & WRITE_TOKENS:
         return "write"
     if tokens & READ_TOKENS:
@@ -184,8 +150,14 @@ def classify_mcp_tool(full_tool_name: str) -> str:
 
 
 def is_sensitivity_flagged(full_tool_name: str) -> bool:
-    """Return True when the tool reads private/DM/secret data (opt-in only)."""
-    return bool(_tokens(full_tool_name) & SENSITIVE_TOKENS)
+    """Return True when the tool reads private/DM/secret data (opt-in only).
+
+    Delegates to the shared name-axis classifier in
+    :mod:`dev10x.domain.sensitivity` so the sensitivity wordlist has a single
+    source across DX014, MCP promotion, the credentialed-CLI allowlist, and
+    skill curation (GH-607).
+    """
+    return name_is_sensitive(full_tool_name)
 
 
 def _read_allow_rules(path: Path) -> list[str]:

--- a/tests/domain/test_sensitivity.py
+++ b/tests/domain/test_sensitivity.py
@@ -11,10 +11,13 @@ from __future__ import annotations
 import pytest
 
 from dev10x.domain.sensitivity import (
+    SENSITIVE_NAME_TOKENS,
     SensitivityClassifier,
     SensitivityLabel,
     SensitivityMatch,
     SensitivityPattern,
+    name_is_sensitive,
+    tokenize_identifier,
 )
 
 # ---------------------------------------------------------------------------
@@ -82,6 +85,42 @@ class TestSecretClassification:
         matches = classifier.classify(command=command)
         labels = {m.label for m in matches}
         assert SensitivityLabel.SECRET in labels, f"Expected SECRET for: {command!r}"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # GH-605: credentialed-CLI secret-exfil reads
+            "aws-vault exec prod -- aws secretsmanager get-secret-value --secret-id db",
+            "aws-vault exec prod -- aws ssm get-parameter --name /db/pw --with-decryption",
+            "aws ssm get-parameters --names /db/pw --with-decryption",
+            "vercel env pull .env.local",
+            "vercel pull",
+        ],
+    )
+    def test_credentialed_cli_exfil_classified_as_secret(
+        self, classifier: SensitivityClassifier, command: str
+    ) -> None:
+        matches = classifier.classify(command=command)
+        labels = {m.label for m in matches}
+        assert SensitivityLabel.SECRET in labels, f"Expected SECRET for: {command!r}"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # GH-605: benign credentialed-CLI reads must NOT be flagged secret
+            "aws-vault exec prod -- aws ecr describe-images --repository-name app",
+            "aws-vault exec prod -- aws s3 ls",
+            "aws ssm get-parameter --name /db/host",  # no --with-decryption
+            "vercel ls",
+        ],
+    )
+    def test_benign_credentialed_reads_not_secret(
+        self, classifier: SensitivityClassifier, command: str
+    ) -> None:
+        matches = classifier.classify(command=command)
+        assert not any(m.label == SensitivityLabel.SECRET for m in matches), (
+            f"Benign read wrongly flagged SECRET: {command!r}"
+        )
 
     def test_benign_gh_pr_not_secret(self, classifier: SensitivityClassifier) -> None:
         matches = classifier.classify(command="gh pr list")
@@ -381,3 +420,78 @@ class TestGH271EvidenceSequence:
         assert expected_label in labels, (
             f"GH-271 evidence {evidence_id}: expected {expected_label} in {labels}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Identifier NAME axis — tokenize_identifier (GH-607)
+# ---------------------------------------------------------------------------
+
+
+class TestTokenizeIdentifier:
+    """The shared identifier tokenizer unified into the domain layer (GH-607)."""
+
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            # snake_case short name
+            ("search_public_and_private", {"search", "public", "and", "private"}),
+            # MCP fully-qualified name → only the final segment tokenizes
+            ("mcp__claude_ai_Slack__search_channels", {"search", "channels"}),
+            # camelCase (GH-593)
+            ("getJiraIssue", {"get", "jira", "issue"}),
+            # acronym run before a CamelWord
+            ("getHTTPSConfig", {"get", "https", "config"}),
+            # digit run
+            ("list_s3_buckets", {"list", "s", "buckets", "3"}),
+        ],
+    )
+    def test_tokenizes_to_lowercase_words(self, name: str, expected: set[str]) -> None:
+        assert tokenize_identifier(name) == expected
+
+
+# ---------------------------------------------------------------------------
+# Identifier NAME axis — name_is_sensitive (GH-607)
+# ---------------------------------------------------------------------------
+
+
+class TestNameIsSensitive:
+    """Name-token sensitivity check shared across all four PAP surfaces."""
+
+    def test_token_set_covers_private_dm_secret_credential(self) -> None:
+        assert SENSITIVE_NAME_TOKENS == {
+            "private",
+            "secret",
+            "secrets",
+            "credential",
+            "credentials",
+            "password",
+            "dm",
+        }
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "mcp__claude_ai_Slack__search_public_and_private",
+            "mcp__svc__getPrivateThread",
+            "mcp__store__get_secret",
+            "list_credentials",
+            "read_db_password",
+        ],
+    )
+    def test_sensitive_names_flagged(self, name: str) -> None:
+        assert name_is_sensitive(name)
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "mcp__claude_ai_Slack__search_channels",
+            "mcp__svc__getJiraIssue",
+            "list_buckets",
+        ],
+    )
+    def test_benign_names_not_flagged(self, name: str) -> None:
+        assert not name_is_sensitive(name)
+
+    def test_custom_token_set_overrides_default(self) -> None:
+        assert name_is_sensitive("get_token", tokens=frozenset({"token"}))
+        assert not name_is_sensitive("get_token")

--- a/tests/skills/permission/test_manifest.py
+++ b/tests/skills/permission/test_manifest.py
@@ -16,6 +16,7 @@ from dev10x.skills.permission.manifest import (
     Sensitivity,
     Surface,
     build_manifest,
+    classify_skill_access,
     discovered_surface_keys,
     find_manifest_drift,
     manifest_from_cli,
@@ -185,6 +186,50 @@ class TestManifestFromSkills:
         )
         (entry,) = manifest_from_skills(tmp_path)
         assert entry.access is Access.READ
+
+
+class TestClassifySkillAccess:
+    """S15 skill access classifier reusing the unified vocabulary (GH-608)."""
+
+    def test_read_when_all_signals_read(self) -> None:
+        assert (
+            classify_skill_access(
+                name="code-review",
+                description="Review the diff and report findings.",
+                allowed_tools=["Read", "Bash(git diff:*)"],
+            )
+            is Access.READ
+        )
+
+    def test_write_via_allowed_tools(self) -> None:
+        assert (
+            classify_skill_access(name="polish", description="Tidy up.", allowed_tools=["Edit"])
+            is Access.WRITE
+        )
+
+    def test_write_via_name_verb(self) -> None:
+        # Write verb in the NAME catches a mutating skill with a sparse
+        # frontmatter (no Edit/Write declared, benign description).
+        assert (
+            classify_skill_access(
+                name="ticket-create", description="Helper.", allowed_tools=["Read"]
+            )
+            is Access.WRITE
+        )
+
+    def test_write_via_description_verb(self) -> None:
+        assert (
+            classify_skill_access(
+                name="scaffold",
+                description="Create a new module from a template.",
+                allowed_tools=[],
+            )
+            is Access.WRITE
+        )
+
+    def test_read_with_defaults(self) -> None:
+        # Bare read-only name, no description, no tools → default-safe.
+        assert classify_skill_access(name="review") is Access.READ
 
 
 class TestBuildManifest:


### PR DESCRIPTION
**When** any layer decides safe-vs-sensitive — the DX014 Bash hook, MCP promotion, the credentialed-CLI allowlist, or skill curation — **I want to** have them share one classifier sourced from the manifest, **so I can** trust the same get-secret-style protection on every surface without the four implementations drifting apart.

This bundles three PERM-M3 (milestone 40) issues that build on the unified classifier:

- **GH-607** — move the identifier tokenizer + name-token sensitivity into `domain/sensitivity.py` as the single source; `promote.py` (and `manifest.py` transitively) delegate. No duplicated wordlists.
- **GH-605** — add credentialed-CLI secret-exfil patterns (`secretsmanager get-secret-value`, `ssm get-parameter --with-decryption`, `vercel env pull`) so DX014 screens them even under a broad wrapper grant. (Vercel benign reads already shipped via `vercel-cli-readonly`; the bare `aws-vault exec` wrapper stays `ask`.)
- **GH-608** — add `classify_skill_access`, reusing the unified vocabulary to grade skills read-only vs mutating for the S15 curation surface.

**Deferred (decision-gated, not in this PR):** GH-604 (HookAsk — research gate D5: Claude Code's hook layer emits only `deny`/`allow`, no `ask`; needs verification first) and GH-606 (verb-aware wrappers — design gate D6). The `aws-vault exec -- aws describe-*/list-*` read allowlist depends on GH-606's verb-aware matching (the profile sits between `exec` and the verb, so a prefix allow-rule is unsafe).

---

[`b2b76ad1`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/680/commits/b2b76ad195175d9c69173aabacd7ac326e4a304b) ✨ GH-607 Unify sensitivity classification across surfaces
Closes #605
Closes #608
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/607

---