### PR TITLE
♻️ GH-515 Enable I/O-free session policy rules

### DIFF
--- a/docs/adr/0007-rule-policy-archetype-unification.md
+++ b/docs/adr/0007-rule-policy-archetype-unification.md
@@ -28,6 +28,15 @@ The Policy Rule tier (`ReadFrictionLevelRule`,
 `BuildAutonomyReassuranceRule`) all expose `apply()`, but nothing
 declares that as a contract — it is "true by reading the source".
 
+> **Follow-up (GH-515 / GH-513 / GH-524):** The D3 fix below later
+> extended to the session rules. `ReadFrictionLevelRule` was dissolved
+> into `SessionYamlDocument` (`domain/documents/session_yaml.py`),
+> which now owns the `session.yaml` read; `BuildAutonomyReassuranceRule`
+> became a pure value-consumer (`friction_level` + `active_modes`
+> fields) and was relocated to `domain/session_rules.py`. The live
+> Policy Rule tier is now `DecisionGuidanceRule`,
+> `BuildAutonomyReassuranceRule`, and `MigratePluginPermissionsRule`.
+
 ### Problems
 
 1. **No named hierarchy (A9).** Three mechanisms, all called "rule"

--- a/docs/adr/0008-context-boundary-protocol.md
+++ b/docs/adr/0008-context-boundary-protocol.md
@@ -109,6 +109,14 @@ mechanism for crossing it.
 re-exports the two moved rules so existing callers keep working
 during transition.
 
+> **Follow-up (GH-515 / GH-513 / GH-524):** `ReadFrictionLevelRule` was
+> later removed entirely — its read moved to `SessionYamlDocument`
+> (`domain/documents/session_yaml.py`) and callers invoke
+> `read_friction_level()` directly. `BuildAutonomyReassuranceRule`, once
+> made I/O-free (GH-513), was relocated from `hooks/` to
+> `domain/session_rules.py` and is re-exported from
+> `hooks/session_policy.py` during transition (GH-524).
+
 ### Code Examples
 
 ```python

--- a/references/policy-rules-pattern.md
+++ b/references/policy-rules-pattern.md
@@ -53,13 +53,19 @@ The rule is a frozen dataclass to:
 
 ```python
 @dataclass(frozen=True)
-class ReadFrictionLevelRule:
-    """Reads friction_level from session.yaml."""
-    project_root: Path
+class BuildAutonomyReassuranceRule:
+    """Reassures the agent in adaptive + solo-maintainer sessions."""
+
+    friction_level: FrictionLevel
+    active_modes: list[str]
 
     def apply(self) -> str:
         ...
 ```
+
+The rule receives already-loaded values as fields — the file read is
+owned by `SessionYamlDocument` (see § Fallback Consistency), keeping the
+rule free of I/O (ADR-0007 D3).
 
 ### apply() Method
 
@@ -75,34 +81,44 @@ The `apply()` method is the rule's only public interface:
 Each rule is tested in isolation:
 
 ```python
-def test_reads_friction_level_when_present():
-    rule = ReadFrictionLevelRule(project_root=Path("/tmp"))
-    result = rule.apply()
-    assert result in ("strict", "guided", "adaptive")
+def test_fires_when_adaptive_and_solo():
+    rule = BuildAutonomyReassuranceRule(
+        friction_level=FrictionLevel.ADAPTIVE, active_modes=["solo-maintainer"]
+    )
+    assert rule.apply() != ""
 
-def test_silent_when_file_missing():
-    rule = ReadFrictionLevelRule(project_root=Path("/nonexistent"))
-    result = rule.apply()
-    assert result == ""
+def test_silent_when_not_adaptive():
+    rule = BuildAutonomyReassuranceRule(
+        friction_level=FrictionLevel.GUIDED, active_modes=["solo-maintainer"]
+    )
+    assert rule.apply() == ""
 ```
+
+Because the rule holds plain values rather than a path, it is tested
+fully in-memory — no temp files. The file-read fallbacks (missing /
+malformed YAML) are tested on `SessionYamlDocument` instead.
 
 ## Re-Export Pattern
 
-Rules are defined in `src/dev10x/hooks/session_policy.py` and
-re-exported via `__all__` in `src/dev10x/hooks/session.py`:
+Pure session rules live in `src/dev10x/domain/session_rules.py`
+(ADR-0008: they depend only on `domain/` types). Adapter-layer modules
+re-export them for backward compatibility:
 
-**session_policy.py:**
+**domain/session_rules.py:**
 ```python
-__all__ = ["ReadFrictionLevelRule", "BuildAutonomyReassuranceRule", ...]
+__all__ = ["DecisionGuidanceRule", "BuildAutonomyReassuranceRule", ...]
 ```
 
-**session.py:**
+**hooks/session_policy.py** (compatibility re-export):
 ```python
-from .session_policy import *  # Imports from __all__
+from dev10x.domain.session_rules import (
+    BuildAutonomyReassuranceRule,
+    DecisionGuidanceRule,
+)
 ```
 
-This makes rules discoverable to orchestrators without tying the
-policy module's internal organization to external imports.
+This keeps the rules discoverable from their historical import path
+without tying the domain module's organization to adapter imports.
 
 ## Composition in Orchestrators
 
@@ -123,38 +139,44 @@ final output.
 
 **All policy rules must handle missing/malformed input gracefully:**
 
+- File reads are owned by a Document (e.g. `SessionYamlDocument`),
+  which returns soft fallbacks (`FrictionLevel.default()`, empty
+  modes) on a missing or malformed file — the rule performs no I/O
+  (ADR-0007 D3)
 - If a rule depends on optional config, return `""` (silent) when
-  config is missing
-- If a rule depends on optional session state, return `""` when
-  state file is missing or malformed
+  the resolved value does not meet its firing conditions
 - **Never raise exceptions** — exceptions break the orchestrator
 
 Example:
 
 ```python
-def apply(self) -> str:
-    try:
-        config = yaml.safe_load(open(self.config_path))
-    except FileNotFoundError:
-        return ""  # Silent — this rule doesn't apply
+# The file read + fallback live in the Document (ADR-0007 D3):
+def read_friction_level(self) -> FrictionLevel:
+    return FrictionLevel.from_yaml(self._load().get("friction_level"))
 
-    if config.get("friction_level") == "adaptive":
+# The rule receives the resolved value and decides — no I/O:
+def apply(self) -> str:
+    if self.friction_level is FrictionLevel.ADAPTIVE:
         return "Reassurance text"
     return ""
 ```
 
 ## Examples
 
-See `src/dev10x/hooks/session_policy.py` for current implementations:
+See `src/dev10x/domain/session_rules.py` for current Policy Rule
+implementations (re-exported from `hooks/session_policy.py`):
 
-1. **`ReadFrictionLevelRule`** — Reads and returns `friction_level`
-   from `session.yaml`
-2. **`BuildAutonomyReassuranceRule`** — Returns reassurance text
-   when adaptive + solo-maintainer is active
-3. **`DecisionGuidanceRule`** — Returns guidance text tailored to
-   the friction level
-4. **`MigratePluginPermissionsRule`** — Guidance for permission
-   migrations (one-time messages)
+1. **`BuildAutonomyReassuranceRule`** — Returns reassurance text
+   when adaptive + solo-maintainer is active. Receives
+   `friction_level` + `active_modes` as fields (no I/O).
+2. **`DecisionGuidanceRule`** — Returns guidance text tailored to
+   the friction level.
+3. **`MigratePluginPermissionsRule`** — Guidance for permission
+   migrations (`hooks/session_policy.py`; delegates file writes to
+   `SettingsDocument`).
+
+The `session.yaml` read those rules used to perform is owned by
+`SessionYamlDocument` (`src/dev10x/domain/documents/session_yaml.py`).
 
 ## Related Patterns
 

--- a/references/session-config-schema.md
+++ b/references/session-config-schema.md
@@ -44,21 +44,24 @@ Empty list is valid (no modes active).
 
 ## Readers (Consumers)
 
-All readers are located in `src/dev10x/hooks/session_policy.py`:
+The file read is owned by `SessionYamlDocument`
+(`src/dev10x/domain/documents/session_yaml.py`); it returns the parsed
+`friction_level` and `active_modes` with soft fallbacks. Policy Rules in
+`src/dev10x/domain/session_rules.py` consume those values and perform no
+I/O (ADR-0007 D3):
 
-1. **`ReadFrictionLevelRule`** (lines 80–101)
-   - Reads `friction_level` field
-   - Fallback: `"strict"` if missing or malformed
-   - Sets context for `BuildAutonomyReassuranceRule` and `DecisionGuidanceRule`
+1. **`SessionYamlDocument`** — owns the `session.yaml` read.
+   `read_friction_level()`, `read_active_modes()`, and
+   `read_friction_and_modes()` apply the fallbacks below.
 
-2. **`BuildAutonomyReassuranceRule`** (lines 104–149)
-   - Reads `friction_level` and `active_modes`
+2. **`BuildAutonomyReassuranceRule`**
+   - Receives `friction_level` and `active_modes` as fields
    - Fires only when: `friction_level == "adaptive"` AND `"solo-maintainer"` in `active_modes`
    - Fallback: Silent (returns empty string) if conditions not met
    - Output: Reassurance text displayed at SessionStart
 
-3. **`DecisionGuidanceRule`** (lines 151+)
-   - Reads `friction_level`
+3. **`DecisionGuidanceRule`**
+   - Receives `friction_level`
    - Provides guidance text tailored to the selected level
 
 ## Fallback Behavior
@@ -94,12 +97,13 @@ active_modes:
 
 ## Testing
 
-Verify session.yaml parsing in `tests/hooks/test_orchestrators.py`:
+Verify session.yaml parsing in
+`tests/domain/documents/test_session_yaml.py` (file reads + fallbacks)
+and rule behaviour in `tests/hooks/test_orchestrators.py` (value-based):
 
-- Test case: `test_autonomy_reassurance_fires_when_adaptive_and_solo`
-- Test case: `test_autonomy_reassurance_silent_when_not_adaptive`
-- Test case: `test_autonomy_reassurance_silent_when_session_yaml_missing`
-- Test case: `test_autonomy_reassurance_silent_when_session_yaml_malformed`
+- `TestReadFrictionLevel` — declared / missing / malformed / unknown
+- `TestReadActiveModes` — declared / unset / non-list / missing file
+- `TestAutonomyReassurance` — fires on adaptive+solo; silent otherwise
 
 ## Related Files
 

--- a/src/dev10x/domain/documents/session_context.py
+++ b/src/dev10x/domain/documents/session_context.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from dev10x.domain.documents.session_yaml import SessionYamlDocument
 from dev10x.domain.friction_level import FrictionLevel
 from dev10x.domain.git_context import GitContext
 from dev10x.domain.session_document import (
@@ -22,7 +23,7 @@ from dev10x.domain.session_document import (
     read_plan_summary,
     state_path_for_toplevel,
 )
-from dev10x.domain.session_rules import DecisionGuidanceRule, ReadFrictionLevelRule
+from dev10x.domain.session_rules import DecisionGuidanceRule
 
 
 def _run_git_safe(git: GitContext, *args: str) -> str:
@@ -55,7 +56,7 @@ class SessionContextQuery:
         plan_path = plan_path_for_toplevel(toplevel=toplevel)
         plan_exists = plan_path.exists()
         plan_data = read_plan_summary(toplevel=toplevel) if plan_exists else {}
-        friction_level = ReadFrictionLevelRule(toplevel=toplevel).apply()
+        friction_level = SessionYamlDocument(toplevel=toplevel).read_friction_level()
 
         return cls(
             toplevel=toplevel,
@@ -85,7 +86,7 @@ class SessionContextQuery:
         plan_path = plan_path_for_toplevel(toplevel=toplevel)
         plan_exists = plan_path.exists()
         plan_data = read_plan_summary(toplevel=toplevel) if plan_exists else {}
-        friction_level = ReadFrictionLevelRule(toplevel=toplevel).apply()
+        friction_level = SessionYamlDocument(toplevel=toplevel).read_friction_level()
 
         return cls(
             toplevel=toplevel,

--- a/src/dev10x/domain/documents/session_yaml.py
+++ b/src/dev10x/domain/documents/session_yaml.py
@@ -1,0 +1,66 @@
+"""SessionYamlDocument — the persistence boundary for ``session.yaml``.
+
+Document archetype (ADR-0007 / ADR-0008): owns reads of
+``.claude/Dev10x/session.yaml`` so that Policy Rules stay free of file
+I/O (the ADR-0007 D3 invariant). Rules and queries receive the parsed
+``FrictionLevel`` and ``active_modes`` values from this Document rather
+than opening the file inside ``apply()`` themselves.
+
+Replaces the in-rule reads previously performed by
+``ReadFrictionLevelRule`` (GH-515) and ``BuildAutonomyReassuranceRule``
+(GH-513). A missing, unreadable, or malformed file yields the soft
+fallbacks — ``FrictionLevel.default()`` and an empty modes list — so
+callers never have to branch on read failure.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from dev10x.domain.friction_level import FrictionLevel
+
+
+@dataclass(frozen=True)
+class SessionYamlDocument:
+    """Reader for ``.claude/Dev10x/session.yaml`` under a repo toplevel."""
+
+    toplevel: str
+
+    @property
+    def path(self) -> Path:
+        return Path(self.toplevel) / ".claude" / "Dev10x" / "session.yaml"
+
+    def _load(self) -> dict[str, Any]:
+        if not self.path.exists():
+            return {}
+        try:
+            data = yaml.safe_load(self.path.read_text())
+        except (OSError, ValueError, yaml.YAMLError):
+            # ValueError covers UnicodeDecodeError on an undecodable file —
+            # a corrupt session.yaml must degrade to defaults, never crash
+            # the SessionStart hook (matches the prior broad fallback).
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def read_friction_level(self) -> FrictionLevel:
+        """Return the session friction level, defaulting on any read failure."""
+        return FrictionLevel.from_yaml(self._load().get("friction_level"))
+
+    def read_active_modes(self) -> list[str]:
+        """Return the active-modes list, or an empty list when unset/invalid."""
+        modes = self._load().get("active_modes")
+        return modes if isinstance(modes, list) else []
+
+    def read_friction_and_modes(self) -> tuple[FrictionLevel, list[str]]:
+        """Return ``(friction_level, active_modes)`` from a single file read."""
+        data = self._load()
+        level = FrictionLevel.from_yaml(data.get("friction_level"))
+        modes = data.get("active_modes")
+        return level, (modes if isinstance(modes, list) else [])
+
+
+__all__ = ["SessionYamlDocument"]

--- a/src/dev10x/domain/session_rules.py
+++ b/src/dev10x/domain/session_rules.py
@@ -4,9 +4,13 @@ These were previously defined in ``dev10x.hooks.session_policy``, which
 forced ``domain.documents.session_context`` to defer its imports into
 function bodies to break the cycle ``hooks.session_dispatch →
 domain.documents.session_context → hooks.session_policy`` (audit memo
-Findings I2 + I10). Both rules depend
-only on ``domain/`` types, so they belong in the core: adapters now
-import them inward instead of reaching up into ``hooks/``.
+Findings I2 + I10). Each rule depends only on ``domain/`` types, so it
+belongs in the core: adapters now import them inward instead of reaching
+up into ``hooks/``.
+
+All rules here are free of file I/O (ADR-0007 D3). The session.yaml read
+is owned by :class:`dev10x.domain.documents.session_yaml.SessionYamlDocument`;
+callers read the parsed values there and pass them in as frozen fields.
 
 See ADR-0008 (context boundary protocol) for the dependency-direction
 rule and ADR-0007 for the Policy Rule archetype these satisfy.
@@ -15,7 +19,6 @@ rule and ADR-0007 for the Policy Rule archetype these satisfy.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any
 
 from dev10x.domain.documents.session_state import PlanSummary
@@ -25,31 +28,6 @@ from dev10x.domain.rules.policy_rule import PolicyRule
 
 class UnknownFrictionLevelError(ValueError):
     """Raised when decision guidance is asked to format an unknown friction level."""
-
-
-@dataclass(frozen=True)
-class ReadFrictionLevelRule(PolicyRule[FrictionLevel]):
-    """Read the friction level from ``.claude/Dev10x/session.yaml``.
-
-    Returns ``FrictionLevel.default()`` when the file is missing or
-    unreadable — that is the soft fallback. Use ``DecisionGuidanceRule``
-    for strict behaviour at format time.
-    """
-
-    toplevel: str
-
-    def apply(self) -> FrictionLevel:
-        session_yaml = Path(self.toplevel) / ".claude" / "Dev10x" / "session.yaml"
-        if not session_yaml.exists():
-            return FrictionLevel.default()
-        try:
-            import yaml
-
-            with open(session_yaml) as f:
-                data = yaml.safe_load(f) or {}
-            return FrictionLevel.from_yaml(data.get("friction_level"))
-        except Exception:
-            return FrictionLevel.default()
 
 
 @dataclass(frozen=True)
@@ -78,8 +56,51 @@ class DecisionGuidanceRule(PolicyRule[str]):
         return self.friction_level.pending_decisions_guidance()
 
 
+@dataclass(frozen=True)
+class BuildAutonomyReassuranceRule(PolicyRule[str]):
+    """Build a reassurance block for autonomous sessions (GH-261).
+
+    Fires only when ``friction_level`` is ``ADAPTIVE`` AND
+    ``solo-maintainer`` is among ``active_modes``. Reassures the agent
+    that long task lists are by design and that re-asking settled scope
+    decisions is the drift mode the supervisor explicitly opted out of.
+
+    Returns an empty string outside the autonomous-shipping profile so
+    the SessionStart orchestrator can drop the segment silently.
+
+    The caller reads ``friction_level`` and ``active_modes`` from
+    :class:`dev10x.domain.documents.session_yaml.SessionYamlDocument` and
+    passes them in as frozen fields — the rule performs no file I/O
+    (ADR-0007 D3). Relocated from ``hooks/session_policy.py`` to its
+    archetype home in ``domain/`` once the I/O was removed (GH-524).
+    """
+
+    friction_level: FrictionLevel
+    active_modes: list[str]
+
+    REASSURANCE_TEXT = (
+        "**Supervisor monitors context.** Long task lists are by design — "
+        "the work-on skill creates one task per play step so the supervisor "
+        'sees scope upfront. Do NOT pause to ask "should I proceed?" when:\n'
+        "\n"
+        "- The user already answered a scope AskUserQuestion\n"
+        "- friction_level: adaptive is set (auto-advance is the contract)\n"
+        "- The skill instructions explicitly cover the next step\n"
+        "\n"
+        "If context truly becomes a problem, the supervisor will interrupt. "
+        "Context anxiety is the agent's drift mode — trust the plan."
+    )
+
+    def apply(self) -> str:
+        if self.friction_level is not FrictionLevel.ADAPTIVE:
+            return ""
+        if "solo-maintainer" not in self.active_modes:
+            return ""
+        return self.REASSURANCE_TEXT
+
+
 __all__ = [
     "UnknownFrictionLevelError",
-    "ReadFrictionLevelRule",
     "DecisionGuidanceRule",
+    "BuildAutonomyReassuranceRule",
 ]

--- a/src/dev10x/hooks/session.py
+++ b/src/dev10x/hooks/session.py
@@ -40,7 +40,6 @@ from dev10x.hooks.session_dispatch import (
 from dev10x.hooks.session_place import session_git_aliases, session_tmpdir
 from dev10x.hooks.session_policy import (
     DecisionGuidanceRule,
-    ReadFrictionLevelRule,
     _build_migration_replacements,
     _deduplicate_rules,
     _migrate_rules,
@@ -62,8 +61,10 @@ def _format_plan_summary(*, plan):
 
 
 def _read_friction_level(*, toplevel: str):
-    """Compatibility shim — prefer ``ReadFrictionLevelRule(toplevel=...).apply()``."""
-    return ReadFrictionLevelRule(toplevel=toplevel).apply()
+    """Compatibility shim — prefer ``SessionYamlDocument(toplevel=...).read_friction_level()``."""
+    from dev10x.domain.documents.session_yaml import SessionYamlDocument
+
+    return SessionYamlDocument(toplevel=toplevel).read_friction_level()
 
 
 def _format_decision_guidance(*, plan, friction_level):

--- a/src/dev10x/hooks/session_dispatch.py
+++ b/src/dev10x/hooks/session_dispatch.py
@@ -119,12 +119,16 @@ def build_autonomy_reassurance_context() -> str:
     Returns an empty string outside the autonomous-shipping profile; the
     orchestrator drops empty segments so non-solo sessions see no change.
     """
-    from dev10x.hooks.session_policy import BuildAutonomyReassuranceRule
+    from dev10x.domain.documents.session_yaml import SessionYamlDocument
+    from dev10x.domain.session_rules import BuildAutonomyReassuranceRule
 
     toplevel = _get_toplevel()
     if not toplevel:
         return ""
-    return BuildAutonomyReassuranceRule(toplevel=toplevel).apply()
+    friction_level, active_modes = SessionYamlDocument(toplevel=toplevel).read_friction_and_modes()
+    return BuildAutonomyReassuranceRule(
+        friction_level=friction_level, active_modes=active_modes
+    ).apply()
 
 
 def build_install_check_context() -> str:

--- a/src/dev10x/hooks/session_policy.py
+++ b/src/dev10x/hooks/session_policy.py
@@ -1,14 +1,15 @@
-"""Session policy — named Rule objects for permission migration and
-autonomy-reassurance synthesis.
+"""Session policy — named Rule objects for permission migration.
 
 Rule archetype (see ADR-0007): each class encapsulates one named
 decision the session hooks make. Pulling these out of
 ``hooks/session.py`` keeps the dispatcher thin and makes the policies
 testable in isolation.
 
-The friction-parsing and decision-guidance rules moved to
-``dev10x.domain.session_rules`` (ADR-0008) because they are pure
-domain policies; they are re-exported here for backward compatibility.
+The friction-parsing, decision-guidance, and autonomy-reassurance rules
+moved to ``dev10x.domain.session_rules`` (ADR-0008) because they are
+pure domain policies; they are re-exported here for backward
+compatibility. The session.yaml read those rules used to perform is now
+owned by ``dev10x.domain.documents.session_yaml.SessionYamlDocument``.
 """
 
 from __future__ import annotations
@@ -17,18 +18,15 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 
-import yaml
-
 from dev10x.domain.documents.settings_document import (
     SettingsDocument,
     _deduplicate_rules,
     _migrate_rules,
 )
-from dev10x.domain.friction_level import FrictionLevel
 from dev10x.domain.rules.policy_rule import PolicyRule
 from dev10x.domain.session_rules import (
+    BuildAutonomyReassuranceRule,
     DecisionGuidanceRule,
-    ReadFrictionLevelRule,
     UnknownFrictionLevelError,
 )
 
@@ -57,52 +55,6 @@ def _build_migration_replacements(
         replacements.append((old_tilde, current_tilde))
 
     return replacements
-
-
-@dataclass(frozen=True)
-class BuildAutonomyReassuranceRule(PolicyRule[str]):
-    """Build a reassurance block for autonomous sessions (GH-261).
-
-    Fires only when ``friction_level: adaptive`` AND ``solo-maintainer`` is in
-    ``active_modes``. Reassures the agent that long task lists are by design
-    and that re-asking settled scope decisions is the drift mode the
-    supervisor explicitly opted out of.
-
-    Returns an empty string outside the autonomous-shipping profile so the
-    SessionStart orchestrator can drop the segment silently.
-    """
-
-    toplevel: str
-
-    REASSURANCE_TEXT = (
-        "**Supervisor monitors context.** Long task lists are by design — "
-        "the work-on skill creates one task per play step so the supervisor "
-        'sees scope upfront. Do NOT pause to ask "should I proceed?" when:\n'
-        "\n"
-        "- The user already answered a scope AskUserQuestion\n"
-        "- friction_level: adaptive is set (auto-advance is the contract)\n"
-        "- The skill instructions explicitly cover the next step\n"
-        "\n"
-        "If context truly becomes a problem, the supervisor will interrupt. "
-        "Context anxiety is the agent's drift mode — trust the plan."
-    )
-
-    def apply(self) -> str:
-        session_yaml = Path(self.toplevel) / ".claude" / "Dev10x" / "session.yaml"
-        if not session_yaml.exists():
-            return ""
-        try:
-            data = yaml.safe_load(session_yaml.read_text()) or {}
-        except (OSError, yaml.YAMLError):
-            return ""
-
-        level = FrictionLevel.from_yaml(data.get("friction_level"))
-        modes = data.get("active_modes") or []
-        if level is not FrictionLevel.ADAPTIVE:
-            return ""
-        if "solo-maintainer" not in modes:
-            return ""
-        return self.REASSURANCE_TEXT
 
 
 @dataclass(frozen=True)
@@ -166,7 +118,6 @@ class MigratePluginPermissionsRule(PolicyRule[tuple[int, list[str]]]):
 
 __all__ = [
     "UnknownFrictionLevelError",
-    "ReadFrictionLevelRule",
     "BuildAutonomyReassuranceRule",
     "DecisionGuidanceRule",
     "MigratePluginPermissionsRule",

--- a/tests/domain/documents/test_session_yaml.py
+++ b/tests/domain/documents/test_session_yaml.py
@@ -1,0 +1,100 @@
+"""Tests for SessionYamlDocument (GH-515 / GH-513).
+
+The Document owns the session.yaml read so Policy Rules stay I/O-free
+(ADR-0007 D3). These cover the soft-fallback behaviour the rules used to
+own: missing file, malformed YAML, and non-mapping / non-list values.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dev10x.domain.documents.session_yaml import SessionYamlDocument
+from dev10x.domain.friction_level import FrictionLevel
+
+
+def _write(*, tmp_path: Path, content: str) -> str:
+    (tmp_path / ".claude" / "Dev10x").mkdir(parents=True)
+    (tmp_path / ".claude" / "Dev10x" / "session.yaml").write_text(content)
+    return str(tmp_path)
+
+
+class TestPath:
+    def test_resolves_under_claude_dev10x(self, tmp_path: Path) -> None:
+        doc = SessionYamlDocument(toplevel=str(tmp_path))
+        assert doc.path == tmp_path / ".claude" / "Dev10x" / "session.yaml"
+
+
+class TestReadFrictionLevel:
+    def test_reads_declared_level(self, tmp_path: Path) -> None:
+        toplevel = _write(tmp_path=tmp_path, content="friction_level: adaptive\n")
+        assert (
+            SessionYamlDocument(toplevel=toplevel).read_friction_level() is FrictionLevel.ADAPTIVE
+        )
+
+    def test_defaults_when_file_missing(self, tmp_path: Path) -> None:
+        doc = SessionYamlDocument(toplevel=str(tmp_path))
+        assert doc.read_friction_level() is FrictionLevel.default()
+
+    def test_defaults_when_malformed(self, tmp_path: Path) -> None:
+        toplevel = _write(tmp_path=tmp_path, content="friction_level: adaptive\nmodes: [a\n")
+        assert (
+            SessionYamlDocument(toplevel=toplevel).read_friction_level() is FrictionLevel.default()
+        )
+
+    def test_defaults_when_unknown_value(self, tmp_path: Path) -> None:
+        toplevel = _write(tmp_path=tmp_path, content="friction_level: bananas\n")
+        assert (
+            SessionYamlDocument(toplevel=toplevel).read_friction_level() is FrictionLevel.default()
+        )
+
+    def test_defaults_when_top_level_not_mapping(self, tmp_path: Path) -> None:
+        toplevel = _write(tmp_path=tmp_path, content="- just\n- a\n- list\n")
+        assert (
+            SessionYamlDocument(toplevel=toplevel).read_friction_level() is FrictionLevel.default()
+        )
+
+    def test_defaults_when_file_undecodable(self, tmp_path: Path) -> None:
+        (tmp_path / ".claude" / "Dev10x").mkdir(parents=True)
+        (tmp_path / ".claude" / "Dev10x" / "session.yaml").write_bytes(b"\xff\xfe\x00bad")
+        doc = SessionYamlDocument(toplevel=str(tmp_path))
+        assert doc.read_friction_level() is FrictionLevel.default()
+
+
+class TestReadActiveModes:
+    def test_reads_declared_modes(self, tmp_path: Path) -> None:
+        toplevel = _write(tmp_path=tmp_path, content="active_modes: [solo-maintainer]\n")
+        assert SessionYamlDocument(toplevel=toplevel).read_active_modes() == ["solo-maintainer"]
+
+    def test_empty_when_unset(self, tmp_path: Path) -> None:
+        toplevel = _write(tmp_path=tmp_path, content="friction_level: adaptive\n")
+        assert SessionYamlDocument(toplevel=toplevel).read_active_modes() == []
+
+    def test_empty_when_not_a_list(self, tmp_path: Path) -> None:
+        toplevel = _write(tmp_path=tmp_path, content="active_modes: solo-maintainer\n")
+        assert SessionYamlDocument(toplevel=toplevel).read_active_modes() == []
+
+    def test_empty_when_file_missing(self, tmp_path: Path) -> None:
+        assert SessionYamlDocument(toplevel=str(tmp_path)).read_active_modes() == []
+
+
+class TestReadFrictionAndModes:
+    def test_reads_both(self, tmp_path: Path) -> None:
+        toplevel = _write(
+            tmp_path=tmp_path,
+            content="friction_level: adaptive\nactive_modes: [solo-maintainer]\n",
+        )
+        level, modes = SessionYamlDocument(toplevel=toplevel).read_friction_and_modes()
+        assert level is FrictionLevel.ADAPTIVE
+        assert modes == ["solo-maintainer"]
+
+    def test_falls_back_when_file_missing(self, tmp_path: Path) -> None:
+        level, modes = SessionYamlDocument(toplevel=str(tmp_path)).read_friction_and_modes()
+        assert level is FrictionLevel.default()
+        assert modes == []
+
+    def test_modes_empty_when_not_a_list(self, tmp_path: Path) -> None:
+        toplevel = _write(tmp_path=tmp_path, content="friction_level: guided\nactive_modes: 3\n")
+        level, modes = SessionYamlDocument(toplevel=toplevel).read_friction_and_modes()
+        assert level is FrictionLevel.GUIDED
+        assert modes == []

--- a/tests/domain/test_policy_rule.py
+++ b/tests/domain/test_policy_rule.py
@@ -9,19 +9,18 @@ import pytest
 
 from dev10x.domain.friction_level import FrictionLevel
 from dev10x.domain.rules.policy_rule import PolicyRule
-from dev10x.domain.session_rules import DecisionGuidanceRule, ReadFrictionLevelRule
-from dev10x.hooks.session_policy import (
+from dev10x.domain.session_rules import (
     BuildAutonomyReassuranceRule,
-    MigratePluginPermissionsRule,
+    DecisionGuidanceRule,
 )
+from dev10x.hooks.session_policy import MigratePluginPermissionsRule
 
 
 @pytest.mark.parametrize(
     "rule",
     [
-        ReadFrictionLevelRule(toplevel="/tmp"),
         DecisionGuidanceRule(plan={}, friction_level=FrictionLevel.default()),
-        BuildAutonomyReassuranceRule(toplevel="/tmp"),
+        BuildAutonomyReassuranceRule(friction_level=FrictionLevel.default(), active_modes=[]),
         MigratePluginPermissionsRule(plugin_root=Path("/p"), home_path=Path("/h")),
     ],
 )

--- a/tests/hooks/test_orchestrators.py
+++ b/tests/hooks/test_orchestrators.py
@@ -15,6 +15,8 @@ from pathlib import Path
 
 import pytest
 
+from dev10x.domain.friction_level import FrictionLevel
+
 SCRIPTS = Path(__file__).resolve().parents[2] / "hooks" / "scripts"
 SESSION_START = SCRIPTS / "session-start.py"
 SESSION_STOP = SCRIPTS / "session-stop.py"
@@ -92,50 +94,28 @@ class TestAutonomyReassurance:
         (toplevel / ".claude" / "Dev10x" / "session.yaml").write_text(content)
         return toplevel
 
-    def test_fires_on_adaptive_solo_maintainer(self, tmp_path: Path) -> None:
-        from dev10x.hooks.session_policy import BuildAutonomyReassuranceRule
+    def test_fires_on_adaptive_solo_maintainer(self) -> None:
+        from dev10x.domain.session_rules import BuildAutonomyReassuranceRule
 
-        toplevel = self._write_session_yaml(
-            tmp_path=tmp_path,
-            content="friction_level: adaptive\nactive_modes: [solo-maintainer]\n",
-        )
-        result = BuildAutonomyReassuranceRule(toplevel=str(toplevel)).apply()
+        result = BuildAutonomyReassuranceRule(
+            friction_level=FrictionLevel.ADAPTIVE, active_modes=["solo-maintainer"]
+        ).apply()
         assert "Supervisor monitors context" in result
         assert "trust the plan" in result
 
-    def test_silent_when_friction_guided(self, tmp_path: Path) -> None:
-        from dev10x.hooks.session_policy import BuildAutonomyReassuranceRule
+    def test_silent_when_friction_guided(self) -> None:
+        from dev10x.domain.session_rules import BuildAutonomyReassuranceRule
 
-        toplevel = self._write_session_yaml(
-            tmp_path=tmp_path,
-            content="friction_level: guided\nactive_modes: [solo-maintainer]\n",
+        rule = BuildAutonomyReassuranceRule(
+            friction_level=FrictionLevel.GUIDED, active_modes=["solo-maintainer"]
         )
-        assert BuildAutonomyReassuranceRule(toplevel=str(toplevel)).apply() == ""
+        assert rule.apply() == ""
 
-    def test_silent_when_solo_maintainer_missing(self, tmp_path: Path) -> None:
-        from dev10x.hooks.session_policy import BuildAutonomyReassuranceRule
+    def test_silent_when_solo_maintainer_missing(self) -> None:
+        from dev10x.domain.session_rules import BuildAutonomyReassuranceRule
 
-        toplevel = self._write_session_yaml(
-            tmp_path=tmp_path,
-            content="friction_level: adaptive\nactive_modes: []\n",
-        )
-        assert BuildAutonomyReassuranceRule(toplevel=str(toplevel)).apply() == ""
-
-    def test_silent_when_session_yaml_missing(self, tmp_path: Path) -> None:
-        from dev10x.hooks.session_policy import BuildAutonomyReassuranceRule
-
-        toplevel = tmp_path / "repo"
-        toplevel.mkdir()
-        assert BuildAutonomyReassuranceRule(toplevel=str(toplevel)).apply() == ""
-
-    def test_silent_when_session_yaml_malformed(self, tmp_path: Path) -> None:
-        from dev10x.hooks.session_policy import BuildAutonomyReassuranceRule
-
-        toplevel = self._write_session_yaml(
-            tmp_path=tmp_path,
-            content="friction_level: adaptive\nactive_modes: [solo-maintainer\n",
-        )
-        assert BuildAutonomyReassuranceRule(toplevel=str(toplevel)).apply() == ""
+        rule = BuildAutonomyReassuranceRule(friction_level=FrictionLevel.ADAPTIVE, active_modes=[])
+        assert rule.apply() == ""
 
     def test_dispatch_returns_empty_without_toplevel(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/session/test_queries.py
+++ b/tests/session/test_queries.py
@@ -129,9 +129,9 @@ class TestGatherReload:
                 "dev10x.domain.documents.session_context.plan_path_for_toplevel",
                 return_value=tmp_path / "plan.json",
             ),
-            patch("dev10x.domain.documents.session_context.ReadFrictionLevelRule") as mock_rule,
+            patch("dev10x.domain.documents.session_context.SessionYamlDocument") as mock_doc,
         ):
-            mock_rule.return_value.apply.return_value = FrictionLevel.default()
+            mock_doc.return_value.read_friction_level.return_value = FrictionLevel.default()
             ctx = SessionContextQuery.gather_reload(toplevel=str(tmp_path))
         assert ctx.toplevel == str(tmp_path)
 
@@ -146,9 +146,9 @@ class TestGatherReload:
                 "dev10x.domain.documents.session_context.plan_path_for_toplevel",
                 return_value=tmp_path / "plan.json",
             ),
-            patch("dev10x.domain.documents.session_context.ReadFrictionLevelRule") as mock_rule,
+            patch("dev10x.domain.documents.session_context.SessionYamlDocument") as mock_doc,
         ):
-            mock_rule.return_value.apply.return_value = FrictionLevel.default()
+            mock_doc.return_value.read_friction_level.return_value = FrictionLevel.default()
             ctx = SessionContextQuery.gather_reload(toplevel=str(tmp_path))
         assert not ctx.plan_exists
 
@@ -169,9 +169,9 @@ class TestGatherReload:
                 "dev10x.domain.documents.session_context.read_plan_summary",
                 return_value={"tasks": []},
             ),
-            patch("dev10x.domain.documents.session_context.ReadFrictionLevelRule") as mock_rule,
+            patch("dev10x.domain.documents.session_context.SessionYamlDocument") as mock_doc,
         ):
-            mock_rule.return_value.apply.return_value = FrictionLevel.default()
+            mock_doc.return_value.read_friction_level.return_value = FrictionLevel.default()
             ctx = SessionContextQuery.gather_reload(toplevel=str(tmp_path))
         assert ctx.plan_exists
 
@@ -189,9 +189,9 @@ class TestGatherReload:
                 "dev10x.domain.documents.session_context.plan_path_for_toplevel",
                 return_value=tmp_path / "plan.json",
             ),
-            patch("dev10x.domain.documents.session_context.ReadFrictionLevelRule") as mock_rule,
+            patch("dev10x.domain.documents.session_context.SessionYamlDocument") as mock_doc,
         ):
-            mock_rule.return_value.apply.return_value = FrictionLevel.default()
+            mock_doc.return_value.read_friction_level.return_value = FrictionLevel.default()
             ctx = SessionContextQuery.gather_reload(toplevel=str(tmp_path))
         assert ctx.state == fake_state
 
@@ -212,9 +212,9 @@ class TestGatherCompaction:
                 "dev10x.domain.documents.session_context.plan_path_for_toplevel",
                 return_value=tmp_path / "plan.json",
             ),
-            patch("dev10x.domain.documents.session_context.ReadFrictionLevelRule") as mock_rule,
+            patch("dev10x.domain.documents.session_context.SessionYamlDocument") as mock_doc,
         ):
-            mock_rule.return_value.apply.return_value = FrictionLevel.default()
+            mock_doc.return_value.read_friction_level.return_value = FrictionLevel.default()
             ctx = SessionContextQuery.gather_compaction(toplevel=str(tmp_path))
         assert ctx.toplevel == str(tmp_path)
 
@@ -228,9 +228,9 @@ class TestGatherCompaction:
                 "dev10x.domain.documents.session_context.plan_path_for_toplevel",
                 return_value=tmp_path / "plan.json",
             ),
-            patch("dev10x.domain.documents.session_context.ReadFrictionLevelRule") as mock_rule,
+            patch("dev10x.domain.documents.session_context.SessionYamlDocument") as mock_doc,
         ):
-            mock_rule.return_value.apply.return_value = FrictionLevel.default()
+            mock_doc.return_value.read_friction_level.return_value = FrictionLevel.default()
             ctx = SessionContextQuery.gather_compaction(toplevel=str(tmp_path))
         assert ctx.branch == "feature/test"
 
@@ -245,9 +245,9 @@ class TestGatherCompaction:
                 "dev10x.domain.documents.session_context.plan_path_for_toplevel",
                 return_value=tmp_path / "plan.json",
             ),
-            patch("dev10x.domain.documents.session_context.ReadFrictionLevelRule") as mock_rule,
+            patch("dev10x.domain.documents.session_context.SessionYamlDocument") as mock_doc,
         ):
-            mock_rule.return_value.apply.return_value = FrictionLevel.default()
+            mock_doc.return_value.read_friction_level.return_value = FrictionLevel.default()
             ctx = SessionContextQuery.gather_compaction(toplevel=str(tmp_path))
         assert ctx.worktree_name == ""
 
@@ -262,9 +262,9 @@ class TestGatherCompaction:
                 "dev10x.domain.documents.session_context.plan_path_for_toplevel",
                 return_value=tmp_path / "plan.json",
             ),
-            patch("dev10x.domain.documents.session_context.ReadFrictionLevelRule") as mock_rule,
+            patch("dev10x.domain.documents.session_context.SessionYamlDocument") as mock_doc,
         ):
-            mock_rule.return_value.apply.return_value = FrictionLevel.default()
+            mock_doc.return_value.read_friction_level.return_value = FrictionLevel.default()
             ctx = SessionContextQuery.gather_compaction(toplevel=str(tmp_path))
         assert ctx.worktree_name == tmp_path.name
 
@@ -280,9 +280,9 @@ class TestGatherCompaction:
                 "dev10x.domain.documents.session_context.plan_path_for_toplevel",
                 return_value=tmp_path / "plan.json",
             ),
-            patch("dev10x.domain.documents.session_context.ReadFrictionLevelRule") as mock_rule,
+            patch("dev10x.domain.documents.session_context.SessionYamlDocument") as mock_doc,
         ):
-            mock_rule.return_value.apply.return_value = FrictionLevel.default()
+            mock_doc.return_value.read_friction_level.return_value = FrictionLevel.default()
             ctx = SessionContextQuery.gather_compaction(toplevel=str(tmp_path))
         assert ctx.modified_files == []
         assert ctx.staged_files == []


### PR DESCRIPTION
**When** I add or unit-test a session policy rule, **I want to** read `.claude/Dev10x/session.yaml` through a Document instead of inside the rule's `apply()`, **so I can** test rules in memory and keep the domain core free of file I/O (ADR-0007 D3).

---

[`6844a12e`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/682/commits/6844a12eab6041edf1c4ca8c85e5759a1afb4d71) ♻️ GH-515 Enable I/O-free session policy rules
Closes #515
Closes #513
Closes #524
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/515

---