### PR TITLE
♻️ GH-584 Seal permission, session, and CWD package boundaries

### DIFF
--- a/.claude/rules/cwd-discipline.md
+++ b/.claude/rules/cwd-discipline.md
@@ -18,6 +18,15 @@ after `EnterWorktree`.
   first-call toplevel permanently. Construct a fresh `GitContext()` per
   call (or `lambda: GitContext().toplevel`). Enforced by
   `tests/test_no_module_scope_gitcontext.py`.
+- **Domain code resolves CWD via the domain seam, not `subprocess_utils`**
+  (GH-584, audit N21): `domain/` modules (e.g. `domain/git_context.py`)
+  call `dev10x.domain.cwd_resolver.resolve_cwd()` instead of importing
+  `subprocess_utils.effective_cwd` — ADR-0008 Rule #1 keeps `domain/`
+  free of outward dependencies. The infra layer (`subprocess_utils`)
+  wires the concrete `effective_cwd` resolver into that seam at import
+  time (infra → domain is the allowed inward direction). The
+  `subprocess_utils.effective_cwd() or os.getcwd()` guidance above still
+  applies to **adapter/infra** code; only domain modules use the seam.
 
 ## Standalone uv-script exception
 

--- a/src/dev10x/commands/init.py
+++ b/src/dev10x/commands/init.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 import click
 
+from dev10x.domain.documents.session_yaml import SessionYamlDocument
+
 QUICK_START_WORKFLOWS = [
     (
         "git-commit",
@@ -56,15 +58,6 @@ overrides: []
 """
 
 
-def _session_yaml_template() -> str:
-    return (
-        "# Dev10x session config — consumed by work-on, verify-acc-dod, and\n"
-        "# the PreCompact recovery hook.\n"
-        "friction_level: guided  # strict | guided | adaptive\n"
-        "active_modes: []\n"
-    )
-
-
 def _write_if_missing(path: Path, content: str) -> bool:
     # GH-562: claim the file atomically with O_EXCL instead of a
     # check-then-write. Two concurrent `dev10x init` runs (CI matrix)
@@ -86,8 +79,9 @@ def _seed_project(project_root: Path) -> list[Path]:
     """Create starter config files. Returns list of paths written."""
     written: list[Path] = []
 
+    session_doc = SessionYamlDocument(toplevel=str(project_root))
     targets = [
-        (project_root / ".claude" / "Dev10x" / "session.yaml", _session_yaml_template()),
+        (session_doc.path, SessionYamlDocument.render()),
         (
             project_root / ".claude" / "Dev10x" / "playbooks" / "work-on.yaml",
             STARTER_WORK_ON_PLAYBOOK,
@@ -142,7 +136,8 @@ def init(*, setup: bool, non_interactive: bool, project_path: Path | None) -> No
         click.echo(f"Project path does not exist: {project_root}", err=True)
         sys.exit(1)
 
-    existing = (project_root / ".claude" / "Dev10x" / "session.yaml").exists()
+    session_doc = SessionYamlDocument(toplevel=str(project_root))
+    existing = session_doc.path.exists()
     if existing and not setup:
         click.echo(f"Dev10x config already present at {project_root}/.claude/Dev10x/")
         _print_card(project_root=project_root)
@@ -169,15 +164,9 @@ def init(*, setup: bool, non_interactive: bool, project_path: Path | None) -> No
         default=False,
     )
 
-    session_yaml_path = project_root / ".claude" / "Dev10x" / "session.yaml"
     modes = ["solo-maintainer"] if solo else []
-    session_yaml_path.parent.mkdir(parents=True, exist_ok=True)
-    session_yaml_path.write_text(
-        "# Dev10x session config\n"
-        f"friction_level: {friction_level.lower()}\n"
-        f"active_modes: {modes!r}\n"
-    )
-    click.echo(f"  + {session_yaml_path.relative_to(project_root)}")
+    session_doc.write(friction_level=friction_level.lower(), active_modes=modes)
+    click.echo(f"  + {session_doc.path.relative_to(project_root)}")
 
     playbook_path = project_root / ".claude" / "Dev10x" / "playbooks" / "work-on.yaml"
     if not playbook_path.exists():

--- a/src/dev10x/commands/permission.py
+++ b/src/dev10x/commands/permission.py
@@ -7,6 +7,7 @@ from types import ModuleType
 import click
 
 from dev10x.domain.common.result import ErrorResult
+from dev10x.permission.service import PermissionContext, load_permission_context
 
 
 @click.group()
@@ -30,6 +31,21 @@ def _require_config(mod: ModuleType) -> Path:
         click.echo(f"ERROR: {resolved.error}", err=True)
         sys.exit(1)
     return resolved.value
+
+
+def _require_context(*, include_user: bool | None = None) -> PermissionContext:
+    """Resolve the permission context via the service or exit (audit N18).
+
+    The CLI counterpart to the MCP adapter's ``load_permission_context``
+    call: both reach the same service instead of inlining the
+    ``find_config`` → ``load_config`` → ``find_settings_files`` triple.
+    The CLI layer owns exit codes, so a config-resolution failure exits 1.
+    """
+    result = load_permission_context(include_user=include_user)
+    if isinstance(result, ErrorResult):
+        click.echo(f"ERROR: {result.error}", err=True)
+        sys.exit(1)
+    return result.value
 
 
 @permission.command(name="update-paths")
@@ -61,15 +77,12 @@ def update_paths(
     if restore:
         sys.exit(mod._restore(config_path=_require_config(mod)))
 
-    config_path = _require_config(mod)
+    ctx = _require_context()
     if not quiet:
-        click.echo(f"Config: {config_path}")
-    config = mod.load_config(config_path)
+        click.echo(f"Config: {ctx.config_path}")
+    config = ctx.config
 
-    settings_files = mod.find_settings_files(
-        roots=config.get("roots", []),
-        include_user=config.get("include_user_settings", True),
-    )
+    settings_files = ctx.settings_files
     if not settings_files:
         click.echo("No settings files found.")
         return
@@ -149,24 +162,18 @@ def ensure_base(*, dry_run: bool, quiet: bool) -> None:
     """Add missing base permissions from projects.yaml."""
     from dev10x.skills.permission import update_paths as mod
 
-    config_path = _require_config(mod)
+    ctx = _require_context()
     if not quiet:
-        click.echo(f"Config: {config_path}")
-    config = mod.load_config(config_path)
-
-    settings_files = mod.find_settings_files(
-        roots=config.get("roots", []),
-        include_user=config.get("include_user_settings", True),
-    )
-    if not settings_files:
+        click.echo(f"Config: {ctx.config_path}")
+    if not ctx.settings_files:
         click.echo("No settings files found.")
         return
 
     sys.exit(
         _emit_result(
             mod.ensure_base(
-                config=config,
-                settings_files=settings_files,
+                config=ctx.config,
+                settings_files=ctx.settings_files,
                 dry_run=dry_run,
                 quiet=quiet,
             )
@@ -181,21 +188,15 @@ def generalize(*, dry_run: bool, quiet: bool) -> None:
     """Replace session-specific permission args with wildcard patterns."""
     from dev10x.skills.permission import update_paths as mod
 
-    config_path = _require_config(mod)
-    config = mod.load_config(config_path)
-
-    settings_files = mod.find_settings_files(
-        roots=config.get("roots", []),
-        include_user=config.get("include_user_settings", True),
-    )
-    if not settings_files:
+    ctx = _require_context()
+    if not ctx.settings_files:
         click.echo("No settings files found.")
         return
 
     sys.exit(
         _emit_result(
             mod.generalize(
-                settings_files=settings_files,
+                settings_files=ctx.settings_files,
                 dry_run=dry_run,
                 quiet=quiet,
             )
@@ -215,22 +216,16 @@ def ensure_workspace(*, dry_run: bool, quiet: bool) -> None:
     """
     from dev10x.skills.permission import update_paths as mod
 
-    config_path = _require_config(mod)
-    config = mod.load_config(config_path)
-
-    settings_files = mod.find_settings_files(
-        roots=config.get("roots", []),
-        include_user=config.get("include_user_settings", True),
-    )
-    if not settings_files:
+    ctx = _require_context()
+    if not ctx.settings_files:
         click.echo("No settings files found.")
         return
 
     sys.exit(
         _emit_result(
             mod.ensure_workspace(
-                config=config,
-                settings_files=settings_files,
+                config=ctx.config,
+                settings_files=ctx.settings_files,
                 dry_run=dry_run,
                 quiet=quiet,
             )
@@ -245,22 +240,16 @@ def ensure_scripts(*, dry_run: bool, quiet: bool) -> None:
     """Verify all plugin scripts have allow rules; add missing ones."""
     from dev10x.skills.permission import update_paths as mod
 
-    config_path = _require_config(mod)
-    config = mod.load_config(config_path)
-
-    settings_files = mod.find_settings_files(
-        roots=config.get("roots", []),
-        include_user=config.get("include_user_settings", True),
-    )
-    if not settings_files:
+    ctx = _require_context()
+    if not ctx.settings_files:
         click.echo("No settings files found.")
         return
 
     sys.exit(
         _emit_result(
             mod.ensure_scripts(
-                config=config,
-                settings_files=settings_files,
+                config=ctx.config,
+                settings_files=ctx.settings_files,
                 dry_run=dry_run,
                 quiet=quiet,
             )
@@ -275,22 +264,16 @@ def ensure_reads(*, dry_run: bool, quiet: bool) -> None:
     """Emit per-skill folder Read rules with ~/ + /home/<user>/ twins."""
     from dev10x.skills.permission import update_paths as mod
 
-    config_path = _require_config(mod)
-    config = mod.load_config(config_path)
-
-    settings_files = mod.find_settings_files(
-        roots=config.get("roots", []),
-        include_user=config.get("include_user_settings", True),
-    )
-    if not settings_files:
+    ctx = _require_context()
+    if not ctx.settings_files:
         click.echo("No settings files found.")
         return
 
     sys.exit(
         _emit_result(
             mod.ensure_reads(
-                config=config,
-                settings_files=settings_files,
+                config=ctx.config,
+                settings_files=ctx.settings_files,
                 dry_run=dry_run,
                 quiet=quiet,
             )
@@ -460,25 +443,18 @@ def clean(
 def enumerate_mcp(*, dry_run: bool, quiet: bool) -> None:
     """Expand `mcp__plugin_Dev10x_*` wildcards into enumerated tool names."""
     from dev10x.skills.permission import enumerate_mcp as mod
-    from dev10x.skills.permission import update_paths as paths_mod
 
-    config_path = _require_config(paths_mod)
+    ctx = _require_context()
     if not quiet:
-        click.echo(f"Config: {config_path}")
-    config = paths_mod.load_config(config_path)
-
-    settings_files = paths_mod.find_settings_files(
-        roots=config.get("roots", []),
-        include_user=config.get("include_user_settings", True),
-    )
-    if not settings_files:
+        click.echo(f"Config: {ctx.config_path}")
+    if not ctx.settings_files:
         click.echo("No settings files found.")
         return
 
     if dry_run and not quiet:
         click.echo("(dry run — no files will be modified)\n")
 
-    mod.enumerate_settings(settings_files, dry_run=dry_run, quiet=quiet)
+    mod.enumerate_settings(ctx.settings_files, dry_run=dry_run, quiet=quiet)
 
 
 @permission.command(name="promote-plan")
@@ -531,7 +507,6 @@ def promote_plan(
     groups (tier 3) are never proactively seeded.
     """
     from dev10x.skills.permission import promote as mod
-    from dev10x.skills.permission import update_paths as paths_mod
 
     global_settings = Path.home() / ".claude" / "settings.json"
     if proactive:
@@ -541,16 +516,11 @@ def promote_plan(
             global_settings_path=global_settings,
         )
     else:
-        config_path = _require_config(paths_mod)
+        ctx = _require_context(include_user=False)
         if not quiet:
-            click.echo(f"Config: {config_path}")
-        config = paths_mod.load_config(config_path)
-        settings_files = paths_mod.find_settings_files(
-            roots=config.get("roots", []),
-            include_user=False,
-        )
+            click.echo(f"Config: {ctx.config_path}")
         plan = mod.build_promotion_plan(
-            project_settings_paths=settings_files,
+            project_settings_paths=ctx.settings_files,
             global_settings_path=global_settings,
         )
     if not apply_changes:
@@ -862,15 +832,9 @@ def doctor_canonicalize(*, dry_run: bool, quiet: bool) -> None:
     them to the version-wildcard form so they survive future updates.
     """
     from dev10x.skills.permission import doctor as mod
-    from dev10x.skills.permission import update_paths as paths_mod
 
-    config_path = _require_config(paths_mod)
-    config = paths_mod.load_config(config_path)
-    settings_files = paths_mod.find_settings_files(
-        roots=config.get("roots", []),
-        include_user=config.get("include_user_settings", True),
-    )
-    if not settings_files:
+    ctx = _require_context()
+    if not ctx.settings_files:
         click.echo("No settings files found.")
         return
 
@@ -879,7 +843,7 @@ def doctor_canonicalize(*, dry_run: bool, quiet: bool) -> None:
 
     total_rewrites = 0
     files_changed = 0
-    for path in sorted(settings_files):
+    for path in sorted(ctx.settings_files):
         result = mod.canonicalize_settings_file(path, dry_run=dry_run)
         if result.changed:
             files_changed += 1
@@ -920,16 +884,10 @@ def doctor_cross_contamination(*, cwd: str | None, quiet: bool) -> None:
 def doctor_apply_deprecations(*, dry_run: bool) -> None:
     """Apply catalog deprecations (canonicalize / remove) to settings files."""
     from dev10x.skills.permission import doctor as mod
-    from dev10x.skills.permission import update_paths as paths_mod
 
     catalog = mod.load_catalog()
-    config_path = _require_config(paths_mod)
-    config = paths_mod.load_config(config_path)
-    settings_files = paths_mod.find_settings_files(
-        roots=config.get("roots", []),
-        include_user=config.get("include_user_settings", True),
-    )
-    if not settings_files:
+    ctx = _require_context()
+    if not ctx.settings_files:
         click.echo("No settings files found.")
         return
 
@@ -938,7 +896,7 @@ def doctor_apply_deprecations(*, dry_run: bool) -> None:
 
     sys.exit(
         _emit_result(
-            mod.apply_deprecations_to_files(settings_files, catalog=catalog, dry_run=dry_run)
+            mod.apply_deprecations_to_files(ctx.settings_files, catalog=catalog, dry_run=dry_run)
         )
     )
 
@@ -949,20 +907,14 @@ def doctor_apply_deprecations(*, dry_run: bool) -> None:
 def doctor_enable_group(*, group_name: str, dry_run: bool) -> None:
     """Add a Tier 3 group's rules from the baseline-permissions catalog."""
     from dev10x.skills.permission import doctor as mod
-    from dev10x.skills.permission import update_paths as paths_mod
 
     catalog = mod.load_catalog()
     rules = catalog.group_rules(group_name)
     if not rules:
         click.echo(f"ERROR: unknown group {group_name!r}")
         sys.exit(1)
-    config_path = _require_config(paths_mod)
-    config = paths_mod.load_config(config_path)
-    settings_files = paths_mod.find_settings_files(
-        roots=config.get("roots", []),
-        include_user=config.get("include_user_settings", True),
-    )
-    if not settings_files:
+    ctx = _require_context()
+    if not ctx.settings_files:
         click.echo("No settings files found.")
         return
     if dry_run:
@@ -971,7 +923,7 @@ def doctor_enable_group(*, group_name: str, dry_run: bool) -> None:
     sys.exit(
         _emit_result(
             mod.enable_group_in_files(
-                settings_files,
+                ctx.settings_files,
                 rules=rules,
                 group_name=group_name,
                 dry_run=dry_run,
@@ -998,20 +950,14 @@ def doctor_anchor_worktree_roots(*, dry_run: bool, quiet: bool) -> None:
        silently target different skill dirs per worktree CWD.
     """
     from dev10x.skills.permission import doctor as mod
-    from dev10x.skills.permission import update_paths as paths_mod
 
-    config_path = _require_config(paths_mod)
-    config = paths_mod.load_config(config_path)
-    roots = config.get("roots", [])
+    ctx = _require_context()
+    roots = ctx.config.get("roots", [])
     if not roots:
         click.echo("No roots configured. Run `dev10x permission init` first.")
         return
 
-    settings_files = paths_mod.find_settings_files(
-        roots=roots,
-        include_user=config.get("include_user_settings", True),
-    )
-    if not settings_files:
+    if not ctx.settings_files:
         click.echo("No settings files found.")
         return
 
@@ -1028,7 +974,7 @@ def doctor_anchor_worktree_roots(*, dry_run: bool, quiet: bool) -> None:
             click.echo("No .worktrees parents found beneath configured roots.")
 
     anchor_result = mod.anchor_worktree_roots(
-        settings_files,
+        ctx.settings_files,
         roots=roots,
         dry_run=dry_run,
     )

--- a/src/dev10x/domain/cwd_resolver.py
+++ b/src/dev10x/domain/cwd_resolver.py
@@ -1,0 +1,50 @@
+"""CwdResolver — domain-owned seam for effective-CWD resolution.
+
+ADR-0008 Rule #1: ``domain/`` depends only on ``domain/`` and the
+standard library. ``GitContext`` must still resolve the caller's
+effective working directory — the ContextVar bound by
+``subprocess_utils.use_cwd`` after EnterWorktree (GH-979) — but it must
+not import the ``subprocess_utils`` infrastructure module to do so
+(audit N21, the ``domain → subprocess_utils`` inversion).
+
+This module declares the :class:`CwdResolver` Protocol in the core plus
+a single injection seam. The concrete resolver
+(``subprocess_utils.effective_cwd``) is wired inward by the infra layer
+at import time — infra depending on domain is the allowed direction.
+
+When no resolver is injected, :func:`resolve_cwd` returns ``None`` —
+identical to an unbound ContextVar — so any process that never imports
+``subprocess_utils`` (and therefore can never have bound a CWD) keeps
+inheriting the OS process CWD with no behavior change.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class CwdResolver(Protocol):
+    """Return the bound effective CWD, or ``None`` when unbound."""
+
+    def __call__(self) -> str | None: ...
+
+
+_resolver: CwdResolver | None = None
+
+
+def set_cwd_resolver(resolver: CwdResolver | None) -> None:
+    """Inject the effective-CWD resolver (infra wiring / tests).
+
+    Pass ``None`` to reset to the unbound default.
+    """
+    global _resolver
+    _resolver = resolver
+
+
+def resolve_cwd() -> str | None:
+    """Return the injected resolver's result, or ``None`` when unset."""
+    return _resolver() if _resolver is not None else None
+
+
+__all__ = ["CwdResolver", "resolve_cwd", "set_cwd_resolver"]

--- a/src/dev10x/domain/documents/session_yaml.py
+++ b/src/dev10x/domain/documents/session_yaml.py
@@ -62,5 +62,27 @@ class SessionYamlDocument:
         modes = data.get("active_modes")
         return level, (modes if isinstance(modes, list) else [])
 
+    @staticmethod
+    def render(*, friction_level: str = "guided", active_modes: list[str] | None = None) -> str:
+        """Render the canonical ``session.yaml`` body.
+
+        The single source of truth for the file's shape — ``dev10x init``
+        (interactive and ``--non-interactive``) routes its writes here
+        instead of duplicating the template inline (audit N19).
+        """
+        return (
+            "# Dev10x session config — consumed by work-on, verify-acc-dod, and\n"
+            "# the PreCompact recovery hook.\n"
+            f"friction_level: {friction_level}  # strict | guided | adaptive\n"
+            f"active_modes: {active_modes or []!r}\n"
+        )
+
+    def write(
+        self, *, friction_level: str = "guided", active_modes: list[str] | None = None
+    ) -> None:
+        """Write ``session.yaml`` for this toplevel, creating parents as needed."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(self.render(friction_level=friction_level, active_modes=active_modes))
+
 
 __all__ = ["SessionYamlDocument"]

--- a/src/dev10x/domain/git_context.py
+++ b/src/dev10x/domain/git_context.py
@@ -11,6 +11,12 @@ hit. Callers either construct a fresh instance per call, or pass
 `cwd=` explicitly. When `cwd` is None, the subprocess inherits the
 ContextVar bound by `subprocess_utils.use_cwd` (set by MCP entry
 points after EnterWorktree).
+
+GH-584 (audit N21): this module resolves the effective CWD through
+the domain-owned `cwd_resolver` seam rather than importing the
+`subprocess_utils` infra module directly — ADR-0008 Rule #1 keeps
+`domain/` free of outward dependencies. The infra layer wires the
+concrete `effective_cwd` resolver into that seam at import time.
 """
 
 from __future__ import annotations
@@ -18,7 +24,7 @@ from __future__ import annotations
 import subprocess
 from functools import cached_property
 
-from dev10x.subprocess_utils import effective_cwd
+from dev10x.domain.cwd_resolver import resolve_cwd
 
 
 class GitContext:
@@ -26,7 +32,7 @@ class GitContext:
         self._cwd = cwd
 
     def _resolved_cwd(self) -> str | None:
-        return self._cwd if self._cwd is not None else effective_cwd()
+        return self._cwd if self._cwd is not None else resolve_cwd()
 
     @cached_property
     def toplevel(self) -> str | None:

--- a/src/dev10x/permission/__init__.py
+++ b/src/dev10x/permission/__init__.py
@@ -15,6 +15,7 @@ import asyncio
 from typing import Any
 
 from dev10x.domain.common.result import ErrorResult, Result, err, ok
+from dev10x.permission.service import load_permission_context
 
 
 def _run_sub_command(
@@ -29,14 +30,11 @@ def _run_sub_command(
 ) -> Result[dict[str, Any]]:
     from dev10x.skills.permission import update_paths as mod
 
-    resolved = mod.find_config()
-    if isinstance(resolved, ErrorResult):
-        return resolved
-    config = mod.load_config(resolved.value)
-    settings_files = mod.find_settings_files(
-        roots=config.get("roots", []),
-        include_user=config.get("include_user_settings", True),
-    )
+    ctx = load_permission_context()
+    if isinstance(ctx, ErrorResult):
+        return ctx
+    config = ctx.value.config
+    settings_files = ctx.value.settings_files
     if not settings_files:
         return err("No settings files found.")
 
@@ -174,16 +172,12 @@ def _run_update_paths(
             "init is not supported via MCP; run `uvx dev10x permission update-paths --init`."
         )
 
-    resolved = mod.find_config()
-    if isinstance(resolved, ErrorResult):
-        return resolved
-    config_path = resolved.value
-    config = mod.load_config(config_path)
-
-    settings_files = mod.find_settings_files(
-        roots=config.get("roots", []),
-        include_user=config.get("include_user_settings", True),
-    )
+    ctx = load_permission_context()
+    if isinstance(ctx, ErrorResult):
+        return ctx
+    config_path = ctx.value.config_path
+    config = ctx.value.config
+    settings_files = ctx.value.settings_files
     if not settings_files:
         return err("No settings files found.")
 

--- a/src/dev10x/permission/service.py
+++ b/src/dev10x/permission/service.py
@@ -1,0 +1,70 @@
+"""Permission maintenance service layer.
+
+The config-resolution boundary shared by the permission MCP adapter
+(``dev10x.permission``) and the CLI (``dev10x.commands.permission``).
+Both previously inlined the same ``find_config`` → ``load_config`` →
+``find_settings_files`` sequence and reached directly into
+``dev10x.skills.permission`` (audit N18). This layer owns that
+sequence once — mirroring ``dev10x.plan.service`` — so the adapters
+depend on the service, not on the skills package internals.
+
+Name derivation and the actual settings mutations stay in
+``dev10x.skills.permission.*``; the service only assembles the
+context those operations consume.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from dev10x.domain.common.result import ErrorResult, Result, ok
+
+
+@dataclass(frozen=True)
+class PermissionContext:
+    """Resolved config + settings files for a permission operation."""
+
+    config_path: Path
+    config: dict[str, Any]
+    settings_files: list[Path]
+
+
+def load_permission_context(*, include_user: bool | None = None) -> Result[PermissionContext]:
+    """Resolve the config path, parse it, and discover settings files.
+
+    Returns the wrapped :class:`PermissionContext` on success, or the
+    :class:`ErrorResult` from ``find_config`` when no userspace config
+    can be resolved. ``settings_files`` may be empty — callers decide
+    whether an empty result is an error (MCP) or a no-op (CLI), so this
+    layer does not impose either policy.
+
+    When ``include_user`` is ``None`` the config's
+    ``include_user_settings`` flag (default ``True``) is honored; pass
+    an explicit bool to override it (e.g. ``promote-plan`` excludes
+    user settings).
+    """
+    from dev10x.skills.permission import update_paths as mod
+
+    resolved = mod.find_config()
+    if isinstance(resolved, ErrorResult):
+        return resolved
+    config_path = resolved.value
+    config = mod.load_config(config_path)
+
+    use_user = config.get("include_user_settings", True) if include_user is None else include_user
+    settings_files = mod.find_settings_files(
+        roots=config.get("roots", []),
+        include_user=use_user,
+    )
+    return ok(
+        PermissionContext(
+            config_path=config_path,
+            config=config,
+            settings_files=settings_files,
+        )
+    )
+
+
+__all__ = ["PermissionContext", "load_permission_context"]

--- a/src/dev10x/subprocess_utils.py
+++ b/src/dev10x/subprocess_utils.py
@@ -13,6 +13,8 @@ from contextvars import ContextVar
 from pathlib import Path
 from typing import Any
 
+from dev10x.domain.cwd_resolver import set_cwd_resolver
+
 log = logging.getLogger(__name__)
 
 # GH-979: long-lived MCP server processes inherit the CWD they were
@@ -324,3 +326,13 @@ def parse_key_value_output(text: str) -> dict[str, str]:
         key, value = line.split("=", 1)
         result[key.strip()] = value.strip()
     return result
+
+
+# GH-584 (audit N21): wire the concrete effective-CWD resolver into the
+# domain seam so `dev10x.domain.git_context` resolves the bound worktree
+# without importing this infra module (ADR-0008 Rule #1). Infra → domain
+# is the allowed inward direction. `use_cwd` lives here too, so any code
+# that can bind a CWD has already imported this module and triggered the
+# wiring; processes that never import it keep the unbound (process-CWD)
+# default.
+set_cwd_resolver(effective_cwd)

--- a/tests/commands/test_permission_context.py
+++ b/tests/commands/test_permission_context.py
@@ -1,0 +1,30 @@
+"""Tests for the CLI `_require_context` helper (GH-584, audit N18).
+
+The CLI counterpart to the MCP adapter's service call: it unwraps
+`load_permission_context` or exits 1 when config resolution fails.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dev10x.commands import permission as cmd
+from dev10x.domain.common.result import err, ok
+from dev10x.permission.service import PermissionContext
+
+
+def test_returns_context_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    ctx = PermissionContext(config_path=Path("/cfg.yaml"), config={"roots": []}, settings_files=[])
+    monkeypatch.setattr(cmd, "load_permission_context", lambda *, include_user=None: ok(ctx))
+    assert cmd._require_context() is ctx
+
+
+def test_exits_when_config_resolution_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        cmd, "load_permission_context", lambda *, include_user=None: err("no config")
+    )
+    with pytest.raises(SystemExit) as excinfo:
+        cmd._require_context()
+    assert excinfo.value.code == 1

--- a/tests/domain/documents/test_session_yaml.py
+++ b/tests/domain/documents/test_session_yaml.py
@@ -98,3 +98,41 @@ class TestReadFrictionAndModes:
         level, modes = SessionYamlDocument(toplevel=toplevel).read_friction_and_modes()
         assert level is FrictionLevel.GUIDED
         assert modes == []
+
+
+class TestRender:
+    """GH-584 N19: the Document owns the session.yaml template (write side)."""
+
+    def test_defaults_to_guided_empty_modes(self) -> None:
+        body = SessionYamlDocument.render()
+        assert "friction_level: guided  # strict | guided | adaptive" in body
+        assert "active_modes: []" in body
+
+    def test_renders_chosen_level_and_modes(self) -> None:
+        body = SessionYamlDocument.render(
+            friction_level="adaptive", active_modes=["solo-maintainer"]
+        )
+        assert "friction_level: adaptive" in body
+        assert "active_modes: ['solo-maintainer']" in body
+
+    def test_round_trips_through_reader(self, tmp_path: Path) -> None:
+        doc = SessionYamlDocument(toplevel=str(tmp_path))
+        (tmp_path / ".claude" / "Dev10x").mkdir(parents=True)
+        doc.path.write_text(SessionYamlDocument.render(friction_level="strict"))
+        assert doc.read_friction_level() is FrictionLevel.STRICT
+
+
+class TestWrite:
+    def test_creates_parents_and_writes(self, tmp_path: Path) -> None:
+        doc = SessionYamlDocument(toplevel=str(tmp_path))
+        doc.write(friction_level="adaptive", active_modes=["solo-maintainer"])
+        level, modes = doc.read_friction_and_modes()
+        assert level is FrictionLevel.ADAPTIVE
+        assert modes == ["solo-maintainer"]
+
+    def test_write_defaults(self, tmp_path: Path) -> None:
+        doc = SessionYamlDocument(toplevel=str(tmp_path))
+        doc.write()
+        level, modes = doc.read_friction_and_modes()
+        assert level is FrictionLevel.GUIDED
+        assert modes == []

--- a/tests/domain/test_cwd_resolver.py
+++ b/tests/domain/test_cwd_resolver.py
@@ -1,0 +1,61 @@
+"""Tests for the domain CwdResolver seam (GH-584, audit N21).
+
+`domain/git_context.py` resolves the effective CWD through this seam
+instead of importing `subprocess_utils`, so `domain/` stays free of
+outward dependencies (ADR-0008 Rule #1). The infra layer wires the
+concrete resolver in at import time.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from dev10x.domain import cwd_resolver
+
+
+@pytest.fixture(autouse=True)
+def _restore_resolver() -> Iterator[None]:
+    """Save/restore the module global so tests don't leak into the
+    infra-wired default (`subprocess_utils.effective_cwd`)."""
+    saved = cwd_resolver._resolver
+    try:
+        yield
+    finally:
+        cwd_resolver.set_cwd_resolver(saved)
+
+
+def test_resolve_returns_none_when_unset() -> None:
+    cwd_resolver.set_cwd_resolver(None)
+    assert cwd_resolver.resolve_cwd() is None
+
+
+def test_resolve_uses_injected_resolver() -> None:
+    cwd_resolver.set_cwd_resolver(lambda: "/bound/worktree")
+    assert cwd_resolver.resolve_cwd() == "/bound/worktree"
+
+
+def test_reset_clears_injected_resolver() -> None:
+    cwd_resolver.set_cwd_resolver(lambda: "/bound/worktree")
+    cwd_resolver.set_cwd_resolver(None)
+    assert cwd_resolver.resolve_cwd() is None
+
+
+def test_git_context_does_not_import_subprocess_utils() -> None:
+    """Regression guard for the N21 inversion: domain/git_context must
+    not import the infra module directly."""
+    source = (
+        Path(__file__).resolve().parents[2] / "src" / "dev10x" / "domain" / "git_context.py"
+    ).read_text()
+    assert "from dev10x.subprocess_utils import" not in source
+    assert "import dev10x.subprocess_utils" not in source
+
+
+def test_infra_import_wires_resolver() -> None:
+    """Importing subprocess_utils wires effective_cwd into the seam."""
+    import dev10x.subprocess_utils as su
+
+    su  # imported for its module-load wiring side effect
+    assert cwd_resolver._resolver is su.effective_cwd

--- a/tests/permission/test_service.py
+++ b/tests/permission/test_service.py
@@ -1,0 +1,72 @@
+"""Tests for the permission service layer (GH-584, audit N18).
+
+The service owns the `find_config` → `load_config` →
+`find_settings_files` sequence shared by the MCP adapter and the CLI,
+so neither inlines the boilerplate nor reaches into
+`skills.permission` directly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dev10x.domain.common.result import ErrorResult, err, ok
+from dev10x.permission import service
+from dev10x.skills.permission import update_paths as up
+
+
+@pytest.fixture
+def stub_config(monkeypatch: pytest.MonkeyPatch) -> dict:
+    """Stub find_config/load_config; record find_settings_files args."""
+    captured: dict = {}
+    monkeypatch.setattr(up, "find_config", lambda: ok(Path("/cfg.yaml")))
+    monkeypatch.setattr(
+        up,
+        "load_config",
+        lambda _path: {"roots": ["/root"], "include_user_settings": True},
+    )
+
+    def fake_find_settings_files(*, roots: list[str], include_user: bool) -> list[Path]:
+        captured["roots"] = roots
+        captured["include_user"] = include_user
+        return [Path("/proj/.claude/settings.local.json")]
+
+    monkeypatch.setattr(up, "find_settings_files", fake_find_settings_files)
+    return captured
+
+
+def test_returns_context_on_success(stub_config: dict) -> None:
+    result = service.load_permission_context()
+    assert not isinstance(result, ErrorResult)
+    ctx = result.value
+    assert ctx.config_path == Path("/cfg.yaml")
+    assert ctx.config["roots"] == ["/root"]
+    assert ctx.settings_files == [Path("/proj/.claude/settings.local.json")]
+
+
+def test_honors_config_include_user_by_default(stub_config: dict) -> None:
+    service.load_permission_context()
+    assert stub_config["include_user"] is True
+
+
+def test_explicit_include_user_overrides_config(stub_config: dict) -> None:
+    service.load_permission_context(include_user=False)
+    assert stub_config["include_user"] is False
+
+
+def test_passes_through_find_config_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(up, "find_config", lambda: err("no config"))
+    result = service.load_permission_context()
+    assert isinstance(result, ErrorResult)
+    assert result.error == "no config"
+
+
+def test_empty_settings_files_is_not_an_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(up, "find_config", lambda: ok(Path("/cfg.yaml")))
+    monkeypatch.setattr(up, "load_config", lambda _path: {"roots": []})
+    monkeypatch.setattr(up, "find_settings_files", lambda *, roots, include_user: [])
+    result = service.load_permission_context()
+    assert not isinstance(result, ErrorResult)
+    assert result.value.settings_files == []


### PR DESCRIPTION
**When** the architecture audit flags package-boundary inversions, **I want to** have each adapter and the domain core depend only through declared seams, **so I can** refactor permission, session, and CWD handling without breaking sibling packages.

---

[`5cc53daf`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/683/commits/5cc53daffccc20e6e49c5f3a87bb076e30f5ea6c) ♻️ GH-584 Seal permission, session, and CWD package boundaries
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/584

---

### Scope (verified against current code, not the 2026-06-10 audit snapshot)

| Audit finding | Disposition |
|---|---|
| **N18** — missing `permission/service.py` layer | ✅ Added `load_permission_context`; MCP adapter + CLI now route through it |
| **N19** — `session.yaml` has no Document owner | ✅ Read side already shipped (GH-515/524); this adds the write side (`SessionYamlDocument.render/write`) and removes the `init.py` bare write + ×3 path-literal duplication |
| **N21** — `domain/` imports `subprocess_utils` | ✅ Resolved via a domain `CwdResolver` seam wired by `subprocess_utils` (infra→domain), per ADR-0008 Rule #1. `hook_input.py:9` from the audit was already clean |
| **N20** — `audit_emit` lazy import → startup injection | ⏸️ **Declined.** The existing `_get_writer()` single-injection seam already implements the ADR-0008 **I6** resolution; eager startup injection regresses the documented CLI/hook startup perf baseline (`performance.md` CI gate). See issue comment for rationale. |

New code is at 100% coverage; full suite green (5080 passed); ruff + mypy clean.