### PR TITLE
✨ GH-606 Enable verb-safe credentialed reads and skill curation

### DIFF
--- a/skills/aws-vault/SKILL.md
+++ b/skills/aws-vault/SKILL.md
@@ -19,6 +19,7 @@ invocation-name: Dev10x:aws-vault
 allowed-tools:
   - Bash(${CLAUDE_PLUGIN_ROOT}/skills/aws-vault/scripts/secrets.sh:*)
   - Bash(${CLAUDE_PLUGIN_ROOT}/skills/aws-vault/scripts/kubectl.sh:*)
+  - Bash(${CLAUDE_PLUGIN_ROOT}/skills/aws-vault/scripts/aws.sh:*)
   - AskUserQuestion
 ---
 
@@ -52,6 +53,17 @@ approves. This applies even to read-only discovery lookups.
 **Never call `kubectl` or `aws-vault exec ... kubectl` directly.**
 Use `${CLAUDE_PLUGIN_ROOT}/skills/aws-vault/scripts/kubectl.sh`
 instead.
+
+**Never call `aws` or `aws-vault exec ... aws` directly.** Use
+`${CLAUDE_PLUGIN_ROOT}/skills/aws-vault/scripts/aws.sh` instead. It
+is strictly read-only: only `describe-*`, `list-*`, `get-*`,
+`lookup-*`, `search-*`, `head-*`, `batch-get-*`, `view-*`, and
+`estimate-*` operations pass through. Secret-exfil reads
+(`secretsmanager get-secret-value`, `ssm get-parameter
+--with-decryption`, `kms decrypt`, `sts get-session-token`,
+`ec2 get-password-data`, `ecr get-login-password`, …) are denied
+even though their verb is "get" — fetch secrets through
+`secrets.sh` under the `AskUserQuestion` gate instead.
 
 **The kubectl wrapper is strictly read-only.** Only the verbs
 listed under "When to Use" pass through; mutating verbs
@@ -202,6 +214,30 @@ read-only from the API's perspective but reveal base64-encoded
 secret values. Treat them as you would a `secrets.sh` call:
 the same `AskUserQuestion` confirmation gate applies before
 invocation.
+
+## Workflow: AWS CLI Operations (read-only)
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/skills/aws-vault/scripts/aws.sh <env> <service> <operation> [args...]
+```
+
+The wrapper resolves the `aws_vault_profile` from the registry per
+environment, enforces a read-operation allowlist + secret-exfil
+denylist, then invokes `aws-vault exec ... -- aws ...`.
+
+Examples (all read-only):
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/skills/aws-vault/scripts/aws.sh staging ec2 describe-instances
+${CLAUDE_PLUGIN_ROOT}/skills/aws-vault/scripts/aws.sh production s3api list-buckets
+${CLAUDE_PLUGIN_ROOT}/skills/aws-vault/scripts/aws.sh staging logs describe-log-groups
+${CLAUDE_PLUGIN_ROOT}/skills/aws-vault/scripts/aws.sh production sts get-caller-identity
+```
+
+Denied (exit non-zero with a copy-pasteable snippet): any mutating
+operation (`create-*`, `delete-*`, `put-*`, `run-*`, `terminate-*`,
+…) and the secret-exfil reads listed under Critical Rules. Run those
+in a separate terminal under your own supervision.
 
 ## Key Lessons
 

--- a/skills/aws-vault/scripts/aws.sh
+++ b/skills/aws-vault/scripts/aws.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Usage: aws.sh [--registry PATH] <env> <service> <operation> [args...]
+#
+# Strictly READ-ONLY wrapper for AWS CLI operations via aws-vault.
+# Claude MUST use this script instead of calling `aws-vault exec ... aws`
+# directly.
+#
+# Only operations whose name begins with a read-prefix in ALLOWED_PREFIXES
+# below are permitted (describe-*, list-*, get-*, lookup-*, ...). Mutating
+# operations (create-*, delete-*, put-*, update-*, run-*, terminate-*,
+# start-*, stop-*, ...) are denied. A handful of read-prefixed operations
+# exfiltrate live secrets or mint credentials (secretsmanager
+# get-secret-value, ssm get-parameter --with-decryption, kms decrypt, sts
+# get-session-token, ec2 get-password-data); those are denied by
+# DENIED_OPERATIONS even though their verb is "get". This mirrors DX014's
+# sensitivity screen so the wrapper and the Bash validator agree
+# (GH-605, GH-606 D6).
+#
+# When an operation is denied the script prints a copy-pasteable snippet
+# for you to run in a separate terminal under your own supervision.
+#
+# Privilege-escalation / credential-redirection flags are denied anywhere
+# in the argument list (--profile, --region override is allowed but
+# --endpoint-url, --no-verify-ssl, --no-sign-request, --debug-as) so the
+# wrapper's profile resolution cannot be bypassed via flag injection.
+#
+# Arguments:
+#   <env>         Environment name (resolved from registry)
+#   <service>     AWS CLI service (e.g. ec2, s3api, ecr, logs)
+#   <operation>   Read operation (e.g. describe-instances, list-buckets)
+#   [args...]     Remaining aws arguments
+#
+# Registry: ~/.config/Dev10x/aws-vault/service-registry.yaml
+
+set -euo pipefail
+
+# Read-operation name prefixes. The AWS CLI names read operations with a
+# small set of verbs; anything outside this set is treated as mutating.
+ALLOWED_PREFIXES=(
+    describe-
+    list-
+    get-
+    lookup-
+    search-
+    head-
+    batch-get-
+    view-
+    estimate-
+)
+
+# Operations that read-prefix but exfiltrate secrets or mint credentials.
+# Denied even though they match ALLOWED_PREFIXES (defense-in-depth with
+# DX014's SECRET sensitivity patterns).
+DENIED_OPERATIONS=(
+    "secretsmanager get-secret-value"
+    "secretsmanager batch-get-secret-value"
+    "ssm get-parameter"
+    "ssm get-parameters"
+    "ssm get-parameters-by-path"
+    "kms decrypt"
+    "kms generate-data-key"
+    "sts get-session-token"
+    "sts get-federation-token"
+    "ec2 get-password-data"
+    "ecr get-login-password"
+    "ecr-public get-login-password"
+    "cognito-idp get-credentials-for-identity"
+)
+
+# A handful of services whose entire surface is read-only-but-sensitive or
+# stateless-but-mutating; bare allowlist by prefix is not enough. `s3 cp`,
+# `s3 sync`, `s3 mv`, `s3 rm` are not describe-/list-/get- so they are
+# already denied by the prefix gate — no special-case needed.
+DENIED_FLAGS=(
+    --endpoint-url
+    --no-verify-ssl
+    --no-sign-request
+)
+
+# Optional leading `--registry <path>` flag (parity with kubectl.sh,
+# GH-311) — avoids the env-prefix invocation friction. Falls back to the
+# DEV10X_AWS_VAULT_REGISTRY env var.
+if [[ "${1:-}" == "--registry" ]]; then
+    DEV10X_AWS_VAULT_REGISTRY="${2:?--registry requires a path}"
+    shift 2
+fi
+
+REGISTRY="${DEV10X_AWS_VAULT_REGISTRY:-$HOME/.config/Dev10x/aws-vault/service-registry.yaml}"
+
+if [[ ! -f "$REGISTRY" ]]; then
+    echo "Registry not found: $REGISTRY" >&2
+    echo "Copy the example from the plugin:" >&2
+    echo "  mkdir -p ~/.config/Dev10x/aws-vault" >&2
+    echo "  cp \${CLAUDE_PLUGIN_ROOT}/skills/aws-vault/references/service-registry.example.yaml \\" >&2
+    echo "     ~/.config/Dev10x/aws-vault/service-registry.yaml" >&2
+    exit 1
+fi
+
+ENV="${1:?Usage: aws.sh <env> <service> <operation> [args...]}"
+shift
+
+SERVICE="${1:?Usage: aws.sh <env> <service> <operation> [args...]}"
+shift
+
+OPERATION="${1:?Usage: aws.sh <env> <service> <operation> [args...]}"
+shift
+
+PROFILE=$(yq ".environments.$ENV.aws_vault_profile" "$REGISTRY")
+if [[ -z "$PROFILE" || "$PROFILE" == "null" ]]; then
+    VALID=$(yq '.environments | keys | join(", ")' "$REGISTRY")
+    echo "Unknown environment: $ENV. Valid: $VALID" >&2
+    exit 1
+fi
+
+deny() {
+    {
+        echo "aws.sh: $1"
+        echo
+        echo "This wrapper is strictly read-only. Allowed operation prefixes:"
+        echo "  ${ALLOWED_PREFIXES[*]}"
+        echo
+        echo "If you need to run '$SERVICE $OPERATION', execute the following in a"
+        echo "separate terminal under your own supervision:"
+        echo
+        echo "    aws-vault exec $PROFILE -- aws $SERVICE $OPERATION $*"
+    } >&2
+    exit 1
+}
+
+# Secret-exfil / credential-minting denylist takes precedence over the
+# read-prefix allowlist.
+for denied in "${DENIED_OPERATIONS[@]}"; do
+    if [[ "$SERVICE $OPERATION" == "$denied" ]]; then
+        deny "operation '$SERVICE $OPERATION' exfiltrates secrets or mints credentials — denied even though it reads."
+    fi
+done
+
+is_allowed_prefix=false
+for prefix in "${ALLOWED_PREFIXES[@]}"; do
+    if [[ "$OPERATION" == "$prefix"* ]]; then
+        is_allowed_prefix=true
+        break
+    fi
+done
+
+if [[ "$is_allowed_prefix" != "true" ]]; then
+    deny "operation '$OPERATION' is not a read operation."
+fi
+
+# `--with-decryption` turns an otherwise-benign ssm read into a secret
+# read; deny it on any operation (belt-and-suspenders with DENIED_OPERATIONS).
+for arg in "$@"; do
+    if [[ "$arg" == "--with-decryption" ]]; then
+        deny "flag '--with-decryption' decrypts secret material — denied."
+    fi
+    for denied in "${DENIED_FLAGS[@]}"; do
+        if [[ "$arg" == "$denied" || "$arg" == "$denied="* ]]; then
+            echo "aws.sh: flag '$arg' is not permitted by this wrapper." >&2
+            echo "  Denied flags: ${DENIED_FLAGS[*]} --with-decryption" >&2
+            echo "  Reason: these flags bypass profile resolution or sign-in checks." >&2
+            exit 1
+        fi
+    done
+done
+
+echo "aws ($ENV, profile: $PROFILE): $SERVICE $OPERATION $*" >&2
+
+aws-vault exec "$PROFILE" -- aws "$SERVICE" "$OPERATION" "$@"

--- a/src/dev10x/commands/permission.py
+++ b/src/dev10x/commands/permission.py
@@ -237,7 +237,7 @@ def ensure_workspace(*, dry_run: bool, quiet: bool) -> None:
 @click.option("--dry-run", is_flag=True, help="Show changes without modifying files")
 @click.option("--quiet", is_flag=True, help="Suppress per-file details")
 def ensure_scripts(*, dry_run: bool, quiet: bool) -> None:
-    """Verify all plugin scripts have allow rules; add missing ones."""
+    """Verify plugin and user-skill scripts have allow rules; add missing ones."""
     from dev10x.skills.permission import update_paths as mod
 
     ctx = _require_context()
@@ -245,16 +245,24 @@ def ensure_scripts(*, dry_run: bool, quiet: bool) -> None:
         click.echo("No settings files found.")
         return
 
-    sys.exit(
-        _emit_result(
-            mod.ensure_scripts(
-                config=ctx.config,
-                settings_files=ctx.settings_files,
-                dry_run=dry_run,
-                quiet=quiet,
-            )
+    plugin_exit = _emit_result(
+        mod.ensure_scripts(
+            config=ctx.config,
+            settings_files=ctx.settings_files,
+            dry_run=dry_run,
+            quiet=quiet,
         )
     )
+    # GH-606 AC2: also enumerate ~/.claude/skills/<dir>/scripts/ so personal
+    # and plugin-installed user skills get canonical allow rules.
+    user_exit = _emit_result(
+        mod.ensure_user_skill_scripts(
+            settings_files=ctx.settings_files,
+            dry_run=dry_run,
+            quiet=quiet,
+        )
+    )
+    sys.exit(max(plugin_exit, user_exit))
 
 
 @permission.command(name="ensure-reads")

--- a/src/dev10x/skills/permission/baseline-permissions.yaml
+++ b/src/dev10x/skills/permission/baseline-permissions.yaml
@@ -443,9 +443,19 @@ groups:
   aws-readonly:
     tier: 3
     description: >
-      AWS CLI read-only ops via aws-vault. Writes blocked at the skill
-      level.
+      AWS CLI read-only ops via aws-vault. The credentialed `aws-vault
+      exec` surface is verb-blind, so the read allowlist is enforced by
+      the `aws.sh` wrapper (GH-606 D6): it passes only describe-/list-/
+      get-/lookup-/… operations and denies secret-exfil reads
+      (`secretsmanager get-secret-value`, `ssm get-parameter
+      --with-decryption`, `kms decrypt`, …) that DX014 also screens
+      (GH-605). The wrapper rule below is verb-safe at `:*` because the
+      script self-filters; a bare `Bash(aws-vault exec:*)` is
+      deliberately ABSENT (it would grant every mutating verb — the
+      GH-606 evidence #4 footgun). The two `aws ecr describe-*` forms are
+      retained for the non-credentialed read path.
     rules:
+      - Bash(${CLAUDE_PLUGIN_ROOT}/skills/aws-vault/scripts/aws.sh:*)
       - Bash(aws ecr describe-images:*)
       - Bash(aws ecr describe-repositories:*)
 
@@ -673,13 +683,23 @@ groups:
     tier: 2
     sensitivity: benign
     description: >
-      Read-only analysis skills that inspect and report without mutating
-      the workspace (evidence #20). Mutating skills are intentionally
+      Analysis-first skills safe to INVOKE without a prompt (evidence
+      #20). The grant pre-approves invocation only; any edits a skill
+      proposes (review fixups, `simplify` clarity passes) still flow
+      through the Write/Edit permission rules, so no write access is
+      granted here. Heavily-mutating skills (commit, PR, merge) are
       absent — they ship through their own delegation paths.
+      D13 (GH-608) resolved CONSERVATIVE: seed only first-party review
+      skills plus `simplify`. Wildcard non-Dev10x families
+      (`impeccable:*`, `superpowers:*`, personal `my:*`, third-party)
+      are deliberately NOT pre-approved — `classify_skill_access`
+      (skills/permission/manifest.py) grades read vs mutating, but
+      *which families to trust* stays a per-user opt-in, not a default.
     rules:
       - Skill(code-review)
       - Skill(security-review)
       - Skill(review)
+      - Skill(simplify)
 
   obsidian-cli:
     tier: 3

--- a/src/dev10x/skills/permission/update_paths.py
+++ b/src/dev10x/skills/permission/update_paths.py
@@ -342,6 +342,94 @@ def build_script_allow_rules(
     return rules
 
 
+# GH-606 AC2: user-skill scripts under ~/.claude/skills/<dir>/scripts/.
+# Personal skills keep the colon in the directory name (``my:daily-yt``);
+# plugin-installed skills strip it (``daily-yt``). The glob matches both
+# because the colon is a literal path character.
+USER_SKILL_SCRIPT_GLOBS: list[str] = [
+    "*/scripts/*.sh",
+    "*/scripts/*.py",
+]
+
+# A credentialed pass-through wrapper execs a privileged CLI with the
+# caller's argv. With a ``:*`` allow rule that grants *every* verb —
+# including ``delete``/``apply`` (GH-606 evidence #4). A wrapper that
+# declares a verb allowlist (kubectl.sh, aws.sh) is verb-aware and safe.
+_CREDENTIALED_EXEC_RE = re.compile(
+    r"\b(?:aws-vault\s+exec|vault\s+(?:login|read)|gcloud\s+auth)\b"
+)
+_PASSTHROUGH_ARGV_RE = re.compile(r'"\$@"')
+_VERB_ALLOWLIST_RE = re.compile(r"ALLOWED_VERBS|ALLOWED_PREFIXES|ALLOWED_OPERATIONS")
+
+
+def scan_user_skill_scripts(skills_root: Path) -> list[Path]:
+    """Return executable scripts under ``skills_root/<dir>/scripts/`` (GH-606).
+
+    ``skills_root`` is ``~/.claude/skills`` in production. Returns a sorted,
+    de-duplicated list. Handles colon-kept personal-skill directories
+    (``my:daily-yt``) and prefix-stripped plugin-skill directories alike.
+    """
+    if not skills_root.is_dir():
+        return []
+    scripts: list[Path] = []
+    for glob_pattern in USER_SKILL_SCRIPT_GLOBS:
+        scripts.extend(skills_root.glob(glob_pattern))
+    return sorted(set(scripts))
+
+
+def is_verb_blind_credentialed_wrapper(script: Path) -> bool:
+    """True when *script* pipes ``"$@"`` to a credentialed CLI with no verb gate.
+
+    Such a wrapper must NOT receive a ``:*`` allow rule (GH-606 AC2): the
+    rule would authorize every verb the privileged CLI exposes. A wrapper
+    that declares an ``ALLOWED_VERBS`` / ``ALLOWED_PREFIXES`` /
+    ``ALLOWED_OPERATIONS`` allowlist is verb-aware (kubectl.sh, aws.sh) and
+    is therefore safe at ``:*``. Unreadable scripts default to *not*
+    verb-blind so a transient read error never silently widens nor narrows
+    coverage on its own — the caller still gates on the allowlist marker.
+    """
+    try:
+        text = script.read_text()
+    except OSError:
+        return False
+    if not _CREDENTIALED_EXEC_RE.search(text):
+        return False
+    if _VERB_ALLOWLIST_RE.search(text):
+        return False
+    return bool(_PASSTHROUGH_ARGV_RE.search(text))
+
+
+def build_user_skill_script_rules(
+    scripts: list[Path],
+    *,
+    skills_root: Path,
+    user_home: Path,
+) -> tuple[list[str], list[Path]]:
+    """Build canonical ``~/`` + ``/home/<user>/`` Bash rules for user scripts.
+
+    Returns ``(rules, skipped)`` where *skipped* lists verb-blind
+    credentialed pass-through wrappers that were intentionally NOT granted
+    a ``:*`` rule (GH-606 AC2) — surfaced so the caller can log the gap
+    rather than silently dropping them. Each emitted script gets a ``~/``
+    rule and its resolved ``/home/<user>/`` twin (GH-271 #192/#215).
+    """
+    home = user_home.expanduser().resolve()
+    try:
+        rel_root = skills_root.relative_to(home)
+    except ValueError:
+        return [], []
+    rules: list[str] = []
+    skipped: list[Path] = []
+    for script in scripts:
+        if is_verb_blind_credentialed_wrapper(script):
+            skipped.append(script)
+            continue
+        rel = script.relative_to(skills_root)
+        rules.append(str(AllowRule.bash(f"~/{rel_root}/{rel}:*")))
+        rules.append(str(AllowRule.bash(f"{home}/{rel_root}/{rel}:*")))
+    return rules, skipped
+
+
 def is_dead_glob_script_rule(entry: str) -> bool:
     """True for a Bash plugin-cache rule that uses a ``**`` glob (GH-471).
 
@@ -1185,6 +1273,86 @@ def ensure_scripts(
         messages.append(
             f"{verb} {files_changed} files "
             f"(+{total_added} concrete rules, -{total_purged} dead ** globs)."
+        )
+
+    return _result(
+        exit_code=0,
+        messages=messages,
+        errors=errors,
+        total_added=total_added,
+        files_changed=files_changed,
+    )
+
+
+def ensure_user_skill_scripts(
+    *,
+    settings_files: list[Path],
+    skills_root: Path | None = None,
+    user_home: Path | None = None,
+    dry_run: bool,
+    quiet: bool = False,
+) -> dict[str, object]:
+    """Seed canonical allow rules for user-skill scripts (GH-606 AC2).
+
+    Enumerates ``~/.claude/skills/<dir>/scripts/*.{sh,py}`` (colon-kept and
+    prefix-stripped dirs alike), emits ``~/`` + ``/home/<user>/`` twin
+    ``Bash(...:*)`` rules, and SKIPS verb-blind credentialed pass-through
+    wrappers so they keep prompting. Matching is exact (like
+    :func:`ensure_reads`), so re-runs are idempotent.
+    """
+    messages: list[str] = []
+    errors: list[str] = []
+
+    root = skills_root or (ClaudeDir.home() / "skills")
+    home = user_home or Path.home()
+    scripts = scan_user_skill_scripts(root)
+    if not scripts:
+        if not quiet:
+            messages.append(f"No user-skill scripts found in {root}")
+        return _result(exit_code=0, messages=messages, errors=errors)
+
+    expected_rules, skipped = build_user_skill_script_rules(
+        scripts, skills_root=root, user_home=home
+    )
+
+    if not quiet:
+        messages.append(f"User-skill scripts root: {root}")
+        messages.append(
+            f"Scripts found: {len(scripts)} ({len(expected_rules)} rules, twins included)"
+        )
+        for wrapper in skipped:
+            messages.append(f"  SKIP (verb-blind credentialed wrapper, no :* rule): {wrapper}")
+        if dry_run:
+            messages.append("(dry run — no files will be modified)\n")
+
+    total_added = 0
+    files_changed = 0
+
+    for path in sorted(settings_files):
+        _covered, missing = verify_read_coverage(
+            settings_path=path,
+            expected_rules=expected_rules,
+        )
+        if not missing:
+            continue
+        count, file_messages = ensure_read_rules(
+            settings_path=path,
+            missing_rules=missing,
+            dry_run=dry_run,
+        )
+        if count > 0:
+            if not quiet:
+                messages.append(f"\n{path}")
+                messages.extend(file_messages)
+            total_added += count
+            files_changed += 1
+
+    if total_added == 0:
+        messages.append("All settings files already cover the user-skill scripts.")
+    else:
+        verb = "Would add" if dry_run else "Added"
+        messages.append(
+            f"{verb} {total_added} user-skill script rules across {files_changed} files."
         )
 
     return _result(

--- a/tests/skills/permission/test_baseline_curation.py
+++ b/tests/skills/permission/test_baseline_curation.py
@@ -13,7 +13,7 @@ import pytest
 import yaml
 
 import dev10x.skills.permission as permission_pkg
-from dev10x.skills.permission.manifest import Access, Sensitivity
+from dev10x.skills.permission.manifest import Access, Sensitivity, classify_skill_access
 from dev10x.skills.permission.promote import classify_mcp_tool
 
 CATALOG = Path(permission_pkg.__file__).parent / "baseline-permissions.yaml"
@@ -132,3 +132,32 @@ class TestManifestAlignment:
         ]
         assert reads
         assert all(Access(classify_mcp_tool(r)) is Access.READ for r in reads)
+
+
+class TestReadonlySkillsCuration:
+    """GH-608 D13: conservative skill-invocation surface."""
+
+    def _skill_rules(self, groups: dict) -> list[str]:
+        return [r for r in groups["readonly-skills"]["rules"] if r.startswith("Skill(")]
+
+    def test_curated_first_party_set(self, groups: dict) -> None:
+        rules = set(self._skill_rules(groups))
+        assert rules == {
+            "Skill(code-review)",
+            "Skill(security-review)",
+            "Skill(review)",
+            "Skill(simplify)",
+        }
+
+    def test_no_wildcard_family_preapproved(self, groups: dict) -> None:
+        # Conservative D13: no `impeccable:*` / `superpowers:*` / `my:*`
+        # / third-party family is pre-approved by default.
+        for rule in self._skill_rules(groups):
+            inner = rule[len("Skill(") : rule.rfind(")")]
+            assert "*" not in inner, f"wildcard family pre-approved: {rule}"
+
+    def test_simplify_not_classified_write(self, groups: dict) -> None:
+        # The grant pre-approves invocation; the name heuristic must not
+        # mark simplify as a write surface (its edits are gated by
+        # Write/Edit rules, not this Skill() grant).
+        assert classify_skill_access(name="simplify") is not Access.WRITE

--- a/tests/skills/upgrade-cleanup/test_ensure_scripts.py
+++ b/tests/skills/upgrade-cleanup/test_ensure_scripts.py
@@ -417,3 +417,222 @@ class TestEnsureScriptsFunction:
 
         assert result["exit_code"] == 0
         assert any("No callable scripts" in m for m in result["messages"])
+
+
+# ── GH-606 AC2: user-skill script enumeration ───────────────────────────
+
+_VERB_AWARE_WRAPPER = (
+    "#!/usr/bin/env bash\n"
+    "ALLOWED_VERBS=(get describe)\n"
+    'aws-vault exec "$PROFILE" -- kubectl "$VERB" "$@"\n'
+)
+_VERB_BLIND_WRAPPER = '#!/usr/bin/env bash\naws-vault exec "$PROFILE" -- kubectl "$@"\n'
+_PLAIN_SCRIPT = "#!/usr/bin/env bash\necho hello\n"
+
+
+class TestScanUserSkillScripts:
+    @pytest.fixture()
+    def skills_root(self, tmp_path: Path) -> Path:
+        root = tmp_path / ".claude" / "skills"
+        (root / "my:daily-yt" / "scripts").mkdir(parents=True)
+        (root / "my:daily-yt" / "scripts" / "run.sh").write_text(_PLAIN_SCRIPT)
+        (root / "kb-checkin" / "scripts").mkdir(parents=True)
+        (root / "kb-checkin" / "scripts" / "checkin.py").write_text("print(1)\n")
+        return root
+
+    def test_finds_sh_and_py(self, skills_root: Path) -> None:
+        result = update_paths.scan_user_skill_scripts(skills_root)
+
+        names = [s.name for s in result]
+        assert "run.sh" in names
+        assert "checkin.py" in names
+
+    def test_handles_colon_kept_personal_dir(self, skills_root: Path) -> None:
+        result = update_paths.scan_user_skill_scripts(skills_root)
+
+        assert any("my:daily-yt" in str(s) for s in result)
+
+    def test_returns_sorted_unique(self, skills_root: Path) -> None:
+        result = update_paths.scan_user_skill_scripts(skills_root)
+
+        assert result == sorted(set(result))
+
+    def test_returns_empty_when_root_absent(self, tmp_path: Path) -> None:
+        assert update_paths.scan_user_skill_scripts(tmp_path / "nope") == []
+
+
+class TestIsVerbBlindCredentialedWrapper:
+    def test_verb_blind_passthrough_is_flagged(self, tmp_path: Path) -> None:
+        script = tmp_path / "wrap.sh"
+        script.write_text(_VERB_BLIND_WRAPPER)
+        assert update_paths.is_verb_blind_credentialed_wrapper(script) is True
+
+    def test_verb_aware_wrapper_is_not_flagged(self, tmp_path: Path) -> None:
+        script = tmp_path / "wrap.sh"
+        script.write_text(_VERB_AWARE_WRAPPER)
+        assert update_paths.is_verb_blind_credentialed_wrapper(script) is False
+
+    def test_non_credentialed_script_is_not_flagged(self, tmp_path: Path) -> None:
+        script = tmp_path / "plain.sh"
+        script.write_text(_PLAIN_SCRIPT)
+        assert update_paths.is_verb_blind_credentialed_wrapper(script) is False
+
+    def test_missing_file_is_not_flagged(self, tmp_path: Path) -> None:
+        assert update_paths.is_verb_blind_credentialed_wrapper(tmp_path / "gone.sh") is False
+
+
+class TestBuildUserSkillScriptRules:
+    def test_emits_home_twins(self, tmp_path: Path) -> None:
+        skills_root = tmp_path / ".claude" / "skills"
+        (skills_root / "kb-checkin" / "scripts").mkdir(parents=True)
+        script = skills_root / "kb-checkin" / "scripts" / "checkin.py"
+        script.write_text("print(1)\n")
+
+        rules, skipped = update_paths.build_user_skill_script_rules(
+            [script], skills_root=skills_root, user_home=tmp_path
+        )
+
+        home = tmp_path.resolve()
+        assert rules == [
+            "Bash(~/.claude/skills/kb-checkin/scripts/checkin.py:*)",
+            f"Bash({home}/.claude/skills/kb-checkin/scripts/checkin.py:*)",
+        ]
+        assert skipped == []
+
+    def test_skips_verb_blind_wrapper(self, tmp_path: Path) -> None:
+        skills_root = tmp_path / ".claude" / "skills"
+        (skills_root / "aws-vault" / "scripts").mkdir(parents=True)
+        blind = skills_root / "aws-vault" / "scripts" / "wrap.sh"
+        blind.write_text(_VERB_BLIND_WRAPPER)
+
+        rules, skipped = update_paths.build_user_skill_script_rules(
+            [blind], skills_root=skills_root, user_home=tmp_path
+        )
+
+        assert rules == []
+        assert skipped == [blind]
+
+    def test_colon_kept_dir_in_rule(self, tmp_path: Path) -> None:
+        skills_root = tmp_path / ".claude" / "skills"
+        (skills_root / "my:daily-yt" / "scripts").mkdir(parents=True)
+        script = skills_root / "my:daily-yt" / "scripts" / "run.sh"
+        script.write_text(_PLAIN_SCRIPT)
+
+        rules, _skipped = update_paths.build_user_skill_script_rules(
+            [script], skills_root=skills_root, user_home=tmp_path
+        )
+
+        assert "Bash(~/.claude/skills/my:daily-yt/scripts/run.sh:*)" in rules
+
+    def test_returns_empty_when_root_outside_home(self, tmp_path: Path) -> None:
+        outside = tmp_path / "elsewhere" / "skills"
+        outside.mkdir(parents=True)
+        rules, skipped = update_paths.build_user_skill_script_rules(
+            [outside / "x.sh"], skills_root=outside, user_home=tmp_path / "home"
+        )
+
+        assert rules == []
+        assert skipped == []
+
+
+class TestEnsureUserSkillScripts:
+    @pytest.fixture()
+    def skills_root(self, tmp_path: Path) -> Path:
+        root = tmp_path / ".claude" / "skills"
+        (root / "kb-checkin" / "scripts").mkdir(parents=True)
+        (root / "kb-checkin" / "scripts" / "checkin.py").write_text("print(1)\n")
+        (root / "aws-vault" / "scripts").mkdir(parents=True)
+        (root / "aws-vault" / "scripts" / "wrap.sh").write_text(_VERB_BLIND_WRAPPER)
+        return root
+
+    def test_adds_rules_and_skips_verb_blind(self, tmp_path: Path, skills_root: Path) -> None:
+        settings = tmp_path / "settings.local.json"
+        settings.write_text(json.dumps({"permissions": {"allow": []}}))
+
+        result = update_paths.ensure_user_skill_scripts(
+            settings_files=[settings],
+            skills_root=skills_root,
+            user_home=tmp_path,
+            dry_run=False,
+            quiet=True,
+        )
+
+        allow = json.loads(settings.read_text())["permissions"]["allow"]
+        assert "Bash(~/.claude/skills/kb-checkin/scripts/checkin.py:*)" in allow
+        assert not any("wrap.sh" in r for r in allow)
+        assert result["files_changed"] == 1
+
+    def test_idempotent_second_run(self, tmp_path: Path, skills_root: Path) -> None:
+        settings = tmp_path / "settings.local.json"
+        settings.write_text(json.dumps({"permissions": {"allow": []}}))
+        update_paths.ensure_user_skill_scripts(
+            settings_files=[settings],
+            skills_root=skills_root,
+            user_home=tmp_path,
+            dry_run=False,
+            quiet=True,
+        )
+        snapshot = settings.read_text()
+
+        result = update_paths.ensure_user_skill_scripts(
+            settings_files=[settings],
+            skills_root=skills_root,
+            user_home=tmp_path,
+            dry_run=False,
+            quiet=True,
+        )
+
+        assert result["files_changed"] == 0
+        assert settings.read_text() == snapshot
+
+    def test_dry_run_does_not_write(self, tmp_path: Path, skills_root: Path) -> None:
+        settings = tmp_path / "settings.local.json"
+        settings.write_text(json.dumps({"permissions": {"allow": []}}))
+        original = settings.read_text()
+
+        update_paths.ensure_user_skill_scripts(
+            settings_files=[settings],
+            skills_root=skills_root,
+            user_home=tmp_path,
+            dry_run=True,
+            quiet=True,
+        )
+
+        assert settings.read_text() == original
+
+    def test_reports_when_no_scripts(self, tmp_path: Path) -> None:
+        settings = tmp_path / "settings.local.json"
+        settings.write_text(json.dumps({"permissions": {"allow": []}}))
+
+        result = update_paths.ensure_user_skill_scripts(
+            settings_files=[settings],
+            skills_root=tmp_path / "empty",
+            user_home=tmp_path,
+            dry_run=False,
+            quiet=False,
+        )
+
+        assert result["exit_code"] == 0
+        assert any("No user-skill scripts" in m for m in result["messages"])
+
+    def test_verbose_dry_run_reports_skips_and_would_add(
+        self, tmp_path: Path, skills_root: Path
+    ) -> None:
+        settings = tmp_path / "settings.local.json"
+        settings.write_text(json.dumps({"permissions": {"allow": []}}))
+        original = settings.read_text()
+
+        result = update_paths.ensure_user_skill_scripts(
+            settings_files=[settings],
+            skills_root=skills_root,
+            user_home=tmp_path,
+            dry_run=True,
+            quiet=False,
+        )
+
+        joined = "\n".join(result["messages"])
+        assert "User-skill scripts root:" in joined
+        assert "SKIP (verb-blind credentialed wrapper" in joined
+        assert "dry run — no files will be modified" in joined
+        assert "Would add" in joined
+        assert settings.read_text() == original

--- a/tests/test_shell_script_flags.py
+++ b/tests/test_shell_script_flags.py
@@ -37,9 +37,28 @@ def test_jira_env_accepts_tenant_flag() -> None:
     assert "JIRA_TENANT" in source
 
 
-@pytest.mark.parametrize("name", ["secrets.sh", "kubectl.sh"])
+@pytest.mark.parametrize("name", ["secrets.sh", "kubectl.sh", "aws.sh"])
 def test_aws_vault_scripts_accept_registry_flag(name: str) -> None:
     source = (REPO_ROOT / "skills" / "aws-vault" / "scripts" / name).read_text()
     assert '"${1:-}" == "--registry"' in source
     # Env var remains the fallback.
     assert "DEV10X_AWS_VAULT_REGISTRY" in source
+
+
+def test_aws_wrapper_is_verb_aware_read_only() -> None:
+    """GH-606 D6 / GH-605: aws.sh enforces a read allowlist + secret denylist.
+
+    The credentialed `aws-vault exec` surface is verb-blind; this wrapper
+    is the read-only gate, so a broad `:*` grant on it cannot run a
+    mutating or secret-exfil AWS operation.
+    """
+    source = (REPO_ROOT / "skills" / "aws-vault" / "scripts" / "aws.sh").read_text()
+    # Verb-aware allowlist marker (matched by update_paths' verb-blind check).
+    assert "ALLOWED_PREFIXES=(" in source
+    # Read prefixes pass; mutating ops fall through to deny.
+    for prefix in ("describe-", "list-", "get-"):
+        assert prefix in source
+    # Secret-exfil reads are denied even though their verb is "get".
+    assert "secretsmanager get-secret-value" in source
+    assert "ssm get-parameter" in source
+    assert "--with-decryption" in source


### PR DESCRIPTION
**When** I run read-only AWS commands or analysis skills through credentialed wrappers, **I want to** pre-approve only the safe, verb-checked reads, **so I can** work without permission prompts while a broad grant still cannot run mutating or secret-exfil operations.

---

[`c20bae60`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/684/commits/c20bae6088ac14fd0c4b27a13778b609039e9593) ✨ GH-606 Enable verb-safe credentialed reads and skill curation
Closes #606
Closes #605
Closes #608
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/606

---