### PR TITLE
♻️ GH-572 Make settings writes and groom results race-safe

### DIFF
--- a/src/dev10x/git/__init__.py
+++ b/src/dev10x/git/__init__.py
@@ -131,7 +131,7 @@ async def rebase_groom(*, seq_path: str, base_ref: str) -> Result[dict[str, Any]
         conflict_aware=True,
     )
     if notice is not None and isinstance(result, SuccessResult):
-        result.value["base_notice"] = notice
+        return ok({**result.value, "base_notice": notice})
     return result
 
 

--- a/src/dev10x/skills/permission/doctor.py
+++ b/src/dev10x/skills/permission/doctor.py
@@ -91,18 +91,7 @@ def canonicalize_rules(rules: Iterable[str]) -> CanonicalizeResult:
     return result
 
 
-def canonicalize_settings_file(
-    settings_path: Path,
-    *,
-    dry_run: bool = False,
-) -> CanonicalizeResult:
-    """Rewrite pinned plugin paths in a settings.json file.
-
-    Operates on ``permissions.allow`` and ``permissions.deny`` lists.
-    Dedupes after rewriting — collisions with already-canonical rules
-    collapse silently.
-    """
-    data = json.loads(settings_path.read_text())
+def _canonicalize_in_place(data: dict[str, Any]) -> CanonicalizeResult:
     perms = data.get("permissions", {})
     result = CanonicalizeResult()
     for bucket in ("allow", "deny", "ask"):
@@ -126,10 +115,33 @@ def canonicalize_settings_file(
             seen.add(final)
             new_rules.append(final)
         perms[bucket] = new_rules
-    if not dry_run and result.changed:
-        data["permissions"] = perms
-        settings_path.write_text(json.dumps(data, indent=2) + "\n")
+    data["permissions"] = perms
     return result
+
+
+def canonicalize_settings_file(
+    settings_path: Path,
+    *,
+    dry_run: bool = False,
+) -> CanonicalizeResult:
+    """Rewrite pinned plugin paths in a settings.json file.
+
+    Operates on ``permissions.allow`` and ``permissions.deny`` lists.
+    Dedupes after rewriting — collisions with already-canonical rules
+    collapse silently. The write goes through ``locked_json_update`` +
+    ``create_backup`` so parallel agents cannot clobber each other's
+    rules (GH-572).
+    """
+    result = _canonicalize_in_place(json.loads(settings_path.read_text()))
+    if dry_run or not result.changed:
+        return result
+
+    from dev10x.skills.permission.backup import create_backup
+    from dev10x.skills.permission.file_lock import locked_json_update
+
+    create_backup(settings_path)
+    with locked_json_update(path=settings_path) as live_data:
+        return _canonicalize_in_place(live_data)
 
 
 @dataclass
@@ -491,8 +503,18 @@ def apply_deprecations_to_files(
                         messages.append(f"  ? {outcome.action.upper()}: {outcome.rule}")
             perms[bucket] = new_rules
         if changes_in_file and not dry_run:
-            data["permissions"] = perms
-            path.write_text(json.dumps(data, indent=2) + "\n")
+            from dev10x.skills.permission.backup import create_backup
+            from dev10x.skills.permission.file_lock import locked_json_update
+
+            create_backup(path)
+            with locked_json_update(path=path) as live_data:
+                live_perms = live_data.get("permissions", {})
+                for bucket in ("allow", "deny", "ask"):
+                    live_rules = live_perms.get(bucket)
+                    if not isinstance(live_rules, list):
+                        continue
+                    live_perms[bucket], _ = apply_deprecations(live_rules, catalog=catalog)
+                live_data["permissions"] = live_perms
         total_actions += changes_in_file
     verb = "Would apply" if dry_run else "Applied"
     messages.append(f"\n{verb} {total_actions} deprecation actions.")
@@ -526,8 +548,14 @@ def enable_group_in_files(
         for rule in added_here:
             messages.append(f"  + {rule}")
         if not dry_run:
-            allow.extend(added_here)
-            path.write_text(json.dumps(data, indent=2) + "\n")
+            from dev10x.skills.permission.backup import create_backup
+            from dev10x.skills.permission.file_lock import locked_json_update
+
+            create_backup(path)
+            with locked_json_update(path=path) as live_data:
+                live_perms = live_data.setdefault("permissions", {})
+                live_allow = live_perms.setdefault("allow", [])
+                live_allow.extend(rule for rule in rule_list if rule not in live_allow)
         total_added += len(added_here)
     verb = "Would add" if dry_run else "Added"
     messages.append(f"\n{verb} {total_added} rules from group {group_name!r}.")

--- a/src/dev10x/skills/permission/update_paths.py
+++ b/src/dev10x/skills/permission/update_paths.py
@@ -109,6 +109,30 @@ def find_settings_files(
     return unique
 
 
+def _rewrite_plugin_version_match(
+    match: re.Match,
+    *,
+    target_publisher: str | None,
+    target_version: str,
+) -> str:
+    """Return the version/publisher-rewritten text for a single match.
+
+    Pure helper shared by the counting pass and the locked re-apply so
+    both agree on the replacement without double-counting.
+    """
+    prefix = match.group(1)
+    publisher = match.group(2)
+    plugin_slug = match.group(3)
+    old_ver = match.group(4)
+    new_publisher = (
+        target_publisher if target_publisher and publisher != target_publisher else publisher
+    )
+    new_ver = target_version if old_ver != target_version else old_ver
+    if new_publisher == publisher and new_ver == old_ver:
+        return match.group(0)
+    return prefix + new_publisher + plugin_slug + new_ver
+
+
 def update_file(
     path: Path,
     target_version: str,
@@ -156,9 +180,21 @@ def update_file(
             return 0, [f"  SKIP (invalid JSON after replacement): {e}"]
 
         from dev10x.skills.permission.backup import create_backup
+        from dev10x.skills.permission.file_lock import locked_json_update
 
         create_backup(path)
-        path.write_text(new_content)
+        with locked_json_update(path=path) as live_data:
+            live_text = json.dumps(live_data, indent=2) + "\n"
+            rewritten = VERSION_PATTERN.sub(
+                lambda m: _rewrite_plugin_version_match(
+                    m,
+                    target_publisher=target_publisher,
+                    target_version=target_version,
+                ),
+                live_text,
+            )
+            live_data.clear()
+            live_data.update(json.loads(rewritten))
 
     messages = []
     for old_pub in sorted(old_publishers):
@@ -804,6 +840,16 @@ def generalize_permission(entry: str) -> str | None:
     return None
 
 
+def _generalizations(allow_list: list[str]) -> list[tuple[str, str]]:
+    existing = set(allow_list)
+    replacements: list[tuple[str, str]] = []
+    for entry in allow_list:
+        generalized = generalize_permission(entry)
+        if generalized and generalized != entry and generalized not in existing:
+            replacements.append((entry, generalized))
+    return replacements
+
+
 def generalize_permissions(
     path: Path,
     *,
@@ -819,26 +865,20 @@ def generalize_permissions(
     if not allow_list:
         return 0, []
 
-    existing = set(allow_list)
-    replacements: list[tuple[str, str]] = []
-    for entry in allow_list:
-        generalized = generalize_permission(entry)
-        if generalized and generalized != entry and generalized not in existing:
-            replacements.append((entry, generalized))
+    replacements = _generalizations(allow_list)
 
     if not replacements:
         return 0, []
 
     if not dry_run:
         from dev10x.skills.permission.backup import create_backup
+        from dev10x.skills.permission.file_lock import locked_json_update
 
         create_backup(path)
-        new_allow = list(allow_list)
-        for old, new in replacements:
-            idx = new_allow.index(old)
-            new_allow[idx] = new
-        data["permissions"]["allow"] = new_allow
-        path.write_text(json.dumps(data, indent=2) + "\n")
+        with locked_json_update(path=path) as live_data:
+            live_allow = live_data.get("permissions", {}).get("allow", [])
+            for old, new in _generalizations(live_allow):
+                live_allow[live_allow.index(old)] = new
 
     messages = [f"  {old} → {new}" for old, new in replacements]
     return len(replacements), messages

--- a/tests/skills/upgrade-cleanup/test_update_paths.py
+++ b/tests/skills/upgrade-cleanup/test_update_paths.py
@@ -218,6 +218,34 @@ class TestUpdateFilePublisher:
         offenders = [rule for rule in data["permissions"]["allow"] if "WooYek" in rule]
         assert not offenders, f"WooYek not stripped from: {offenders}"
 
+    def test_leaves_already_current_rule_untouched(self, settings_file: Path) -> None:
+        # Mixed file: one stale rule (drives the locked rewrite) plus one
+        # already-current rule (exercises the no-change branch of the
+        # locked re-apply without inflating the change count).
+        settings_file.write_text(
+            json.dumps(
+                {
+                    "permissions": {
+                        "allow": [
+                            "Bash(~/.claude/plugins/cache/WooYek/Dev10x/0.48.0/skills/a.sh:*)",
+                            "Bash(~/.claude/plugins/cache/Dev10x-Guru/Dev10x/0.54.0/skills/b.sh:*)",
+                        ]
+                    }
+                }
+            )
+        )
+
+        count, _ = update_file(
+            settings_file,
+            target_version="0.54.0",
+            target_publisher="Dev10x-Guru",
+        )
+
+        assert count == 1
+        allow = json.loads(settings_file.read_text())["permissions"]["allow"]
+        assert "Dev10x-Guru/Dev10x/0.54.0/skills/a.sh" in allow[0]
+        assert "Dev10x-Guru/Dev10x/0.54.0/skills/b.sh" in allow[1]
+
     def test_dry_run_does_not_write(self, settings_file: Path) -> None:
         content = json.dumps(
             {


### PR DESCRIPTION
**When** parallel agents groom commits or rewrite shared settings files, **I want to** route every read-modify-write through a lock and stop mutating frozen result objects, **so I can** trust that concurrent permission edits and groom notices never silently clobber each other.

---

[`bf75b538`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/685/commits/bf75b53858d1af2b081d58ac7c473166c42858b2) ♻️ GH-531 Preserve frozen Result contract in groom notice path
[`f1feab01`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/685/commits/f1feab01c6070889361d0d555c26fb77bba83a10) ♻️ GH-572 Prevent lost-update races in settings mutators

Part of milestone PKG-M11 (cross-cutting architecture audit). Sibling GH-579 was verified stale and closed.

Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/531
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/572