### PR TITLE
✨ GH-353 Enable continuous learning loop and any-repo install

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,7 +16,8 @@
         "git", "commits", "pull-requests", "code-review",
         "workflow", "tasks", "JTBD", "gitmoji", "hooks",
         "worktrees", "ticket-management", "metrics",
-        "session-persistence", "MCP"
+        "session-persistence", "MCP", "github-action",
+        "automated-review", "learned-rules"
       ]
     }
   ]

--- a/action.yml
+++ b/action.yml
@@ -13,9 +13,11 @@
 # Scope note: GH-351 shipped the runnable skeleton + install/permissions
 # contract. GH-352 implements the `review` path — packaged reviewer
 # checklist + learned rules mined from the consumer repo (see the
-# "Prepare review context" and "Run Dev10x review" steps). One extension
-# point remains:
-#   - GH-353: continuous learning loop (fills in the `learn` mode stub)
+# "Prepare review context" and "Run Dev10x review" steps). GH-353
+# implements the `learn` path — on a closed PR it mines validated
+# reference rules and opens a rules-update PR for human approval (see the
+# "Harvest review learnings" step; needs `contents: write` +
+# `pull-requests: write`).
 name: "Dev10x PR Review"
 description: >-
   Automated, supervisor-style PR review powered by Claude Code. Reviews
@@ -167,11 +169,34 @@ runs:
           --model ${{ inputs.model }}
           --allowed-tools "Read,Grep,Glob,mcp__github_inline_comment__create_inline_comment,mcp__github__get_pull_request_review_comments,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh pr ready:*),Bash(gh api:*)"
 
-    - name: Harvest review learnings (scaffold)
+    - name: Checkout repository (learn)
+      # GH-353: the learning loop writes generated rule docs and pushes a
+      # branch, so it needs the repo checked out. Branch from the default
+      # branch (not the just-merged PR head) so the rules-update PR has a
+      # clean base. fetch-depth: 0 gives `git push --force-with-lease` the
+      # remote ref it compares against.
+      if: steps.resolve.outputs.mode == 'learn'
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.repository.default_branch }}
+        fetch-depth: 0
+
+    - name: Set up uv (learn)
+      if: steps.resolve.outputs.mode == 'learn'
+      uses: astral-sh/setup-uv@v5
+
+    - name: Harvest review learnings
+      # GH-353: mine this repository's merged-PR review history into
+      # validated reference rules and open a rules-update PR for human
+      # approval. The bot only proposes — merging the PR adopts the rules.
+      # Requires `contents: write` (push the branch) and
+      # `pull-requests: write` (open the PR); see docs/github-action-install.md.
       if: steps.resolve.outputs.mode == 'learn'
       shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
       run: |
-        # GH-353: harvest new patterns from this closed PR's review threads
-        # and open a rules-update PR for human approval. Stubbed until the
-        # continuous-learning loop lands.
-        echo "::notice::Dev10x learning loop is not enabled yet (tracked in GH-353). No action taken on closed PR."
+        set -e
+        uvx --from "$GITHUB_ACTION_PATH" dev10x github learn \
+          --repo "$GITHUB_REPOSITORY" \
+          --base-dir "$GITHUB_WORKSPACE"

--- a/docs/github-action-install.md
+++ b/docs/github-action-install.md
@@ -5,16 +5,16 @@ Dev10x GitHub Action. This is independent of the Claude Code plugin
 install ([installation.md](installation.md)) — you do not need the
 plugin to use the Action.
 
-> **Status (M6).** The install flow (GH-351) and the learned-rules
-> review path (GH-352) are live. The continuous learning loop (GH-353,
-> the `learn` mode) extends this and is tracked separately.
+> **Status (M6).** The full pipeline is live: the install flow (GH-351),
+> the learned-rules review path (GH-352), and the continuous learning
+> loop (GH-353, the `learn` mode).
 
 ## What it does
 
 | PR event | Mode | Behavior |
 |----------|------|----------|
 | `opened`, `synchronize`, `ready_for_review` | `review` | Reviews the diff with the packaged reviewer checklist + learned rules, posts inline + summary comments |
-| `closed` | `learn` | Harvests review patterns (scaffolded — no-op until GH-353) |
+| `closed` | `learn` | Mines recurring review patterns into validated rules and opens a *rules-update* PR for human approval |
 
 ### How the review works (GH-352)
 
@@ -35,6 +35,25 @@ workspace under `.dev10x-review/` before invoking the model:
 When the review finds issues it converts the PR to draft so you can
 batch fixes without re-triggering a review on each push; mark it
 *Ready for review* when done.
+
+### How the learning loop works (GH-353)
+
+On the `learn` path — triggered when a PR is **closed** — the Action
+mines your repository's merged-PR review history into validated
+reference rules and opens a **rules-update PR** proposing them:
+
+1. Mine recurring reviewer comments and validate each against recent
+   diffs (the same pipeline that feeds `review` mode).
+2. Write one rule doc per validated pattern under
+   `references/review-checks/generated/`.
+3. Force-push them to the `dev10x/learned-rules` branch and open (or
+   refresh) a PR titled *"🤖 Propose N learned review rule(s)"*.
+
+The bot only **proposes** — merging the PR adopts the rules, closing it
+discards them. Nothing is enforced without your approval. When no
+pattern validates, or the proposal is already up to date, the learn run
+is a no-op (it opens no PR). Because the loop pushes a branch and opens
+a PR, the `learn` path needs `contents: write` (see Step 3).
 
 ## Prerequisites
 
@@ -76,19 +95,22 @@ maximum reproducibility.
 ## Step 3 — Permissions
 
 The workflow job must grant these permissions so the Action can read the
-PR and post review feedback:
+PR, post review feedback, and open the learning-loop's rules-update PR:
 
 ```yaml
 permissions:
-  contents: read         # check out the PR head
-  pull-requests: write   # post inline + summary review comments
+  contents: write        # check out the PR head; push the rules branch (learn)
+  pull-requests: write   # post review comments; open the rules-update PR
   issues: write          # post issue-style comments / labels
   id-token: write        # OIDC for the Claude Code action
 ```
 
-These are **job-level** permissions in the consumer workflow — the
-Action does not request additional scopes. No GitHub App installation is
-required for the Action route.
+`contents: write` (rather than `read`) is required only by the `learn`
+path, which pushes the `dev10x/learned-rules` branch. If you run
+**review only** (drop the `closed` event from the trigger), `contents:
+read` is sufficient. These are **job-level** permissions in the consumer
+workflow — the Action does not request additional scopes. No GitHub App
+installation is required for the Action route.
 
 ## Action inputs
 
@@ -113,3 +135,56 @@ check appears in the PR's Checks tab; review comments post on completion.
 If nothing runs, confirm the workflow file path
 (`.github/workflows/dev10x-review.yml`), the `ANTHROPIC_API_KEY` secret,
 and that the PR is not a draft (draft PRs are skipped on the review path).
+
+To confirm the learning loop, **close or merge** a PR that has review
+comments. The `learn` run opens (or refreshes) the
+*"🤖 Propose N learned review rule(s)"* PR; if no pattern yet validates,
+the run logs a no-op notice and opens nothing.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| No check appears on the PR | Workflow not on the default branch, or wrong path | The workflow must live at `.github/workflows/dev10x-review.yml` on the repo's default branch |
+| Review never runs, only on close | PR is a draft | Draft PRs are skipped on the review path — mark *Ready for review* |
+| `401`/`403` from the model step | Missing or invalid `ANTHROPIC_API_KEY` | Re-add the secret (Settings → Secrets and variables → Actions) |
+| Review posts no comments | Diff is clean, or all findings failed the false-positive gate | Expected — a clean PR gets a single "looks good" summary |
+| Learn run fails pushing the branch | Job lacks `contents: write` | Set `contents: write` (Step 3); review-only repos can keep `read` |
+| No rules-update PR after closing PRs | Not enough recurring review history yet | The loop needs repeated reviewer comments before a pattern validates |
+| Learned rules look wrong | They are heuristic proposals | Close the rules-update PR to discard, or edit it before merging |
+
+## FAQ
+
+**Do I need the Claude Code plugin to use the Action?**
+No. The Action is fully independent — it only needs the workflow file
+and the `ANTHROPIC_API_KEY` secret.
+
+**Will the bot change my code or rules automatically?**
+No. Review mode only comments. Learn mode only *opens a PR* proposing
+new rule docs — you merge or close it. Nothing lands without approval.
+
+**Which model should I use?**
+`haiku` (default) is fast and inexpensive for most reviews. Bump to
+`sonnet` or `opus` via the `model` input for deeper analysis on
+larger or higher-risk diffs.
+
+**Can I run review without the learning loop?**
+Yes. Drop `closed` from the workflow `on.pull_request.types` and set
+`contents: read`. You lose rule proposals but keep review on open PRs.
+
+**Where do learned rules live?**
+Under `references/review-checks/generated/` in your repo, added by the
+rules-update PR. Review mode picks them up on the next run.
+
+## Cost
+
+Each review and each learn run makes Anthropic API calls billed to your
+`ANTHROPIC_API_KEY`. Cost scales with the model and the diff size:
+
+- `haiku` (default) is the cheapest — suitable for routine PR review.
+- `sonnet`/`opus` cost more per run but reason more deeply.
+
+There is no Dev10x-side charge — you pay only Anthropic API usage and
+standard GitHub Actions minutes. See
+[Anthropic pricing](https://www.anthropic.com/pricing) for current
+per-token rates, and cap spend with a budget on your Anthropic console.

--- a/docs/install/dev10x-review.yml
+++ b/docs/install/dev10x-review.yml
@@ -1,4 +1,4 @@
-# Dev10x PR Review — consumer workflow template (GH-351).
+# Dev10x PR Review — consumer workflow template (GH-351, GH-353).
 #
 # Copy this file into your repository at .github/workflows/dev10x-review.yml
 # and add an ANTHROPIC_API_KEY repository secret. See
@@ -18,14 +18,16 @@ on:
 
 jobs:
   dev10x-review:
-    # Skip drafts on the review path; closed events still run for the
-    # (scaffolded) learning loop.
+    # Skip drafts on the review path; closed events still run the
+    # learning loop (GH-353), which opens a rules-update PR.
     if: >-
       github.event.action == 'closed' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: write
+      # `write` (not `read`) so the learn mode can push a branch of
+      # proposed rules on PR close. Review mode only reads.
+      contents: write
+      pull-requests: write   # post review comments + open the rules-update PR
       issues: write
       id-token: write
     steps:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -96,9 +96,10 @@ claude plugin marketplace update Dev10x-Guru
 To run Dev10x automated PR review on a repository — independent of the
 Claude Code plugin — install the **Dev10x PR Review** GitHub Action.
 Add an `ANTHROPIC_API_KEY` secret and a workflow that references
-`Dev10x-Guru/dev10x-claude@v1`. See
-[GitHub Action install](github-action-install.md) for the full install
-and permissions flow.
+`Dev10x-Guru/dev10x-claude@v1`. It reviews PRs on open and, on close,
+proposes learned review rules via a rules-update PR for your approval.
+See [GitHub Action install](github-action-install.md) for the full
+install, permissions, troubleshooting, and cost guidance.
 
 ## Verify the installation
 

--- a/src/dev10x/commands/github.py
+++ b/src/dev10x/commands/github.py
@@ -136,3 +136,97 @@ def review_rules(
             routing_fragment=result.value["routing_fragment"],
         )
     )
+
+
+@github.command(name="learn")
+@click.option(
+    "--repo",
+    default=None,
+    help="owner/name to mine and target. Defaults to the current repository.",
+)
+@click.option(
+    "--base-dir",
+    default=None,
+    help="Checked-out repo root where rule docs are written and git runs. "
+    "Defaults to the current directory ($GITHUB_WORKSPACE in the Action).",
+)
+@click.option(
+    "--branch",
+    default=None,
+    help="Branch the rules-update PR is force-pushed to.",
+)
+@click.option(
+    "--base",
+    "base_branch",
+    default=None,
+    help="PR base branch. Defaults to the repository's default branch.",
+)
+@click.option(
+    "--limit",
+    type=int,
+    default=50,
+    show_default=True,
+    help="Max merged PRs scanned for review comments.",
+)
+@click.option(
+    "--min-frequency",
+    type=int,
+    default=2,
+    show_default=True,
+    help="Minimum reviewer frequency for a validated pattern.",
+)
+@click.option(
+    "--max-fp-rate",
+    type=float,
+    default=0.5,
+    show_default=True,
+    help="Maximum estimated false-positive rate for a validated pattern.",
+)
+def learn(
+    *,
+    repo: str | None,
+    base_dir: str | None,
+    branch: str | None,
+    base_branch: str | None,
+    limit: int,
+    min_frequency: int,
+    max_fp_rate: float,
+) -> None:
+    """Run the continuous learning loop: mine rules, open a rules-update PR.
+
+    Wraps :func:`dev10x.github.learn_loop.run_learning_loop`. On a closed
+    PR the Action invokes this to harvest the repository's recurring
+    reviewer patterns into validated reference rules and open a PR
+    proposing them for human approval. When no pattern validates (or the
+    proposal is already up to date) it prints a notice and exits 0 so the
+    Action's learn step is a no-op rather than a failure. A genuine mining,
+    git, or ``gh`` failure prints to stderr and exits non-zero.
+    """
+    import os
+
+    from dev10x.domain.common.result import SuccessResult
+    from dev10x.github import learn_loop
+
+    result = asyncio.run(
+        learn_loop.run_learning_loop(
+            base_dir=base_dir or os.getcwd(),
+            repo=repo,
+            branch=branch or learn_loop.DEFAULT_LEARN_BRANCH,
+            base_branch=base_branch,
+            limit=limit,
+            min_frequency=min_frequency,
+            max_fp_rate=max_fp_rate,
+        )
+    )
+
+    if not isinstance(result, SuccessResult):
+        click.echo(f"[ERROR] {result.error}", err=True)
+        sys.exit(1)
+
+    if result.value["opened_pr"]:
+        click.echo(
+            f"Opened rules-update PR with {result.value['rules_authored']} "
+            f"rule(s): {result.value['pr_url']}"
+        )
+    else:
+        click.echo(f"No rules-update PR opened: {result.value['reason']}.")

--- a/src/dev10x/github/learn_loop.py
+++ b/src/dev10x/github/learn_loop.py
@@ -1,0 +1,346 @@
+"""Continuous learning loop for the installable review Action (GH-353).
+
+Closes the review-bot learning cycle: when a PR is closed, mine the
+consumer repository's merged-PR review history into validated reference
+rules (the GH-346→GH-349 pipeline), materialize them under
+``references/review-checks/generated/``, and open a *rules-update* PR for
+human approval. The PR is the approval gate — nothing is enforced until a
+human merges it, mirroring the dry-run philosophy of every upstream step.
+
+The Action's ``learn`` mode shells out to ``dev10x github learn`` (see
+``dev10x.commands.github``), which owns stdout and the process exit code
+per ADR-0010. This module is the side-effect-bearing orchestrator: it
+returns ``Result[T]`` and never calls ``print`` or ``sys.exit``. Git and
+``gh`` invocations route through :func:`dev10x.subprocess_utils.async_run`
+with an explicit ``cwd`` so the loop operates on the checked-out consumer
+workspace, not the process start directory.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from dev10x.domain.common.result import Result, SuccessResult, err, ok
+from dev10x.github import rule_authoring
+from dev10x.github.rule_authoring import RuleDoc
+from dev10x.subprocess_utils import async_run
+
+logger = logging.getLogger(__name__)
+
+# Stable branch the bot reuses for its rules-update PR. Reusing one branch
+# (force-pushed each run) keeps a single open proposal per repo rather than
+# accumulating one branch per closed PR.
+DEFAULT_LEARN_BRANCH = "dev10x/learned-rules"
+
+# Identity stamped on the bot's commit when the runner has no git config.
+_BOT_NAME = "dev10x-review[bot]"
+_BOT_EMAIL = "dev10x-review@users.noreply.github.com"
+
+
+def render_pr_body(
+    *,
+    rules: list[dict[str, Any]],
+    routing_fragment: str,
+    summary: dict[str, Any],
+) -> str:
+    """Compose the rules-update PR body from authored rule docs.
+
+    Pure string assembly so the rendering is unit-testable without git or
+    ``gh``. Each rule already carries its own heuristic-confidence caveat,
+    so the body adds a short preamble plus the routing fragment a human
+    pastes into ``.claude/rules/INDEX.md`` on approval.
+    """
+    scanned = summary.get("repos_scanned", [])
+    scanned_text = ", ".join(scanned) if scanned else "this repository"
+    lines = [
+        "## Proposed learned review rules",
+        "",
+        f"Dev10x mined **{len(rules)}** recurring reviewer pattern(s) from "
+        f"the merged-PR review history of {scanned_text} and authored a "
+        "reference-rule doc for each. Frequencies and false-positive rates "
+        "are heuristic estimates — **review each rule before merging**.",
+        "",
+        "Merging this PR adopts the rules; closing it discards them. The "
+        "review bot only proposes — it never enforces a rule without human "
+        "approval.",
+        "",
+        "### Generated rules",
+        "",
+    ]
+    for rule in rules:
+        lines.append(f"- `{rule.get('path', '')}` — {rule.get('title', '')}")
+    lines.extend(
+        [
+            "",
+            "### Routing",
+            "",
+            "Add these rows to `.claude/rules/INDEX.md` so the review agents "
+            "pick up the generated docs:",
+            "",
+            routing_fragment,
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+async def _git(
+    args: list[str], *, cwd: str, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    return await async_run(args=["git", *args], cwd=cwd, env=env, timeout=60)
+
+
+async def _prepare_branch(*, branch: str, cwd: str) -> Result[None]:
+    """Create or reset the rules-update branch at the current HEAD.
+
+    Uses ``git checkout -B`` so a stale local branch from a previous run is
+    reset rather than colliding. The branch is force-pushed later, so a
+    fresh local pointer is the only requirement here.
+    """
+    result = await _git(["checkout", "-B", branch], cwd=cwd)
+    if result.returncode != 0:
+        return err(result.stderr.strip() or "failed to create rules-update branch")
+    return ok(None)
+
+
+async def _commit_rules(*, generated_dir: str, branch: str, cwd: str) -> Result[None]:
+    """Stage the generated rules and commit them on the rules-update branch.
+
+    Returns ``err`` when nothing was staged so the caller can surface a
+    "no changes" outcome instead of opening an empty PR.
+    """
+    add = await _git(["add", "--", generated_dir], cwd=cwd)
+    if add.returncode != 0:
+        return err(add.stderr.strip() or "git add failed")
+
+    staged = await _git(["diff", "--cached", "--quiet"], cwd=cwd)
+    if staged.returncode == 0:
+        # Exit 0 from --quiet means no staged changes.
+        return err("no_changes")
+
+    # Merge onto os.environ — async_run passes env straight to the
+    # subprocess, which REPLACES (not extends) the environment. A bare
+    # 4-key dict would drop PATH/HOME and the runner could not find git.
+    commit_env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": _BOT_NAME,
+        "GIT_AUTHOR_EMAIL": _BOT_EMAIL,
+        "GIT_COMMITTER_NAME": _BOT_NAME,
+        "GIT_COMMITTER_EMAIL": _BOT_EMAIL,
+    }
+    commit = await _git(
+        ["commit", "-m", "🤖 Update learned review rules"],
+        cwd=cwd,
+        env=commit_env,
+    )
+    if commit.returncode != 0:
+        return err(commit.stderr.strip() or "git commit failed")
+    return ok(None)
+
+
+async def _push_branch(*, branch: str, cwd: str) -> Result[None]:
+    result = await _git(
+        ["push", "--force-with-lease", "origin", branch],
+        cwd=cwd,
+    )
+    if result.returncode != 0:
+        return err(result.stderr.strip() or "git push failed")
+    return ok(None)
+
+
+async def _existing_pr_url(*, branch: str, repo: str | None, cwd: str) -> str | None:
+    args = ["gh", "pr", "view", branch, "--json", "url", "--jq", ".url"]
+    if repo:
+        args.extend(["--repo", repo])
+    result = await async_run(args=args, cwd=cwd, timeout=30)
+    if result.returncode == 0 and result.stdout.strip():
+        return result.stdout.strip()
+    return None
+
+
+async def _open_pr(
+    *,
+    branch: str,
+    base_branch: str | None,
+    repo: str | None,
+    title: str,
+    body: str,
+    cwd: str,
+) -> Result[str]:
+    """Open the rules-update PR, returning its URL.
+
+    When a PR for ``branch`` already exists, ``gh pr create`` exits
+    non-zero; we recover by looking up the open PR's URL so a re-run that
+    only refreshes the branch reports the same PR instead of failing.
+    """
+    body_file = tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False, encoding="utf-8")
+    body_file.write(body)
+    body_file.close()
+    body_path = Path(body_file.name)
+
+    args = [
+        "gh",
+        "pr",
+        "create",
+        "--head",
+        branch,
+        "--title",
+        title,
+        "--body-file",
+        str(body_path),
+    ]
+    if repo:
+        args.extend(["--repo", repo])
+    if base_branch:
+        args.extend(["--base", base_branch])
+
+    try:
+        result = await async_run(args=args, cwd=cwd, timeout=60)
+    finally:
+        body_path.unlink(missing_ok=True)
+
+    if result.returncode == 0:
+        url = next(
+            (line.strip() for line in result.stdout.splitlines() if line.startswith("http")),
+            result.stdout.strip(),
+        )
+        return ok(url)
+
+    existing = await _existing_pr_url(branch=branch, repo=repo, cwd=cwd)
+    if existing:
+        return ok(existing)
+    return err(result.stderr.strip() or "gh pr create failed")
+
+
+async def run_learning_loop(
+    *,
+    base_dir: str,
+    repo: str | None = None,
+    branch: str = DEFAULT_LEARN_BRANCH,
+    base_branch: str | None = None,
+    limit: int = 50,
+    top_n: int = 20,
+    diff_limit: int = 20,
+    min_frequency: int = 2,
+    max_fp_rate: float = 0.5,
+) -> Result[dict[str, Any]]:
+    """Mine validated review rules and open a rules-update PR for approval.
+
+    Orchestrates the full continuous-learning loop:
+
+    1. Author reference rules from the repo's merged-PR review history
+       (delegates to GH-346→GH-349; no rules ⇒ no PR).
+    2. Materialize each rule doc under ``base_dir``.
+    3. Branch, commit, and force-push the generated docs.
+    4. Open (or reuse) a rules-update PR for human approval.
+
+    Args:
+        base_dir: Checked-out repository root where rule docs are written
+            and git runs. In the Action this is ``$GITHUB_WORKSPACE``.
+        repo: ``owner/name`` to mine and target. Defaults to the current
+            repository when omitted.
+        branch: Branch the bot force-pushes the proposal to.
+        base_branch: PR base. ``None`` lets ``gh`` target the default branch.
+        limit: Max merged PRs scanned for review comments.
+        top_n: Number of top candidate patterns to consider.
+        diff_limit: Max recent merged PRs sampled for diff matching.
+        min_frequency: Minimum reviewer frequency for a validated pattern.
+        max_fp_rate: Maximum estimated false-positive rate.
+
+    Returns:
+        ``ok({"opened_pr": bool, "rules_authored": int, "summary": {...}})``
+        — plus ``"pr_url"`` and ``"branch"`` when a PR was opened, or
+        ``"reason"`` when none was. ``err(...)`` on a mining, git, or ``gh``
+        failure.
+    """
+    authored = await rule_authoring.author_reference_rules(
+        repos=[repo] if repo else None,
+        limit=limit,
+        top_n=top_n,
+        diff_limit=diff_limit,
+        min_frequency=min_frequency,
+        max_fp_rate=max_fp_rate,
+    )
+    if not isinstance(authored, SuccessResult):
+        return authored
+
+    rules = authored.value["rules"]
+    summary = authored.value["summary"]
+    routing_fragment = authored.value["routing_fragment"]
+
+    if not rules:
+        return ok(
+            {
+                "opened_pr": False,
+                "reason": "no validated review patterns",
+                "rules_authored": 0,
+                "summary": summary,
+            }
+        )
+
+    docs = [
+        RuleDoc(
+            slug=rule["slug"],
+            title=rule["title"],
+            path=rule["path"],
+            content=rule["content"],
+        )
+        for rule in rules
+    ]
+    rule_authoring.write_rule_docs(docs=docs, base_dir=Path(base_dir))
+
+    branch_result = await _prepare_branch(branch=branch, cwd=base_dir)
+    if not isinstance(branch_result, SuccessResult):
+        return branch_result
+
+    commit_result = await _commit_rules(
+        generated_dir=rule_authoring.GENERATED_RULES_DIR,
+        branch=branch,
+        cwd=base_dir,
+    )
+    if not isinstance(commit_result, SuccessResult):
+        if commit_result.error == "no_changes":
+            return ok(
+                {
+                    "opened_pr": False,
+                    "reason": "rules already up to date",
+                    "rules_authored": len(rules),
+                    "summary": summary,
+                }
+            )
+        return commit_result
+
+    push_result = await _push_branch(branch=branch, cwd=base_dir)
+    if not isinstance(push_result, SuccessResult):
+        return push_result
+
+    plural = "rule" if len(rules) == 1 else "rules"
+    pr_result = await _open_pr(
+        branch=branch,
+        base_branch=base_branch,
+        repo=repo,
+        title=f"🤖 Propose {len(rules)} learned review {plural}",
+        body=render_pr_body(
+            rules=rules,
+            routing_fragment=routing_fragment,
+            summary=summary,
+        ),
+        cwd=base_dir,
+    )
+    if not isinstance(pr_result, SuccessResult):
+        return pr_result
+
+    return ok(
+        {
+            "opened_pr": True,
+            "pr_url": pr_result.value,
+            "branch": branch,
+            "rules_authored": len(rules),
+            "summary": summary,
+        }
+    )

--- a/tests/commands/test_github_learn.py
+++ b/tests/commands/test_github_learn.py
@@ -1,0 +1,101 @@
+"""Tests for `dev10x github learn` (GH-353).
+
+Contract class: mock
+  The command path patches the learn-loop orchestrator so no git/gh
+  subprocess runs; only the CLI seam (option wiring, stdout, exit code)
+  is exercised here.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from dev10x.cli import cli
+from dev10x.domain.common.result import err, ok
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+class TestLearnCommandRegistration:
+    def test_learn_exposed(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["github", "--help"])
+
+        assert result.exit_code == 0
+        assert "learn" in result.output
+
+    def test_learn_help_lists_options(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["github", "learn", "--help"])
+
+        assert result.exit_code == 0
+        assert "--repo" in result.output
+        assert "--base-dir" in result.output
+        assert "--base" in result.output
+
+
+class TestLearnCommand:
+    @patch("dev10x.github.learn_loop.run_learning_loop", new_callable=AsyncMock)
+    def test_opened_pr_prints_url(self, mock_loop: AsyncMock, runner: CliRunner) -> None:
+        mock_loop.return_value = ok(
+            {
+                "opened_pr": True,
+                "pr_url": "https://github.com/o/r/pull/9",
+                "branch": "dev10x/learned-rules",
+                "rules_authored": 2,
+                "summary": {},
+            }
+        )
+
+        result = runner.invoke(
+            cli, ["github", "learn", "--repo", "o/r", "--base-dir", "/tmp/work"]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "https://github.com/o/r/pull/9" in result.output
+        assert "2 rule(s)" in result.output
+        assert mock_loop.await_args.kwargs["repo"] == "o/r"
+        assert mock_loop.await_args.kwargs["base_dir"] == "/tmp/work"
+
+    @patch("dev10x.github.learn_loop.run_learning_loop", new_callable=AsyncMock)
+    def test_no_pr_prints_reason(self, mock_loop: AsyncMock, runner: CliRunner) -> None:
+        mock_loop.return_value = ok(
+            {
+                "opened_pr": False,
+                "reason": "no validated review patterns",
+                "rules_authored": 0,
+                "summary": {},
+            }
+        )
+
+        result = runner.invoke(cli, ["github", "learn", "--repo", "o/r"])
+
+        assert result.exit_code == 0, result.output
+        assert "no validated review patterns" in result.output
+
+    @patch("dev10x.github.learn_loop.run_learning_loop", new_callable=AsyncMock)
+    def test_default_base_dir_is_cwd(self, mock_loop: AsyncMock, runner: CliRunner) -> None:
+        import os
+
+        mock_loop.return_value = ok(
+            {"opened_pr": False, "reason": "x", "rules_authored": 0, "summary": {}}
+        )
+
+        result = runner.invoke(cli, ["github", "learn"])
+
+        assert result.exit_code == 0, result.output
+        assert mock_loop.await_args.kwargs["base_dir"] == os.getcwd()
+        assert mock_loop.await_args.kwargs["repo"] is None
+
+    @patch("dev10x.github.learn_loop.run_learning_loop", new_callable=AsyncMock)
+    def test_error_exits_nonzero(self, mock_loop: AsyncMock, runner: CliRunner) -> None:
+        mock_loop.return_value = err("git push failed")
+
+        result = runner.invoke(cli, ["github", "learn", "--repo", "o/r"])
+
+        assert result.exit_code == 1
+        assert "git push failed" in result.output

--- a/tests/github/test_learn_loop.py
+++ b/tests/github/test_learn_loop.py
@@ -1,0 +1,338 @@
+"""Unit tests for dev10x.github.learn_loop (GH-353).
+
+Contract class: mock
+  ``render_pr_body`` is a pure function tested without mocks. The
+  orchestrator patches the GH-349 author and the ``async_run`` chokepoint
+  so no ``gh``/``git`` subprocess runs; rule docs are written under
+  ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dev10x.domain.common.result import ErrorResult, SuccessResult, err, ok
+
+ll = pytest.importorskip("dev10x.github.learn_loop", reason="dev10x not installed")
+
+
+def _rule(*, slug: str = "block-chaining") -> dict:
+    return {
+        "slug": slug,
+        "title": "Block chaining",
+        "path": f"references/review-checks/generated/{slug}.md",
+        "content": f"# Block chaining\n\nbody for {slug}\n",
+    }
+
+
+def _authored(*, rules: list[dict] | None = None) -> dict:
+    return {
+        "rules": rules if rules is not None else [_rule()],
+        "routing_fragment": "| Generated rule | Reviewer agent |\n|---|---|",
+        "summary": {"repos_scanned": ["o/r"], "rules_authored": len(rules or [_rule()])},
+    }
+
+
+def _cp(
+    returncode: int = 0, stdout: str = "", stderr: str = ""
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+class TestRenderPrBody:
+    def test_lists_rules_routing_and_count(self) -> None:
+        body = ll.render_pr_body(
+            rules=[_rule(), _rule(slug="named-params")],
+            routing_fragment="| Generated rule | Reviewer agent |",
+            summary={"repos_scanned": ["o/r"]},
+        )
+        assert "mined **2**" in body
+        assert "o/r" in body
+        assert "`references/review-checks/generated/block-chaining.md`" in body
+        assert "`references/review-checks/generated/named-params.md`" in body
+        assert "### Routing" in body
+        assert "| Generated rule | Reviewer agent |" in body
+
+    def test_falls_back_to_this_repository_when_no_scan(self) -> None:
+        body = ll.render_pr_body(rules=[_rule()], routing_fragment="x", summary={})
+        assert "this repository" in body
+
+
+class TestRunLearningLoopNoPr:
+    @pytest.mark.asyncio
+    @patch("dev10x.github.learn_loop.async_run", new_callable=AsyncMock)
+    @patch("dev10x.github.rule_authoring.author_reference_rules", new_callable=AsyncMock)
+    async def test_no_rules_opens_no_pr(
+        self,
+        mock_author: AsyncMock,
+        mock_run: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        mock_author.return_value = ok(_authored(rules=[]))
+
+        result = await ll.run_learning_loop(base_dir=str(tmp_path), repo="o/r")
+
+        assert isinstance(result, SuccessResult)
+        assert result.value["opened_pr"] is False
+        assert result.value["reason"] == "no validated review patterns"
+        assert result.value["rules_authored"] == 0
+        mock_run.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.rule_authoring.author_reference_rules", new_callable=AsyncMock)
+    async def test_propagates_author_error(self, mock_author: AsyncMock, tmp_path: Path) -> None:
+        mock_author.return_value = err("no repository specified")
+
+        result = await ll.run_learning_loop(base_dir=str(tmp_path))
+
+        assert isinstance(result, ErrorResult)
+        assert result.error == "no repository specified"
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.learn_loop.async_run", new_callable=AsyncMock)
+    @patch("dev10x.github.rule_authoring.author_reference_rules", new_callable=AsyncMock)
+    async def test_no_changes_reports_up_to_date(
+        self,
+        mock_author: AsyncMock,
+        mock_run: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        mock_author.return_value = ok(_authored())
+        # checkout -B, add, then diff --cached --quiet returns 0 (no staged change).
+        mock_run.side_effect = [_cp(0), _cp(0), _cp(0)]
+
+        result = await ll.run_learning_loop(base_dir=str(tmp_path), repo="o/r")
+
+        assert isinstance(result, SuccessResult)
+        assert result.value["opened_pr"] is False
+        assert result.value["reason"] == "rules already up to date"
+        assert result.value["rules_authored"] == 1
+
+
+class TestRunLearningLoopHappyPath:
+    @pytest.mark.asyncio
+    @patch("dev10x.github.learn_loop.async_run", new_callable=AsyncMock)
+    @patch("dev10x.github.rule_authoring.author_reference_rules", new_callable=AsyncMock)
+    async def test_opens_pr_and_writes_docs(
+        self,
+        mock_author: AsyncMock,
+        mock_run: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        mock_author.return_value = ok(_authored())
+        mock_run.side_effect = [
+            _cp(0),  # checkout -B
+            _cp(0),  # add
+            _cp(1),  # diff --cached --quiet → changes staged
+            _cp(0),  # commit
+            _cp(0),  # push
+            _cp(0, stdout="https://github.com/o/r/pull/9\n"),  # gh pr create
+        ]
+
+        result = await ll.run_learning_loop(base_dir=str(tmp_path), repo="o/r")
+
+        assert isinstance(result, SuccessResult)
+        assert result.value["opened_pr"] is True
+        assert result.value["pr_url"] == "https://github.com/o/r/pull/9"
+        assert result.value["branch"] == ll.DEFAULT_LEARN_BRANCH
+        assert result.value["rules_authored"] == 1
+        # The rule doc was materialized under base_dir.
+        written = tmp_path / "references/review-checks/generated/block-chaining.md"
+        assert written.read_text(encoding="utf-8").startswith("# Block chaining")
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.learn_loop.async_run", new_callable=AsyncMock)
+    @patch("dev10x.github.rule_authoring.author_reference_rules", new_callable=AsyncMock)
+    async def test_commit_env_merges_os_environ(
+        self,
+        mock_author: AsyncMock,
+        mock_run: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        mock_author.return_value = ok(_authored())
+        mock_run.side_effect = [
+            _cp(0),  # checkout -B
+            _cp(0),  # add
+            _cp(1),  # diff → changes staged
+            _cp(0),  # commit
+            _cp(0),  # push
+            _cp(0, stdout="https://github.com/o/r/pull/9"),  # gh pr create
+        ]
+
+        await ll.run_learning_loop(base_dir=str(tmp_path), repo="o/r")
+
+        commit_call = next(
+            call
+            for call in mock_run.await_args_list
+            if call.kwargs["args"][:2] == ["git", "commit"]
+        )
+        env = commit_call.kwargs["env"]
+        # The bot identity is set …
+        assert env["GIT_AUTHOR_NAME"] == ll._BOT_NAME
+        assert env["GIT_COMMITTER_EMAIL"] == ll._BOT_EMAIL
+        # … without clobbering the inherited environment (PATH/HOME).
+        assert "PATH" in env
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.learn_loop.async_run", new_callable=AsyncMock)
+    @patch("dev10x.github.rule_authoring.author_reference_rules", new_callable=AsyncMock)
+    async def test_base_branch_passed_to_pr_create(
+        self,
+        mock_author: AsyncMock,
+        mock_run: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        mock_author.return_value = ok(_authored())
+        mock_run.side_effect = [
+            _cp(0),  # checkout -B
+            _cp(0),  # add
+            _cp(1),  # diff
+            _cp(0),  # commit
+            _cp(0),  # push
+            _cp(0, stdout="https://github.com/o/r/pull/9"),  # gh pr create
+        ]
+
+        result = await ll.run_learning_loop(
+            base_dir=str(tmp_path), repo="o/r", base_branch="develop"
+        )
+
+        assert isinstance(result, SuccessResult)
+        create_args = mock_run.await_args_list[-1].kwargs["args"]
+        assert "--base" in create_args
+        assert "develop" in create_args
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.learn_loop.async_run", new_callable=AsyncMock)
+    @patch("dev10x.github.rule_authoring.author_reference_rules", new_callable=AsyncMock)
+    async def test_recovers_existing_pr_url_on_create_failure(
+        self,
+        mock_author: AsyncMock,
+        mock_run: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        mock_author.return_value = ok(_authored())
+        mock_run.side_effect = [
+            _cp(0),  # checkout -B
+            _cp(0),  # add
+            _cp(1),  # diff
+            _cp(0),  # commit
+            _cp(0),  # push
+            _cp(1, stderr="a pull request already exists"),  # gh pr create fails
+            _cp(0, stdout="https://github.com/o/r/pull/4"),  # gh pr view → existing url
+        ]
+
+        result = await ll.run_learning_loop(base_dir=str(tmp_path), repo="o/r")
+
+        assert isinstance(result, SuccessResult)
+        assert result.value["opened_pr"] is True
+        assert result.value["pr_url"] == "https://github.com/o/r/pull/4"
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.learn_loop.async_run", new_callable=AsyncMock)
+    @patch("dev10x.github.rule_authoring.author_reference_rules", new_callable=AsyncMock)
+    async def test_push_failure_propagates(
+        self,
+        mock_author: AsyncMock,
+        mock_run: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        mock_author.return_value = ok(_authored())
+        mock_run.side_effect = [
+            _cp(0),  # checkout -B
+            _cp(0),  # add
+            _cp(1),  # diff
+            _cp(0),  # commit
+            _cp(1, stderr="remote rejected"),  # push fails
+        ]
+
+        result = await ll.run_learning_loop(base_dir=str(tmp_path), repo="o/r")
+
+        assert isinstance(result, ErrorResult)
+        assert "remote rejected" in result.error
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.learn_loop.async_run", new_callable=AsyncMock)
+    @patch("dev10x.github.rule_authoring.author_reference_rules", new_callable=AsyncMock)
+    async def test_create_failure_without_existing_pr_errors(
+        self,
+        mock_author: AsyncMock,
+        mock_run: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        mock_author.return_value = ok(_authored())
+        mock_run.side_effect = [
+            _cp(0),  # checkout -B
+            _cp(0),  # add
+            _cp(1),  # diff
+            _cp(0),  # commit
+            _cp(0),  # push
+            _cp(1, stderr="validation failed"),  # gh pr create fails
+            _cp(1, stderr="no pr found"),  # gh pr view finds nothing
+        ]
+
+        result = await ll.run_learning_loop(base_dir=str(tmp_path), repo="o/r")
+
+        assert isinstance(result, ErrorResult)
+        assert "validation failed" in result.error
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.learn_loop.async_run", new_callable=AsyncMock)
+    @patch("dev10x.github.rule_authoring.author_reference_rules", new_callable=AsyncMock)
+    async def test_branch_creation_failure_propagates(
+        self,
+        mock_author: AsyncMock,
+        mock_run: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        mock_author.return_value = ok(_authored())
+        mock_run.side_effect = [_cp(1, stderr="cannot create branch")]
+
+        result = await ll.run_learning_loop(base_dir=str(tmp_path), repo="o/r")
+
+        assert isinstance(result, ErrorResult)
+        assert "cannot create branch" in result.error
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.learn_loop.async_run", new_callable=AsyncMock)
+    @patch("dev10x.github.rule_authoring.author_reference_rules", new_callable=AsyncMock)
+    async def test_git_add_failure_propagates(
+        self,
+        mock_author: AsyncMock,
+        mock_run: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        mock_author.return_value = ok(_authored())
+        mock_run.side_effect = [_cp(0), _cp(1, stderr="add failed")]
+
+        result = await ll.run_learning_loop(base_dir=str(tmp_path), repo="o/r")
+
+        assert isinstance(result, ErrorResult)
+        assert "add failed" in result.error
+
+    @pytest.mark.asyncio
+    @patch("dev10x.github.learn_loop.async_run", new_callable=AsyncMock)
+    @patch("dev10x.github.rule_authoring.author_reference_rules", new_callable=AsyncMock)
+    async def test_commit_failure_propagates(
+        self,
+        mock_author: AsyncMock,
+        mock_run: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        mock_author.return_value = ok(_authored())
+        mock_run.side_effect = [
+            _cp(0),  # checkout -B
+            _cp(0),  # add
+            _cp(1),  # diff → changes staged
+            _cp(1, stderr="commit failed"),  # commit fails
+        ]
+
+        result = await ll.run_learning_loop(base_dir=str(tmp_path), repo="o/r")
+
+        assert isinstance(result, ErrorResult)
+        assert "commit failed" in result.error


### PR DESCRIPTION
**When** I adopt Dev10x PR review on my own repository, **I want to** have the bot propose review rules learned from my merged PRs and follow a documented one-step install, **so I can** get review quality that improves over time without hand-maintaining rules.

---

[`7cd7337b`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/686/commits/7cd7337b57c593fb8d803c1e47502dfeb19776be) ✨ GH-353 Enable continuous learning loop
[`cd673205`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/686/commits/cd6732055e069f7d7d1c59588c2956eb9f1ce09b) 📝 GH-354 Document any-repo install and learning loop
Closes #353
Closes #354
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/353

---