### PR TITLE
⚡️ GH-550 Reduce subprocess fan-out in release + session stop

### DIFF
--- a/src/dev10x/hooks/session_dispatch.py
+++ b/src/dev10x/hooks/session_dispatch.py
@@ -52,9 +52,9 @@ def _escape_for_json(*, s: str) -> str:
     )
 
 
-def _run_git(*args: str) -> str:
+def _run_git_safe(git: GitContext, *args: str) -> str:
     try:
-        return GitContext().run(*args)
+        return git.run(*args)
     except (subprocess.CalledProcessError, FileNotFoundError):
         return ""
 
@@ -255,10 +255,11 @@ def session_persist(data: dict | None = None) -> None:
     state_dir.mkdir(parents=True, exist_ok=True)
     state_dir.chmod(0o700)
 
+    git = GitContext(cwd=toplevel)
     state = SessionState.capture(
         session_id=session_id,
         toplevel=toplevel,
-        run_git=_run_git,
+        run_git=lambda *args: _run_git_safe(git, *args),
         timestamp=datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
     ).to_dict()
     state["working_directory"] = toplevel

--- a/src/dev10x/skills/release/collect_prs.py
+++ b/src/dev10x/skills/release/collect_prs.py
@@ -42,6 +42,11 @@ from dev10x.skills.release.classifier import (
 
 DEFAULT_TICKET_PATTERN = TICKET_ID_PATTERN
 
+# Upper bound on merged PRs fetched in one batch (GH-550). A release
+# window rarely exceeds this; the former per-ticket search had no such
+# cap but paid one subprocess per ticket.
+MERGED_PR_FETCH_LIMIT = 300
+
 
 @dataclass
 class Commit:
@@ -168,23 +173,27 @@ def collect_ticket_groups(
     return dict(groups)
 
 
-def find_prs_for_ticket(
-    ticket_id: str,
+def fetch_merged_prs(
     repo_path: str,
+    limit: int = MERGED_PR_FETCH_LIMIT,
 ) -> list[dict]:
+    """Fetch all merged PRs in one ``gh`` call (GH-550).
+
+    Replaces the former per-ticket ``gh pr list --search <id>`` loop,
+    which spawned one subprocess per release ticket (N+1). Ticket IDs
+    are matched against these PRs in-memory by ``find_matching_prs``.
+    """
     output = run(
         [
             "gh",
             "pr",
             "list",
-            "--search",
-            ticket_id,
             "--state",
             "merged",
             "--json",
             "number,title,body",
             "--limit",
-            "5",
+            str(limit),
         ],
         cwd=repo_path,
         check=False,
@@ -195,6 +204,20 @@ def find_prs_for_ticket(
         return json.loads(output)
     except json.JSONDecodeError:
         return []
+
+
+def find_matching_prs(
+    ticket_id: str,
+    merged_prs: list[dict],
+) -> list[dict]:
+    """Return merged PRs whose title or body references ``ticket_id``."""
+    pattern = re.compile(rf"\b{re.escape(ticket_id)}\b")
+    matches: list[dict] = []
+    for pr in merged_prs:
+        haystack = f"{pr.get('title', '')}\n{pr.get('body', '')}"
+        if pattern.search(haystack):
+            matches.append(pr)
+    return matches
 
 
 def parse_args() -> argparse.Namespace:
@@ -260,6 +283,8 @@ def main() -> None:
 
     skipped = [c for c in commits if c.sha in reverted_shas or c.category in SKIP_CATEGORIES]
 
+    merged_prs = fetch_merged_prs(repo_path=repo_path)
+
     seen_pr_numbers: dict[int, PRInfo] = {}
     feature_prs: list[PRInfo] = []
     maintenance_prs: list[PRInfo] = []
@@ -268,9 +293,9 @@ def main() -> None:
     for ticket_id, group_commits in ticket_groups.items():
         group_category = classify_group(categories={c.category for c in group_commits})
 
-        pr_list = find_prs_for_ticket(
+        pr_list = find_matching_prs(
             ticket_id=ticket_id,
-            repo_path=repo_path,
+            merged_prs=merged_prs,
         )
 
         if pr_list:

--- a/tests/hooks/test_session_stop_hooks.py
+++ b/tests/hooks/test_session_stop_hooks.py
@@ -57,7 +57,7 @@ class TestSessionPersist:
 
         monkeypatch.setattr(mod, "_get_toplevel", lambda: str(project_dir))
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        monkeypatch.setattr(mod, "_run_git", lambda *a: "")
+        monkeypatch.setattr(mod, "_run_git_safe", lambda git, *a: "")
 
         result = runner.invoke(
             cli,
@@ -116,7 +116,7 @@ class TestSessionPersist:
 
         monkeypatch.setattr(mod, "_get_toplevel", lambda: str(project_dir))
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        monkeypatch.setattr(mod, "_run_git", lambda *a: "")
+        monkeypatch.setattr(mod, "_run_git_safe", lambda git, *a: "")
 
         runner.invoke(
             cli,
@@ -127,6 +127,37 @@ class TestSessionPersist:
         state_dir = tmp_path / ".claude" / "projects" / "_session_state"
         assert state_dir.exists()
         assert state_dir.stat().st_mode & 0o777 == 0o700
+
+
+class TestRunGitSafe:
+    def test_returns_git_output(self) -> None:
+        import dev10x.hooks.session_dispatch as mod
+
+        class FakeGit:
+            def run(self, *args: str) -> str:
+                return "main"
+
+        assert mod._run_git_safe(FakeGit(), "rev-parse", "--abbrev-ref", "HEAD") == "main"
+
+    def test_swallows_called_process_error(self) -> None:
+        import subprocess
+
+        import dev10x.hooks.session_dispatch as mod
+
+        class FailGit:
+            def run(self, *args: str) -> str:
+                raise subprocess.CalledProcessError(1, "git")
+
+        assert mod._run_git_safe(FailGit(), "status") == ""
+
+    def test_swallows_missing_git(self) -> None:
+        import dev10x.hooks.session_dispatch as mod
+
+        class NoGit:
+            def run(self, *args: str) -> str:
+                raise FileNotFoundError()
+
+        assert mod._run_git_safe(NoGit(), "status") == ""
 
 
 class TestSessionGoodbye:

--- a/tests/skills/release/test_collect_prs.py
+++ b/tests/skills/release/test_collect_prs.py
@@ -1,0 +1,73 @@
+"""Tests for collect_prs merged-PR batch fetch + matching (GH-550)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from dev10x.skills.release.collect_prs import (
+    MERGED_PR_FETCH_LIMIT,
+    fetch_merged_prs,
+    find_matching_prs,
+)
+
+_RUN = "dev10x.skills.release.collect_prs.run"
+
+
+class TestFetchMergedPrs:
+    def test_single_batch_call_without_search(self) -> None:
+        prs = [{"number": 1, "title": "GH-1 x", "body": ""}]
+        with patch(_RUN, return_value=json.dumps(prs)) as mock_run:
+            result = fetch_merged_prs(repo_path="/repo")
+        assert result == prs
+        cmd = mock_run.call_args.args[0]
+        assert cmd[:3] == ["gh", "pr", "list"]
+        assert "--state" in cmd
+        assert "merged" in cmd
+        assert "--limit" in cmd
+        assert str(MERGED_PR_FETCH_LIMIT) in cmd
+        # GH-550: no per-ticket --search; one batch call instead.
+        assert "--search" not in cmd
+
+    def test_custom_limit_is_passed(self) -> None:
+        with patch(_RUN, return_value="[]") as mock_run:
+            fetch_merged_prs(repo_path="/repo", limit=42)
+        assert "42" in mock_run.call_args.args[0]
+
+    def test_empty_output_returns_empty(self) -> None:
+        with patch(_RUN, return_value=""):
+            assert fetch_merged_prs(repo_path="/repo") == []
+
+    def test_invalid_json_returns_empty(self) -> None:
+        with patch(_RUN, return_value="not json"):
+            assert fetch_merged_prs(repo_path="/repo") == []
+
+
+class TestFindMatchingPrs:
+    _PRS = [
+        {"number": 1, "title": "✨ GH-1 Add feature", "body": "Fixes: GH-1"},
+        {"number": 2, "title": "🐛 Fix bug", "body": "Closes GH-2 and GH-1"},
+        {"number": 3, "title": "Unrelated", "body": "no ticket"},
+    ]
+
+    def test_matches_ticket_in_title_or_body(self) -> None:
+        result = find_matching_prs(ticket_id="GH-1", merged_prs=self._PRS)
+        assert {pr["number"] for pr in result} == {1, 2}
+
+    def test_matches_ticket_in_body_only(self) -> None:
+        result = find_matching_prs(ticket_id="GH-2", merged_prs=self._PRS)
+        assert [pr["number"] for pr in result] == [2]
+
+    def test_no_match_returns_empty(self) -> None:
+        assert find_matching_prs(ticket_id="GH-99", merged_prs=self._PRS) == []
+
+    def test_does_not_substring_match_longer_ticket(self) -> None:
+        # GH-55 must not match a PR that only references GH-550 (word boundary).
+        prs = [{"number": 9, "title": "Fix", "body": "Fixes: GH-550"}]
+        assert find_matching_prs(ticket_id="GH-55", merged_prs=prs) == []
+
+    def test_handles_missing_title_and_body(self) -> None:
+        assert find_matching_prs(ticket_id="GH-1", merged_prs=[{"number": 5}]) == []
+
+    def test_empty_pr_list(self) -> None:
+        assert find_matching_prs(ticket_id="GH-1", merged_prs=[]) == []


### PR DESCRIPTION
**When** running release-notes collection and session-stop persistence across the Dev10x plugin, **I want to** collapse repeated per-item subprocess and `gh` calls into single batched operations, **so I can** keep these paths fast as release ranges and session history grow.

---

[`3dabcee4`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/688/commits/3dabcee476ecd28051eafa056c5284cf917bdabf) ♻️ GH-552 Reduce git subprocess forks at session stop
[`f5693b07`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/688/commits/f5693b0754a3763b522f8bc2a6c54b1c6e6191dd) ⚡️ GH-550 Speed up release PR collection with one batch query

This bundle ships the verified-safe perf findings from milestone
**PKG-M11** (cross-cutting architecture audit). Two sibling
findings were dropped after verification: GH-561 (target code
removed in GH-540) and GH-559 (recommended `lru_cache` is a no-op
for per-invocation Edit/Write hook processes). GH-566 was deferred
(L1 risky, L2 intentional per GH-442, L3 already a no-op).

Closes #550
Closes #552

Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/550