### PR TITLE
♻️ GH-587 Stabilize skills package config and notify paths

### DIFF
--- a/skills/git-worktree/evals/evals.json
+++ b/skills/git-worktree/evals/evals.json
@@ -1,0 +1,210 @@
+{
+  "skill_name": "Dev10x:git-worktree",
+  "eval_dimensions": [
+    {
+      "id": "mode_selection",
+      "name": "Mode Selection Gate",
+      "description": "Presents Same Session vs External+New Session via AskUserQuestion; does NOT auto-select a mode without user input"
+    },
+    {
+      "id": "branch_naming",
+      "name": "Branch Naming",
+      "description": "Derives branch name following username/TICKET-ID/slug convention; detects existing username from git branch -a"
+    },
+    {
+      "id": "path_a_execution",
+      "name": "Path A — EnterWorktree",
+      "description": "Calls EnterWorktree tool (not a shell command) for same-session mode; session CWD switches correctly"
+    },
+    {
+      "id": "path_b_execution",
+      "name": "Path B — External Worktree",
+      "description": "Creates worktree via script, installs SessionEnd cleanup hook, then STOPS — does not continue ticket workflow"
+    },
+    {
+      "id": "hook_setup",
+      "name": "post-checkout Hook Setup",
+      "description": "Reads existing post-checkout hook; proposes template only when missing or incomplete; requires user approval before writing"
+    }
+  ],
+  "evals": [
+    {
+      "id": 1,
+      "name": "same-session-enter-worktree",
+      "prompt": "/Dev10x:git-worktree",
+      "description": "User chooses Same Session mode for ticket GH-42. Skill must call EnterWorktree and resume workflow inside the new worktree.",
+      "setup": {
+        "repo": "example-org/app-pos",
+        "current_branch": "main",
+        "ticket": "GH-42",
+        "user_choice": "same_session"
+      },
+      "dimensions": ["mode_selection", "branch_naming", "path_a_execution"],
+      "assertions": [
+        {
+          "id": "presents-mode-gate",
+          "text": "Calls AskUserQuestion with Same Session and External+New Session options",
+          "check": "tool_called",
+          "signals": ["AskUserQuestion", "Same session", "External"]
+        },
+        {
+          "id": "derives-branch-from-ticket",
+          "text": "Derived branch name contains GH-42 ticket segment",
+          "check": "transcript_contains",
+          "signals": ["GH-42"]
+        },
+        {
+          "id": "calls-enter-worktree-tool",
+          "text": "Uses EnterWorktree tool call (not git worktree add via Bash)",
+          "check": "tool_called",
+          "signals": ["EnterWorktree"]
+        },
+        {
+          "id": "no-stop-message-path-a",
+          "text": "Does NOT print the 'close this session' hand-off message for Path A",
+          "check": "output_absent",
+          "signals": ["Close this session", "cd <worktree-path> && claude"]
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "name": "external-worktree-hands-off",
+      "prompt": "/Dev10x:git-worktree",
+      "description": "User chooses External+New Session mode. Skill must create the worktree, install SessionEnd hook, print the hand-off message, and STOP.",
+      "setup": {
+        "repo": "example-org/app-pos",
+        "current_branch": "main",
+        "ticket": "GH-55",
+        "user_choice": "external"
+      },
+      "dimensions": ["mode_selection", "path_b_execution"],
+      "assertions": [
+        {
+          "id": "confirms-worktree-path",
+          "text": "Asks user to confirm the calculated worktree path before creating it",
+          "check": "tool_called",
+          "signals": ["AskUserQuestion", "worktree", "path"]
+        },
+        {
+          "id": "prints-handoff-message",
+          "text": "Prints the hand-off message instructing user to close session and open new one",
+          "check": "output_contains",
+          "signals": ["Close this session", "claude"]
+        },
+        {
+          "id": "stops-after-handoff",
+          "text": "Does NOT continue with ticket workflow steps after Path B hand-off",
+          "check": "behavioral",
+          "signals": ["STOP", "hand-off", "no further steps"]
+        },
+        {
+          "id": "installs-session-end-hook",
+          "text": "Runs setup-session-end-hook.sh so the new session prompts cleanup on exit",
+          "check": "command_contains",
+          "signals": ["setup-session-end-hook.sh"]
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "name": "post-checkout-hook-missing",
+      "prompt": "/Dev10x:git-worktree",
+      "description": "Python/uv project has no post-checkout hook. Skill must detect project type, propose Template A, and require approval before writing.",
+      "setup": {
+        "repo": "example-org/app-pos",
+        "has_post_checkout_hook": false,
+        "project_type": "python_uv",
+        "user_choice": "same_session"
+      },
+      "dimensions": ["hook_setup", "path_a_execution"],
+      "assertions": [
+        {
+          "id": "reads-existing-hook-first",
+          "text": "Attempts to read .git/hooks/post-checkout or .husky/post-checkout before proposing template",
+          "check": "tool_called",
+          "signals": ["Read", "post-checkout"]
+        },
+        {
+          "id": "proposes-template-a",
+          "text": "Proposes Template A (Python/uv) based on uv.lock or pyproject.toml detection",
+          "check": "transcript_contains",
+          "signals": ["Template A", "uv sync", "post-checkout"]
+        },
+        {
+          "id": "requires-user-approval-before-write",
+          "text": "Does NOT write the hook file without user approval",
+          "check": "tool_called",
+          "signals": ["AskUserQuestion"]
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "name": "branch-naming-from-git-log",
+      "prompt": "/Dev10x:git-worktree GH-100 enable-caching",
+      "description": "Skill detects the current user's username from existing branch patterns in git branch -a and constructs a properly formatted branch name.",
+      "setup": {
+        "repo": "example-org/app-pos",
+        "existing_branches": ["janusz/GH-90/prior-work", "janusz/GH-91/other-fix"],
+        "ticket": "GH-100"
+      },
+      "dimensions": ["branch_naming"],
+      "assertions": [
+        {
+          "id": "detects-username-from-branches",
+          "text": "Runs git branch -a to detect existing username pattern",
+          "check": "command_contains",
+          "signals": ["git branch"]
+        },
+        {
+          "id": "branch-contains-ticket",
+          "text": "Proposed branch name contains the ticket ID GH-100",
+          "check": "transcript_contains",
+          "signals": ["GH-100"]
+        },
+        {
+          "id": "branch-follows-convention",
+          "text": "Branch name follows username/TICKET-ID/slug pattern",
+          "check": "output_matches_pattern",
+          "pattern": "[a-z]+/GH-100/[a-z0-9-]+"
+        }
+      ]
+    }
+  ],
+  "trigger_evals": {
+    "description": "Queries that should/should-not trigger the git-worktree skill",
+    "should_trigger": [
+      {
+        "query": "/Dev10x:git-worktree",
+        "rationale": "Direct invocation"
+      },
+      {
+        "query": "create a worktree for GH-42 so I can work in isolation",
+        "rationale": "Explicit worktree creation request"
+      },
+      {
+        "query": "I need a new isolated workspace for this feature branch",
+        "rationale": "Workspace isolation is the core use case"
+      },
+      {
+        "query": "start working on GH-200 in a separate worktree",
+        "rationale": "Feature work needing isolation — canonical trigger"
+      }
+    ],
+    "should_not_trigger": [
+      {
+        "query": "list all my worktrees",
+        "rationale": "Read-only query — use git worktree list directly"
+      },
+      {
+        "query": "remove the worktree at ../.worktrees/app-pos-3",
+        "rationale": "Cleanup action — use git worktree remove directly"
+      },
+      {
+        "query": "I'm already in a worktree, let's commit these changes",
+        "rationale": "Already isolated — use Dev10x:git-commit instead"
+      }
+    ]
+  }
+}

--- a/skills/upgrade-cleanup/evals/evals.json
+++ b/skills/upgrade-cleanup/evals/evals.json
@@ -1,0 +1,168 @@
+{
+  "skill_name": "Dev10x:upgrade-cleanup",
+  "eval_dimensions": [
+    {
+      "id": "delegation",
+      "name": "Correct Delegation",
+      "description": "Invokes Dev10x:plugin-maintenance in full mode after running config migrate; does NOT run maintenance steps inline"
+    },
+    {
+      "id": "migration",
+      "name": "Config Migration Step",
+      "description": "Runs 'dev10x config migrate' as Step 1 before delegating; skips gracefully if already migrated"
+    },
+    {
+      "id": "version_record",
+      "name": "Version Recording",
+      "description": "Calls mcp__plugin_Dev10x_cli__record_upgrade after a successful maintenance pass; skips if maintenance reported failures"
+    },
+    {
+      "id": "trigger_guard",
+      "name": "Trigger Guard",
+      "description": "Does NOT invoke when permissions are working correctly; steers user to Dev10x:plugin-maintenance bootstrap for fast subset"
+    }
+  ],
+  "evals": [
+    {
+      "id": 1,
+      "name": "post-upgrade-happy-path",
+      "prompt": "/Dev10x:upgrade-cleanup",
+      "description": "Standard post-upgrade invocation. Plugin version changed, config at legacy paths. Full maintenance pass should run and version should be recorded.",
+      "setup": {
+        "plugin_version_changed": true,
+        "config_at_legacy_paths": true
+      },
+      "dimensions": ["delegation", "migration", "version_record"],
+      "assertions": [
+        {
+          "id": "runs-config-migrate",
+          "text": "Executes 'dev10x config migrate' as Step 1",
+          "check": "command_contains",
+          "signals": ["dev10x config migrate"]
+        },
+        {
+          "id": "delegates-to-plugin-maintenance-full",
+          "text": "Invokes Skill(Dev10x:plugin-maintenance) with args='full'",
+          "check": "tool_called",
+          "signals": ["Skill", "Dev10x:plugin-maintenance", "full"]
+        },
+        {
+          "id": "records-upgrade-after-success",
+          "text": "Calls mcp__plugin_Dev10x_cli__record_upgrade after maintenance pass succeeds",
+          "check": "tool_called",
+          "signals": ["mcp__plugin_Dev10x_cli__record_upgrade"]
+        },
+        {
+          "id": "no-inline-maintenance-steps",
+          "text": "Does NOT run maintenance sub-steps inline (update-paths, ensure-base, etc.) — delegates entirely",
+          "check": "behavioral",
+          "signals": ["delegates", "plugin-maintenance"]
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "name": "maintenance-failure-skips-version-record",
+      "prompt": "/Dev10x:upgrade-cleanup",
+      "description": "Maintenance pass reports failures. version.yml must NOT be updated so the upgrade prompt stays visible.",
+      "setup": {
+        "plugin_version_changed": true,
+        "maintenance_pass_result": "failure"
+      },
+      "dimensions": ["version_record"],
+      "assertions": [
+        {
+          "id": "skips-record-upgrade-on-failure",
+          "text": "Does NOT call mcp__plugin_Dev10x_cli__record_upgrade when maintenance reported failures",
+          "check": "tool_absent",
+          "signals": ["mcp__plugin_Dev10x_cli__record_upgrade"]
+        },
+        {
+          "id": "surfaces-failure-to-user",
+          "text": "Informs user that version was not recorded due to maintenance failures",
+          "check": "output_contains",
+          "signals": ["failure", "not recorded", "resolve"]
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "name": "already-migrated-idempotent",
+      "prompt": "/Dev10x:upgrade-cleanup",
+      "description": "Config already at XDG location. migrate step runs but is a no-op. Full pass continues normally.",
+      "setup": {
+        "config_at_legacy_paths": false,
+        "plugin_version_changed": true
+      },
+      "dimensions": ["migration", "delegation"],
+      "assertions": [
+        {
+          "id": "migrate-still-runs",
+          "text": "Still runs 'dev10x config migrate' even when config is already migrated (idempotent)",
+          "check": "command_contains",
+          "signals": ["dev10x config migrate"]
+        },
+        {
+          "id": "still-delegates-full-pass",
+          "text": "Proceeds to delegate full maintenance pass regardless of migrate output",
+          "check": "tool_called",
+          "signals": ["Skill", "Dev10x:plugin-maintenance"]
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "name": "no-trigger-when-permissions-working",
+      "prompt": "Skill(Dev10x:upgrade-cleanup)",
+      "description": "Orchestrator context: permissions working, no version change detected. Skill should advise user rather than running a full pass.",
+      "setup": {
+        "plugin_version_changed": false,
+        "permission_friction": false
+      },
+      "dimensions": ["trigger_guard"],
+      "assertions": [
+        {
+          "id": "advises-no-action-needed",
+          "text": "Informs user that no upgrade cleanup is needed when permissions work and version is current",
+          "check": "output_contains",
+          "signals": ["no upgrade", "up to date", "working", "not needed"]
+        }
+      ]
+    }
+  ],
+  "trigger_evals": {
+    "description": "Queries that should/should-not trigger the upgrade-cleanup skill",
+    "should_trigger": [
+      {
+        "query": "/Dev10x:upgrade-cleanup",
+        "rationale": "Direct invocation"
+      },
+      {
+        "query": "I just updated the plugin, now I'm getting permission prompts",
+        "rationale": "Post-upgrade friction is the canonical trigger"
+      },
+      {
+        "query": "upgrade-cleanup after updating Dev10x",
+        "rationale": "Explicit post-upgrade intent"
+      },
+      {
+        "query": "config files are still in the old location after the update",
+        "rationale": "Legacy config path is a trigger condition"
+      }
+    ],
+    "should_not_trigger": [
+      {
+        "query": "run a quick bootstrap so the demo skills work",
+        "rationale": "Bootstrap subset — use Dev10x:plugin-maintenance bootstrap instead"
+      },
+      {
+        "query": "permissions are working fine, just want to check skill coverage",
+        "rationale": "Permissions working — no cleanup needed"
+      },
+      {
+        "query": "show me the plugin version",
+        "rationale": "Read-only info query, no cleanup action"
+      }
+    ]
+  }
+}

--- a/src/dev10x/commands/skill.py
+++ b/src/dev10x/commands/skill.py
@@ -78,18 +78,16 @@ def slack_send(
 
     from dev10x.skills.notifications import slack_notify
 
-    if workspace is not None:
-        slack_notify.set_workspace(workspace)
-
     msg: str
     if message_file is not None:
         msg = message_file.read_text()
     else:
         msg = message  # type: ignore[assignment]  # validated above
 
-    result = slack_notify.send_slack_message(
+    result = slack_notify.notify_slack(
         channel=channel,
         message=msg,
+        workspace=workspace,
         thread_ts=thread_ts,
     )
     if isinstance(result, ErrorResult):

--- a/src/dev10x/domain/common/baseline_catalog.py
+++ b/src/dev10x/domain/common/baseline_catalog.py
@@ -1,0 +1,52 @@
+"""Single chokepoint for reading ``baseline-permissions.yaml`` (GH-587).
+
+Two consumers used to YAML-parse the baseline catalog independently —
+``PolicyCatalog.load`` (projecting into ``list[Policy]``) and
+``doctor.load_catalog`` (projecting into a ``Catalog`` dataclass). Two
+parsers reading the same file is a schema-drift risk: a change to how the
+baseline is read (encoding, tolerance, structural assumptions) had to be
+mirrored in both places or they would silently diverge.
+
+This module exposes one loader, :func:`load_baseline_dict`, that both
+consumers route through. It only reads and YAML-parses the file into the
+top-level mapping; each consumer keeps its own projection model — they
+have different downstream consumers and must not be merged.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+def load_baseline_dict(path: Path, *, strict: bool = False) -> dict:
+    """Read and YAML-parse a baseline catalog file into its top-level mapping.
+
+    ``strict=False`` (default) mirrors ``PolicyCatalog``'s tolerance: a
+    missing file, a :class:`yaml.YAMLError`, or a non-mapping top-level
+    value all return ``{}``.
+
+    ``strict=True`` preserves ``doctor.load_catalog``'s raise-on-missing
+    contract: a missing file raises :class:`FileNotFoundError`, a YAML
+    error propagates, and a non-mapping top-level value raises
+    :class:`ValueError`.
+    """
+    if not path.is_file():
+        if strict:
+            raise FileNotFoundError(f"Baseline catalog not found: {path}")
+        return {}
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (yaml.YAMLError, OSError):
+        if strict:
+            raise
+        return {}
+    if not isinstance(data, dict):
+        if strict:
+            raise ValueError(f"Baseline catalog top-level value is not a mapping: {path}")
+        return {}
+    return data
+
+
+__all__ = ["load_baseline_dict"]

--- a/src/dev10x/domain/common/policy.py
+++ b/src/dev10x/domain/common/policy.py
@@ -25,9 +25,8 @@ from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
 
-import yaml
-
 from dev10x.domain.common.allow_rule import AllowRule
+from dev10x.domain.common.baseline_catalog import load_baseline_dict
 
 
 class PolicyEffect(StrEnum):
@@ -175,17 +174,10 @@ class PolicyCatalog:
 
         Returns ``[]`` for a missing file, unparseable YAML, or a
         top-level value that is not a mapping — mirroring
-        :meth:`AllowRuleLoader.load`.
+        :meth:`AllowRuleLoader.load`. Reading and parsing the baseline
+        YAML is delegated to the shared loader (GH-587).
         """
-        p = Path(path)
-        if not p.is_file():
-            return []
-        try:
-            data = yaml.safe_load(p.read_text(encoding="utf-8"))
-        except (yaml.YAMLError, OSError):
-            return []
-        if not isinstance(data, dict):
-            return []
+        data = load_baseline_dict(Path(path), strict=False)
         return PolicyCatalog.from_baseline_dict(data, source=source)
 
 

--- a/src/dev10x/domain/dev10x_paths.py
+++ b/src/dev10x/domain/dev10x_paths.py
@@ -28,6 +28,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 from dev10x.domain.claude_paths import ClaudeDir
+from dev10x.domain.file_locks import file_lock
 
 CONFIG_HOME_ENV_VAR = "DEV10X_CONFIG_HOME"
 XDG_CONFIG_HOME_ENV_VAR = "XDG_CONFIG_HOME"
@@ -66,11 +67,19 @@ def migrate_path(*, legacy: Path, current: Path) -> bool:
     Returns True when a copy happened. Leaves the legacy path in
     place so a downgrade can still read it; eager cleanup deletes
     the legacy entry once parity is confirmed.
+
+    The check-then-copy runs under an exclusive lock on ``current``
+    with a re-check inside the lock (double-checked locking) so two
+    worktrees/agents racing first-call migration cannot both copy and
+    clobber each other — GH-587.
     """
     if current.exists() or not legacy.exists():
         return False
-    _log.info("Migrating Dev10x config: %s -> %s", legacy, current)
-    _copy(source=legacy, destination=current)
+    with file_lock(current):
+        if current.exists() or not legacy.exists():
+            return False
+        _log.info("Migrating Dev10x config: %s -> %s", legacy, current)
+        _copy(source=legacy, destination=current)
     return True
 
 

--- a/src/dev10x/skills/monitor/pr_notify.py
+++ b/src/dev10x/skills/monitor/pr_notify.py
@@ -366,7 +366,7 @@ def cmd_send(args: argparse.Namespace) -> None:
             from dev10x.domain.common.result import ErrorResult
             from dev10x.skills.notifications import slack_notify as _slack
 
-            result = _slack.send_slack_message(channel=args.channel, message=message)
+            result = _slack.notify_slack(channel=args.channel, message=message)
             if isinstance(result, ErrorResult):
                 print(f"❌ Slack notification failed: {result.error}", file=sys.stderr)
                 sys.exit(1)

--- a/src/dev10x/skills/notifications/slack_notify.py
+++ b/src/dev10x/skills/notifications/slack_notify.py
@@ -18,6 +18,7 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from dev10x import subprocess_utils
 from dev10x.domain.common.result import ErrorResult, Result, err, ok
 from dev10x.domain.dev10x_paths import Dev10xConfigDir
 
@@ -99,7 +100,7 @@ def _keyring_lookup(*, service: str, key: str) -> str | None:
     else:
         cmd = ["secret-tool", "lookup", "service", service, "key", key]
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        result = subprocess_utils.run(cmd, capture_output=True, text=True, check=True)
         return result.stdout.strip() or None
     except (subprocess.CalledProcessError, FileNotFoundError):
         return None
@@ -120,12 +121,16 @@ def _keyring_service() -> str:
     return f"slack-{_active_workspace}"
 
 
-def get_token() -> str:
-    """Resolve the Slack bot token.
+def get_token() -> Result[str]:
+    """Resolve the Slack bot token (GH-587).
+
+    Returns a :class:`Result` instead of raising so callers share one
+    Result-based error style rather than mixing ``raise RuntimeError``
+    with ``Result`` returns.
 
     Resolution order:
       1. If --workspace was set: keyring at the workspace's service name.
-         Raise if missing — workspace was explicitly requested.
+         Error if missing — workspace was explicitly requested.
       2. SLACK_TOKEN environment variable.
       3. Default keyring at service=slack.
     """
@@ -133,18 +138,18 @@ def get_token() -> str:
         service = _keyring_service()
         token = _keyring_lookup(service=service, key="bot_token")
         if token:
-            return token
-        raise RuntimeError(
+            return ok(token)
+        return err(
             f"No Slack token found in keyring for workspace "
             f"'{_active_workspace}' (service={service})"
         )
     env_token = os.environ.get("SLACK_TOKEN")
     if env_token:
-        return env_token
+        return ok(env_token)
     token = _keyring_lookup(service="slack", key="bot_token")
     if token:
-        return token
-    raise RuntimeError(
+        return ok(token)
+    return err(
         "No Slack token found. Set SLACK_TOKEN env, configure the default "
         "keyring (service=slack, key=bot_token), or pass --workspace NAME."
     )
@@ -166,7 +171,11 @@ def send_slack_message(
         return err(f"Failed to send Slack message: {ex}")
     try:
         resolved_message = resolve_mentions(message)
-        token = get_token()
+        token_result = get_token()
+        if isinstance(token_result, ErrorResult):
+            log.error("Failed to send Slack message: %s", token_result.error)
+            return token_result
+        token = token_result.value
         is_user_token = token.startswith("xoxp-")
         client = WebClient(token=token)
         result = client.chat_postMessage(
@@ -188,6 +197,36 @@ def send_slack_message(
         return err(f"Failed to send Slack message: {ex}")
 
 
+def notify_slack(
+    *,
+    channel: str,
+    message: str,
+    workspace: str | None = None,
+    thread_ts: str | None = None,
+    broadcast: bool = False,
+    reactions: list[str] | None = None,
+    unfurl: bool = False,
+) -> Result[str]:
+    """Single service entry for sending a Slack message (GH-587).
+
+    Consolidates the previously-scattered ``set_workspace`` +
+    ``send_slack_message`` call sites behind one ``Result``-returning
+    service so every caller shares the same error contract instead of
+    three divergent styles. Returns ``ok(ts)`` or ``err(reason)``;
+    callers own their own user-facing output formatting.
+    """
+    if workspace is not None:
+        set_workspace(workspace)
+    return send_slack_message(
+        channel=channel,
+        message=message,
+        thread_ts=thread_ts,
+        broadcast=broadcast,
+        reactions=reactions,
+        unfurl=unfurl,
+    )
+
+
 def upload_slack_files(
     channel: str,
     file_paths: list[str],
@@ -197,7 +236,11 @@ def upload_slack_files(
     from slack_sdk import WebClient
     from slack_sdk.errors import SlackApiError
 
-    token = get_token()
+    token_result = get_token()
+    if isinstance(token_result, ErrorResult):
+        print(f"❌ {token_result.error}", file=sys.stderr)
+        return None
+    token = token_result.value
     client = WebClient(token=token)
     resolved_message = resolve_mentions(message) if message else None
 
@@ -280,7 +323,11 @@ def send_reminder(message: str) -> str | None:
     try:
         from slack_sdk import WebClient
 
-        token = get_token()
+        token_result = get_token()
+        if isinstance(token_result, ErrorResult):
+            print(f"❌ Failed to send reminder: {token_result.error}", file=sys.stderr)
+            return None
+        token = token_result.value
         client = WebClient(token=token)
         dm = client.conversations_open(users=self_user_id)
         channel = dm["channel"]["id"]
@@ -299,7 +346,11 @@ def update_slack_message(channel: str, ts: str, message: str) -> bool:
         from slack_sdk import WebClient
 
         resolved_message = resolve_mentions(message)
-        token = get_token()
+        token_result = get_token()
+        if isinstance(token_result, ErrorResult):
+            print(f"❌ Failed to update Slack message: {token_result.error}", file=sys.stderr)
+            return False
+        token = token_result.value
         client = WebClient(token=token)
         client.chat_update(channel=channel, ts=ts, text=resolved_message)
         return True
@@ -312,7 +363,11 @@ def delete_slack_message(channel: str, ts: str) -> bool:
     try:
         from slack_sdk import WebClient
 
-        token = get_token()
+        token_result = get_token()
+        if isinstance(token_result, ErrorResult):
+            print(f"❌ Failed to delete Slack message: {token_result.error}", file=sys.stderr)
+            return False
+        token = token_result.value
         client = WebClient(token=token)
         client.chat_delete(channel=channel, ts=ts)
         return True
@@ -325,7 +380,11 @@ def delete_slack_file(file_id: str) -> bool:
     try:
         from slack_sdk import WebClient
 
-        token = get_token()
+        token_result = get_token()
+        if isinstance(token_result, ErrorResult):
+            print(f"❌ Failed to delete Slack file: {token_result.error}", file=sys.stderr)
+            return False
+        token = token_result.value
         client = WebClient(token=token)
         client.files_delete(file=file_id)
         return True

--- a/src/dev10x/skills/permission/doctor.py
+++ b/src/dev10x/skills/permission/doctor.py
@@ -31,9 +31,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-import yaml
-
 from dev10x import subprocess_utils
+from dev10x.domain.common.baseline_catalog import load_baseline_dict
 from dev10x.domain.plugin_identity import PLUGIN_NAMES
 
 PINNED_VERSION_RE = re.compile(
@@ -388,8 +387,13 @@ class Catalog:
 
 
 def load_catalog(path: Path = CATALOG_PATH) -> Catalog:
-    """Load the baseline-permissions catalog from YAML."""
-    raw = yaml.safe_load(path.read_text())
+    """Load the baseline-permissions catalog from YAML.
+
+    Reading and parsing the baseline YAML is delegated to the shared
+    loader (GH-587); ``strict=True`` preserves the raise-on-missing
+    contract this consumer has always had.
+    """
+    raw = load_baseline_dict(path, strict=True)
     return Catalog(
         version=int(raw.get("version", 0)),
         last_audited=str(raw.get("last_audited", "")),

--- a/src/dev10x/skills/permission/update_paths.py
+++ b/src/dev10x/skills/permission/update_paths.py
@@ -1521,6 +1521,8 @@ def init_userspace_config() -> dict[str, object]:
     for downgrade safety; ``upgrade-cleanup``/``plugin-doctor`` remove
     it once parity is confirmed. Returns a result dict.
     """
+    from dev10x.domain.file_locks import atomic_write_text, file_lock
+
     messages: list[str] = []
     errors: list[str] = []
 
@@ -1530,24 +1532,31 @@ def init_userspace_config() -> dict[str, object]:
 
     MEMORY_CONFIG.parent.mkdir(parents=True, exist_ok=True)
 
-    if USERSPACE_CONFIG.is_file():
-        MEMORY_CONFIG.write_text(USERSPACE_CONFIG.read_text())
-        messages.append(f"Migrated {USERSPACE_CONFIG} -> {MEMORY_CONFIG}")
-        messages.append(f"{USERSPACE_CONFIG} is deprecated; edit {MEMORY_CONFIG} from now on.")
+    # Double-checked locking (GH-587): two worktrees/agents racing first-call
+    # init must not both pass the exists-check and clobber each other's write.
+    with file_lock(MEMORY_CONFIG):
+        if MEMORY_CONFIG.is_file():
+            messages.append(f"Config already exists: {MEMORY_CONFIG}")
+            return _result(exit_code=0, messages=messages, errors=errors)
+
+        if USERSPACE_CONFIG.is_file():
+            atomic_write_text(MEMORY_CONFIG, USERSPACE_CONFIG.read_text())
+            messages.append(f"Migrated {USERSPACE_CONFIG} -> {MEMORY_CONFIG}")
+            messages.append(f"{USERSPACE_CONFIG} is deprecated; edit {MEMORY_CONFIG} from now on.")
+            return _result(exit_code=0, messages=messages, errors=errors)
+
+        if not PLUGIN_CONFIG.is_file():
+            errors.append(f"ERROR: Plugin default config not found: {PLUGIN_CONFIG}")
+            return _result(exit_code=1, messages=messages, errors=errors)
+
+        content = PLUGIN_CONFIG.read_text()
+        detected_cache = _detect_plugin_cache()
+        content = content.replace(
+            "~/.claude/plugins/cache/Dev10x-Guru/dev10x-claude",
+            detected_cache,
+        )
+        atomic_write_text(MEMORY_CONFIG, content)
+        messages.append(f"Created: {MEMORY_CONFIG}")
+        messages.append(f"Plugin cache: {detected_cache}")
+        messages.append("Edit this file to add your project roots.")
         return _result(exit_code=0, messages=messages, errors=errors)
-
-    if not PLUGIN_CONFIG.is_file():
-        errors.append(f"ERROR: Plugin default config not found: {PLUGIN_CONFIG}")
-        return _result(exit_code=1, messages=messages, errors=errors)
-
-    content = PLUGIN_CONFIG.read_text()
-    detected_cache = _detect_plugin_cache()
-    content = content.replace(
-        "~/.claude/plugins/cache/Dev10x-Guru/dev10x-claude",
-        detected_cache,
-    )
-    MEMORY_CONFIG.write_text(content)
-    messages.append(f"Created: {MEMORY_CONFIG}")
-    messages.append(f"Plugin cache: {detected_cache}")
-    messages.append("Edit this file to add your project roots.")
-    return _result(exit_code=0, messages=messages, errors=errors)

--- a/tests/domain/common/test_baseline_catalog.py
+++ b/tests/domain/common/test_baseline_catalog.py
@@ -1,0 +1,49 @@
+"""Tests for the shared baseline-catalog loader (GH-587)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from dev10x.domain.common.baseline_catalog import load_baseline_dict
+
+
+class TestLoadBaselineDict:
+    def test_valid_mapping_is_returned(self, tmp_path: Path) -> None:
+        path = tmp_path / "baseline.yaml"
+        path.write_text(
+            yaml.safe_dump({"version": 1, "groups": {}}),
+            encoding="utf-8",
+        )
+        assert load_baseline_dict(path) == {"version": 1, "groups": {}}
+
+    def test_missing_file_non_strict_returns_empty(self, tmp_path: Path) -> None:
+        assert load_baseline_dict(tmp_path / "nope.yaml") == {}
+
+    def test_missing_file_strict_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            load_baseline_dict(tmp_path / "nope.yaml", strict=True)
+
+    def test_malformed_yaml_non_strict_returns_empty(self, tmp_path: Path) -> None:
+        path = tmp_path / "baseline.yaml"
+        path.write_text("{not: valid: yaml:", encoding="utf-8")
+        assert load_baseline_dict(path) == {}
+
+    def test_malformed_yaml_strict_propagates(self, tmp_path: Path) -> None:
+        path = tmp_path / "baseline.yaml"
+        path.write_text("{not: valid: yaml:", encoding="utf-8")
+        with pytest.raises(yaml.YAMLError):
+            load_baseline_dict(path, strict=True)
+
+    def test_non_mapping_non_strict_returns_empty(self, tmp_path: Path) -> None:
+        path = tmp_path / "baseline.yaml"
+        path.write_text(yaml.safe_dump(["a", "list"]), encoding="utf-8")
+        assert load_baseline_dict(path) == {}
+
+    def test_non_mapping_strict_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "baseline.yaml"
+        path.write_text(yaml.safe_dump(["a", "list"]), encoding="utf-8")
+        with pytest.raises(ValueError, match="not a mapping"):
+            load_baseline_dict(path, strict=True)

--- a/tests/domain/test_dev10x_paths.py
+++ b/tests/domain/test_dev10x_paths.py
@@ -129,6 +129,29 @@ def test_migrate_path_copies_directory(tmp_path: Path) -> None:
     assert (current / "b.yaml").read_text() == "b"
 
 
+def test_migrate_path_rechecks_inside_lock_when_current_appears(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Double-checked locking (GH-587): a writer that wins the race inside
+    the lock must not be clobbered by a second arrival."""
+    from contextlib import contextmanager
+
+    legacy = tmp_path / "old" / "file.yaml"
+    current = tmp_path / "new" / "file.yaml"
+    legacy.parent.mkdir()
+    legacy.write_text("legacy")
+
+    @contextmanager
+    def racing_lock(path: Path, **_: object):
+        current.parent.mkdir(parents=True, exist_ok=True)
+        current.write_text("winner")
+        yield
+
+    monkeypatch.setattr("dev10x.domain.dev10x_paths.file_lock", racing_lock)
+    assert migrate_path(legacy=legacy, current=current) is False
+    assert current.read_text() == "winner"
+
+
 def test_lazy_migration_runs_on_accessor(isolated_dirs: tuple[Path, Path]) -> None:
     legacy_root, new_root = isolated_dirs
     legacy = ClaudeDir.memory_projects_yaml()

--- a/tests/skills/gh-pr-monitor/test_pr_notify.py
+++ b/tests/skills/gh-pr-monitor/test_pr_notify.py
@@ -1,10 +1,13 @@
-"""Tests for pr-notify.py formatting functions."""
+"""Tests for pr-notify.py formatting functions and arg-building logic."""
 
+import argparse
 import importlib.util
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest  # type: ignore[import-not-found]
 
+# Load the shim script so the module object is available for patching.
 _repo_root = Path(__file__).resolve().parent.parent.parent.parent
 _spec = importlib.util.spec_from_file_location(
     "pr_notify",
@@ -22,6 +25,12 @@ format_slack_message = _mod.format_slack_message
 format_status_report = _mod.format_status_report
 md_to_slack_bold = _mod.md_to_slack_bold
 split_title_jtbd = _mod.split_title_jtbd
+update_pr_checklist = _mod.update_pr_checklist
+
+# Private helper — import directly from the underlying module (not the * shim).
+from dev10x.skills.monitor import pr_notify as _pr_notify_module  # noqa: E402
+
+_repo_name = _pr_notify_module._repo_name
 
 
 class TestSplitTitleJtbd:
@@ -274,3 +283,238 @@ class TestFormatStatusReport:
         assert "No CI checks found." in result
         assert "No unhandled review comments." in result
         assert "No reviewers assigned." in result
+
+
+class TestRepoName:
+    """Unit tests for _repo_name helper — pure logic, no network."""
+
+    def test_owner_slash_name_returns_name(self):
+        assert _repo_name(repo="example-org/app-pos") == "app-pos"
+
+    def test_valid_repository_ref_parsed_to_name(self):
+        # RepositoryRef.try_parse succeeds for owner/name strings
+        assert _repo_name(repo="acme/my-service") == "my-service"
+
+    def test_bare_name_without_slash_returns_whole_string(self):
+        # When RepositoryRef.try_parse returns None, fallback is split("/")[-1]
+        # A bare name with no slash should return itself.
+        result = _repo_name(repo="standalone")
+        assert result == "standalone"
+
+
+class TestUpdatePrChecklistArgBuilding:
+    """Tests for update_pr_checklist arg-building — which gh pr edit args are assembled.
+
+    The function builds a replacements list from diff content, then calls
+    gh_run with those replacements applied to the PR body.  We mock gh_json
+    (to supply the current body) and gh_run (to capture the edited body) so
+    the pure arg-building logic can be exercised without network access.
+    """
+
+    def _run(
+        self,
+        diff: str,
+        initial_body: str = (
+            "- [ ] CI is passing\n"
+            "- [ ] A person or better yet a group is selected in the reviewers section\n"
+            "- [ ] Clean history with auto-squashed fixup! commits\n"
+            "- [ ] **Data migrations** are present (if applicable) and unit tested\n"
+            "- [ ] **New environment variables** are documented\n"
+            "- [ ] **Breaking changes** are communicated to the team\n"
+        ),
+    ) -> str | None:
+        """Run update_pr_checklist and return the body passed to gh pr edit, or None."""
+        captured: list[str] = []
+
+        def fake_gh_json(args: list[str]) -> dict:
+            return {"body": initial_body}
+
+        def fake_gh_run(args: list[str]) -> None:
+            # args is: ["pr", "edit", "<pr>", "--repo", "<repo>", "--body", "<body>"]
+            body_idx = args.index("--body")
+            captured.append(args[body_idx + 1])
+
+        with (
+            patch.object(_pr_notify_module, "gh_json", side_effect=fake_gh_json),
+            patch.object(_pr_notify_module, "gh_run", side_effect=fake_gh_run),
+        ):
+            update_pr_checklist(pr_number=1, repo="owner/repo", diff=diff)
+
+        return captured[0] if captured else None
+
+    def test_no_migrations_in_diff_strikes_through_migration_item(self):
+        body = self._run(diff="some/other/file.py changed")
+        assert body is not None
+        assert "~**Data migrations**" in body
+        assert "- [ ] **Data migrations**" not in body
+
+    def test_migrations_in_diff_leaves_migration_item_unchecked(self):
+        body = self._run(diff="migrations/0042_add_column.py\n+ new line")
+        assert body is not None
+        # Migration item should NOT be struck through; it stays as-is (checked or unchecked)
+        assert "~**Data migrations**" not in body
+
+    def test_no_env_changes_in_diff_strikes_through_env_item(self):
+        body = self._run(diff="src/views.py changed")
+        assert body is not None
+        assert "~**New environment variables**" in body
+
+    def test_env_changes_in_diff_leaves_env_item_unchecked(self):
+        # diff contains "settings" and an assignment pattern
+        body = self._run(diff="settings/base.py\n+SECRET_KEY='abc'")
+        assert body is not None
+        assert "~**New environment variables**" not in body
+
+    def test_breaking_false_strikes_through_breaking_item(self):
+        # has_breaking is always False (conservative default) in current impl
+        body = self._run(diff="anything")
+        assert body is not None
+        assert "~**Breaking changes**" in body
+
+    def test_standard_checklist_items_are_checked(self):
+        body = self._run(diff="")
+        assert body is not None
+        assert "- [x] CI is passing" in body
+        assert "- [x] A person or better yet a group is selected in the reviewers section" in body
+        assert "- [x] Clean history with auto-squashed fixup! commits" in body
+
+    def test_no_changes_when_checklist_items_absent(self):
+        # If the body has no checklist markers, gh_run is never called (no-op)
+        captured: list[str] = []
+
+        def fake_gh_json(args: list[str]) -> dict:
+            return {"body": "Just a plain PR body with no checklist."}
+
+        def fake_gh_run(args: list[str]) -> None:
+            captured.append("called")
+
+        with (
+            patch.object(_pr_notify_module, "gh_json", side_effect=fake_gh_json),
+            patch.object(_pr_notify_module, "gh_run", side_effect=fake_gh_run),
+        ):
+            update_pr_checklist(pr_number=1, repo="owner/repo", diff="")
+
+        assert captured == []
+
+    def test_none_body_treated_as_empty_string(self):
+        # gh_json returns body=None — should not raise
+        captured: list[str] = []
+
+        def fake_gh_json(args: list[str]) -> dict:
+            return {"body": None}
+
+        def fake_gh_run(args: list[str]) -> None:
+            captured.append("called")
+
+        with (
+            patch.object(_pr_notify_module, "gh_json", side_effect=fake_gh_json),
+            patch.object(_pr_notify_module, "gh_run", side_effect=fake_gh_run),
+        ):
+            update_pr_checklist(pr_number=1, repo="owner/repo", diff="")
+
+        # No checklist items in None/empty body → no edit needed
+        assert captured == []
+
+
+class TestSendSubcommandArgDefaults:
+    """Tests that the send subcommand's argparse defaults are correct.
+
+    Builds the parser inline (mirrors main() structure) so defaults can be
+    asserted without calling main() which triggers RepositoryRef.parse().
+    """
+
+    @pytest.fixture()
+    def send_parser(self) -> argparse.ArgumentParser:
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers(dest="command")
+        p_send = subparsers.add_parser("send")
+        p_send.add_argument("--pr", type=int, required=True)
+        p_send.add_argument("--repo", required=True)
+        p_send.add_argument("--channel")
+        p_send.add_argument("--message")
+        p_send.add_argument("--message-file")
+        p_send.add_argument("--reviewer")
+        p_send.add_argument("--skip-slack", action="store_true")
+        p_send.add_argument("--skip-reviewers", action="store_true")
+        p_send.add_argument("--skip-checklist", action="store_true")
+        return parser
+
+    def test_skip_flags_default_to_false(self, send_parser: argparse.ArgumentParser):
+        args = send_parser.parse_args(["send", "--pr", "42", "--repo", "owner/repo"])
+        assert args.skip_slack is False
+        assert args.skip_reviewers is False
+        assert args.skip_checklist is False
+
+    def test_optional_args_default_to_none(self, send_parser: argparse.ArgumentParser):
+        args = send_parser.parse_args(["send", "--pr", "42", "--repo", "owner/repo"])
+        assert args.channel is None
+        assert args.message is None
+        assert args.message_file is None
+        assert args.reviewer is None
+
+    def test_skip_slack_flag_parsed(self, send_parser: argparse.ArgumentParser):
+        args = send_parser.parse_args(
+            ["send", "--pr", "1", "--repo", "owner/repo", "--skip-slack"]
+        )
+        assert args.skip_slack is True
+
+    def test_skip_reviewers_flag_parsed(self, send_parser: argparse.ArgumentParser):
+        args = send_parser.parse_args(
+            ["send", "--pr", "1", "--repo", "owner/repo", "--skip-reviewers"]
+        )
+        assert args.skip_reviewers is True
+
+    def test_skip_checklist_flag_parsed(self, send_parser: argparse.ArgumentParser):
+        args = send_parser.parse_args(
+            ["send", "--pr", "1", "--repo", "owner/repo", "--skip-checklist"]
+        )
+        assert args.skip_checklist is True
+
+    def test_all_optional_args_provided(self, send_parser: argparse.ArgumentParser):
+        args = send_parser.parse_args(
+            [
+                "send",
+                "--pr",
+                "99",
+                "--repo",
+                "myorg/myrepo",
+                "--channel",
+                "C123456",
+                "--message",
+                "Hello",
+                "--reviewer",
+                "myorg/reviewers",
+            ]
+        )
+        assert args.pr == 99
+        assert args.repo == "myorg/myrepo"
+        assert args.channel == "C123456"
+        assert args.message == "Hello"
+        assert args.reviewer == "myorg/reviewers"
+
+    def test_pr_parsed_as_int(self, send_parser: argparse.ArgumentParser):
+        args = send_parser.parse_args(["send", "--pr", "123", "--repo", "owner/repo"])
+        assert isinstance(args.pr, int)
+        assert args.pr == 123
+
+    def test_status_json_flag_default_false(self):
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers(dest="command")
+        p_status = subparsers.add_parser("status")
+        p_status.add_argument("--pr", type=int, required=True)
+        p_status.add_argument("--repo", required=True)
+        p_status.add_argument("--json", action="store_true")
+
+        args = parser.parse_args(["status", "--pr", "5", "--repo", "owner/repo"])
+        assert args.json is False
+
+    def test_status_json_flag_parsed(self):
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers(dest="command")
+        p_status = subparsers.add_parser("status")
+        p_status.add_argument("--pr", type=int, required=True)
+        p_status.add_argument("--repo", required=True)
+        p_status.add_argument("--json", action="store_true")
+
+        args = parser.parse_args(["status", "--pr", "5", "--repo", "owner/repo", "--json"])
+        assert args.json is True

--- a/tests/skills/release/test_collect_prs.py
+++ b/tests/skills/release/test_collect_prs.py
@@ -1,14 +1,20 @@
-"""Tests for collect_prs merged-PR batch fetch + matching (GH-550)."""
+"""Tests for collect_prs: merged-PR batch fetch/matching (GH-550) and
+pure-logic helpers (GH-587 F4a)."""
 
 from __future__ import annotations
 
 import json
 from unittest.mock import patch
 
+import pytest
+
 from dev10x.skills.release.collect_prs import (
     MERGED_PR_FETCH_LIMIT,
+    Commit,
+    collect_ticket_groups,
     fetch_merged_prs,
     find_matching_prs,
+    find_reverted_shas,
 )
 
 _RUN = "dev10x.skills.release.collect_prs.run"
@@ -71,3 +77,211 @@ class TestFindMatchingPrs:
 
     def test_empty_pr_list(self) -> None:
         assert find_matching_prs(ticket_id="GH-1", merged_prs=[]) == []
+
+
+def _commit(
+    sha: str,
+    subject: str,
+    is_revert: bool = False,
+    ticket_id: str | None = None,
+    category: str = "feature",
+    gitmoji: str = "✨",
+) -> Commit:
+    return Commit(
+        sha=sha,
+        subject=subject,
+        gitmoji=gitmoji,
+        category=category,
+        ticket_id=ticket_id,
+        is_revert=is_revert,
+    )
+
+
+class TestFindRevertedShas:
+    def test_empty_list_returns_empty_set(self):
+        result = find_reverted_shas(commits=[])
+        assert result == set()
+
+    def test_no_reverts_returns_empty_set(self):
+        commits = [
+            _commit(sha="abc12345", subject="✨ GH-1 Add feature"),
+            _commit(sha="def67890", subject="🐛 GH-2 Fix bug"),
+        ]
+        result = find_reverted_shas(commits=commits)
+        assert result == set()
+
+    def test_revert_with_full_sha_in_subject_adds_both(self):
+        full_sha = "a" * 40
+        commits = [
+            _commit(
+                sha="aaaaaa1a",
+                subject=f"Revert 'Fix something' (was {full_sha})",
+                is_revert=True,
+            ),
+        ]
+        result = find_reverted_shas(commits=commits)
+        # Adds truncated (first 8 chars) of the full SHA found in subject
+        assert "aaaaaaaa" in result
+        # Also adds the revert commit's own sha
+        assert "aaaaaa1a" in result
+
+    def test_revert_without_sha_in_subject_adds_only_revert_sha(self):
+        commits = [
+            _commit(
+                sha="deadbeef",
+                subject="Revert 'Some PR title' without a sha",
+                is_revert=True,
+            ),
+        ]
+        result = find_reverted_shas(commits=commits)
+        assert result == {"deadbeef"}
+
+    def test_non_revert_with_sha_in_subject_is_ignored(self):
+        full_sha = "b" * 40
+        commits = [
+            _commit(
+                sha="c0ffee01",
+                subject=f"✨ GH-10 References {full_sha} in message",
+                is_revert=False,
+            ),
+        ]
+        result = find_reverted_shas(commits=commits)
+        assert result == set()
+
+    def test_multiple_reverts(self):
+        sha1 = "1" * 40
+        sha2 = "2" * 40
+        commits = [
+            _commit(sha="aabbccdd", subject=f"Revert X ({sha1})", is_revert=True),
+            _commit(sha="11223344", subject=f"Revert Y ({sha2})", is_revert=True),
+        ]
+        result = find_reverted_shas(commits=commits)
+        assert "11111111" in result
+        assert "22222222" in result
+        assert "aabbccdd" in result
+        assert "11223344" in result
+
+    def test_revert_sha_truncated_to_8_chars(self):
+        full_sha = "fedcba9876543210" + "a" * 24
+        commits = [
+            _commit(
+                sha="00001111",
+                subject=f"Revert commit {full_sha}",
+                is_revert=True,
+            ),
+        ]
+        result = find_reverted_shas(commits=commits)
+        assert "fedcba98" in result
+
+    @pytest.mark.parametrize(
+        "subject",
+        [
+            "revert 'something'",
+            "REVERT something",
+            "Revert-and-fix nothing",
+        ],
+    )
+    def test_is_revert_flag_checked_not_subject(self, subject: str):
+        # The function uses c.is_revert (set by caller), not re-parsing subject.
+        # A commit tagged is_revert=False but with "revert" in subject is NOT treated as revert.
+        commits = [_commit(sha="cafebabe", subject=subject, is_revert=False)]
+        result = find_reverted_shas(commits=commits)
+        assert result == set()
+
+
+class TestCollectTicketGroups:
+    def test_empty_commits_returns_empty_dict(self):
+        result = collect_ticket_groups(commits=[], skip_shas=set())
+        assert result == {}
+
+    def test_commit_with_ticket_id_grouped_by_ticket(self):
+        commits = [
+            _commit(sha="aaa11111", subject="✨ GH-1 Feature", ticket_id="GH-1"),
+        ]
+        result = collect_ticket_groups(commits=commits, skip_shas=set())
+        assert "GH-1" in result
+        assert len(result["GH-1"]) == 1
+        assert result["GH-1"][0].sha == "aaa11111"
+
+    def test_multiple_commits_same_ticket_grouped_together(self):
+        commits = [
+            _commit(sha="aaa11111", subject="✨ GH-5 Feature part 1", ticket_id="GH-5"),
+            _commit(sha="bbb22222", subject="✨ GH-5 Feature part 2", ticket_id="GH-5"),
+        ]
+        result = collect_ticket_groups(commits=commits, skip_shas=set())
+        assert "GH-5" in result
+        assert len(result["GH-5"]) == 2
+
+    def test_commit_without_ticket_id_keyed_by_sha(self):
+        commits = [
+            _commit(sha="orphan01", subject="orphan commit", ticket_id=None),
+        ]
+        result = collect_ticket_groups(commits=commits, skip_shas=set())
+        assert "orphan01" in result
+        assert "GH-" not in str(list(result.keys()))
+
+    def test_skipped_sha_excluded(self):
+        commits = [
+            _commit(sha="skip0001", subject="✨ GH-99 Will be skipped", ticket_id="GH-99"),
+        ]
+        result = collect_ticket_groups(commits=commits, skip_shas={"skip0001"})
+        assert result == {}
+
+    def test_skip_category_excluded(self):
+        commits = [
+            _commit(
+                sha="bump0001",
+                subject="🔖 Bump version 1.2.3",
+                ticket_id=None,
+                category="version_bump",
+            ),
+        ]
+        result = collect_ticket_groups(commits=commits, skip_shas=set())
+        assert result == {}
+
+    def test_mix_of_skipped_and_normal_commits(self):
+        commits = [
+            _commit(sha="keep0001", subject="✨ GH-10 Normal", ticket_id="GH-10"),
+            _commit(sha="skip0002", subject="🔖 Bump", category="version_bump"),
+            _commit(sha="skip0003", subject="Revert X", ticket_id="GH-11", is_revert=True),
+        ]
+        result = collect_ticket_groups(commits=commits, skip_shas={"skip0003"})
+        assert "GH-10" in result
+        # skip0003 is in skip_shas
+        assert "GH-11" not in result
+        # version_bump category skipped
+        assert "skip0002" not in result
+        assert len(result) == 1
+
+    def test_distinct_tickets_separate_groups(self):
+        commits = [
+            _commit(sha="aaa11111", subject="✨ GH-1 Feature A", ticket_id="GH-1"),
+            _commit(sha="bbb22222", subject="🐛 GH-2 Fix B", ticket_id="GH-2"),
+        ]
+        result = collect_ticket_groups(commits=commits, skip_shas=set())
+        assert "GH-1" in result
+        assert "GH-2" in result
+        assert len(result) == 2
+
+    def test_commit_category_not_in_skip_categories_included(self):
+        commits = [
+            _commit(
+                sha="feat0001", subject="✨ GH-3 feature", ticket_id="GH-3", category="feature"
+            ),
+            _commit(sha="test0001", subject="✅ GH-4 tests", ticket_id="GH-4", category="test"),
+        ]
+        # "test" is in MAINTENANCE_CATEGORIES but NOT in SKIP_CATEGORIES
+        result = collect_ticket_groups(commits=commits, skip_shas=set())
+        assert "GH-3" in result
+        assert "GH-4" in result
+
+    def test_no_none_ticket_collision(self):
+        # Two commits without ticket IDs should each be keyed by their own sha
+        commits = [
+            _commit(sha="orphan01", subject="orphan 1", ticket_id=None),
+            _commit(sha="orphan02", subject="orphan 2", ticket_id=None),
+        ]
+        result = collect_ticket_groups(commits=commits, skip_shas=set())
+        assert "orphan01" in result
+        assert "orphan02" in result
+        assert len(result) == 2

--- a/tests/skills/slack/test_slack_notify_module.py
+++ b/tests/skills/slack/test_slack_notify_module.py
@@ -33,7 +33,7 @@ class TestGetToken:
             return "xoxb-from-default-keyring"
 
         monkeypatch.setattr(mod, "_keyring_lookup", fake_lookup)
-        assert mod.get_token() == "xoxb-from-default-keyring"
+        assert mod.get_token() == ok("xoxb-from-default-keyring")
         assert calls == [{"service": "slack", "key": "bot_token"}]
 
     def test_env_var_wins_over_default_keyring(
@@ -46,7 +46,7 @@ class TestGetToken:
             "_keyring_lookup",
             lambda *, service, key: "xoxb-from-default-keyring",
         )
-        assert mod.get_token() == "xoxb-from-env"
+        assert mod.get_token() == ok("xoxb-from-env")
 
     def test_workspace_uses_namespaced_keyring(
         self,
@@ -60,25 +60,27 @@ class TestGetToken:
 
         monkeypatch.setattr(mod, "_keyring_lookup", fake_lookup)
         mod.set_workspace("aperture")
-        assert mod.get_token() == "xoxb-aperture"
+        assert mod.get_token() == ok("xoxb-aperture")
         assert looked_up == ["slack-aperture"]
 
-    def test_workspace_missing_token_raises(
+    def test_workspace_missing_token_returns_err(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.setattr(mod, "_keyring_lookup", lambda *, service, key: None)
         mod.set_workspace("aperture")
-        with pytest.raises(RuntimeError, match="aperture"):
-            mod.get_token()
+        result = mod.get_token()
+        assert isinstance(result, ErrorResult)
+        assert "aperture" in result.error
 
-    def test_no_sources_raises(
+    def test_no_sources_returns_err(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.setattr(mod, "_keyring_lookup", lambda *, service, key: None)
-        with pytest.raises(RuntimeError, match="No Slack token found"):
-            mod.get_token()
+        result = mod.get_token()
+        assert isinstance(result, ErrorResult)
+        assert "No Slack token found" in result.error
 
     def test_workspace_keyring_service_override(
         self,
@@ -97,8 +99,35 @@ class TestGetToken:
 
         monkeypatch.setattr(mod, "_keyring_lookup", fake_lookup)
         mod.set_workspace("aperture")
-        assert mod.get_token() == "xoxb-aperture"
+        assert mod.get_token() == ok("xoxb-aperture")
         assert looked_up == ["custom-aperture"]
+
+
+class TestKeyringLookup:
+    """GH-587: _keyring_lookup routes through subprocess_utils.run."""
+
+    def test_returns_stripped_stdout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class FakeCompleted:
+            stdout = "  xoxb-secret\n"
+
+        monkeypatch.setattr(mod.subprocess_utils, "run", lambda *a, **k: FakeCompleted())
+        assert mod._keyring_lookup(service="slack", key="bot_token") == "xoxb-secret"
+
+    def test_returns_none_on_empty_stdout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class FakeCompleted:
+            stdout = "   \n"
+
+        monkeypatch.setattr(mod.subprocess_utils, "run", lambda *a, **k: FakeCompleted())
+        assert mod._keyring_lookup(service="slack", key="bot_token") is None
+
+    def test_returns_none_on_called_process_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import subprocess
+
+        def boom(*a: object, **k: object):
+            raise subprocess.CalledProcessError(returncode=1, cmd="lookup")
+
+        monkeypatch.setattr(mod.subprocess_utils, "run", boom)
+        assert mod._keyring_lookup(service="slack", key="bot_token") is None
 
 
 class TestWorkspaceConfigResolution:
@@ -231,6 +260,36 @@ class TestSendSlackMessageResult:
         monkeypatch.setattr(slack_sdk, "WebClient", BrokenClient)
         with pytest.raises(KeyError):
             mod.send_slack_message(channel="C123", message="hi")
+
+
+class TestNotifySlack:
+    """GH-587: notify_slack consolidates set_workspace + send behind one Result."""
+
+    def test_selects_workspace_and_passes_through(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict = {}
+
+        def fake_send(**kwargs: object):
+            captured.update(kwargs)
+            return ok("9.9")
+
+        monkeypatch.setattr(mod, "send_slack_message", fake_send)
+        result = mod.notify_slack(channel="C1", message="hi", workspace="aperture")
+        assert result == ok("9.9")
+        assert mod._active_workspace == "aperture"
+        assert captured["channel"] == "C1"
+        assert captured["message"] == "hi"
+
+    def test_no_workspace_leaves_active_unchanged(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(mod, "send_slack_message", lambda **_: ok("1.0"))
+        result = mod.notify_slack(channel="C1", message="hi")
+        assert result == ok("1.0")
+        assert mod._active_workspace is None
 
 
 class TestUvxEnvImportSmoke:

--- a/tests/skills/upgrade-cleanup/test_update_paths.py
+++ b/tests/skills/upgrade-cleanup/test_update_paths.py
@@ -377,6 +377,31 @@ class TestInitUserspaceConfig:
         assert result["exit_code"] == 1
         assert any("Plugin default config not found" in e for e in result["errors"])
 
+    def test_rechecks_inside_lock_when_config_appears(
+        self,
+        config_paths: tuple[Path, Path, Path],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Double-checked locking (GH-587): a config that appears between the
+        outer check and the lock must not be clobbered."""
+        from contextlib import contextmanager
+
+        memory, userspace, _plugin = config_paths
+        userspace.write_text("roots: [/work/legacy]\n")
+
+        @contextmanager
+        def racing_lock(path: Path, **_: object):
+            memory.write_text("roots: [/work/winner]\n")
+            yield
+
+        monkeypatch.setattr("dev10x.domain.file_locks.file_lock", racing_lock)
+
+        result = init_userspace_config()
+
+        assert result["exit_code"] == 0
+        assert memory.read_text() == "roots: [/work/winner]\n"
+        assert any("already exists" in m for m in result["messages"])
+
 
 class TestEnsureBasePermissions:
     @pytest.fixture()


### PR DESCRIPTION
**When** the 2026-06-10 architecture audit flags hardening gaps in the skills package, **I want to** unify the baseline-catalog loaders, adopt Result-based Slack notifications, close the init-path TOCTOU races, and backfill missing test/eval coverage, **so I can** keep src/dev10x/skills free of schema drift, silent failures, and lost-update races.

---

[`0096c408`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/689/commits/0096c408f0dc6caaf034dae95fced0c1d894843e) ♻️ GH-587 Stabilize skills package config and notify paths
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/587

---