### PR TITLE
♻️ GH-505 Enable typed permission policy in proactive seeding

### DIFF
--- a/src/dev10x/domain/common/policy.py
+++ b/src/dev10x/domain/common/policy.py
@@ -13,6 +13,12 @@ GH-271 evidence converged on:
   The shipped baseline is an allow catalog, but the model carries the
   effect so the deny catalog and ask-tier work can build on it.
 
+A fourth catalog attribute, **sensitivity** (``benign`` / ``pii`` /
+``secret``), rides alongside the converged three: it is the data-class of
+what a rule grants access to, and it gates which groups are safe to seed
+proactively. Untagged groups stay ``unspecified`` and are not assumed
+benign.
+
 A :class:`Policy` wraps an :class:`AllowRule` (the canonical matching
 value object) rather than reimplementing pattern matching. ``PolicyCatalog``
 parses the existing grouped catalog YAML into ``Policy`` objects, mirroring
@@ -73,6 +79,30 @@ class PolicySource(StrEnum):
         return _parse_enum(cls, raw)
 
 
+class PolicySensitivity(StrEnum):
+    """Data-sensitivity class of what a policy grants — gates proactive seeding."""
+
+    BENIGN = "benign"
+    PII = "pii"
+    SECRET = "secret"
+    UNSPECIFIED = "unspecified"
+
+    @classmethod
+    def default(cls) -> PolicySensitivity:
+        """Untagged groups are not assumed benign — they stay UNSPECIFIED."""
+        return cls.UNSPECIFIED
+
+    @classmethod
+    def from_yaml(cls, raw: object) -> PolicySensitivity:
+        """Parse a raw YAML value into a PolicySensitivity.
+
+        Empty/unknown/non-string values fall back to :meth:`default`
+        (``UNSPECIFIED``), so a missing tag never reads as ``BENIGN``.
+        Case-insensitive; trims surrounding whitespace.
+        """
+        return _parse_enum(cls, raw)
+
+
 def _parse_enum[E: StrEnum](enum_cls: type[E], raw: object) -> E:
     if not isinstance(raw, str):
         return enum_cls.default()  # type: ignore[attr-defined]
@@ -91,6 +121,7 @@ class Policy:
     tier: int
     source: PolicySource
     effect: PolicyEffect = PolicyEffect.ALLOW
+    sensitivity: PolicySensitivity = PolicySensitivity.UNSPECIFIED
     group: str = ""
 
     @property
@@ -110,6 +141,7 @@ class Policy:
         tier: int,
         source: PolicySource,
         effect: PolicyEffect = PolicyEffect.ALLOW,
+        sensitivity: PolicySensitivity = PolicySensitivity.UNSPECIFIED,
         group: str = "",
     ) -> Policy:
         return cls(
@@ -117,6 +149,7 @@ class Policy:
             tier=tier,
             source=source,
             effect=effect,
+            sensitivity=sensitivity,
             group=group,
         )
 
@@ -134,7 +167,8 @@ class PolicyCatalog:
 
         Each group contributes its ``rules`` as Policies carrying the
         group's ``tier`` (default ``0``), optional group-level ``effect``
-        (default ``allow``), the group name, and the supplied ``source``.
+        (default ``allow``), optional group-level ``sensitivity`` (default
+        ``unspecified``), the group name, and the supplied ``source``.
         Malformed groups, missing/non-list ``rules``, and non-string rule
         entries are skipped rather than raising.
         """
@@ -150,6 +184,7 @@ class PolicyCatalog:
                 continue
             tier = group.get("tier", 0)
             effect = PolicyEffect.from_yaml(group.get("effect"))
+            sensitivity = PolicySensitivity.from_yaml(group.get("sensitivity"))
             for rule in rules:
                 if not isinstance(rule, str):
                     continue
@@ -159,6 +194,7 @@ class PolicyCatalog:
                         tier=tier,
                         source=source,
                         effect=effect,
+                        sensitivity=sensitivity,
                         group=name,
                     )
                 )
@@ -181,4 +217,10 @@ class PolicyCatalog:
         return PolicyCatalog.from_baseline_dict(data, source=source)
 
 
-__all__ = ["Policy", "PolicyCatalog", "PolicyEffect", "PolicySource"]
+__all__ = [
+    "Policy",
+    "PolicyCatalog",
+    "PolicyEffect",
+    "PolicySensitivity",
+    "PolicySource",
+]

--- a/src/dev10x/skills/permission/promote.py
+++ b/src/dev10x/skills/permission/promote.py
@@ -37,9 +37,8 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 
-import yaml
-
 from dev10x.domain.common.mcp_tool_name import McpToolName
+from dev10x.domain.common.policy import PolicyCatalog, PolicySensitivity
 from dev10x.domain.sensitivity import name_is_sensitive, tokenize_identifier
 from dev10x.skills.permission.enumerate_mcp import (
     _server_prefix_from_tool,
@@ -424,25 +423,27 @@ def catalog_default_safe_surface(catalog_path: Path) -> tuple[list[str], list[st
     groups are skipped. Only MCP-tool and ``WebFetch(domain:…)`` rules are
     returned; ``Bash``/``Skill`` rules are seeded into project settings by
     ``ensure_base``, not promoted to global here.
+
+    The catalog is read through :meth:`PolicyCatalog.load` (GH-505) so the
+    tier/sensitivity gate runs against typed :class:`Policy` objects rather
+    than a raw dict — the proactive seeder is the first production consumer
+    of the GH-271 permission-policy model. ``load`` already tolerates a
+    missing file, unparseable YAML, or a non-mapping document by returning
+    an empty policy list, so this surface stays empty in those cases.
     """
-    try:
-        data = yaml.safe_load(Path(catalog_path).read_text())
-    except (OSError, yaml.YAMLError):
-        return [], []
+    policies = PolicyCatalog.load(catalog_path)
     tools: list[str] = []
     domains: list[str] = []
-    for group in (data or {}).get("groups", {}).values():
-        if group.get("tier") != 2 or group.get("sensitivity") != "benign":
+    for policy in policies:
+        if policy.tier != 2 or policy.sensitivity != PolicySensitivity.BENIGN:
             continue
-        for rule in group.get("rules", []):
-            if not isinstance(rule, str):
-                continue
-            if McpToolName.is_mcp(rule) and not rule.endswith("*"):
-                tools.append(rule)
-            else:
-                match = _WEBFETCH_RE.match(rule)
-                if match:
-                    domains.append(match.group("domain"))
+        rule = policy.signature
+        if McpToolName.is_mcp(rule) and not rule.endswith("*"):
+            tools.append(rule)
+        else:
+            match = _WEBFETCH_RE.match(rule)
+            if match:
+                domains.append(match.group("domain"))
     return tools, domains
 
 

--- a/tests/domain/common/test_policy.py
+++ b/tests/domain/common/test_policy.py
@@ -22,6 +22,7 @@ from dev10x.domain.common.policy import (
     Policy,
     PolicyCatalog,
     PolicyEffect,
+    PolicySensitivity,
     PolicySource,
 )
 
@@ -77,6 +78,33 @@ class TestPolicySource:
         assert PolicySource.PLUGIN_DEFAULT.value == "plugin-default"
 
 
+class TestPolicySensitivity:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("benign", PolicySensitivity.BENIGN),
+            ("pii", PolicySensitivity.PII),
+            ("secret", PolicySensitivity.SECRET),
+            ("BENIGN", PolicySensitivity.BENIGN),
+            ("  Secret  ", PolicySensitivity.SECRET),
+        ],
+    )
+    def test_from_yaml_parses_known_values(self, raw: str, expected: PolicySensitivity) -> None:
+        assert PolicySensitivity.from_yaml(raw) == expected
+
+    @pytest.mark.parametrize("raw", ["", "  ", "private", None, 5, ["benign"]])
+    def test_from_yaml_falls_back_to_default(self, raw: object) -> None:
+        assert PolicySensitivity.from_yaml(raw) == PolicySensitivity.default()
+
+    def test_default_is_unspecified(self) -> None:
+        # A missing sensitivity tag must NOT read as benign — untagged groups
+        # are excluded from the proactive-seed surface.
+        assert PolicySensitivity.default() == PolicySensitivity.UNSPECIFIED
+
+    def test_str_value_round_trips(self) -> None:
+        assert PolicySensitivity.PII.value == "pii"
+
+
 class TestPolicy:
     def test_from_rule_str_parses_allow_rule(self) -> None:
         policy = Policy.from_rule_str(
@@ -97,6 +125,19 @@ class TestPolicy:
     def test_group_defaults_to_empty(self) -> None:
         policy = Policy.from_rule_str("Bash(ls:*)", tier=1, source=PolicySource.PLUGIN_DEFAULT)
         assert policy.group == ""
+
+    def test_sensitivity_defaults_to_unspecified(self) -> None:
+        policy = Policy.from_rule_str("Bash(ls:*)", tier=1, source=PolicySource.PLUGIN_DEFAULT)
+        assert policy.sensitivity == PolicySensitivity.UNSPECIFIED
+
+    def test_explicit_sensitivity_is_preserved(self) -> None:
+        policy = Policy.from_rule_str(
+            "mcp__claude_ai_Sentry__search_issues",
+            tier=2,
+            source=PolicySource.PLUGIN_DEFAULT,
+            sensitivity=PolicySensitivity.BENIGN,
+        )
+        assert policy.sensitivity == PolicySensitivity.BENIGN
 
     def test_explicit_effect_is_preserved(self) -> None:
         policy = Policy.from_rule_str(
@@ -172,6 +213,23 @@ class TestPolicyCatalogFromDict:
         policies = PolicyCatalog.from_baseline_dict(_BASELINE)
         danger = next(p for p in policies if p.group == "danger")
         assert danger.effect == PolicyEffect.DENY
+
+    def test_missing_sensitivity_defaults_to_unspecified(self) -> None:
+        policies = PolicyCatalog.from_baseline_dict(_BASELINE)
+        assert all(p.sensitivity == PolicySensitivity.UNSPECIFIED for p in policies)
+
+    def test_group_level_sensitivity_applies_to_all_rules(self) -> None:
+        data = {
+            "groups": {
+                "mcp-readonly": {
+                    "tier": 2,
+                    "sensitivity": "benign",
+                    "rules": ["mcp__claude_ai_Acme__search", "mcp__claude_ai_Acme__get"],
+                },
+            }
+        }
+        policies = PolicyCatalog.from_baseline_dict(data)
+        assert all(p.sensitivity == PolicySensitivity.BENIGN for p in policies)
 
     def test_source_defaults_to_plugin_default(self) -> None:
         policies = PolicyCatalog.from_baseline_dict(_BASELINE)


### PR DESCRIPTION
**When** the proactive permission seeder reads the baseline catalog as raw dicts while the GH-271 `Policy`/`PolicyCatalog` model sits unused (exercised only by tests), **I want to** route the default-safe seed surface through the typed `PolicyCatalog`, **so I can** give the permission-policy model its first real production consumer and stop it drifting from the live string-based path.

---

[`f6bf5c52`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/690/commits/f6bf5c5264ed15cb54a59d1821a6275ae12396aa) ♻️ GH-505 Enable typed permission policy in proactive seeding
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/505

---