### PR TITLE
♻️ GH-518 Type domain models with value objects and enums

### DIFF
--- a/docs/adr/0008-context-boundary-protocol.md
+++ b/docs/adr/0008-context-boundary-protocol.md
@@ -242,6 +242,23 @@ Shipped together under GH-244 (one PR, atomic commits per finding):
 
 5. I1 (`audit → skills`) — tracked for M7 under ADR-0010.
 
+## Patterns Used
+
+This ADR's "domain owns the contract, adapters inject the
+implementation" shape is the **Separated Interface** pattern
+(Fowler, *PoEAA*): the interface is declared in one package and its
+implementation lives in another, so the using package depends only
+on the interface. In this codebase:
+
+- `dev10x.domain.audit_writer.AuditWriter` — implemented by
+  `dev10x.audit.log_reader` (the `hooks → audit` inversion).
+- `dev10x.domain.config_loader.ConfigLoader` — implemented by
+  `dev10x.config.loader`.
+
+Both Protocols are structural Separated Interfaces (PEP 544), and
+their docstrings name the pattern so contributors can cross-
+reference them against each other.
+
 ## References
 
 ### Internal References

--- a/src/dev10x/domain/audit_writer.py
+++ b/src/dev10x/domain/audit_writer.py
@@ -1,12 +1,16 @@
 """AuditWriter — domain-owned contract for the hook audit log surface.
 
-The hooks layer (``dev10x.hooks.audit_emit``) needs to mint span ids,
-classify outcomes, and append audit records, but it must not import the
+This Protocol is a **Separated Interface** (Fowler PoEAA): the
+interface lives in the ``domain/`` core while its implementation
+lives in a different package (``audit/``). The hooks layer
+(``dev10x.hooks.audit_emit``) needs to mint span ids, classify
+outcomes, and append audit records, but it must not import the
 ``audit/`` adapter's internals directly (audit memo Finding I6 — the
 ``hooks → audit`` inversion). This Protocol declares the surface in the
 core; ``dev10x.audit.log_reader`` provides the concrete implementation,
 and the hooks layer depends on the Protocol and receives the concrete
-writer through a single injection seam.
+writer through a single injection seam. ``ConfigLoader`` in
+``dev10x.domain.config_loader`` is the same pattern in the same layer.
 
 See ADR-0008 (context boundary protocol) for the dependency-direction
 rule this enforces.

--- a/src/dev10x/domain/common/__init__.py
+++ b/src/dev10x/domain/common/__init__.py
@@ -1,0 +1,20 @@
+"""Value Objects shared across the domain core (Fowler PoEAA).
+
+Most modules in this package define a frozen dataclass that is a
+textbook **Value Object** — identity by value, immutable, no
+lifecycle. ``SkillName``, ``BranchName``, ``TicketId``,
+``RepositoryRef``, and ``AllowRule`` are the canonical examples;
+their sibling single-value wrappers follow the same shape. (The
+``policy`` module additionally hosts ``StrEnum`` effect/tier types,
+and ``result`` holds the shared ``Result`` contract — neither is a
+Value Object.)
+
+New Value Objects added here should preserve the convention:
+``@dataclass(frozen=True)`` with equality by value and no mutable
+state. Document deviations explicitly rather than introducing a
+mutable variant by accident.
+
+This package re-exports nothing — import the concrete type from its
+sibling module (e.g. ``from dev10x.domain.common.branch_name import
+BranchName``).
+"""

--- a/src/dev10x/domain/config_loader.py
+++ b/src/dev10x/domain/config_loader.py
@@ -1,9 +1,12 @@
 """ConfigLoader Protocol — shared interface for YAML config loading.
 
-Defines the loading interface that config/loader.py implements
-with msgpack caching. Standalone uv scripts in skills/permission/
-may inline their own loading — this is an acceptable trade-off
-since they run outside the dev10x package context.
+This is a **Separated Interface** (Fowler PoEAA): the interface lives
+in the ``domain/`` core while ``config/loader.py`` provides the
+concrete implementation with msgpack caching — the same pattern as
+``dev10x.domain.audit_writer.AuditWriter``. Standalone uv scripts in
+skills/permission/ may inline their own loading — this is an
+acceptable trade-off since they run outside the dev10x package
+context.
 """
 
 from __future__ import annotations

--- a/src/dev10x/domain/documents/session_context.py
+++ b/src/dev10x/domain/documents/session_context.py
@@ -12,8 +12,8 @@ from __future__ import annotations
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
 
+from dev10x.domain.documents.session_state import PlanSummary, SessionState
 from dev10x.domain.documents.session_yaml import SessionYamlDocument
 from dev10x.domain.friction_level import FrictionLevel
 from dev10x.domain.git_context import GitContext
@@ -40,9 +40,9 @@ class SessionContextQuery:
     toplevel: str
     branch: str = "unknown"
     worktree_name: str = ""
-    state: dict[str, Any] = field(default_factory=dict)
+    session_state: SessionState | None = None
     plan_exists: bool = False
-    plan_data: dict[str, Any] = field(default_factory=dict)
+    plan: PlanSummary | None = None
     friction_level: FrictionLevel = field(default_factory=FrictionLevel.default)
     modified_files: list[str] = field(default_factory=list)
     staged_files: list[str] = field(default_factory=list)
@@ -55,14 +55,18 @@ class SessionContextQuery:
         state = claim_state_file(path=state_path_for_toplevel(toplevel=toplevel))
         plan_path = plan_path_for_toplevel(toplevel=toplevel)
         plan_exists = plan_path.exists()
-        plan_data = read_plan_summary(toplevel=toplevel) if plan_exists else {}
+        plan = (
+            PlanSummary.from_dict(data=read_plan_summary(toplevel=toplevel))
+            if plan_exists
+            else None
+        )
         friction_level = SessionYamlDocument(toplevel=toplevel).read_friction_level()
 
         return cls(
             toplevel=toplevel,
-            state=state,
+            session_state=SessionState.from_dict(data=state) if state else None,
             plan_exists=plan_exists,
-            plan_data=plan_data,
+            plan=plan,
             friction_level=friction_level,
         )
 
@@ -85,7 +89,11 @@ class SessionContextQuery:
 
         plan_path = plan_path_for_toplevel(toplevel=toplevel)
         plan_exists = plan_path.exists()
-        plan_data = read_plan_summary(toplevel=toplevel) if plan_exists else {}
+        plan = (
+            PlanSummary.from_dict(data=read_plan_summary(toplevel=toplevel))
+            if plan_exists
+            else None
+        )
         friction_level = SessionYamlDocument(toplevel=toplevel).read_friction_level()
 
         return cls(
@@ -93,7 +101,7 @@ class SessionContextQuery:
             branch=branch,
             worktree_name=worktree_name,
             plan_exists=plan_exists,
-            plan_data=plan_data,
+            plan=plan,
             friction_level=friction_level,
             modified_files=modified,
             staged_files=staged,
@@ -108,23 +116,20 @@ def _format_files(*, files: list[str]) -> str:
 
 def format_reload_context(*, ctx: SessionContextQuery) -> str:
     """Render a SessionContextQuery as the SessionStart additionalContext."""
-    from dev10x.domain.documents.session_state import PlanSummary, SessionState
 
-    if not ctx.state and not ctx.plan_exists:
+    if ctx.session_state is None and ctx.plan is None:
         return ""
 
     parts: list[str] = []
-    if ctx.state:
-        state_text = SessionState.from_dict(data=ctx.state).format_for_display()
+    if ctx.session_state is not None:
+        state_text = ctx.session_state.format_for_display()
         if state_text:
             parts.append(state_text)
-    if ctx.plan_exists:
-        plan_text = PlanSummary.from_dict(data=ctx.plan_data).format_for_display()
+    if ctx.plan is not None:
+        plan_text = ctx.plan.format_for_display()
         if plan_text:
             parts.append(plan_text)
-        guidance = DecisionGuidanceRule(
-            plan=ctx.plan_data, friction_level=ctx.friction_level
-        ).apply()
+        guidance = DecisionGuidanceRule(plan=ctx.plan, friction_level=ctx.friction_level).apply()
         if guidance:
             parts.append(guidance)
     return "\n\n".join(parts)
@@ -132,7 +137,6 @@ def format_reload_context(*, ctx: SessionContextQuery) -> str:
 
 def format_compaction_summary(*, ctx: SessionContextQuery, plugin_root: Path) -> str:
     """Render a SessionContextQuery as the PreCompact systemMessage body."""
-    from dev10x.domain.documents.session_state import PlanSummary
 
     essentials_file = plugin_root / ".claude" / "rules" / "essentials.md"
     essentials = essentials_file.read_text() if essentials_file.exists() else ""
@@ -152,16 +156,13 @@ def format_compaction_summary(*, ctx: SessionContextQuery, plugin_root: Path) ->
     if essentials:
         summary += f"\n\n## Essential Conventions (from essentials.md)\n{essentials}"
 
-    if ctx.plan_exists:
-        plan = PlanSummary.from_dict(data=ctx.plan_data)
-        summary += "\n\n" + plan.format_for_compaction()
-        if not plan.context.routing_table:
+    if ctx.plan is not None:
+        summary += "\n\n" + ctx.plan.format_for_compaction()
+        if not ctx.plan.context.routing_table:
             recovery_file = plugin_root / "references" / "compaction-recovery.md"
             if recovery_file.exists():
                 summary += f"\n\n{recovery_file.read_text()}"
-        guidance = DecisionGuidanceRule(
-            plan=ctx.plan_data, friction_level=ctx.friction_level
-        ).apply()
+        guidance = DecisionGuidanceRule(plan=ctx.plan, friction_level=ctx.friction_level).apply()
         if guidance:
             summary += f"\n\n### Resume Guidance\n{guidance}"
         summary += (

--- a/src/dev10x/domain/session_rules.py
+++ b/src/dev10x/domain/session_rules.py
@@ -19,7 +19,6 @@ rule and ADR-0007 for the Policy Rule archetype these satisfy.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
 
 from dev10x.domain.documents.session_state import PlanSummary
 from dev10x.domain.friction_level import FrictionLevel
@@ -40,16 +39,15 @@ class DecisionGuidanceRule(PolicyRule[str]):
     for adaptive sessions) as a latent bug.
     """
 
-    plan: dict[str, Any]
+    plan: PlanSummary
     friction_level: FrictionLevel
 
     def apply(self) -> str:
         if not isinstance(self.friction_level, FrictionLevel):
             raise UnknownFrictionLevelError(f"Unknown friction level: {self.friction_level!r}")
 
-        summary = PlanSummary.from_dict(data=self.plan)
-        if not summary.pending_decisions:
-            if summary.has_remaining_tasks:
+        if not self.plan.pending_decisions:
+            if self.plan.has_remaining_tasks:
                 return "Session resumed with tasks remaining. Auto-advance through the task list."
             return ""
 

--- a/src/dev10x/hooks/session.py
+++ b/src/dev10x/hooks/session.py
@@ -69,7 +69,11 @@ def _read_friction_level(*, toplevel: str):
 
 def _format_decision_guidance(*, plan, friction_level):
     """Compatibility shim — prefer ``DecisionGuidanceRule(...).apply()``."""
-    return DecisionGuidanceRule(plan=plan, friction_level=friction_level).apply()
+    from dev10x.domain.documents.session_state import PlanSummary
+
+    return DecisionGuidanceRule(
+        plan=PlanSummary.from_dict(data=plan), friction_level=friction_level
+    ).apply()
 
 
 __all__ = [

--- a/src/dev10x/scope/_matcher.py
+++ b/src/dev10x/scope/_matcher.py
@@ -1,13 +1,11 @@
 """Shared path-matching helper for norms/safeguards renderers (GH-170).
 
-Uses ``fnmatch`` semantics over POSIX paths. ``**`` is treated as
-``*`` after a one-time substitution, matching the loose convention
-INDEX.md uses (e.g. ``**/*.py``).
+Per-entry matching (``**`` → ``*`` fnmatch semantics) is owned by
+:meth:`dev10x.scope.index_parser.RuleEntry.matches`; this module only
+selects which entries match any affected file.
 """
 
 from __future__ import annotations
-
-from fnmatch import fnmatch
 
 from dev10x.scope.index_parser import RuleEntry
 
@@ -19,11 +17,4 @@ def select_matching(
 ) -> list[RuleEntry]:
     """Return entries whose any pattern matches any affected file."""
 
-    matched: list[RuleEntry] = []
-    for entry in entries:
-        for pattern in entry.patterns:
-            normalized = pattern.replace("**/", "*/").replace("**", "*")
-            if any(fnmatch(path, pattern) or fnmatch(path, normalized) for path in affected_files):
-                matched.append(entry)
-                break
-    return matched
+    return [entry for entry in entries if any(entry.matches(path=path) for path in affected_files)]

--- a/src/dev10x/scope/index_parser.py
+++ b/src/dev10x/scope/index_parser.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from fnmatch import fnmatch
 from pathlib import Path
 
 
@@ -36,6 +37,19 @@ class RuleEntry:
     patterns: tuple[str, ...]
     source: str
     description: str
+
+    def matches(self, *, path: str) -> bool:
+        """True when ``path`` matches any of this entry's patterns.
+
+        ``**`` is treated as ``*`` after a one-time substitution, matching
+        the loose convention INDEX.md uses (e.g. ``**/*.py``). Owning the
+        match here keeps the pattern-iteration loop out of callers.
+        """
+        for pattern in self.patterns:
+            normalized = pattern.replace("**/", "*/").replace("**", "*")
+            if fnmatch(path, pattern) or fnmatch(path, normalized):
+                return True
+        return False
 
 
 _TABLE_ROW_RE = re.compile(r"^\|(.+)\|\s*$")

--- a/src/dev10x/skills/doctor/registry.py
+++ b/src/dev10x/skills/doctor/registry.py
@@ -1,5 +1,12 @@
 """Strategy registry for Dev10x:plugin-doctor (GH-87).
 
+``load_strategies`` is a **Plugin loader** (Fowler PoEAA): module
+paths act as configuration and each module is bound late via
+``import_module``, collecting its ``STRATEGY`` constant. This is the
+same Plugin pattern ``dev10x.validators.registry`` uses for
+validators; the two loaders are independent today (a shared
+``PluginLoader[T]`` utility is a possible future consolidation).
+
 The registry knows how to load shipped strategies (plus optional
 user-defined strategies under
 ``~/.claude/Dev10x/doctor/strategies/``). Loading is explicit —

--- a/src/dev10x/skills/doctor/strategies/forbidden_token_priming.py
+++ b/src/dev10x/skills/doctor/strategies/forbidden_token_priming.py
@@ -17,6 +17,7 @@ authors.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 
 from dev10x.skills.doctor.strategy import (
@@ -25,6 +26,25 @@ from dev10x.skills.doctor.strategy import (
     Remediation,
     Strategy,
 )
+
+
+@dataclass(frozen=True)
+class ForbiddenTokenRemediation:
+    """Remediation payload for a forbidden-token-priming finding."""
+
+    token: str
+    suggested_replacement: str
+
+    def to_remediation(self, *, finding: Finding) -> Remediation:
+        return Remediation(
+            kind="file_issue",
+            target=finding.location,
+            action={
+                "token": self.token,
+                "replacement": self.suggested_replacement,
+            },
+        )
+
 
 FORBIDDEN_TOKENS: dict[str, str] = {
     "DEV10X_SKIP_CMD_VALIDATION": (
@@ -77,10 +97,10 @@ def _scan_skill_docs(*, context: Context) -> list[Finding]:
                             f"replace the literal mention with {suggested_replacement}; "
                             "keep the env var's true documentation in the hook layer only"
                         ),
-                        metadata={
-                            "token": token,
-                            "suggested_replacement": suggested_replacement,
-                        },
+                        data=ForbiddenTokenRemediation(
+                            token=token,
+                            suggested_replacement=suggested_replacement,
+                        ),
                     )
                 )
     return findings
@@ -91,14 +111,7 @@ def detect(context: Context) -> list[Finding]:
 
 
 def remediate(finding: Finding) -> Remediation:
-    return Remediation(
-        kind="file_issue",
-        target=finding.location,
-        action={
-            "token": finding.metadata.get("token"),
-            "replacement": finding.metadata.get("suggested_replacement"),
-        },
-    )
+    return finding.to_remediation()
 
 
 STRATEGY = Strategy(

--- a/src/dev10x/skills/doctor/strategies/mcp_horizontal_duplicates.py
+++ b/src/dev10x/skills/doctor/strategies/mcp_horizontal_duplicates.py
@@ -19,6 +19,7 @@ one machine (claude.ai, user-installed, plugin-distributed).
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 
 from dev10x.skills.doctor.strategy import (
@@ -32,6 +33,30 @@ from dev10x.skills.permission.enumerate_mcp import (
     build_capability_groups,
     discover_all_mcp_servers,
 )
+
+
+@dataclass(frozen=True)
+class HorizontalDuplicateRemediation:
+    """Remediation payload for an mcp-horizontal-duplicates finding."""
+
+    capability_group: str
+    server_count: int
+    entries: tuple[tuple[str, str], ...]
+
+    def to_remediation(self, *, finding: Finding) -> Remediation:
+        return Remediation(
+            kind="file_issue",
+            target="permissions.allow",
+            action={
+                "capability_group": self.capability_group,
+                "server_count": self.server_count,
+                "entries": [{"prefix": prefix, "tool": tool} for prefix, tool in self.entries],
+                "reason": (
+                    "Multiple MCP servers expose the same capability. "
+                    "Review and consolidate to reduce auth overhead."
+                ),
+            },
+        )
 
 
 def _settings_paths_from_context(context: Context) -> list[Path]:
@@ -75,14 +100,11 @@ def detect(context: Context) -> list[Finding]:
                     "Consolidating to a single source reduces auth/connection "
                     "overhead and simplifies the catalog."
                 ),
-                metadata={
-                    "capability_group": group.capability_group,
-                    "tool_name": group.tool_name,
-                    "server_count": group.server_count,
-                    "entries": [
-                        {"prefix": prefix, "tool": tool} for prefix, tool in group.entries
-                    ],
-                },
+                data=HorizontalDuplicateRemediation(
+                    capability_group=group.capability_group,
+                    server_count=group.server_count,
+                    entries=tuple(group.entries),
+                ),
             )
         )
     return findings
@@ -90,19 +112,7 @@ def detect(context: Context) -> list[Finding]:
 
 def remediate(finding: Finding) -> Remediation:
     """Propose surfacing the duplication as an informational file issue."""
-    return Remediation(
-        kind="file_issue",
-        target="permissions.allow",
-        action={
-            "capability_group": finding.metadata.get("capability_group"),
-            "server_count": finding.metadata.get("server_count"),
-            "entries": finding.metadata.get("entries", []),
-            "reason": (
-                "Multiple MCP servers expose the same capability. "
-                "Review and consolidate to reduce auth overhead."
-            ),
-        },
-    )
+    return finding.to_remediation()
 
 
 STRATEGY = Strategy(

--- a/src/dev10x/skills/doctor/strategies/mcp_vs_script_drift.py
+++ b/src/dev10x/skills/doctor/strategies/mcp_vs_script_drift.py
@@ -12,12 +12,36 @@ full equivalence table and detection heuristics.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from dev10x.skills.doctor.strategy import (
     Context,
     Finding,
     Remediation,
+    RemediationKind,
     Strategy,
 )
+
+
+@dataclass(frozen=True)
+class ScriptDriftRemediation:
+    """Remediation payload for an mcp-vs-script-drift finding.
+
+    ``kind`` is fixed at detection time (``edit_memory`` for memory
+    files, ``file_issue`` for SKILL.md ordering), so the remediator
+    no longer sniffs the evidence string to decide.
+    """
+
+    mcp_tool: str
+    kind: RemediationKind
+
+    def to_remediation(self, *, finding: Finding) -> Remediation:
+        return Remediation(
+            kind=self.kind,
+            target=finding.location,
+            action={"mcp_tool": self.mcp_tool},
+        )
+
 
 SCRIPT_TO_MCP: dict[str, str] = {
     "/tmp/Dev10x/bin/mktmp.sh": "mcp__plugin_Dev10x_cli__mktmp",
@@ -54,10 +78,10 @@ def _scan_memory(*, context: Context) -> list[Finding]:
                                 f"({mcp_tool}) instead — avoid quoting the obsolete "
                                 f"path even in negative examples"
                             ),
-                            metadata={
-                                "mcp_tool": mcp_tool,
-                                "script_marker": script_token,
-                            },
+                            data=ScriptDriftRemediation(
+                                mcp_tool=mcp_tool,
+                                kind="edit_memory",
+                            ),
                         )
                     )
     return findings
@@ -92,10 +116,10 @@ def _scan_skill_docs(*, context: Context) -> list[Finding]:
                             "first-class option; demote the script form to a "
                             "footnoted fallback"
                         ),
-                        metadata={
-                            "mcp_tool": mcp_tool,
-                            "script_marker": script_token,
-                        },
+                        data=ScriptDriftRemediation(
+                            mcp_tool=mcp_tool,
+                            kind="file_issue",
+                        ),
                     )
                 )
     return findings
@@ -106,17 +130,7 @@ def detect(context: Context) -> list[Finding]:
 
 
 def remediate(finding: Finding) -> Remediation:
-    if "memory" in finding.evidence:
-        return Remediation(
-            kind="edit_memory",
-            target=finding.location,
-            action={"mcp_tool": finding.metadata.get("mcp_tool")},
-        )
-    return Remediation(
-        kind="file_issue",
-        target=finding.location,
-        action={"mcp_tool": finding.metadata.get("mcp_tool")},
-    )
+    return finding.to_remediation()
 
 
 STRATEGY = Strategy(

--- a/src/dev10x/skills/doctor/strategies/missing_linear_mcp_allow.py
+++ b/src/dev10x/skills/doctor/strategies/missing_linear_mcp_allow.py
@@ -16,6 +16,7 @@ only incidentally.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 
 from dev10x.domain.common.allow_rule import AllowRuleLoader
@@ -25,6 +26,24 @@ from dev10x.skills.doctor.strategy import (
     Remediation,
     Strategy,
 )
+
+
+@dataclass(frozen=True)
+class LinearBaselineRemediation:
+    """Remediation payload for a missing-linear-mcp-allow finding."""
+
+    missing_tools: tuple[str, ...]
+
+    def to_remediation(self, *, finding: Finding) -> Remediation:
+        return Remediation(
+            kind="delegate_skill",
+            target="Dev10x:upgrade-cleanup",
+            action={
+                "reason": "install Linear MCP baseline allow rules",
+                "missing_tools": list(self.missing_tools),
+            },
+        )
+
 
 LINEAR_RULE_PREFIXES: tuple[str, ...] = (
     "mcp__claude_ai_Linear__",
@@ -81,23 +100,14 @@ def detect(context: Context) -> list[Finding]:
                     "ensure-base`) to install the Linear MCP baseline shipped "
                     "in `skills/upgrade-cleanup/projects.yaml`"
                 ),
-                metadata={
-                    "missing_tools": missing,
-                },
+                data=LinearBaselineRemediation(missing_tools=tuple(missing)),
             )
         )
     return findings
 
 
 def remediate(finding: Finding) -> Remediation:
-    return Remediation(
-        kind="delegate_skill",
-        target="Dev10x:upgrade-cleanup",
-        action={
-            "reason": "install Linear MCP baseline allow rules",
-            "missing_tools": finding.metadata.get("missing_tools", []),
-        },
-    )
+    return finding.to_remediation()
 
 
 STRATEGY = Strategy(

--- a/src/dev10x/skills/doctor/strategy.py
+++ b/src/dev10x/skills/doctor/strategy.py
@@ -39,6 +39,29 @@ class Context:
 
 
 @dataclass
+class Remediation:
+    """Concrete action that resolves a :class:`Finding`."""
+
+    kind: RemediationKind
+    target: str
+    action: dict = field(default_factory=dict)
+
+
+@runtime_checkable
+class RemediationData(Protocol):
+    """Typed remediation payload a strategy attaches to its findings.
+
+    Replaces the former untyped ``Finding.metadata`` dict (GH-518).
+    Each strategy defines a frozen dataclass implementing this
+    protocol so the knowledge of "which fields map to a Remediation"
+    lives with the data, not in an external ``remediate`` body that
+    reaches into a string-keyed bag.
+    """
+
+    def to_remediation(self, *, finding: Finding) -> Remediation: ...
+
+
+@dataclass
 class Finding:
     """One drift instance detected by a strategy."""
 
@@ -47,16 +70,21 @@ class Finding:
     location: str
     evidence: str
     proposed_fix: str
-    metadata: dict = field(default_factory=dict)
+    data: RemediationData | None = None
 
+    def to_remediation(self) -> Remediation:
+        """Build the :class:`Remediation` this finding's data describes.
 
-@dataclass
-class Remediation:
-    """Concrete action that resolves a :class:`Finding`."""
-
-    kind: RemediationKind
-    target: str
-    action: dict = field(default_factory=dict)
+        Tell-Don't-Ask: the finding owns the state needed to produce
+        a remediation, so it produces one instead of exposing a
+        dict for an external caller to unpack.
+        """
+        if self.data is None:
+            raise ValueError(
+                f"Finding for strategy {self.strategy_id!r} carries no "
+                "remediation data; cannot build a Remediation"
+            )
+        return self.data.to_remediation(finding=self)
 
 
 @runtime_checkable

--- a/src/dev10x/skills/permission_investigator/matrix.py
+++ b/src/dev10x/skills/permission_investigator/matrix.py
@@ -10,8 +10,19 @@ exercise the corresponding tool call, and records the outcome.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import StrEnum
 from itertools import product
 from typing import Literal
+
+
+class MatrixStatus(StrEnum):
+    """Outcome of exercising one matrix cell's rule shape."""
+
+    ERROR = "error"
+    WORKS = "works"
+    PROMPTS = "prompts"
+    UNKNOWN = "unknown"
+
 
 ToolKind = Literal["Read", "Bash", "Edit", "Write", "MCP"]
 RuleLocation = Literal["global", "project", "both", "neither"]
@@ -72,14 +83,14 @@ class MatrixResult:
     notes: str = ""
 
     @property
-    def status(self) -> str:
+    def status(self) -> MatrixStatus:
         if self.error:
-            return "error"
+            return MatrixStatus.ERROR
         if self.auto_approved and not self.prompted:
-            return "works"
+            return MatrixStatus.WORKS
         if self.prompted:
-            return "prompts"
-        return "unknown"
+            return MatrixStatus.PROMPTS
+        return MatrixStatus.UNKNOWN
 
 
 @dataclass
@@ -112,13 +123,13 @@ class MatrixQuery:
 
     matrix: Matrix
 
-    def aggregate(self) -> dict[str, list[MatrixResult]]:
+    def aggregate(self) -> dict[MatrixStatus, list[MatrixResult]]:
         """Group recorded results by status (works / prompts / error / unknown)."""
-        grouped: dict[str, list[MatrixResult]] = {
-            "works": [],
-            "prompts": [],
-            "error": [],
-            "unknown": [],
+        grouped: dict[MatrixStatus, list[MatrixResult]] = {
+            MatrixStatus.WORKS: [],
+            MatrixStatus.PROMPTS: [],
+            MatrixStatus.ERROR: [],
+            MatrixStatus.UNKNOWN: [],
         }
         known = {cell.cell_id for cell in self.matrix.cells}
         for cell_id, result in self.matrix.results.items():
@@ -127,7 +138,7 @@ class MatrixQuery:
             grouped.setdefault(result.status, []).append(result)
         return grouped
 
-    def shapes_for_status(self, *, status: str) -> set[tuple[PathPrefix, WildcardShape]]:
+    def shapes_for_status(self, *, status: MatrixStatus) -> set[tuple[PathPrefix, WildcardShape]]:
         """Return the (prefix, wildcard) shapes whose cells recorded ``status``."""
         return {
             (cell.shape.prefix, cell.shape.wildcard)

--- a/src/dev10x/skills/permission_investigator/report.py
+++ b/src/dev10x/skills/permission_investigator/report.py
@@ -19,6 +19,7 @@ from dev10x.skills.permission_investigator.matrix import (
     Matrix,
     MatrixQuery,
     MatrixResult,
+    MatrixStatus,
     PathPrefix,
     WildcardShape,
 )
@@ -30,7 +31,7 @@ class Delta:
     suggested_rules: list[str]
 
 
-def aggregate_results(matrix: Matrix) -> dict[str, list[MatrixResult]]:
+def aggregate_results(matrix: Matrix) -> dict[MatrixStatus, list[MatrixResult]]:
     """Group results by status (works / prompts / error / unknown)."""
     return MatrixQuery(matrix=matrix).aggregate()
 
@@ -48,7 +49,12 @@ def render_markdown_report(matrix: Matrix) -> str:
     lines.append("")
     lines.append("| Status | Count |")
     lines.append("|--------|-------|")
-    for status in ("works", "prompts", "error", "unknown"):
+    for status in (
+        MatrixStatus.WORKS,
+        MatrixStatus.PROMPTS,
+        MatrixStatus.ERROR,
+        MatrixStatus.UNKNOWN,
+    ):
         lines.append(f"| {status} | {len(grouped.get(status, []))} |")
     lines.append("")
 
@@ -58,11 +64,11 @@ def render_markdown_report(matrix: Matrix) -> str:
     lines.append("|------|------|--------|----------|----------|--------|-------|")
     for cell in matrix.cells:
         result = matrix.results.get(cell.cell_id)
-        status = result.status if result else "(not run)"
+        cell_status = result.status if result else "(not run)"
         notes = (result.notes if result else "").replace("|", "\\|")
         lines.append(
             f"| `{cell.cell_id}` | {cell.shape.tool} | {cell.shape.prefix} | "
-            f"{cell.shape.wildcard} | {cell.location} | {status} | {notes} |"
+            f"{cell.shape.wildcard} | {cell.location} | {cell_status} | {notes} |"
         )
     lines.append("")
     return "\n".join(lines) + "\n"
@@ -78,8 +84,8 @@ def compute_delta(
     A rule is flagged ineffective when at least one matrix cell with
     a matching wildcard/prefix shape was recorded as ``prompts``.
     """
-    prompting_shapes = _shapes_for_status(matrix=matrix, status="prompts")
-    working_shapes = _shapes_for_status(matrix=matrix, status="works")
+    prompting_shapes = _shapes_for_status(matrix=matrix, status=MatrixStatus.PROMPTS)
+    working_shapes = _shapes_for_status(matrix=matrix, status=MatrixStatus.WORKS)
 
     ineffective: list[str] = []
     for rule in base_permissions:
@@ -99,7 +105,7 @@ def compute_delta(
 def _shapes_for_status(
     *,
     matrix: Matrix,
-    status: str,
+    status: MatrixStatus,
 ) -> set[tuple[PathPrefix, WildcardShape]]:
     return MatrixQuery(matrix=matrix).shapes_for_status(status=status)
 

--- a/src/dev10x/skills/playbook/compare.py
+++ b/src/dev10x/skills/playbook/compare.py
@@ -28,7 +28,19 @@ or a CLI summary without re-parsing.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import StrEnum
 from typing import Any
+
+
+class DiffStatus(StrEnum):
+    """Outcome of comparing one step or play against the default."""
+
+    NEW = "new"
+    REMOVED = "removed"
+    CHANGED = "changed"
+    UNCHANGED = "unchanged"
+    NOT_OVERRIDDEN = "not-overridden"
+
 
 # Step fields the diff inspects. ``steps`` (epic children) and ``fragment``
 # are handled separately because they recurse / are structural references.
@@ -56,14 +68,26 @@ class FieldDiff:
     user_value: Any  # MISSING sentinel when the user did not set the field
 
 
+_STEP_SYMBOLS: dict[DiffStatus, str] = {
+    DiffStatus.NEW: "+",
+    DiffStatus.REMOVED: "-",
+    DiffStatus.CHANGED: "~",
+    DiffStatus.UNCHANGED: " ",
+}
+
+
 @dataclass
 class StepDiff:
     """Per-step diff entry."""
 
     subject: str
-    status: str  # "new" | "removed" | "changed" | "unchanged"
+    status: DiffStatus
     customized_fields: list[str] = field(default_factory=list)
     upstream_changed_fields: list[FieldDiff] = field(default_factory=list)
+
+    def symbol(self) -> str:
+        """Return the one-character render marker for this step's status."""
+        return _STEP_SYMBOLS.get(self.status, "?")
 
 
 @dataclass
@@ -71,9 +95,13 @@ class PlayDiff:
     """Per-play diff entry."""
 
     play_name: str
-    status: str  # "new" | "removed" | "changed" | "unchanged" | "not-overridden"
+    status: DiffStatus
     step_diffs: list[StepDiff] = field(default_factory=list)
     prompt_changed: bool = False
+
+    def is_actionable(self) -> bool:
+        """True when the play needs user attention (not unchanged/defaulted)."""
+        return self.status not in (DiffStatus.UNCHANGED, DiffStatus.NOT_OVERRIDDEN)
 
 
 @dataclass
@@ -90,10 +118,7 @@ class PlaybookDiff:
 
     @property
     def has_findings(self) -> bool:
-        return any(
-            p.status not in ("unchanged", "not-overridden")
-            for p in self.play_diffs + self.fragment_diffs
-        )
+        return any(p.is_actionable() for p in self.play_diffs + self.fragment_diffs)
 
 
 def _step_key(step: dict[str, Any]) -> str:
@@ -142,7 +167,7 @@ def _diff_step(
             continue
         if user_value != default_value:
             customized.append(key)
-    status = "changed" if upstream_changed or customized else "unchanged"
+    status = DiffStatus.CHANGED if upstream_changed or customized else DiffStatus.UNCHANGED
     return StepDiff(
         subject=subject,
         status=status,
@@ -174,10 +199,10 @@ def _diff_steps(
                 )
             )
         else:
-            diffs.append(StepDiff(subject=key, status="new"))
+            diffs.append(StepDiff(subject=key, status=DiffStatus.NEW))
     for key in user_index:
         if key not in default_index:
-            diffs.append(StepDiff(subject=key, status="removed"))
+            diffs.append(StepDiff(subject=key, status=DiffStatus.REMOVED))
     return diffs
 
 
@@ -204,10 +229,10 @@ def _diff_play(
     """Diff one play. ``user_steps=None`` means the user has not overridden it."""
     default_steps = default_play.get("steps") or []
     if user_steps is None:
-        return PlayDiff(play_name=play_name, status="not-overridden")
+        return PlayDiff(play_name=play_name, status=DiffStatus.NOT_OVERRIDDEN)
     step_diffs = _diff_steps(default_steps=default_steps, user_steps=user_steps)
-    has_changes = any(diff.status != "unchanged" for diff in step_diffs)
-    status = "changed" if has_changes else "unchanged"
+    has_changes = any(diff.status != DiffStatus.UNCHANGED for diff in step_diffs)
+    status = DiffStatus.CHANGED if has_changes else DiffStatus.UNCHANGED
     return PlayDiff(play_name=play_name, status=status, step_diffs=step_diffs)
 
 
@@ -223,20 +248,20 @@ def _diff_fragments(
             continue
         user_steps = user_fragments.get(name)
         if not isinstance(user_steps, list):
-            diffs.append(PlayDiff(play_name=name, status="not-overridden"))
+            diffs.append(PlayDiff(play_name=name, status=DiffStatus.NOT_OVERRIDDEN))
             continue
         step_diffs = _diff_steps(default_steps=default_steps, user_steps=user_steps)
-        has_changes = any(d.status != "unchanged" for d in step_diffs)
+        has_changes = any(d.status != DiffStatus.UNCHANGED for d in step_diffs)
         diffs.append(
             PlayDiff(
                 play_name=name,
-                status="changed" if has_changes else "unchanged",
+                status=DiffStatus.CHANGED if has_changes else DiffStatus.UNCHANGED,
                 step_diffs=step_diffs,
             )
         )
     for name in user_fragments:
         if name not in default_fragments:
-            diffs.append(PlayDiff(play_name=name, status="removed"))
+            diffs.append(PlayDiff(play_name=name, status=DiffStatus.REMOVED))
     return diffs
 
 
@@ -279,7 +304,7 @@ def compare_playbooks(
             continue
         play_name = override.get("play")
         if play_name and play_name not in default_play_names:
-            play_diffs.append(PlayDiff(play_name=str(play_name), status="removed"))
+            play_diffs.append(PlayDiff(play_name=str(play_name), status=DiffStatus.REMOVED))
 
     fragment_diffs = _diff_fragments(
         default_fragments=default_fragments,

--- a/src/dev10x/skills/playbook/report.py
+++ b/src/dev10x/skills/playbook/report.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dev10x.skills.playbook.compare import (
     MISSING,
+    DiffStatus,
     FieldDiff,
     PlaybookDiff,
     PlayDiff,
@@ -32,13 +33,7 @@ def _render_field_diff(diff: FieldDiff) -> str:
 
 
 def _render_step(step_diff: StepDiff) -> list[str]:
-    symbol = {
-        "new": "+",
-        "removed": "-",
-        "changed": "~",
-        "unchanged": " ",
-    }.get(step_diff.status, "?")
-    header = f"{symbol} **{step_diff.subject}** _({step_diff.status})_"
+    header = f"{step_diff.symbol()} **{step_diff.subject}** _({step_diff.status})_"
     lines = [header]
     if step_diff.customized_fields:
         joined = ", ".join(sorted(step_diff.customized_fields))
@@ -50,15 +45,15 @@ def _render_step(step_diff: StepDiff) -> list[str]:
 
 def _render_play(play: PlayDiff, *, kind: str) -> list[str]:
     heading = f"### {kind}: `{play.play_name}` — {play.status}"
-    if play.status == "unchanged":
+    if play.status == DiffStatus.UNCHANGED:
         return [heading, "  (no upstream changes detected)"]
-    if play.status == "not-overridden":
+    if play.status == DiffStatus.NOT_OVERRIDDEN:
         return [heading, "  (user has not overridden this — defaults apply)"]
-    if play.status == "removed":
+    if play.status == DiffStatus.REMOVED:
         return [heading, "  (no longer present in plugin default — orphan override)"]
     lines: list[str] = [heading]
     for step_diff in play.step_diffs:
-        if step_diff.status == "unchanged":
+        if step_diff.status == DiffStatus.UNCHANGED:
             continue
         lines.extend(_render_step(step_diff))
     return lines
@@ -79,7 +74,7 @@ def render_markdown_report(diff: PlaybookDiff) -> str:
         lines.append("**No upstream changes detected.** User customizations are up to date.")
         return "\n".join(lines) + "\n"
 
-    overridden = [p for p in diff.play_diffs if p.status not in ("unchanged", "not-overridden")]
+    overridden = [p for p in diff.play_diffs if p.is_actionable()]
     if overridden:
         lines.append("### Plays with upstream changes")
         lines.append("")
@@ -87,9 +82,7 @@ def render_markdown_report(diff: PlaybookDiff) -> str:
             lines.extend(_render_play(play, kind="Play"))
             lines.append("")
 
-    fragments_with_changes = [
-        f for f in diff.fragment_diffs if f.status not in ("unchanged", "not-overridden")
-    ]
+    fragments_with_changes = [f for f in diff.fragment_diffs if f.is_actionable()]
     if fragments_with_changes:
         lines.append("### Fragments with upstream changes")
         lines.append("")

--- a/tests/domain/test_policy_rule.py
+++ b/tests/domain/test_policy_rule.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from dev10x.domain.documents.session_state import PlanSummary
 from dev10x.domain.friction_level import FrictionLevel
 from dev10x.domain.rules.policy_rule import PolicyRule
 from dev10x.domain.session_rules import (
@@ -19,7 +20,9 @@ from dev10x.hooks.session_policy import MigratePluginPermissionsRule
 @pytest.mark.parametrize(
     "rule",
     [
-        DecisionGuidanceRule(plan={}, friction_level=FrictionLevel.default()),
+        DecisionGuidanceRule(
+            plan=PlanSummary.from_dict(data={}), friction_level=FrictionLevel.default()
+        ),
         BuildAutonomyReassuranceRule(friction_level=FrictionLevel.default(), active_modes=[]),
         MigratePluginPermissionsRule(plugin_root=Path("/p"), home_path=Path("/h")),
     ],

--- a/tests/scope/test_index_parser.py
+++ b/tests/scope/test_index_parser.py
@@ -73,3 +73,24 @@ class TestParseIndex:
         entries = parse_index(index_path=path)
         assert len(entries) == 1
         assert entries[0].source == "good"
+
+
+class TestRuleEntryMatches:
+    def _entry(self, *patterns: str) -> RuleEntry:
+        return RuleEntry(patterns=patterns, source="s", description="d")
+
+    def test_matches_literal_pattern(self) -> None:
+        entry = self._entry("src/foo.py")
+        assert entry.matches(path="src/foo.py") is True
+
+    def test_matches_double_star_glob(self) -> None:
+        entry = self._entry("**/*.py")
+        assert entry.matches(path="src/dev10x/foo.py") is True
+
+    def test_matches_any_of_multiple_patterns(self) -> None:
+        entry = self._entry("**/*.md", "**/*.py")
+        assert entry.matches(path="docs/readme.md") is True
+
+    def test_returns_false_when_no_pattern_matches(self) -> None:
+        entry = self._entry("**/*.py")
+        assert entry.matches(path="Makefile") is False

--- a/tests/session/test_queries.py
+++ b/tests/session/test_queries.py
@@ -13,7 +13,17 @@ from dev10x.domain.documents.session_context import (
     format_compaction_summary,
     format_reload_context,
 )
+from dev10x.domain.documents.session_state import PlanSummary, SessionState
 from dev10x.domain.friction_level import FrictionLevel
+
+
+def _plan(*, tasks: list[dict] | None = None) -> PlanSummary:
+    return PlanSummary.from_dict(
+        data={
+            "plan": {"branch": "b", "status": "in_progress", "last_synced": "t"},
+            "tasks": tasks if tasks is not None else [{"subject": "X", "status": "pending"}],
+        }
+    )
 
 
 def _ctx(**kwargs: Any) -> SessionContextQuery:
@@ -29,9 +39,13 @@ class TestSessionContextQueryDefaults:
         ctx = _ctx()
         assert ctx.worktree_name == ""
 
-    def test_state_defaults_to_empty_dict(self) -> None:
+    def test_session_state_defaults_to_none(self) -> None:
         ctx = _ctx()
-        assert ctx.state == {}
+        assert ctx.session_state is None
+
+    def test_plan_defaults_to_none(self) -> None:
+        ctx = _ctx()
+        assert ctx.plan is None
 
     def test_plan_exists_defaults_to_false(self) -> None:
         ctx = _ctx()
@@ -55,12 +69,28 @@ class TestSessionContextQueryDefaults:
 
 class TestFormatReloadContext:
     def test_returns_empty_when_no_state_and_no_plan(self) -> None:
-        ctx = _ctx(state={}, plan_exists=False)
+        ctx = _ctx(session_state=None, plan=None)
         assert format_reload_context(ctx=ctx) == ""
 
     def test_returns_empty_with_empty_state(self) -> None:
-        ctx = _ctx(state={}, plan_exists=False)
+        ctx = _ctx(session_state=None, plan=None)
         assert format_reload_context(ctx=ctx) == ""
+
+    def test_renders_state_section_when_present(self) -> None:
+        state = SessionState.from_dict(
+            data={
+                "timestamp": "2026-06-18T10:00:00+00:00",
+                "branch": "feature/x",
+                "session_id": "s",
+            }
+        )
+        ctx = _ctx(session_state=state)
+        assert "feature/x" in format_reload_context(ctx=ctx)
+
+    def test_renders_plan_section_and_guidance_when_present(self) -> None:
+        ctx = _ctx(plan_exists=True, plan=_plan())
+        rendered = format_reload_context(ctx=ctx)
+        assert "Auto-advance" in rendered
 
 
 class TestFormatCompactionSummary:
@@ -115,6 +145,12 @@ class TestFormatCompactionSummary:
     def test_returns_string(self, tmp_path: Path) -> None:
         ctx = _ctx()
         assert isinstance(format_compaction_summary(ctx=ctx, plugin_root=tmp_path), str)
+
+    def test_includes_plan_section_and_resume_guidance(self, tmp_path: Path) -> None:
+        ctx = _ctx(plan_exists=True, plan=_plan())
+        result = format_compaction_summary(ctx=ctx, plugin_root=tmp_path)
+        assert "Resume Guidance" in result
+        assert "Reconstructed from persisted plan file" in result
 
 
 class TestGatherReload:
@@ -193,7 +229,7 @@ class TestGatherReload:
         ):
             mock_doc.return_value.read_friction_level.return_value = FrictionLevel.default()
             ctx = SessionContextQuery.gather_reload(toplevel=str(tmp_path))
-        assert ctx.state == fake_state
+        assert ctx.session_state == SessionState.from_dict(data=fake_state)
 
 
 class TestGatherCompaction:

--- a/tests/skills/doctor/test_forbidden_token_priming.py
+++ b/tests/skills/doctor/test_forbidden_token_priming.py
@@ -10,6 +10,9 @@ strategy_mod = pytest.importorskip(
     "dev10x.skills.doctor.strategies.forbidden_token_priming",
     reason="dev10x not installed",
 )
+from dev10x.skills.doctor.strategies.forbidden_token_priming import (  # noqa: E402
+    ForbiddenTokenRemediation,
+)
 from dev10x.skills.doctor.strategy import Context, Finding  # noqa: E402
 
 
@@ -32,7 +35,8 @@ class TestDetect:
         finding = findings[0]
         assert finding.strategy_id == "forbidden-token-priming"
         assert finding.severity == "drift"
-        assert finding.metadata["token"] == "DEV10X_SKIP_CMD_VALIDATION"
+        assert finding.data is not None
+        assert finding.data.token == "DEV10X_SKIP_CMD_VALIDATION"
 
     def test_instructions_md_mentioning_forbidden_token_produces_finding(
         self,
@@ -118,10 +122,10 @@ class TestRemediate:
             location="/tmp/plugin/skills/x/SKILL.md",
             evidence="skill doc names forbidden token 'DEV10X_SKIP_CMD_VALIDATION'",
             proposed_fix="replace with structural guidance",
-            metadata={
-                "token": "DEV10X_SKIP_CMD_VALIDATION",
-                "suggested_replacement": "structural guidance",
-            },
+            data=ForbiddenTokenRemediation(
+                token="DEV10X_SKIP_CMD_VALIDATION",
+                suggested_replacement="structural guidance",
+            ),
         )
         remediation = strategy_mod.remediate(finding)
         assert remediation.kind == "file_issue"

--- a/tests/skills/doctor/test_mcp_horizontal_duplicates.py
+++ b/tests/skills/doctor/test_mcp_horizontal_duplicates.py
@@ -80,9 +80,9 @@ class TestMcpHorizontalDuplicatesDetect:
         findings = mcp_horizontal_duplicates.detect(context)
 
         for f in findings:
-            assert "capability_group" in f.metadata
-            assert "server_count" in f.metadata
-            assert f.metadata["server_count"] >= 2
+            assert f.data is not None
+            assert f.data.capability_group
+            assert f.data.server_count >= 2
 
     def test_finding_severity_is_suggestion(
         self, settings_with_three_sentry_servers: Path
@@ -155,11 +155,12 @@ class TestMcpHorizontalDuplicatesDetect:
         findings = mcp_horizontal_duplicates.detect(context)
 
         for f in findings:
-            entries = f.metadata.get("entries", [])
+            assert f.data is not None
+            entries = f.data.entries
             assert len(entries) >= 2
-            for entry in entries:
-                assert "prefix" in entry
-                assert "tool" in entry
+            for prefix, tool in entries:
+                assert prefix
+                assert tool
 
 
 class TestMcpHorizontalDuplicatesRemediate:

--- a/tests/skills/doctor/test_mcp_vs_script_drift.py
+++ b/tests/skills/doctor/test_mcp_vs_script_drift.py
@@ -28,7 +28,9 @@ class TestDetect:
         finding = findings[0]
         assert finding.strategy_id == "mcp-vs-script-drift"
         assert finding.severity == "drift"
-        assert finding.metadata["mcp_tool"] == "mcp__plugin_Dev10x_cli__mktmp"
+        assert finding.data is not None
+        assert finding.data.mcp_tool == "mcp__plugin_Dev10x_cli__mktmp"
+        assert finding.data.kind == "edit_memory"
 
     def test_skill_md_with_script_before_mcp_produces_finding(
         self,
@@ -79,13 +81,17 @@ class TestRemediate:
             location="/tmp/memory/old.md",
             evidence="memory references obsolete script ('/tmp/.../mktmp.sh')",
             proposed_fix="rewrite memory body",
-            metadata={"mcp_tool": "mcp__plugin_Dev10x_cli__mktmp"},
+            data=strategy_mod.ScriptDriftRemediation(
+                mcp_tool="mcp__plugin_Dev10x_cli__mktmp",
+                kind="edit_memory",
+            ),
         )
 
         remediation = strategy_mod.remediate(finding=finding)
 
         assert remediation.kind == "edit_memory"
         assert remediation.target == "/tmp/memory/old.md"
+        assert remediation.action["mcp_tool"] == "mcp__plugin_Dev10x_cli__mktmp"
 
     def test_skill_md_finding_maps_to_file_issue(self) -> None:
         from dev10x.skills.doctor.strategy import Finding
@@ -96,7 +102,10 @@ class TestRemediate:
             location="/plugin/skills/example/SKILL.md",
             evidence="SKILL.md shows script form before MCP form",
             proposed_fix="reorder",
-            metadata={"mcp_tool": "mcp__plugin_Dev10x_cli__pr_detect"},
+            data=strategy_mod.ScriptDriftRemediation(
+                mcp_tool="mcp__plugin_Dev10x_cli__pr_detect",
+                kind="file_issue",
+            ),
         )
 
         remediation = strategy_mod.remediate(finding=finding)

--- a/tests/skills/doctor/test_missing_linear_mcp_allow.py
+++ b/tests/skills/doctor/test_missing_linear_mcp_allow.py
@@ -73,10 +73,9 @@ class TestMissingLinearMcpAllowDetect:
         assert findings[0].strategy_id == "missing-linear-mcp-allow"
         assert findings[0].severity == "drift"
         assert str(settings_with_partial_linear) == findings[0].location
-        assert "missing_tools" in findings[0].metadata
+        assert findings[0].data is not None
         assert (
-            len(findings[0].metadata["missing_tools"])
-            >= missing_linear_mcp_allow.MISSING_THRESHOLD - 1
+            len(findings[0].data.missing_tools) >= missing_linear_mcp_allow.MISSING_THRESHOLD - 1
         )
 
     def test_silent_when_baseline_complete(self, settings_with_full_baseline: Path) -> None:

--- a/tests/skills/doctor/test_strategy.py
+++ b/tests/skills/doctor/test_strategy.py
@@ -1,0 +1,50 @@
+"""Tests for the shared doctor strategy types (GH-518)."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("dev10x.skills.doctor.strategy", reason="dev10x not installed")
+
+from dev10x.skills.doctor.strategy import (  # noqa: E402
+    Finding,
+    Remediation,
+    RemediationData,
+)
+
+
+class _StubData:
+    def to_remediation(self, *, finding: Finding) -> Remediation:
+        return Remediation(kind="file_issue", target=finding.location)
+
+
+class TestFindingToRemediation:
+    def test_delegates_to_attached_data(self) -> None:
+        finding = Finding(
+            strategy_id="stub",
+            severity="drift",
+            location="/tmp/x",
+            evidence="e",
+            proposed_fix="f",
+            data=_StubData(),
+        )
+
+        remediation = finding.to_remediation()
+
+        assert remediation.kind == "file_issue"
+        assert remediation.target == "/tmp/x"
+
+    def test_raises_when_no_data_attached(self) -> None:
+        finding = Finding(
+            strategy_id="stub",
+            severity="drift",
+            location="/tmp/x",
+            evidence="e",
+            proposed_fix="f",
+        )
+
+        with pytest.raises(ValueError, match="no remediation data"):
+            finding.to_remediation()
+
+    def test_stub_data_satisfies_protocol(self) -> None:
+        assert isinstance(_StubData(), RemediationData)

--- a/tests/skills/permission-investigator/test_matrix.py
+++ b/tests/skills/permission-investigator/test_matrix.py
@@ -13,6 +13,7 @@ from dev10x.skills.permission_investigator.matrix import (
     MatrixCell,
     MatrixQuery,
     MatrixResult,
+    MatrixStatus,
     RuleShape,
     generate_matrix,
 )
@@ -150,7 +151,7 @@ class TestMatrixResultStatus:
             prompted=False,
         )
 
-        assert result.status == "works"
+        assert result.status is MatrixStatus.WORKS
 
     def test_prompts_when_prompted_flag_set(self) -> None:
         result = MatrixResult(
@@ -159,7 +160,7 @@ class TestMatrixResultStatus:
             prompted=True,
         )
 
-        assert result.status == "prompts"
+        assert result.status is MatrixStatus.PROMPTS
 
     def test_error_short_circuits_status(self) -> None:
         result = MatrixResult(
@@ -169,7 +170,7 @@ class TestMatrixResultStatus:
             error="boom",
         )
 
-        assert result.status == "error"
+        assert result.status is MatrixStatus.ERROR
 
 
 class TestMatrixQuery:
@@ -198,9 +199,9 @@ class TestMatrixQuery:
 
         grouped = MatrixQuery(matrix=matrix).aggregate()
 
-        assert len(grouped["works"]) == 1
-        assert len(grouped["prompts"]) == 1
-        assert grouped["error"] == []
+        assert len(grouped[MatrixStatus.WORKS]) == 1
+        assert len(grouped[MatrixStatus.PROMPTS]) == 1
+        assert grouped[MatrixStatus.ERROR] == []
 
     def test_aggregate_ignores_results_without_a_cell(self) -> None:
         matrix = Matrix()
@@ -218,7 +219,7 @@ class TestMatrixQuery:
             }
         )
 
-        shapes = MatrixQuery(matrix=matrix).shapes_for_status(status="works")
+        shapes = MatrixQuery(matrix=matrix).shapes_for_status(status=MatrixStatus.WORKS)
 
         assert shapes == {("tilde", "literal")}
 

--- a/tests/skills/permission-investigator/test_report.py
+++ b/tests/skills/permission-investigator/test_report.py
@@ -8,6 +8,7 @@ from dev10x.skills.permission_investigator.matrix import (
     Matrix,
     MatrixCell,
     MatrixResult,
+    MatrixStatus,
     RuleShape,
 )
 from dev10x.skills.permission_investigator.report import (
@@ -61,9 +62,9 @@ class TestAggregateResults:
     def test_groups_results_by_status(self, populated_matrix: Matrix) -> None:
         grouped = aggregate_results(populated_matrix)
 
-        assert len(grouped["works"]) == 1
-        assert len(grouped["prompts"]) == 1
-        assert len(grouped["error"]) == 1
+        assert len(grouped[MatrixStatus.WORKS]) == 1
+        assert len(grouped[MatrixStatus.PROMPTS]) == 1
+        assert len(grouped[MatrixStatus.ERROR]) == 1
 
     def test_ignores_results_without_matching_cell(self) -> None:
         matrix = Matrix()
@@ -71,7 +72,7 @@ class TestAggregateResults:
 
         grouped = aggregate_results(matrix)
 
-        assert grouped["works"] == []
+        assert grouped[MatrixStatus.WORKS] == []
 
 
 class TestRenderMarkdownReport:

--- a/tests/skills/playbook/test_compare.py
+++ b/tests/skills/playbook/test_compare.py
@@ -6,6 +6,9 @@ import pytest
 
 from dev10x.skills.playbook.compare import (
     MISSING,
+    DiffStatus,
+    PlayDiff,
+    StepDiff,
     compare_playbooks,
 )
 
@@ -233,3 +236,31 @@ class TestComparePlaybooks:
         }
         result = _diff(default_doc, user)
         assert result.has_findings is True
+
+
+class TestDiffStatusBehavior:
+    def test_step_symbols_cover_each_status(self) -> None:
+        symbols = {
+            DiffStatus.NEW: "+",
+            DiffStatus.REMOVED: "-",
+            DiffStatus.CHANGED: "~",
+            DiffStatus.UNCHANGED: " ",
+        }
+        for status, expected in symbols.items():
+            assert StepDiff(subject="s", status=status).symbol() == expected
+
+    def test_not_overridden_step_symbol_falls_back(self) -> None:
+        step = StepDiff(subject="s", status=DiffStatus.NOT_OVERRIDDEN)
+        assert step.symbol() == "?"
+
+    def test_is_actionable_true_for_changes(self) -> None:
+        for status in (DiffStatus.NEW, DiffStatus.REMOVED, DiffStatus.CHANGED):
+            assert PlayDiff(play_name="p", status=status).is_actionable() is True
+
+    def test_is_actionable_false_for_quiet_statuses(self) -> None:
+        for status in (DiffStatus.UNCHANGED, DiffStatus.NOT_OVERRIDDEN):
+            assert PlayDiff(play_name="p", status=status).is_actionable() is False
+
+    def test_status_renders_as_its_string_value(self) -> None:
+        assert f"{DiffStatus.NOT_OVERRIDDEN}" == "not-overridden"
+        assert DiffStatus.NEW == "new"


### PR DESCRIPTION
**When** the PKG-M11 audit flags domain models that carry raw dicts or stringly-typed status, **I want to** replace them with typed value objects and StrEnums, **so I can** let static analysis catch key/status typos and keep behavior with the data it owns.

---

[`c4faf673`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/691/commits/c4faf673e2293cff48def2e1f8580261564f0703) ♻️ GH-518 Type doctor finding remediation payloads
[`b8457b83`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/691/commits/b8457b8335fab4607bc868961425968e24a77919) ♻️ GH-535 Type playbook diff status with DiffStatus enum
[`2962b3be`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/691/commits/2962b3be5d86db75df9d64725deeef993a258589) ♻️ GH-539 Type session, matrix, and rule-entry domain models
[`6d01ff5f`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/691/commits/6d01ff5fae233752d4c8f720e60d9c083663ed87) 📝 GH-534 Name Value Object, Plugin, and Separated Interface patterns

Bundle of the PKG-M11 (milestone #37) typed-value-object audit slice.
Note: GH-527 from the same slice was verified already-resolved on
develop and closed separately. Constituent issues are closed manually
after merge (keyword auto-close does not fire on the develop base).

Fixes: #518
Fixes: #535
Fixes: #539
Fixes: #534