### PR TITLE
♻️ GH-516 Name audit patterns and tighten module boundaries

### DIFF
--- a/docs/adr/0013-gateway-layer.md
+++ b/docs/adr/0013-gateway-layer.md
@@ -1,0 +1,57 @@
+# 13. Name the Gateway layer on `dev10x.github` and `subprocess_utils`
+
+Date: 2026-06-18
+
+## Status
+
+Accepted
+
+## Context
+
+The 2026-06-10 architecture audit (finding behind GH-516) observed
+that two modules implement the Gateway pattern (Fowler, *Patterns of
+Enterprise Application Architecture*) without ever naming it:
+
+| Module | External system | Uniform surface |
+|---|---|---|
+| `dev10x.github` | `gh` CLI + GitHub REST/GraphQL | `_gh_api_raw`, `async_run`, `async_run_script` |
+| `dev10x.subprocess_utils` | OS subprocess boundary | `run`, `async_run`, `async_run_script` |
+
+Both encapsulate access to an external system behind a single call
+surface, inject cross-cutting concerns (GitHub auth via `as_bot`,
+effective-CWD routing via `_effective_cwd` / `use_cwd`), and shield
+callers from the raw interface. The pattern was fully present, but
+neither module, nor any doc, named it. ADR-0006 records the *decision*
+to keep an internal GitHub Gateway rather than adopt the official
+GitHub MCP server, but it does not name the structural pattern — so a
+contributor adding the next external integration (Slack, Linear) had
+no template for how the boundary layer should be shaped.
+
+## Decision
+
+Name both modules as **Gateways** in their module docstrings, and
+record the layer here so the vocabulary is discoverable:
+
+- A Gateway wraps exactly one external system behind a uniform,
+  in-process call surface.
+- Cross-cutting concerns for that system (authentication, working
+  directory, timeout, output parsing) live *inside* the Gateway, not
+  at the call sites.
+- Callers MUST go through the Gateway — they never invoke `gh` or
+  `subprocess.run` directly. This is already enforced for subprocess
+  CWD routing by `.claude/rules/cwd-discipline.md` (GH-979).
+
+New external integrations should follow the same shape: one module,
+one external system, a uniform surface, concerns injected internally.
+
+## Consequences
+
+- Reviewers and contributors share a name for the boundary layer, and
+  a documented template for future integrations.
+- No behavioural change — this ADR and the docstrings are descriptive;
+  the code already implemented the pattern.
+- Extracting an explicit `GitGateway` class from the free functions in
+  `dev10x.git` (floated in the audit) is **deferred**: the free
+  functions already present a uniform surface, and a class wrapper
+  would be churn without a caller that needs polymorphism. Revisit if
+  a second git backend or a test-double seam is ever required.

--- a/src/dev10x/domain/common/singleton_holder.py
+++ b/src/dev10x/domain/common/singleton_holder.py
@@ -1,0 +1,49 @@
+"""Typed process-level singleton holder.
+
+**Not a Registry.** Per audit finding A3 the name ``Registry`` is
+reserved for static lookup tables (see ``dev10x.platform.registry`` and
+``PlatformRepository``'s docstring). This type owns a single *mutable*
+process-level slot — one swappable instance — so modules stop
+reimplementing the ``global _x`` + ``get_x()`` + ``set_x()`` trio
+independently (the DRY-at-the-architectural-level concern behind
+GH-522).
+
+Usage: construct one module-level holder seeded with a default (or
+empty), then expose thin ``get_*`` / ``set_*`` accessors that delegate
+to it::
+
+    _holder: SingletonHolder[SessionStore] = SingletonHolder(default=SessionStore())
+
+    def get_store() -> SessionStore:
+        store = _holder.get()
+        if store is None:
+            store = SessionStore()
+            _holder.set(store)
+        return store
+
+Tests swap the instance via the holder (or the public ``set_*``
+accessor) instead of monkey-patching a bare module global.
+"""
+
+from __future__ import annotations
+
+
+class SingletonHolder[T]:
+    """Holds one swappable process-level instance behind a typed slot."""
+
+    __slots__ = ("_value",)
+
+    def __init__(self, *, default: T | None = None) -> None:
+        self._value: T | None = default
+
+    def get(self) -> T | None:
+        """Return the held instance, or ``None`` when unset."""
+        return self._value
+
+    def set(self, value: T | None) -> None:
+        """Replace the held instance; pass ``None`` to clear the slot."""
+        self._value = value
+
+    def reset(self) -> None:
+        """Clear the slot back to ``None``."""
+        self._value = None

--- a/src/dev10x/github/__init__.py
+++ b/src/dev10x/github/__init__.py
@@ -3,6 +3,17 @@
 Extracted from cli_server.py — cohesive GitHub API and CLI operations.
 Each function takes explicit parameters and returns Result types.
 All public functions are async to avoid blocking the MCP event loop.
+
+**Pattern: Gateway** (Fowler, *PoEAA*). This module is the Gateway to
+the GitHub external system: every call to the ``gh`` CLI and the GitHub
+REST/GraphQL APIs is funnelled through ``_gh_api_raw`` / ``async_run`` /
+``async_run_script``, giving callers a uniform Python surface and a
+single place to inject auth (``as_bot`` bot-token routing) and the
+effective working directory. Callers never shell out to ``gh`` directly
+— they go through this Gateway, so authentication, repo resolution, and
+error wrapping stay in one layer. ADR-0006 records the decision to keep
+this internal Gateway instead of the official GitHub MCP server;
+ADR-0013 names the pattern across this module and ``subprocess_utils``.
 """
 
 from __future__ import annotations

--- a/src/dev10x/hooks/session.py
+++ b/src/dev10x/hooks/session.py
@@ -41,8 +41,6 @@ from dev10x.hooks.session_place import session_git_aliases, session_tmpdir
 from dev10x.hooks.session_policy import (
     DecisionGuidanceRule,
     _build_migration_replacements,
-    _deduplicate_rules,
-    _migrate_rules,
 )
 
 
@@ -93,11 +91,9 @@ __all__ = [
     "session_tmpdir",
     "_build_migration_replacements",
     "_claim_state_file",
-    "_deduplicate_rules",
     "_format_decision_guidance",
     "_format_plan_summary",
     "_format_session_state",
-    "_migrate_rules",
     "_read_friction_level",
     "_read_json",
 ]

--- a/src/dev10x/hooks/session_policy.py
+++ b/src/dev10x/hooks/session_policy.py
@@ -18,11 +18,7 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 
-from dev10x.domain.documents.settings_document import (
-    SettingsDocument,
-    _deduplicate_rules,
-    _migrate_rules,
-)
+from dev10x.domain.documents.settings_document import SettingsDocument
 from dev10x.domain.rules.policy_rule import PolicyRule
 from dev10x.domain.session_rules import (
     BuildAutonomyReassuranceRule,
@@ -122,6 +118,4 @@ __all__ = [
     "DecisionGuidanceRule",
     "MigratePluginPermissionsRule",
     "_build_migration_replacements",
-    "_migrate_rules",
-    "_deduplicate_rules",
 ]

--- a/src/dev10x/mcp/roots_manager.py
+++ b/src/dev10x/mcp/roots_manager.py
@@ -41,6 +41,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from dev10x.domain.common.result import Result, ok
+from dev10x.domain.common.singleton_holder import SingletonHolder
 
 if TYPE_CHECKING:  # pragma: no cover
     from mcp.server.session import ServerSession
@@ -212,7 +213,10 @@ class ClientRootsManager:
 
 # ── module-level registry ──────────────────────────────────────────
 
-_manager: ClientRootsManager | None = None
+#: Module-level singleton slot for the active manager. Backed by
+#: :class:`SingletonHolder` so the ``global``/``get``/``set`` trio is not
+#: reimplemented here (GH-522).
+_holder: SingletonHolder[ClientRootsManager] = SingletonHolder()
 
 # GH-498: the event loop holds only weak references to bare
 # ``create_task`` results, so a fire-and-forget refresh can be garbage
@@ -224,7 +228,7 @@ _background_tasks: set[asyncio.Task[None]] = set()
 
 def get_manager() -> ClientRootsManager | None:
     """Return the currently registered :class:`ClientRootsManager`, or ``None``."""
-    return _manager
+    return _holder.get()
 
 
 def list_roots() -> Result[dict[str, Any]]:
@@ -277,8 +281,7 @@ def wire_roots_to_server(
 
     import mcp.types as mcp_types
 
-    global _manager
-    _manager = manager
+    _holder.set(manager)
 
     async def _on_initialized(notification: mcp_types.InitializedNotification) -> None:
         try:

--- a/src/dev10x/mcp/session_store.py
+++ b/src/dev10x/mcp/session_store.py
@@ -12,7 +12,8 @@ Architecture
 designed to be owned by :class:`~dev10x.mcp.daemon.DaemonLifecycle`
 so all session data is cleared on daemon stop.
 
-The module exposes a *process-level singleton* (``_store``) that
+The module exposes a *process-level singleton* (held in a
+:class:`~dev10x.domain.common.singleton_holder.SingletonHolder`) that
 tool handlers can access via :func:`get_store`.  This pattern avoids
 threading the store through every call chain while keeping the
 store injectable for tests.
@@ -63,6 +64,8 @@ import os
 import threading
 import time
 from typing import Any
+
+from dev10x.domain.common.singleton_holder import SingletonHolder
 
 log = logging.getLogger(__name__)
 
@@ -358,9 +361,11 @@ class SessionStore:
 # Process-level singleton
 # ---------------------------------------------------------------------------
 
-#: Module-level singleton, used by tool handlers when no explicit store is
-#: injected.  Tests override it via :func:`set_store`.
-_store: SessionStore = SessionStore()
+#: Module-level singleton slot, used by tool handlers when no explicit
+#: store is injected.  Tests override it via :func:`set_store`. Backed by
+#: :class:`SingletonHolder` so the ``global``/``get``/``set`` trio is not
+#: reimplemented here (GH-522).
+_holder: SingletonHolder[SessionStore] = SingletonHolder(default=SessionStore())
 
 
 def get_store() -> SessionStore:
@@ -373,7 +378,11 @@ def get_store() -> SessionStore:
 
         entry = get_store().get_or_create(session_id)
     """
-    return _store
+    store = _holder.get()
+    if store is None:
+        store = SessionStore()
+        _holder.set(store)
+    return store
 
 
 def set_store(store: SessionStore) -> None:
@@ -382,13 +391,11 @@ def set_store(store: SessionStore) -> None:
     Intended for testing — inject a fresh store with custom TTL/max
     settings and restore it on teardown::
 
-        def test_something(monkeypatch):
-            fresh = SessionStore(ttl=60, max_sessions=10)
-            monkeypatch.setattr("dev10x.mcp.session_store._store", fresh)
+        def test_something():
+            set_store(SessionStore(ttl=60, max_sessions=10))
             ...
     """
-    global _store
-    _store = store
+    _holder.set(store)
 
 
 # ---------------------------------------------------------------------------

--- a/src/dev10x/subprocess_utils.py
+++ b/src/dev10x/subprocess_utils.py
@@ -1,4 +1,14 @@
-"""Shared utilities for calling external scripts via subprocess."""
+"""Shared utilities for calling external scripts via subprocess.
+
+**Pattern: Gateway** (Fowler, *PoEAA*). This module is the Gateway to
+the operating-system subprocess boundary: ``run`` / ``async_run`` /
+``async_run_script`` wrap every external-process invocation behind one
+call surface that transparently routes to the caller's effective
+working directory (see ``_effective_cwd`` / ``use_cwd`` below). Callers
+never reach for ``subprocess.run`` directly — going through this Gateway
+keeps CWD routing, timeout handling, and output parsing in a single
+layer. ADR-0013 names the pattern here and on ``dev10x.github``.
+"""
 
 from __future__ import annotations
 

--- a/src/dev10x/validators/README.md
+++ b/src/dev10x/validators/README.md
@@ -1,0 +1,46 @@
+# Validators
+
+Bash-command validators for Claude Code hooks. Each validator inspects a
+`HookInput` and decides whether to block, allow, or abstain (PreToolUse),
+and optionally how to correct a denied command (PermissionDenied).
+
+## Architecture
+
+The package is built from three named design patterns. Naming them keeps
+the short-circuit-vs-accumulate and add-a-filter decisions legible to
+contributors.
+
+| Pattern | GoF / PoEAA | Class | Role |
+|---|---|---|---|
+| Chain of Responsibility | GoF | `ValidatorChain.correct` | First validator returning a `HookRetry` wins — short-circuits the chain. |
+| Chain of Responsibility (accumulating variant) | GoF | `ValidatorChain.run` | Every applicable validator may emit a result; iteration continues so multiple validators speak. |
+| Strategy | GoF | `ValidatorFilter` (`ProfileFilter`, `DisableListFilter`, `ExperimentalFilter`) | Interchangeable `keep(spec)` predicates the registry applies at build time; new filtering policy = new strategy. |
+| Template Method | GoF | `ValidatorBase` | Declares the `should_run → validate` gate and the `rule_id`/`profile`/`experimental` metadata contract subclasses fill in. |
+
+`ValidatorRegistry` owns the `ValidatorSpec` list, applies the active
+`ValidatorFilter` strategies before importing any validator module
+(lazy import), and verifies each class's declared metadata matches its
+spec at registration time.
+
+### Choosing a chain variant
+
+When adding a validator, pick the path by intent:
+
+- **Pre-emptive** (must stop other validators from speaking) → implement
+  `correct()` so it joins the short-circuit `ValidatorChain.correct`
+  path.
+- **Independent opinion** (one of several voices) → implement
+  `validate()`; it joins the accumulating `ValidatorChain.run` path.
+
+### Adding a filter
+
+Write a new `@dataclass(frozen=True)` implementing the `ValidatorFilter`
+Protocol's `keep(spec) -> bool`, then add it to the `filters` list passed
+to `ValidatorRegistry`. No registry changes are required — that is the
+point of the Strategy boundary.
+
+## Profile tiers and rule IDs
+
+See `.claude/rules/hook-patterns.md` § Profile Tiers for the
+`minimal`/`standard`/`strict` tier assignments and the `DXNNN` rule-ID
+table.

--- a/src/dev10x/validators/registry.py
+++ b/src/dev10x/validators/registry.py
@@ -56,7 +56,14 @@ class ValidatorSpec:
 
 
 class ValidatorFilter(Protocol):
-    """Composable predicate applied to specs at registry-build time."""
+    """Composable predicate applied to specs at registry-build time.
+
+    **Pattern: Strategy** (GoF). Each concrete filter (:class:`ProfileFilter`,
+    :class:`DisableListFilter`, :class:`ExperimentalFilter`) is an
+    interchangeable ``keep`` strategy; the registry holds a list of them
+    and applies them in turn, so new filtering policies are added by
+    writing a new strategy rather than editing the registry.
+    """
 
     def keep(self, spec: ValidatorSpec) -> bool:
         """Return True to retain ``spec`` in the active set."""
@@ -201,13 +208,20 @@ def _assert_metadata_matches(*, instance: Validator, spec: ValidatorSpec) -> Non
 class ValidatorChain:
     """Iterates active validators for a single :class:`HookInput`.
 
-    Two entry points:
+    **Pattern: Chain of Responsibility** (GoF), in two variants:
 
-      :meth:`run` — for PreToolUse: emits every non-None ``validate()``
-        result; iteration continues so multiple validators may speak.
+      :meth:`correct` — for PermissionDenied: the canonical CoR —
+        short-circuits at the first validator returning a
+        :class:`HookRetry` (first handler wins).
 
-      :meth:`correct` — for PermissionDenied: short-circuits at the
-        first validator returning a :class:`HookRetry`.
+      :meth:`run` — for PreToolUse: an *accumulating* CoR variant —
+        emits every non-None ``validate()`` result; iteration continues
+        so multiple validators may speak rather than the first winning.
+
+    Choosing the variant is the contributor's decision per new
+    validator: a validator that must pre-empt others belongs on the
+    short-circuit path; one that contributes an independent opinion
+    belongs on the accumulating path.
 
     A validator raising during ``should_run``/``validate``/``correct``
     is always logged (GH-494 — previously silent unless ``HOOK_DEBUG``).

--- a/tests/domain/common/test_singleton_holder.py
+++ b/tests/domain/common/test_singleton_holder.py
@@ -1,0 +1,30 @@
+"""Unit tests for the typed process-level singleton holder (GH-522)."""
+
+from __future__ import annotations
+
+from dev10x.domain.common.singleton_holder import SingletonHolder
+
+
+class TestSingletonHolder:
+    def test_empty_holder_returns_none(self) -> None:
+        holder: SingletonHolder[str] = SingletonHolder()
+        assert holder.get() is None
+
+    def test_seeded_holder_returns_default(self) -> None:
+        holder: SingletonHolder[str] = SingletonHolder(default="seed")
+        assert holder.get() == "seed"
+
+    def test_set_replaces_value(self) -> None:
+        holder: SingletonHolder[str] = SingletonHolder(default="seed")
+        holder.set("replaced")
+        assert holder.get() == "replaced"
+
+    def test_set_none_clears_slot(self) -> None:
+        holder: SingletonHolder[str] = SingletonHolder(default="seed")
+        holder.set(None)
+        assert holder.get() is None
+
+    def test_reset_clears_slot(self) -> None:
+        holder: SingletonHolder[str] = SingletonHolder(default="seed")
+        holder.reset()
+        assert holder.get() is None

--- a/tests/hooks/test_session_start_hooks.py
+++ b/tests/hooks/test_session_start_hooks.py
@@ -459,7 +459,7 @@ class TestBuildMigrationReplacements:
 
 class TestMigrateRules:
     def test_replaces_old_path_in_rule(self, tmp_path: Path) -> None:
-        from dev10x.hooks.session import _migrate_rules
+        from dev10x.domain.documents.settings_document import _migrate_rules
 
         old = str(tmp_path / "old") + "/"
         new = str(tmp_path / "new") + "/"
@@ -470,7 +470,7 @@ class TestMigrateRules:
         assert new in result[0]
 
     def test_preserves_unmatched_rules(self) -> None:
-        from dev10x.hooks.session import _migrate_rules
+        from dev10x.domain.documents.settings_document import _migrate_rules
 
         rules = ["Read", "Write", "Bash(~/.claude/tools/:*)"]
         result, count = _migrate_rules(rules=rules, replacements=[("/old/", "/new/")])
@@ -481,7 +481,7 @@ class TestMigrateRules:
 
 class TestDeduplicateRules:
     def test_removes_duplicates(self) -> None:
-        from dev10x.hooks.session import _deduplicate_rules
+        from dev10x.domain.documents.settings_document import _deduplicate_rules
 
         rules = ["rule-a", "rule-b", "rule-a", "rule-c"]
         result = _deduplicate_rules(rules=rules)
@@ -489,7 +489,7 @@ class TestDeduplicateRules:
         assert result == ["rule-a", "rule-b", "rule-c"]
 
     def test_preserves_order(self) -> None:
-        from dev10x.hooks.session import _deduplicate_rules
+        from dev10x.domain.documents.settings_document import _deduplicate_rules
 
         rules = ["c", "a", "b", "a"]
         result = _deduplicate_rules(rules=rules)

--- a/tests/mcp/test_session_store.py
+++ b/tests/mcp/test_session_store.py
@@ -26,6 +26,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from dev10x.domain.common.singleton_holder import SingletonHolder
 from dev10x.mcp.session_store import (
     SessionEntry,
     SessionStore,
@@ -407,7 +408,7 @@ class TestSingleton:
 
     def test_set_store_replaces_singleton(self, monkeypatch: pytest.MonkeyPatch) -> None:
         fresh = SessionStore(ttl=10.0, max_sessions=5)
-        monkeypatch.setattr("dev10x.mcp.session_store._store", fresh)
+        monkeypatch.setattr("dev10x.mcp.session_store._holder", SingletonHolder(default=fresh))
         assert get_store() is fresh
 
     def test_set_store_function(self, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
**When** reviewing or extending the plugin internals after the 2026-06-10 architecture audit, **I want to** have the Gateway, Chain-of-Responsibility, Strategy, and process-singleton boundaries named and sealed, **so I can** reuse the right template for new code and trust that archetype boundaries hold.

This bundles four PKG-M11 pattern/naming findings into one review cycle: GH-516 (Gateway layer), GH-526 (validator Chain of Responsibility + Strategy), GH-521 (Document-helper boundary seal), and GH-522 (typed singleton holder — re-scoped, see below).

Note: GH-522's original "Registry[T]" recommendation was stale — finding A10 already removed the validators `_registry` global and finding A3 reserves the name "Registry" for static lookup tables. Re-scoped to a typed `SingletonHolder[T]` (explicitly not a Registry) for the two remaining mutable singletons; `sampling_manager` is left as a follow-up adopter.

---

[`8426fd9c`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/692/commits/8426fd9cd6ba3afed7a7703a227b72e25188cebd) 📝 GH-516 Name the Gateway layer on github and subprocess
[`b114b9ad`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/692/commits/b114b9ad0d27768d45b22f8dc75fc2f9dd7a0dc8) 📝 GH-526 Name the validator Chain of Responsibility patterns
[`b6359dee`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/692/commits/b6359dee20154845148c5101954731c8502d6825) ♻️ GH-521 Seal Document helpers behind their archetype boundary
[`c9bfc858`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/692/commits/c9bfc8587650909226d6453cb443baf0cccb70b9) ♻️ GH-522 Unify process-level singletons behind a typed holder
Closes #526
Closes #521
Closes #522
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/516

---