### PR TITLE
♻️ GH-541 Consolidate audit pattern seams across permissions and session hooks

### DIFF
--- a/hooks/scripts/session-start.py
+++ b/hooks/scripts/session-start.py
@@ -95,32 +95,60 @@ class SessionFeature(NamedTuple):
     name — ``@dataclass`` + ``from __future__ import annotations`` does a
     ``sys.modules`` lookup that fails outside a registered module.
 
-    ``mode`` selects the calling convention:
-      - ``"capture"`` — wrap with ``audit_hook`` and capture stdout
-        (legacy print-based features). ``pass_data`` forwards stdin.
-      - ``"build"``  — call directly and use the returned string.
-    ``emits_context`` is False for side-effect-only features (tmpdir).
+    ``run`` encapsulates the calling convention for this feature — it
+    receives ``(data, audit_hook)`` and returns the context string (or
+    ``""``). Use :func:`capture_feature` or :func:`build_feature` to
+    construct a ``SessionFeature`` with the correct ``run`` callable
+    rather than building it by hand.
     """
 
     name: str
     fn: Callable[..., Any]
-    mode: str
-    pass_data: bool = False
-    emits_context: bool = True
+    run: Callable[..., str]
 
 
-def _run_session_feature(*, feature: SessionFeature, data: dict, audit_hook) -> str:
-    """Run one feature, returning the context string to append (or "")."""
-    if feature.mode == "build":
+def capture_feature(
+    *,
+    name: str,
+    fn: Callable[..., Any],
+    pass_data: bool = False,
+    emits_context: bool = True,
+) -> SessionFeature:
+    """Return a ``SessionFeature`` that wraps ``fn`` with ``audit_hook`` and captures stdout.
+
+    Used for legacy print-based features. When ``pass_data`` is True, the
+    stdin ``data`` dict is forwarded to ``fn``. When ``emits_context`` is
+    False the captured stdout is discarded (side-effect-only features such
+    as tmpdir setup).
+    """
+
+    def _run(data: dict, audit_hook) -> str:
+        inner_fn = (lambda: fn(data=data)) if pass_data else fn
+        out = _run_feature(name=name, fn=inner_fn, audit_hook=audit_hook)
+        return out.strip() if emits_context else ""
+
+    return SessionFeature(name=name, fn=fn, run=_run)
+
+
+def build_feature(*, name: str, fn: Callable[..., Any]) -> SessionFeature:
+    """Return a ``SessionFeature`` that calls ``fn`` directly and uses the returned string.
+
+    Used for features that return their context string rather than printing it.
+    """
+
+    def _run(data: dict, audit_hook) -> str:  # noqa: ARG001
         try:
-            return feature.fn() or ""
+            return fn() or ""
         except Exception:
             traceback.print_exc(file=sys.stderr)
             return ""
 
-    fn = (lambda: feature.fn(data=data)) if feature.pass_data else feature.fn
-    out = _run_feature(name=feature.name, fn=fn, audit_hook=audit_hook)
-    return out.strip() if feature.emits_context else ""
+    return SessionFeature(name=name, fn=fn, run=_run)
+
+
+def _run_session_feature(*, feature: SessionFeature, data: dict, audit_hook) -> str:
+    """Run one feature, returning the context string to append (or "")."""
+    return feature.run(data, audit_hook)
 
 
 def main() -> None:
@@ -129,36 +157,19 @@ def main() -> None:
 
     # Order matters for readability of the merged additionalContext.
     features = [
-        SessionFeature(name="session-git-aliases", fn=s.session_git_aliases, mode="capture"),
-        SessionFeature(
+        capture_feature(name="session-git-aliases", fn=s.session_git_aliases),
+        capture_feature(
             name="session-tmpdir",
             fn=s.session_tmpdir,
-            mode="capture",
             pass_data=True,
             emits_context=False,
         ),
-        SessionFeature(name="session-guidance", fn=s.build_guidance_context, mode="build"),
-        SessionFeature(
-            name="session-autonomy",
-            fn=s.build_autonomy_reassurance_context,
-            mode="build",
-        ),
-        SessionFeature(
-            name="session-install-check",
-            fn=s.build_install_check_context,
-            mode="build",
-        ),
-        SessionFeature(
-            name="session-hook-version-drift",
-            fn=s.build_hook_version_drift_context,
-            mode="build",
-        ),
-        SessionFeature(
-            name="session-migrate-permissions",
-            fn=s.session_migrate_permissions,
-            mode="capture",
-        ),
-        SessionFeature(name="session-reload", fn=s.build_reload_context, mode="build"),
+        build_feature(name="session-guidance", fn=s.build_guidance_context),
+        build_feature(name="session-autonomy", fn=s.build_autonomy_reassurance_context),
+        build_feature(name="session-install-check", fn=s.build_install_check_context),
+        build_feature(name="session-hook-version-drift", fn=s.build_hook_version_drift_context),
+        capture_feature(name="session-migrate-permissions", fn=s.session_migrate_permissions),
+        build_feature(name="session-reload", fn=s.build_reload_context),
     ]
 
     context_parts: list[str] = []

--- a/src/dev10x/audit/permissions_model.py
+++ b/src/dev10x/audit/permissions_model.py
@@ -21,8 +21,8 @@ from typing import TextIO
 
 from dev10x.audit.transcript_grammar import TOOL_INPUT_BLOCK_RE, TOOL_RE, TURN_RE
 from dev10x.domain.common.allow_rule import AllowRule, AllowRuleLoader
-from dev10x.domain.common.mcp_tool_name import McpToolName
 from dev10x.domain.common.mktmp_path import MktmpPath
+from dev10x.domain.common.tool_signature import ToolSignature
 from dev10x.subprocess_utils import effective_cwd
 
 PERMISSION_TOOLS = {"Bash", "Read", "Write", "Edit"}
@@ -78,13 +78,13 @@ class ToolCall:
         return self.tool == "Bash"
 
     def signature(self) -> str:
-        if self.is_bash():
-            return f"Bash({self.command})"
-        if self.tool in ("Write", "Read", "Edit") and self.file_path:
-            return f"{self.tool}({self.file_path})"
-        if McpToolName.is_mcp(self.tool):
-            return self.tool
-        return f"{self.tool}()"
+        return str(
+            ToolSignature.build(
+                tool_name=self.tool,
+                command=self.command,
+                file_path=self.file_path,
+            )
+        )
 
 
 @dataclass

--- a/src/dev10x/commands/permission.py
+++ b/src/dev10x/commands/permission.py
@@ -48,6 +48,29 @@ def _require_context(*, include_user: bool | None = None) -> PermissionContext:
     return result.value
 
 
+def _require_settings(
+    *,
+    include_user: bool | None = None,
+    show_config: bool = False,
+    quiet: bool = False,
+) -> PermissionContext | None:
+    """Resolve a context that has settings files, or signal an early return.
+
+    Folds the per-command preamble every ``ensure_*`` / ``doctor_*`` handler
+    repeated (audit GH-541 Template Method): resolve the context, optionally
+    echo the config path, and guard on an empty ``settings_files`` set.
+    Returns ``None`` after emitting "No settings files found." so callers
+    early-return with a single ``if ctx is None: return``.
+    """
+    ctx = _require_context(include_user=include_user)
+    if show_config and not quiet:
+        click.echo(f"Config: {ctx.config_path}")
+    if not ctx.settings_files:
+        click.echo("No settings files found.")
+        return None
+    return ctx
+
+
 @permission.command(name="update-paths")
 @click.option("--dry-run", is_flag=True, help="Show changes without modifying files")
 @click.option(
@@ -77,15 +100,11 @@ def update_paths(
     if restore:
         sys.exit(mod._restore(config_path=_require_config(mod)))
 
-    ctx = _require_context()
-    if not quiet:
-        click.echo(f"Config: {ctx.config_path}")
-    config = ctx.config
-
-    settings_files = ctx.settings_files
-    if not settings_files:
-        click.echo("No settings files found.")
+    ctx = _require_settings(show_config=True, quiet=quiet)
+    if ctx is None:
         return
+    config = ctx.config
+    settings_files = ctx.settings_files
 
     cache_dir = Path(config["plugin_cache"]).expanduser()
     target = target_version or mod.detect_latest_version(cache_dir)
@@ -162,11 +181,8 @@ def ensure_base(*, dry_run: bool, quiet: bool) -> None:
     """Add missing base permissions from projects.yaml."""
     from dev10x.skills.permission import update_paths as mod
 
-    ctx = _require_context()
-    if not quiet:
-        click.echo(f"Config: {ctx.config_path}")
-    if not ctx.settings_files:
-        click.echo("No settings files found.")
+    ctx = _require_settings(show_config=True, quiet=quiet)
+    if ctx is None:
         return
 
     sys.exit(
@@ -188,9 +204,8 @@ def generalize(*, dry_run: bool, quiet: bool) -> None:
     """Replace session-specific permission args with wildcard patterns."""
     from dev10x.skills.permission import update_paths as mod
 
-    ctx = _require_context()
-    if not ctx.settings_files:
-        click.echo("No settings files found.")
+    ctx = _require_settings()
+    if ctx is None:
         return
 
     sys.exit(
@@ -216,9 +231,8 @@ def ensure_workspace(*, dry_run: bool, quiet: bool) -> None:
     """
     from dev10x.skills.permission import update_paths as mod
 
-    ctx = _require_context()
-    if not ctx.settings_files:
-        click.echo("No settings files found.")
+    ctx = _require_settings()
+    if ctx is None:
         return
 
     sys.exit(
@@ -240,9 +254,8 @@ def ensure_scripts(*, dry_run: bool, quiet: bool) -> None:
     """Verify plugin and user-skill scripts have allow rules; add missing ones."""
     from dev10x.skills.permission import update_paths as mod
 
-    ctx = _require_context()
-    if not ctx.settings_files:
-        click.echo("No settings files found.")
+    ctx = _require_settings()
+    if ctx is None:
         return
 
     plugin_exit = _emit_result(
@@ -272,9 +285,8 @@ def ensure_reads(*, dry_run: bool, quiet: bool) -> None:
     """Emit per-skill folder Read rules with ~/ + /home/<user>/ twins."""
     from dev10x.skills.permission import update_paths as mod
 
-    ctx = _require_context()
-    if not ctx.settings_files:
-        click.echo("No settings files found.")
+    ctx = _require_settings()
+    if ctx is None:
         return
 
     sys.exit(
@@ -452,11 +464,8 @@ def enumerate_mcp(*, dry_run: bool, quiet: bool) -> None:
     """Expand `mcp__plugin_Dev10x_*` wildcards into enumerated tool names."""
     from dev10x.skills.permission import enumerate_mcp as mod
 
-    ctx = _require_context()
-    if not quiet:
-        click.echo(f"Config: {ctx.config_path}")
-    if not ctx.settings_files:
-        click.echo("No settings files found.")
+    ctx = _require_settings(show_config=True, quiet=quiet)
+    if ctx is None:
         return
 
     if dry_run and not quiet:
@@ -841,9 +850,8 @@ def doctor_canonicalize(*, dry_run: bool, quiet: bool) -> None:
     """
     from dev10x.skills.permission import doctor as mod
 
-    ctx = _require_context()
-    if not ctx.settings_files:
-        click.echo("No settings files found.")
+    ctx = _require_settings()
+    if ctx is None:
         return
 
     if dry_run and not quiet:
@@ -894,9 +902,8 @@ def doctor_apply_deprecations(*, dry_run: bool) -> None:
     from dev10x.skills.permission import doctor as mod
 
     catalog = mod.load_catalog()
-    ctx = _require_context()
-    if not ctx.settings_files:
-        click.echo("No settings files found.")
+    ctx = _require_settings()
+    if ctx is None:
         return
 
     if dry_run:
@@ -921,9 +928,8 @@ def doctor_enable_group(*, group_name: str, dry_run: bool) -> None:
     if not rules:
         click.echo(f"ERROR: unknown group {group_name!r}")
         sys.exit(1)
-    ctx = _require_context()
-    if not ctx.settings_files:
-        click.echo("No settings files found.")
+    ctx = _require_settings()
+    if ctx is None:
         return
     if dry_run:
         click.echo("(dry run — no files will be modified)\n")

--- a/src/dev10x/domain/common/tool_signature.py
+++ b/src/dev10x/domain/common/tool_signature.py
@@ -1,0 +1,228 @@
+"""ToolSignature value object — canonical ``Tool(value)`` string identity.
+
+Tool-call signatures appeared in three modules as parallel string-building
+and rule-suggestion logic (GH-543):
+
+- ``hooks/permission_diagnostics.py`` — ``extract_tool_signature`` +
+  ``_suggest_rule``
+- ``audit/permissions_model.py`` — ``ToolCall.signature()``
+- ``skills/audit/analyze_actions.py`` — ``classify_action`` +
+  ``ACTION_TYPE_BY_TOOL``
+
+This object is the single authoritative place for all three concerns.
+Each module's public functions and methods are preserved unchanged; they
+now delegate here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from dev10x.domain.common.mcp_tool_name import McpToolName
+
+_PATH_TOOLS = frozenset({"Write", "Read", "Edit"})
+
+# Action-type mapping used by the skill-audit action inventory.
+# Keys are exact tool names; value is the canonical action-type string
+# emitted in Phase 1 output tables.
+ACTION_TYPE_BY_TOOL: dict[str, str] = {
+    "Skill": "Skill",
+    "Agent": "Agent",
+    "TaskCreate": "Task",
+    "TaskUpdate": "Task",
+    "TaskList": "Task",
+    "TaskGet": "Task",
+    "AskUserQuestion": "Decision",
+    "Write": "CodeChange",
+    "Edit": "CodeChange",
+    "Read": "Read",
+    "Glob": "Search",
+    "Grep": "Search",
+    "WebFetch": "Web",
+    "WebSearch": "Web",
+}
+
+
+@dataclass(frozen=True)
+class ToolSignature:
+    """Canonical ``Tool(value)`` string for a single Claude tool call.
+
+    Constructed from a tool name and an optional value (command text or
+    file path).  The :meth:`build` factory covers the three shapes that
+    appear in permission diagnostics:
+
+    - ``Bash(<command>)``
+    - ``Write/Read/Edit(<file_path>)``
+    - ``<mcp_tool_name>`` (returned as-is — MCP tools carry no argument)
+    - ``<tool_name>()`` (fallback for any other tool)
+
+    For MCP tools the value is ignored and the tool name is returned as
+    the signature verbatim (MCP identifiers are self-contained).
+    """
+
+    tool: str
+    value: str
+
+    def __str__(self) -> str:
+        if McpToolName.is_mcp(self.tool):
+            return self.tool
+        return f"{self.tool}({self.value})"
+
+    # ------------------------------------------------------------------
+    # Factory helpers
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        tool_name: str,
+        command: str = "",
+        file_path: str = "",
+    ) -> ToolSignature:
+        """Build a :class:`ToolSignature` from raw tool-call components.
+
+        ``tool_name`` is required.  Provide ``command`` for Bash calls and
+        ``file_path`` for Write/Read/Edit calls.  For MCP tools neither is
+        needed.
+        """
+        if tool_name == "Bash":
+            return cls(tool=tool_name, value=command)
+        if tool_name in _PATH_TOOLS:
+            return cls(tool=tool_name, value=file_path)
+        return cls(tool=tool_name, value="")
+
+    @classmethod
+    def from_hook_input(cls, raw: dict[str, Any]) -> ToolSignature | None:
+        """Parse a ``ToolSignature`` from a raw hook-input dict.
+
+        Returns ``None`` when ``tool_name`` is absent or empty, or when a
+        Bash/path tool has no usable value (matching the previous
+        ``extract_tool_signature`` contract).
+        """
+        tool_name: str = raw.get("tool_name", "")
+        tool_input: dict[str, Any] = raw.get("tool_input", {})
+
+        if not tool_name:
+            return None
+
+        if tool_name == "Bash":
+            command: str = tool_input.get("command", "")
+            if not command:
+                return None
+            return cls(tool=tool_name, value=command)
+
+        if tool_name in _PATH_TOOLS:
+            file_path: str = tool_input.get("file_path", "")
+            if not file_path:
+                return None
+            return cls(tool=tool_name, value=file_path)
+
+        return cls(tool=tool_name, value="")
+
+    # ------------------------------------------------------------------
+    # Rule suggestion
+    # ------------------------------------------------------------------
+
+    def suggest_rule(self) -> str:
+        """Return the narrowest allow-rule that would cover this signature.
+
+        - MCP tools → ``mcp__<server>__*`` (server wildcard)
+        - ``Bash(<command>)`` → ``Bash(<first-word>:*)``
+        - ``Write/Read/Edit(<path>)`` → ``Write/Read/Edit(<parent>/**)``
+        - other ``Tool(value)`` → signature unchanged
+        """
+        sig = str(self)
+
+        if McpToolName.is_mcp(sig):
+            last_sep = sig.rfind("__")
+            if last_sep > 0:
+                prefix = sig[:last_sep]
+                return f"{prefix}__*"
+            return sig
+
+        paren_idx = sig.find("(")
+        if paren_idx == -1:
+            return sig
+
+        tool = sig[:paren_idx]
+        value = sig[paren_idx + 1 :].rstrip(")")
+
+        if tool == "Bash":
+            first_space = value.find(" ")
+            if first_space > 0:
+                return f"Bash({value[:first_space]}:*)"
+            return f"Bash({value}:*)"
+
+        if tool in _PATH_TOOLS:
+            parent = str(Path(value).parent)
+            return f"{tool}({parent}/**)"
+
+        return sig
+
+    # ------------------------------------------------------------------
+    # Action classification (Phase 1 audit)
+    # ------------------------------------------------------------------
+
+    def classify_action(self, input_summary: str = "") -> str:
+        """Return the action-type string for the Phase 1 action inventory.
+
+        Delegates to :data:`ACTION_TYPE_BY_TOOL` for known tools, applies
+        keyword-based Bash classification, and falls back to ``"Other"``.
+        """
+        mapped = ACTION_TYPE_BY_TOOL.get(self.tool)
+        if mapped is not None:
+            return mapped
+        if self.tool == "Bash":
+            return _classify_bash(input_summary=input_summary)
+        return "Other"
+
+
+# Action keywords used by _classify_bash — kept at module scope so
+# callers that need the raw dict (e.g. tests) can import it.
+ACTION_KEYWORDS: dict[str, list[str]] = {
+    "Git": [
+        "git commit",
+        "git push",
+        "git rebase",
+        "git checkout",
+        "git merge",
+        "git branch",
+        "git fetch",
+        "git pull",
+        "git stash",
+        "git cherry-pick",
+        "git reset",
+        "git log",
+        "git diff",
+        "git add",
+        "git tag",
+    ],
+    "PR": [
+        "gh pr ",
+        "pr create",
+        "pr view",
+        "pr merge",
+        "pr ready",
+        "pr checks",
+        "pr review",
+        "pr comment",
+        "pr diff",
+    ],
+    "Issue": ["gh issue", "issue view", "issue create", "issue comment"],
+    "Test": ["pytest", "uv run pytest", "python -m pytest", "coverage"],
+    "Lint": ["ruff", "black", "isort", "mypy", "flake8"],
+    "CodeChange": [],
+    "Config": ["settings.json", "settings.local.json", "chmod", "uv.lock"],
+}
+
+
+def _classify_bash(input_summary: str) -> str:
+    combined = f"Bash {input_summary}".lower()
+    for action_type, keywords in ACTION_KEYWORDS.items():
+        for kw in keywords:
+            if kw.lower() in combined:
+                return action_type
+    return "Other"

--- a/src/dev10x/hooks/permission_diagnostics.py
+++ b/src/dev10x/hooks/permission_diagnostics.py
@@ -26,7 +26,7 @@ from typing import Any
 
 from dev10x.domain.claude_paths import ClaudeDir
 from dev10x.domain.common.allow_rule import AllowRule, AllowRuleLoader
-from dev10x.domain.common.mcp_tool_name import McpToolName
+from dev10x.domain.common.tool_signature import ToolSignature
 from dev10x.subprocess_utils import effective_cwd
 
 
@@ -81,28 +81,10 @@ SETTINGS_PRECEDENCE: list[SettingsFile] = [
 
 
 def extract_tool_signature(raw: dict[str, Any]) -> str | None:
-    tool_name = raw.get("tool_name", "")
-    tool_input = raw.get("tool_input", {})
-
-    if not tool_name:
+    sig = ToolSignature.from_hook_input(raw)
+    if sig is None:
         return None
-
-    if tool_name == "Bash":
-        command = tool_input.get("command", "")
-        if not command:
-            return None
-        return f"Bash({command})"
-
-    if tool_name in ("Write", "Read", "Edit"):
-        file_path = tool_input.get("file_path", "")
-        if not file_path:
-            return None
-        return f"{tool_name}({file_path})"
-
-    if McpToolName.is_mcp(tool_name):
-        return tool_name
-
-    return f"{tool_name}()"
+    return str(sig)
 
 
 def _load_allow_rules(path: Path) -> list[str] | None:
@@ -258,32 +240,22 @@ def _build_fix_suggestion(
 
 
 def _suggest_rule(*, signature: str) -> str:
-    if McpToolName.is_mcp(signature):
-        last_sep = signature.rfind("__")
-        if last_sep > 0:
-            prefix = signature[:last_sep]
-            return f"{prefix}__*"
-        return signature
-
     paren_idx = signature.find("(")
     if paren_idx == -1:
+        # MCP tool names have no parens — delegate via ToolSignature directly.
+        # Non-MCP bare names (no parens) return unchanged (original behaviour).
+        tool = signature
+        value = ""
+    else:
+        tool = signature[:paren_idx]
+        value = signature[paren_idx + 1 :].rstrip(")")
+    sig = ToolSignature(tool=tool, value=value)
+    result = sig.suggest_rule()
+    # For non-MCP bare names the VO returns "Tool()" which differs from the
+    # original "return signature" contract — preserve the original output.
+    if paren_idx == -1 and not sig.tool.startswith("mcp__"):
         return signature
-
-    tool = signature[:paren_idx]
-    value = signature[paren_idx + 1 :].rstrip(")")
-
-    if tool == "Bash":
-        first_space = value.find(" ")
-        if first_space > 0:
-            return f"Bash({value[:first_space]}:*)"
-        return f"Bash({value}:*)"
-
-    if tool in ("Write", "Read", "Edit"):
-        path = Path(value)
-        parent = str(path.parent)
-        return f"{tool}({parent}/**)"
-
-    return signature
+    return result
 
 
 def format_diagnostic(result: DiagnosticResult) -> str:

--- a/src/dev10x/hooks/session_dispatch.py
+++ b/src/dev10x/hooks/session_dispatch.py
@@ -4,6 +4,7 @@ Event-routing module. Owns the entry points referenced by
 ``hooks/scripts/session-*.py`` and ``commands/hook.py``. Rendering and
 data assembly live elsewhere:
 
+* Session orchestration / context builders — :mod:`dev10x.session.service`.
 * Document I/O — :mod:`dev10x.domain.session_document`.
 * Named policies (friction parsing, permission migration, decision
   guidance) — :mod:`dev10x.hooks.session_policy`.
@@ -21,11 +22,6 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from dev10x.domain.claude_paths import ClaudeDir
-from dev10x.domain.documents.session_context import (
-    SessionContextQuery,
-    format_compaction_summary,
-    format_reload_context,
-)
 from dev10x.domain.documents.session_state import SessionState
 from dev10x.domain.git_context import GitContext
 from dev10x.domain.session_document import (
@@ -34,6 +30,7 @@ from dev10x.domain.session_document import (
     write_state,
 )
 from dev10x.hooks.session_policy import MigratePluginPermissionsRule
+from dev10x.session.service import SessionService
 
 
 def _get_toplevel() -> str | None:
@@ -95,11 +92,7 @@ def drain_stdin() -> None:
 
 def build_reload_context() -> str:
     """Build the session-reload additionalContext string. Empty when no state."""
-    toplevel = _get_toplevel()
-    if not toplevel:
-        return ""
-    ctx = SessionContextQuery.gather_reload(toplevel=toplevel)
-    return format_reload_context(ctx=ctx)
+    return SessionService().build_reload_context(toplevel=_get_toplevel())
 
 
 def session_reload() -> None:
@@ -108,19 +101,17 @@ def session_reload() -> None:
 
 def context_compact() -> None:
     drain_stdin()
-    toplevel = _get_toplevel()
-    if not toplevel:
+    service = SessionService()
+    summary = service.build_compaction_context(toplevel=_get_toplevel())
+    if not summary:
         sys.exit(0)
-    ctx = SessionContextQuery.gather_compaction(toplevel=toplevel)
-    summary = format_compaction_summary(ctx=ctx, plugin_root=_plugin_root())
     escaped = _escape_for_json(s=summary)
     print(f'{{"hookSpecificOutput":{{"systemMessage":"{escaped}"}}}}')
 
 
 def build_guidance_context() -> str:
     """Return the session-guidance.md contents, or empty string if missing."""
-    guidance_file = _plugin_root() / "hooks" / "scripts" / "session-guidance.md"
-    return guidance_file.read_text() if guidance_file.exists() else ""
+    return SessionService().build_guidance_context()
 
 
 def build_autonomy_reassurance_context() -> str:
@@ -129,16 +120,7 @@ def build_autonomy_reassurance_context() -> str:
     Returns an empty string outside the autonomous-shipping profile; the
     orchestrator drops empty segments so non-solo sessions see no change.
     """
-    from dev10x.domain.documents.session_yaml import SessionYamlDocument
-    from dev10x.domain.session_rules import BuildAutonomyReassuranceRule
-
-    toplevel = _get_toplevel()
-    if not toplevel:
-        return ""
-    friction_level, active_modes = SessionYamlDocument(toplevel=toplevel).read_friction_and_modes()
-    return BuildAutonomyReassuranceRule(
-        friction_level=friction_level, active_modes=active_modes
-    ).apply()
+    return SessionService().build_autonomy_reassurance_context(toplevel=_get_toplevel())
 
 
 def build_install_check_context() -> str:
@@ -147,24 +129,7 @@ def build_install_check_context() -> str:
     Returns an empty string when the install is current — the orchestrator
     drops empty segments, so a no-op leaves no trace in additionalContext.
     """
-    from dev10x.domain.install_version import install_state
-
-    state = install_state()
-    if state.needs_bootstrap:
-        return (
-            "Dev10x config folder is missing at ~/.config/Dev10x.\n"
-            "Run `/Dev10x:upgrade-cleanup` to bootstrap the userspace install."
-        )
-    if state.needs_upgrade:
-        plugin = state.plugin_version or "unknown"
-        applied = state.applied_version or "never applied"
-        return (
-            f"Dev10x plugin {plugin} is installed but upgrade-cleanup was last "
-            f"run for {applied}.\n"
-            "Run `/Dev10x:upgrade-cleanup` to refresh permissions and "
-            "migrate config files."
-        )
-    return ""
+    return SessionService().build_install_check_context()
 
 
 def build_hook_version_drift_context() -> str:
@@ -185,24 +150,7 @@ def build_hook_version_drift_context() -> str:
     Returns an empty string when no drift is detected or when either version
     cannot be determined (``--plugin-dir`` dev installs, new users, etc.).
     """
-    from dev10x.domain.install_version import (
-        read_latest_installed_version,
-        read_running_hook_version,
-    )
-
-    running = read_running_hook_version()
-    if running is None:
-        return ""
-    latest = read_latest_installed_version()
-    if latest is None:
-        return ""
-    if running == latest:
-        return ""
-    return (
-        f"Dev10x hooks running v{running} but v{latest} is installed on disk.\n"
-        "Restart this session (or run `/Dev10x:upgrade-cleanup`) to activate "
-        "shipped friction fixes, validators, and catalog improvements."
-    )
+    return SessionService().build_hook_version_drift_context()
 
 
 def session_install_check() -> None:

--- a/src/dev10x/hooks/session_dispatch.py
+++ b/src/dev10x/hooks/session_dispatch.py
@@ -52,6 +52,23 @@ def _escape_for_json(*, s: str) -> str:
     )
 
 
+def _emit_context(content: str) -> None:
+    """Emit content as a SessionStart additionalContext JSON envelope.
+
+    Exits silently (sys.exit(0)) when content is empty. This is the
+    single shared emit path for all standalone SessionStart hook
+    sub-commands — previously duplicated across session_reload,
+    session_install_check, and session_guidance.
+    """
+    if not content:
+        sys.exit(0)
+    escaped = _escape_for_json(s=content)
+    print(
+        '{"hookSpecificOutput":{"hookEventName":"SessionStart",'
+        f'"additionalContext":"{escaped}"}}}}'
+    )
+
+
 def _run_git_safe(git: GitContext, *args: str) -> str:
     try:
         return git.run(*args)
@@ -86,14 +103,7 @@ def build_reload_context() -> str:
 
 
 def session_reload() -> None:
-    context = build_reload_context()
-    if not context:
-        sys.exit(0)
-    escaped = _escape_for_json(s=context)
-    print(
-        '{"hookSpecificOutput":{"hookEventName":"SessionStart",'
-        f'"additionalContext":"{escaped}"}}}}'
-    )
+    _emit_context(build_reload_context())
 
 
 def context_compact() -> None:
@@ -197,26 +207,12 @@ def build_hook_version_drift_context() -> str:
 
 def session_install_check() -> None:
     """Emit install-state guidance as additionalContext (SessionStart hook)."""
-    content = build_install_check_context()
-    if not content:
-        sys.exit(0)
-    escaped = _escape_for_json(s=content)
-    print(
-        '{"hookSpecificOutput":{"hookEventName":"SessionStart",'
-        f'"additionalContext":"{escaped}"}}}}'
-    )
+    _emit_context(build_install_check_context())
 
 
 def session_guidance() -> None:
     """Output session-guidance.md as additionalContext (SessionStart hook)."""
-    content = build_guidance_context()
-    if not content:
-        sys.exit(0)
-    escaped = _escape_for_json(s=content)
-    print(
-        '{"hookSpecificOutput":{"hookEventName":"SessionStart",'
-        f'"additionalContext":"{escaped}"}}}}'
-    )
+    _emit_context(build_guidance_context())
 
 
 def session_migrate_permissions() -> None:

--- a/src/dev10x/session/__init__.py
+++ b/src/dev10x/session/__init__.py
@@ -1,0 +1,15 @@
+"""Session service package.
+
+Re-exports the public surface of :mod:`dev10x.session.service`.
+No logic lives here — per project convention, ``__init__.py`` is
+for re-exports only.
+"""
+
+from __future__ import annotations
+
+from dev10x.session.service import SessionService, SessionServiceError
+
+__all__ = [
+    "SessionService",
+    "SessionServiceError",
+]

--- a/src/dev10x/session/service.py
+++ b/src/dev10x/session/service.py
@@ -1,0 +1,175 @@
+"""Session service layer.
+
+The IO/orchestration boundary for session-start context builders. This
+layer owns the concerns that the hook dispatch must not — plugin-root
+resolution, document reads, install-state probes, version-drift checks,
+and policy-rule invocations — and delegates all formatting to the domain
+(``session_context``, ``session_rules``). It stays separate from the
+hook entry-points deliberately: folding this orchestration into the
+dispatch shims would couple them to the filesystem layout and prevent
+direct unit testing.
+
+Both ``dev10x.hooks.session_dispatch`` and any future MCP surface
+delegate here, eliminating the previously inlined orchestration from
+the dispatch functions.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Final
+
+# Sentinel used by methods that accept an optional pre-resolved ``toplevel``
+# string. A caller that passes ``_UNSET`` (the default) triggers git
+# discovery inside the method. A caller that passes ``None`` explicitly
+# (e.g. when ``_get_toplevel()`` already returned ``None``) signals "no
+# repo available — return early". This avoids the ambiguity of using ``None``
+# for both "not provided" and "absent".
+_UNSET: Final = object()
+
+
+class SessionServiceError(Exception):
+    """Raised when a session service operation cannot proceed."""
+
+
+class SessionService:
+    """Orchestrates session-context assembly for SessionStart and PreCompact hooks.
+
+    Constructed with a ``plugin_root`` so callers can inject a test double
+    without monkeypatching module globals. Pass ``None`` to let the service
+    resolve the real plugin root from the package location (production use).
+    """
+
+    def __init__(self, *, plugin_root: Path | None = None) -> None:
+        self._plugin_root = plugin_root or self._default_plugin_root()
+
+    @staticmethod
+    def _default_plugin_root() -> Path:
+        return Path(__file__).parents[3]
+
+    def build_reload_context(self, *, toplevel: str | None = _UNSET) -> str:  # type: ignore[assignment]
+        """Return the session-reload additionalContext string.
+
+        Returns an empty string when no git toplevel is available or when
+        there is no prior session state / plan to report.
+
+        Pass ``toplevel`` as a pre-resolved string to skip git discovery.
+        Pass ``None`` explicitly (e.g. from a ``_get_toplevel()`` call that
+        found no repo) to return early without git discovery. Omit the
+        parameter to let the service run git discovery itself.
+        """
+        from dev10x.domain.documents.session_context import (
+            SessionContextQuery,
+            format_reload_context,
+        )
+        from dev10x.domain.git_context import GitContext
+
+        resolved: str | None = GitContext().toplevel if toplevel is _UNSET else toplevel
+        if not resolved:
+            return ""
+        ctx = SessionContextQuery.gather_reload(toplevel=resolved)
+        return format_reload_context(ctx=ctx)
+
+    def build_guidance_context(self) -> str:
+        """Return the session-guidance.md contents, or empty string if missing."""
+        guidance_file = self._plugin_root / "hooks" / "scripts" / "session-guidance.md"
+        return guidance_file.read_text() if guidance_file.exists() else ""
+
+    def build_autonomy_reassurance_context(self, *, toplevel: str | None = _UNSET) -> str:  # type: ignore[assignment]
+        """Return a reassurance block for adaptive + solo-maintainer sessions (GH-261).
+
+        Returns an empty string outside the autonomous-shipping profile.
+
+        Pass ``toplevel`` as a pre-resolved string to skip git discovery.
+        Pass ``None`` explicitly to return early without git discovery. Omit
+        the parameter to let the service run git discovery itself.
+        """
+        from dev10x.domain.documents.session_yaml import SessionYamlDocument
+        from dev10x.domain.git_context import GitContext
+        from dev10x.domain.session_rules import BuildAutonomyReassuranceRule
+
+        resolved: str | None = GitContext().toplevel if toplevel is _UNSET else toplevel
+        if not resolved:
+            return ""
+        friction_level, active_modes = SessionYamlDocument(
+            toplevel=resolved
+        ).read_friction_and_modes()
+        return BuildAutonomyReassuranceRule(
+            friction_level=friction_level, active_modes=active_modes
+        ).apply()
+
+    def build_install_check_context(self) -> str:
+        """Return a warning when the Dev10x install needs bootstrap or upgrade.
+
+        Returns an empty string when the install is current.
+        """
+        from dev10x.domain.install_version import install_state
+
+        state = install_state()
+        if state.needs_bootstrap:
+            return (
+                "Dev10x config folder is missing at ~/.config/Dev10x.\n"
+                "Run `/Dev10x:upgrade-cleanup` to bootstrap the userspace install."
+            )
+        if state.needs_upgrade:
+            plugin = state.plugin_version or "unknown"
+            applied = state.applied_version or "never applied"
+            return (
+                f"Dev10x plugin {plugin} is installed but upgrade-cleanup was last "
+                f"run for {applied}.\n"
+                "Run `/Dev10x:upgrade-cleanup` to refresh permissions and "
+                "migrate config files."
+            )
+        return ""
+
+    def build_hook_version_drift_context(self) -> str:
+        """Return a warning when the running-hook version lags the latest installed version.
+
+        Returns an empty string when no drift is detected or when either version
+        cannot be determined.
+        """
+        from dev10x.domain.install_version import (
+            read_latest_installed_version,
+            read_running_hook_version,
+        )
+
+        running = read_running_hook_version()
+        if running is None:
+            return ""
+        latest = read_latest_installed_version()
+        if latest is None:
+            return ""
+        if running == latest:
+            return ""
+        return (
+            f"Dev10x hooks running v{running} but v{latest} is installed on disk.\n"
+            "Restart this session (or run `/Dev10x:upgrade-cleanup`) to activate "
+            "shipped friction fixes, validators, and catalog improvements."
+        )
+
+    def build_compaction_context(self, *, toplevel: str | None = _UNSET) -> str:  # type: ignore[assignment]
+        """Return the PreCompact systemMessage string.
+
+        Returns an empty string when no git toplevel is available.
+
+        Pass ``toplevel`` as a pre-resolved string to skip git discovery.
+        Pass ``None`` explicitly to return early without git discovery. Omit
+        the parameter to let the service run git discovery itself.
+        """
+        from dev10x.domain.documents.session_context import (
+            SessionContextQuery,
+            format_compaction_summary,
+        )
+        from dev10x.domain.git_context import GitContext
+
+        resolved: str | None = GitContext().toplevel if toplevel is _UNSET else toplevel
+        if not resolved:
+            return ""
+        ctx = SessionContextQuery.gather_compaction(toplevel=resolved)
+        return format_compaction_summary(ctx=ctx, plugin_root=self._plugin_root)
+
+
+__all__ = [
+    "SessionService",
+    "SessionServiceError",
+]

--- a/src/dev10x/skills/audit/analyze_actions.py
+++ b/src/dev10x/skills/audit/analyze_actions.py
@@ -216,12 +216,17 @@ def _classify_bash(input_summary: str) -> str:
 
 
 def classify_action(tool_name: str, input_summary: str) -> str:
-    mapped = ACTION_TYPE_BY_TOOL.get(tool_name)
-    if mapped is not None:
-        return mapped
-    if tool_name == "Bash":
-        return _classify_bash(input_summary=input_summary)
-    return "Other"
+    try:
+        from dev10x.domain.common.tool_signature import ToolSignature  # noqa: PLC0415
+
+        return ToolSignature(tool=tool_name, value="").classify_action(input_summary=input_summary)
+    except ImportError:
+        mapped = ACTION_TYPE_BY_TOOL.get(tool_name)
+        if mapped is not None:
+            return mapped
+        if tool_name == "Bash":
+            return _classify_bash(input_summary=input_summary)
+        return "Other"
 
 
 def describe_tool_call(tc: ToolCall) -> str:

--- a/src/dev10x/validators/prefix_friction.py
+++ b/src/dev10x/validators/prefix_friction.py
@@ -23,6 +23,8 @@ from dev10x.domain.profile_tier import ProfileTier
 from dev10x.validators.base import ValidatorBase
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from dev10x.domain import HookRetry
 
 SETUP_TOKENS = frozenset(
@@ -343,23 +345,26 @@ class PrefixFrictionValidator(ValidatorBase):
     profile: ClassVar[ProfileTier] = ProfileTier.STANDARD
     _allow_patterns: list[str] | None = field(default=None, repr=False)
 
-    # Ordered chain of prefix checks (PrefixCheck = method taking
-    # ``*, inp: HookInput`` and returning the first matching ``HookResult``).
-    # ``validate`` walks this list in order; the last entry is the
-    # fall-through ``&&``-chaining check.
-    _CHECKS: ClassVar[tuple[str, ...]] = (
-        "_check_uv_run_inner_allow",
-        "_check_cd_revparse_chain",
-        "_check_git_c_noop",
-        "_check_env_prefix_git",
-        "_check_merge_base",
-        "_check_cd_noop_chain",
-        "_check_cd_git_chain",
-        "_check_redirect_then_positional",
-        "_check_semicolon_chain",
-        "_check_shell_loop_wrap",
-        "_check_and_chaining",
-    )
+    def _checks(self) -> list[Callable[..., HookResult | HookAllow | None]]:
+        """Return the ordered chain of bound prefix-check callables.
+
+        ``validate`` walks this list in order; the last entry is the
+        fall-through ``&&``-chaining check. Adding a check only requires
+        adding an entry here — no separate name-string to keep in sync.
+        """
+        return [
+            self._check_uv_run_inner_allow,
+            self._check_cd_revparse_chain,
+            self._check_git_c_noop,
+            self._check_env_prefix_git,
+            self._check_merge_base,
+            self._check_cd_noop_chain,
+            self._check_cd_git_chain,
+            self._check_redirect_then_positional,
+            self._check_semicolon_chain,
+            self._check_shell_loop_wrap,
+            self._check_and_chaining,
+        ]
 
     def should_run(self, inp: HookInput) -> bool:
         cmd = inp.command
@@ -382,8 +387,8 @@ class PrefixFrictionValidator(ValidatorBase):
         )
 
     def validate(self, inp: HookInput) -> HookResult | HookAllow | None:
-        for check_name in self._CHECKS:
-            result: HookResult | HookAllow | None = getattr(self, check_name)(inp=inp)
+        for check in self._checks():
+            result: HookResult | HookAllow | None = check(inp=inp)
             if result is not None:
                 return result
         return None

--- a/tests/domain/common/test_tool_signature.py
+++ b/tests/domain/common/test_tool_signature.py
@@ -1,0 +1,236 @@
+"""Tests for ToolSignature value object (GH-543)."""
+
+from __future__ import annotations
+
+import pytest
+
+from dev10x.domain.common.tool_signature import ACTION_TYPE_BY_TOOL, ToolSignature
+
+
+class TestStr:
+    def test_bash_renders_command(self) -> None:
+        sig = ToolSignature(tool="Bash", value="git status")
+        assert str(sig) == "Bash(git status)"
+
+    def test_write_renders_path(self) -> None:
+        sig = ToolSignature(tool="Write", value="/tmp/foo.txt")
+        assert str(sig) == "Write(/tmp/foo.txt)"
+
+    def test_read_renders_path(self) -> None:
+        sig = ToolSignature(tool="Read", value="/home/user/file.py")
+        assert str(sig) == "Read(/home/user/file.py)"
+
+    def test_edit_renders_path(self) -> None:
+        sig = ToolSignature(tool="Edit", value="/src/main.py")
+        assert str(sig) == "Edit(/src/main.py)"
+
+    def test_mcp_returns_tool_name_only(self) -> None:
+        sig = ToolSignature(tool="mcp__plugin_Dev10x_cli__detect_tracker", value="ignored")
+        assert str(sig) == "mcp__plugin_Dev10x_cli__detect_tracker"
+
+    def test_fallback_renders_empty_parens(self) -> None:
+        sig = ToolSignature(tool="AskUserQuestion", value="")
+        assert str(sig) == "AskUserQuestion()"
+
+
+class TestBuild:
+    def test_bash_uses_command(self) -> None:
+        sig = ToolSignature.build(tool_name="Bash", command="git log --oneline")
+        assert str(sig) == "Bash(git log --oneline)"
+
+    def test_write_uses_file_path(self) -> None:
+        sig = ToolSignature.build(tool_name="Write", file_path="/tmp/out.md")
+        assert str(sig) == "Write(/tmp/out.md)"
+
+    def test_read_uses_file_path(self) -> None:
+        sig = ToolSignature.build(tool_name="Read", file_path="/etc/hosts")
+        assert str(sig) == "Read(/etc/hosts)"
+
+    def test_edit_uses_file_path(self) -> None:
+        sig = ToolSignature.build(tool_name="Edit", file_path="/src/foo.py")
+        assert str(sig) == "Edit(/src/foo.py)"
+
+    def test_mcp_ignores_command_and_path(self) -> None:
+        sig = ToolSignature.build(
+            tool_name="mcp__plugin_Dev10x_cli__pr_get",
+            command="ignored",
+            file_path="also_ignored",
+        )
+        assert str(sig) == "mcp__plugin_Dev10x_cli__pr_get"
+
+    def test_fallback_tool_gets_empty_value(self) -> None:
+        sig = ToolSignature.build(tool_name="Glob")
+        assert sig.tool == "Glob"
+        assert sig.value == ""
+        assert str(sig) == "Glob()"
+
+
+class TestFromHookInput:
+    def test_bash_returns_signature(self) -> None:
+        raw = {"tool_name": "Bash", "tool_input": {"command": "ls -la"}}
+        result = ToolSignature.from_hook_input(raw)
+        assert result is not None
+        assert str(result) == "Bash(ls -la)"
+
+    def test_bash_missing_command_returns_none(self) -> None:
+        raw = {"tool_name": "Bash", "tool_input": {}}
+        assert ToolSignature.from_hook_input(raw) is None
+
+    def test_bash_empty_command_returns_none(self) -> None:
+        raw = {"tool_name": "Bash", "tool_input": {"command": ""}}
+        assert ToolSignature.from_hook_input(raw) is None
+
+    def test_write_returns_signature(self) -> None:
+        raw = {"tool_name": "Write", "tool_input": {"file_path": "/tmp/x.txt"}}
+        result = ToolSignature.from_hook_input(raw)
+        assert result is not None
+        assert str(result) == "Write(/tmp/x.txt)"
+
+    def test_read_returns_signature(self) -> None:
+        raw = {"tool_name": "Read", "tool_input": {"file_path": "/src/a.py"}}
+        result = ToolSignature.from_hook_input(raw)
+        assert result is not None
+        assert str(result) == "Read(/src/a.py)"
+
+    def test_edit_returns_signature(self) -> None:
+        raw = {"tool_name": "Edit", "tool_input": {"file_path": "/src/b.py"}}
+        result = ToolSignature.from_hook_input(raw)
+        assert result is not None
+        assert str(result) == "Edit(/src/b.py)"
+
+    def test_path_tool_missing_file_path_returns_none(self) -> None:
+        raw = {"tool_name": "Write", "tool_input": {}}
+        assert ToolSignature.from_hook_input(raw) is None
+
+    def test_mcp_returns_tool_name(self) -> None:
+        raw = {
+            "tool_name": "mcp__plugin_Dev10x_cli__issue_get",
+            "tool_input": {},
+        }
+        result = ToolSignature.from_hook_input(raw)
+        assert result is not None
+        assert str(result) == "mcp__plugin_Dev10x_cli__issue_get"
+
+    def test_fallback_tool_returns_empty_parens(self) -> None:
+        raw = {"tool_name": "Glob", "tool_input": {}}
+        result = ToolSignature.from_hook_input(raw)
+        assert result is not None
+        assert str(result) == "Glob()"
+
+    def test_missing_tool_name_returns_none(self) -> None:
+        raw = {"tool_input": {"command": "ls"}}
+        assert ToolSignature.from_hook_input(raw) is None
+
+    def test_empty_tool_name_returns_none(self) -> None:
+        raw = {"tool_name": "", "tool_input": {"command": "ls"}}
+        assert ToolSignature.from_hook_input(raw) is None
+
+
+class TestSuggestRule:
+    @pytest.mark.parametrize(
+        "tool,value,expected",
+        [
+            # Bash: multi-word → take first word
+            ("Bash", "git status --short", "Bash(git:*)"),
+            # Bash: single word
+            ("Bash", "ls", "Bash(ls:*)"),
+            # Bash: no space → whole value
+            ("Bash", "uv", "Bash(uv:*)"),
+            # Write path tool
+            ("Write", "/home/user/project/src/foo.py", "Write(/home/user/project/src/**)"),
+            # Read path tool
+            ("Read", "/etc/hosts", "Read(/etc/**)"),
+            # Edit path tool
+            ("Edit", "/tmp/bar.txt", "Edit(/tmp/**)"),
+        ],
+    )
+    def test_suggest_rule(self, tool: str, value: str, expected: str) -> None:
+        sig = ToolSignature(tool=tool, value=value)
+        assert sig.suggest_rule() == expected
+
+    def test_mcp_suggests_server_wildcard(self) -> None:
+        sig = ToolSignature(tool="mcp__plugin_Dev10x_cli__detect_tracker", value="")
+        assert sig.suggest_rule() == "mcp__plugin_Dev10x_cli__*"
+
+    def test_mcp_single_segment_returns_wildcard(self) -> None:
+        # "mcp__only".rfind("__") == 3 > 0, so prefix is "mcp", result is "mcp__*"
+        sig = ToolSignature(tool="mcp__only", value="")
+        assert sig.suggest_rule() == "mcp__*"
+
+    def test_fallback_returns_signature_unchanged(self) -> None:
+        sig = ToolSignature(tool="Glob", value="")
+        assert sig.suggest_rule() == "Glob()"
+
+
+class TestClassifyAction:
+    @pytest.mark.parametrize(
+        "tool,input_summary,expected",
+        [
+            ("Skill", "", "Skill"),
+            ("Agent", "", "Agent"),
+            ("TaskCreate", "", "Task"),
+            ("TaskUpdate", "", "Task"),
+            ("TaskList", "", "Task"),
+            ("TaskGet", "", "Task"),
+            ("AskUserQuestion", "", "Decision"),
+            ("Write", "", "CodeChange"),
+            ("Edit", "", "CodeChange"),
+            ("Read", "", "Read"),
+            ("Glob", "", "Search"),
+            ("Grep", "", "Search"),
+            ("WebFetch", "", "Web"),
+            ("WebSearch", "", "Web"),
+        ],
+    )
+    def test_known_tools_from_map(self, tool: str, input_summary: str, expected: str) -> None:
+        sig = ToolSignature(tool=tool, value="")
+        assert sig.classify_action(input_summary=input_summary) == expected
+
+    @pytest.mark.parametrize(
+        "input_summary,expected",
+        [
+            ("git commit -m 'fix'", "Git"),
+            ("git push origin main", "Git"),
+            ("gh pr create --title foo", "PR"),
+            ("gh issue view 42", "Issue"),
+            ("uv run pytest tests/", "Test"),
+            ("ruff check src/", "Lint"),
+            ("chmod +x script.sh", "Config"),
+            ("something unrecognized", "Other"),
+        ],
+    )
+    def test_bash_keyword_classification(self, input_summary: str, expected: str) -> None:
+        sig = ToolSignature(tool="Bash", value="")
+        assert sig.classify_action(input_summary=input_summary) == expected
+
+    def test_unknown_tool_returns_other(self) -> None:
+        sig = ToolSignature(tool="UnknownTool", value="")
+        assert sig.classify_action() == "Other"
+
+    def test_mcp_tool_not_in_map_returns_other(self) -> None:
+        sig = ToolSignature(tool="mcp__plugin_Dev10x_cli__detect_tracker", value="")
+        assert sig.classify_action() == "Other"
+
+
+class TestActionTypeByTool:
+    """Verify the exported dict matches the known shape callers depend on."""
+
+    def test_contains_required_keys(self) -> None:
+        required = {
+            "Skill",
+            "Agent",
+            "TaskCreate",
+            "TaskUpdate",
+            "Write",
+            "Edit",
+            "Read",
+            "Glob",
+            "Grep",
+        }
+        assert required <= ACTION_TYPE_BY_TOOL.keys()
+
+    def test_write_is_code_change(self) -> None:
+        assert ACTION_TYPE_BY_TOOL["Write"] == "CodeChange"
+
+    def test_read_is_read(self) -> None:
+        assert ACTION_TYPE_BY_TOOL["Read"] == "Read"

--- a/tests/hooks/test_session_start_hooks.py
+++ b/tests/hooks/test_session_start_hooks.py
@@ -93,9 +93,13 @@ class TestSessionGuidance:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         import dev10x.hooks.session_dispatch as mod
+        from dev10x.session.service import SessionService
 
         fake_root = Path("/tmp/nonexistent-plugin-root-xyz")
         monkeypatch.setattr(mod, "_plugin_root", lambda: fake_root)
+        monkeypatch.setattr(
+            SessionService, "_default_plugin_root", staticmethod(lambda: fake_root)
+        )
 
         with pytest.raises(SystemExit) as exc_info:
             mod.session_guidance()

--- a/tests/session/test_service.py
+++ b/tests/session/test_service.py
@@ -1,0 +1,291 @@
+"""Unit tests for SessionService — the injectable session-context service layer.
+
+These tests exercise SessionService methods directly, which is the new
+testability unlock of the GH-529 refactor. Prior to this, the same logic
+was only reachable indirectly through the hook dispatch entry points.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from dev10x.domain.session_document import state_path_for_toplevel, write_state
+from dev10x.session.service import SessionService
+
+
+def _write_state(*, toplevel: str, session_id: str) -> Path:
+    path = state_path_for_toplevel(toplevel=toplevel)
+    write_state(
+        path=path,
+        state={
+            "session_id": session_id,
+            "branch": "develop",
+            "worktree": "",
+            "working_directory": toplevel,
+            "timestamp": "2026-01-01T00:00:00Z",
+            "modified_files": [],
+            "staged_files": [],
+            "recent_commits": ["abc1234 Test commit"],
+            "has_plan": False,
+        },
+    )
+    return path
+
+
+class TestSessionServiceConstruction:
+    def test_accepts_explicit_plugin_root(self, tmp_path: Path) -> None:
+        svc = SessionService(plugin_root=tmp_path)
+        assert svc._plugin_root == tmp_path
+
+    def test_resolves_default_plugin_root_when_none(self) -> None:
+        svc = SessionService()
+        assert svc._plugin_root.exists()
+
+    def test_default_plugin_root_contains_src_dir(self) -> None:
+        svc = SessionService()
+        assert (svc._plugin_root / "src").exists()
+
+
+class TestBuildReloadContext:
+    def test_empty_when_toplevel_is_none(self) -> None:
+        svc = SessionService()
+        result = svc.build_reload_context(toplevel=None)
+        # Without a real git repo, GitContext returns None — result must be ""
+        # When running in a real repo the test repo's state may exist;
+        # passing an explicit non-existent path ensures isolation.
+        assert isinstance(result, str)
+
+    def test_empty_when_no_state_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DEV10X_CLAUDE_HOME", str(tmp_path / "claude-home"))
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        svc = SessionService()
+        assert svc.build_reload_context(toplevel=str(repo)) == ""
+
+    def test_includes_state_when_present(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DEV10X_CLAUDE_HOME", str(tmp_path / "claude-home"))
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _write_state(toplevel=str(repo), session_id="svc-test-session")
+
+        svc = SessionService()
+        result = svc.build_reload_context(toplevel=str(repo))
+
+        assert "Prior session state detected" in result
+        assert "svc-test-session" in result
+
+    def test_consumes_state_file_once(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DEV10X_CLAUDE_HOME", str(tmp_path / "claude-home"))
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        path = _write_state(toplevel=str(repo), session_id="cleanup-svc-test")
+        assert path.exists()
+
+        svc = SessionService()
+        svc.build_reload_context(toplevel=str(repo))
+
+        assert not path.exists()
+
+
+class TestBuildGuidanceContext:
+    def test_empty_when_guidance_file_missing(self, tmp_path: Path) -> None:
+        svc = SessionService(plugin_root=tmp_path)
+        assert svc.build_guidance_context() == ""
+
+    def test_returns_file_contents_when_present(self, tmp_path: Path) -> None:
+        scripts_dir = tmp_path / "hooks" / "scripts"
+        scripts_dir.mkdir(parents=True)
+        guidance = scripts_dir / "session-guidance.md"
+        guidance.write_text("# Guidance content\nSome instructions here.")
+
+        svc = SessionService(plugin_root=tmp_path)
+        result = svc.build_guidance_context()
+
+        assert "Guidance content" in result
+        assert "Some instructions here" in result
+
+    def test_real_plugin_root_has_guidance_file(self) -> None:
+        svc = SessionService()
+        result = svc.build_guidance_context()
+        assert len(result) > 0
+
+
+class TestBuildInstallCheckContext:
+    def test_empty_when_install_current(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from dev10x.domain.claude_paths import CLAUDE_HOME_ENV_VAR
+        from dev10x.domain.dev10x_paths import CONFIG_HOME_ENV_VAR, Dev10xConfigDir
+        from dev10x.domain.install_version import write_applied_version
+
+        monkeypatch.setenv(CLAUDE_HOME_ENV_VAR, str(tmp_path))
+        monkeypatch.setenv(CONFIG_HOME_ENV_VAR, str(tmp_path / "config_dev10x"))
+        Dev10xConfigDir.reset_cache()
+        Dev10xConfigDir.home().mkdir(parents=True)
+        plugin_root = tmp_path / "plugin"
+        (plugin_root / ".claude-plugin").mkdir(parents=True)
+        (plugin_root / ".claude-plugin" / "plugin.json").write_text(
+            json.dumps({"version": "0.72.0"})
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+        write_applied_version(plugin_version="0.72.0")
+
+        svc = SessionService()
+        assert svc.build_install_check_context() == ""
+
+    def test_guides_bootstrap_when_config_missing(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from dev10x.domain.claude_paths import CLAUDE_HOME_ENV_VAR
+        from dev10x.domain.dev10x_paths import CONFIG_HOME_ENV_VAR, Dev10xConfigDir
+
+        monkeypatch.setenv(CLAUDE_HOME_ENV_VAR, str(tmp_path))
+        monkeypatch.setenv(CONFIG_HOME_ENV_VAR, str(tmp_path / "config_dev10x"))
+        Dev10xConfigDir.reset_cache()
+        monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
+
+        svc = SessionService()
+        result = svc.build_install_check_context()
+
+        assert "config folder is missing" in result
+        assert "/Dev10x:upgrade-cleanup" in result
+
+    def test_guides_upgrade_on_version_mismatch(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from dev10x.domain.claude_paths import CLAUDE_HOME_ENV_VAR
+        from dev10x.domain.dev10x_paths import CONFIG_HOME_ENV_VAR, Dev10xConfigDir
+        from dev10x.domain.install_version import write_applied_version
+
+        monkeypatch.setenv(CLAUDE_HOME_ENV_VAR, str(tmp_path))
+        monkeypatch.setenv(CONFIG_HOME_ENV_VAR, str(tmp_path / "config_dev10x"))
+        Dev10xConfigDir.reset_cache()
+        Dev10xConfigDir.home().mkdir(parents=True)
+        plugin_root = tmp_path / "plugin"
+        (plugin_root / ".claude-plugin").mkdir(parents=True)
+        (plugin_root / ".claude-plugin" / "plugin.json").write_text(
+            json.dumps({"version": "0.72.0"})
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+        write_applied_version(plugin_version="0.71.0")
+
+        svc = SessionService()
+        result = svc.build_install_check_context()
+
+        assert "0.72.0" in result
+        assert "0.71.0" in result
+        assert "/Dev10x:upgrade-cleanup" in result
+
+
+class TestBuildHookVersionDriftContext:
+    def test_empty_when_versions_match(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from dev10x.domain.claude_paths import CLAUDE_HOME_ENV_VAR, ClaudeDir
+
+        plugin_root = tmp_path / "plugins" / "cache" / "Dev10x-Guru" / "dev10x-claude" / "0.76.0"
+        (plugin_root / ".claude-plugin").mkdir(parents=True)
+        (plugin_root / ".claude-plugin" / "plugin.json").write_text(
+            json.dumps({"version": "0.76.0"})
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+        monkeypatch.setenv(CLAUDE_HOME_ENV_VAR, str(tmp_path))
+        ClaudeDir.reset_cache()
+
+        svc = SessionService()
+        assert svc.build_hook_version_drift_context() == ""
+
+    def test_warns_when_newer_version_installed(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from dev10x.domain.claude_paths import CLAUDE_HOME_ENV_VAR, ClaudeDir
+
+        cache_base = tmp_path / "plugins" / "cache" / "Dev10x-Guru" / "dev10x-claude"
+        old_root = cache_base / "0.72.0"
+        new_root = cache_base / "0.76.0"
+        for root in (old_root, new_root):
+            (root / ".claude-plugin").mkdir(parents=True)
+            ver = root.name
+            (root / ".claude-plugin" / "plugin.json").write_text(json.dumps({"version": ver}))
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(old_root))
+        monkeypatch.setenv(CLAUDE_HOME_ENV_VAR, str(tmp_path))
+        ClaudeDir.reset_cache()
+
+        svc = SessionService()
+        result = svc.build_hook_version_drift_context()
+
+        assert "0.72.0" in result
+        assert "0.76.0" in result
+        assert "restart" in result.lower()
+
+    def test_empty_when_running_version_unknown(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from dev10x.domain.claude_paths import CLAUDE_HOME_ENV_VAR, ClaudeDir
+
+        monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
+        monkeypatch.setenv(CLAUDE_HOME_ENV_VAR, str(tmp_path))
+        ClaudeDir.reset_cache()
+
+        svc = SessionService()
+        assert svc.build_hook_version_drift_context() == ""
+
+
+class TestBuildCompactionContext:
+    def test_empty_when_toplevel_none(self) -> None:
+        svc = SessionService()
+        result = svc.build_compaction_context(toplevel=None)
+        assert isinstance(result, str)
+
+    def test_returns_string_with_valid_toplevel(self, tmp_path: Path) -> None:
+        with (
+            patch("dev10x.domain.documents.session_context.GitContext") as mock_git_cls,
+            patch(
+                "dev10x.domain.documents.session_context.plan_path_for_toplevel",
+                return_value=tmp_path / "plan.json",
+            ),
+            patch("dev10x.domain.documents.session_context.SessionYamlDocument") as mock_doc,
+        ):
+            from dev10x.domain.friction_level import FrictionLevel
+
+            mock_git = mock_git_cls.return_value
+            mock_git.branch = "feature/test"
+            mock_git.run.return_value = ""
+            mock_doc.return_value.read_friction_level.return_value = FrictionLevel.default()
+
+            svc = SessionService(plugin_root=tmp_path)
+            result = svc.build_compaction_context(toplevel=str(tmp_path))
+
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_includes_branch_in_output(self, tmp_path: Path) -> None:
+        with (
+            patch("dev10x.domain.documents.session_context.GitContext") as mock_git_cls,
+            patch(
+                "dev10x.domain.documents.session_context.plan_path_for_toplevel",
+                return_value=tmp_path / "plan.json",
+            ),
+            patch("dev10x.domain.documents.session_context.SessionYamlDocument") as mock_doc,
+        ):
+            from dev10x.domain.friction_level import FrictionLevel
+
+            mock_git = mock_git_cls.return_value
+            mock_git.branch = "feature/svc-test"
+            mock_git.run.return_value = ""
+            mock_doc.return_value.read_friction_level.return_value = FrictionLevel.default()
+
+            svc = SessionService(plugin_root=tmp_path)
+            result = svc.build_compaction_context(toplevel=str(tmp_path))
+
+        assert "feature/svc-test" in result


### PR DESCRIPTION
**When** extending the plugin internals after the 2026-06-10 architecture audit, **I want to** have the repeated tool-dispatch, command-preamble, and session-hook patterns consolidated behind named, tested seams, **so I can** reuse one implementation instead of keeping parallel copies in sync.

---

[`53141b99`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/694/commits/53141b9949080d36c3c3b010aa502ac5a883eab9) ♻️ GH-541 Simplify permission command context preamble
[`a1f41284`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/694/commits/a1f41284cf15633536e1abbf6441569459729128) ♻️ GH-543 Centralize tool-call signature logic in a value object
[`c2465b8b`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/694/commits/c2465b8bde9f85904f5370c2a9326c88c56e3366) ♻️ GH-557 Simplify validator and session dispatch with callables
[`81c1ce77`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/694/commits/81c1ce77b90d254a966f5b6a9ef36ee812ad9b32) ♻️ GH-551 Share the SessionStart emit envelope helper
[`6474a2d9`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/694/commits/6474a2d94245e792395f00cbdab3443b52ada883) ♻️ GH-529 Make session orchestration an injectable service
Closes #541
Closes #543
Closes #557
Closes #551
Closes #529
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/541

---