### PR TITLE
✨ GH-604 Enable in-session approval of sensitive read probes

### DIFF
--- a/.claude/rules/hook-patterns.md
+++ b/.claude/rules/hook-patterns.md
@@ -174,6 +174,46 @@ higher tiers — `minimal` rules are always active.
 | DX015 | spec-drift | standard (experimental) |
 | DX016 | inline-linter | standard |
 
+### DX014 Sensitivity Axis: `ask`, Not `deny` (GH-604)
+
+DX014 classifies *what the target is* (SECRET / CREDENTIAL / PII /
+INFRA) — the third PAP axis, orthogonal to tier and reversibility. A
+read-only-but-sensitive probe (`nc -zv` to infra, `gh secret list`,
+`.env` read) is genuinely worth a prompt but must not be hard-blocked:
+a hard `deny` drops the user to a manual `!` shell. DX014 therefore
+emits `HookAsk` (`permissionDecision: "ask"`, exit 0) so the user can
+approve in-session.
+
+Genuine destructive writes are still hard-denied — by the safety-tier
+validators (DX001–DX005/DX012), which run **before** DX014 in the
+chain and short-circuit on a `deny`. DX014 only ever sees commands the
+safety axis already cleared, so its `ask` (and a blessed `allow`, below)
+never overrides a real block.
+
+**Sensitivity-exception catalog (Tier 2, synced).** A user-owned
+`~/.config/Dev10x/sensitivity-exceptions.yaml` downgrades blessed probes
+from `ask` to `allow` (or keeps an explicit `ask`). It lives in the
+user config home, so it syncs across every worktree. Entries use a
+hybrid target+shape model — an entry applies when *every* supplied
+matcher matches:
+
+```yaml
+exceptions:
+  - description: bastion port probe
+    label: infra              # optional: only when every match is this label
+    shape: '\bnc\b.*-[zv]+'   # optional: regex on the command string
+    target: 'bastion\.example\.internal'  # optional: regex on the command
+    effect: allow             # allow (default) | ask
+```
+
+At least one of `label`/`shape`/`target` is required; a matcher-less
+entry is rejected at load. A `label`-scoped entry only applies when
+*all* sensitivity matches share that label, so it cannot silently bless
+a command that also trips a second, un-blessed label. First applicable
+entry wins (catalog order). A missing/malformed catalog fails open to
+the default `ask`. The validator exposes `with_exceptions()` (mirroring
+`with_patterns()`) as the injection seam.
+
 ### Configuration
 
 Set via environment variables in `.claude/settings.json` or shell:

--- a/src/dev10x/domain/__init__.py
+++ b/src/dev10x/domain/__init__.py
@@ -3,7 +3,13 @@ from dev10x.domain.common.result import ErrorResult, Result, SuccessResult, err,
 from dev10x.domain.config_loader import ConfigLoader
 from dev10x.domain.documents.config_document import Config
 from dev10x.domain.documents.plan import Plan
-from dev10x.domain.events.hook_input import HookAllow, HookInput, HookResult, HookRetry
+from dev10x.domain.events.hook_input import (
+    HookAllow,
+    HookAsk,
+    HookInput,
+    HookResult,
+    HookRetry,
+)
 from dev10x.domain.git_context import GitContext
 from dev10x.domain.rules.rule_engine import RuleEngine, RuleMatch
 from dev10x.domain.rules.sql import SqlStatement, is_read_only_sql
@@ -16,6 +22,7 @@ __all__ = [
     "Config",
     "ConfigLoader",
     "HookAllow",
+    "HookAsk",
     "HookInput",
     "HookResult",
     "HookRetry",

--- a/src/dev10x/domain/dev10x_paths.py
+++ b/src/dev10x/domain/dev10x_paths.py
@@ -141,6 +141,15 @@ class Dev10xConfigDir:
         )
 
     @classmethod
+    def sensitivity_exceptions_yaml(cls) -> Path:
+        """User-owned sensitivity-exception catalog (GH-604).
+
+        No legacy migration: introduced after the ``~/.config/Dev10x``
+        move, so it only ever lives at the canonical path.
+        """
+        return cls._resolve("sensitivity-exceptions.yaml")
+
+    @classmethod
     def github_bot_dir(cls) -> Path:
         return _with_lazy_migration(cls._resolve("github-bot"), _legacy_github_bot_dir)
 

--- a/src/dev10x/domain/events/hook_input.py
+++ b/src/dev10x/domain/events/hook_input.py
@@ -46,6 +46,24 @@ class HookAllow:
 
 
 @dataclass(frozen=True)
+class HookAsk:
+    """Prompt the user to approve/deny the tool call in-session (GH-604).
+
+    The sensitivity axis (DX014) emits this for read-only-but-sensitive
+    commands: a hard ``deny`` (``HookResult``) would drop the user to a
+    manual ``!`` shell, whereas ``ask`` lets them approve the probe in
+    the permission dialog. ``reason`` populates Claude Code's
+    ``permissionDecisionReason``; ``message`` populates ``systemMessage``.
+    """
+
+    message: str = ""
+    reason: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        return {"message": self.message, "decision": "ask", "reason": self.reason}
+
+
+@dataclass(frozen=True)
 class HookRetry:
     message: str
 

--- a/src/dev10x/domain/sensitivity.py
+++ b/src/dev10x/domain/sensitivity.py
@@ -315,6 +315,91 @@ class SensitivityClassifier:
 
 
 # ---------------------------------------------------------------------------
+# Sensitivity-exception catalog — the user-owned downgrade layer (GH-604)
+#
+# DX014 elevates a sensitive command to ``ask`` by default. A user who
+# has blessed a specific read-only probe to a known target should not be
+# re-prompted every time. The exception catalog (Tier 2, synced via
+# ~/.config/Dev10x/sensitivity-exceptions.yaml) downgrades blessed hits
+# from ``ask`` to ``allow`` (or keeps an explicit ``ask``).
+#
+# These value objects and the resolver are pure domain logic; loading the
+# YAML file is an infra concern handled in
+# ``dev10x.validators.sensitivity_exceptions``.
+# ---------------------------------------------------------------------------
+
+
+class ExceptionEffect(StrEnum):
+    """Effect a matched catalog entry applies to a DX014 sensitivity hit."""
+
+    ALLOW = "allow"
+    ASK = "ask"
+
+    def __repr__(self) -> str:
+        return f"ExceptionEffect.{self.name}"
+
+
+@dataclass(frozen=True)
+class SensitivityException:
+    """One blessed entry in the sensitivity-exception catalog (GH-604).
+
+    Hybrid target+shape matching (decision D5): an entry downgrades a
+    DX014 hit to ``effect`` when *every* supplied matcher applies —
+
+        label   apply only when every match carries this exact label
+        shape   regex searched against the full command string
+        target  regex searched against the full command string
+
+    At least one matcher must be set; a matcher-less entry would bless
+    every sensitive command and is rejected at construction. The
+    ``label`` guard uses ``all(...)`` so a command that trips a second,
+    un-blessed label (e.g. CREDENTIAL alongside a blessed INFRA probe)
+    is not silently downgraded — only a label-less (shape/target) entry
+    can bless a multi-label command, which is the user's explicit call.
+    """
+
+    effect: ExceptionEffect = ExceptionEffect.ALLOW
+    label: SensitivityLabel | None = None
+    shape: re.Pattern[str] | None = None
+    target: re.Pattern[str] | None = None
+    description: str = ""
+
+    def __post_init__(self) -> None:
+        if self.label is None and self.shape is None and self.target is None:
+            raise ValueError("SensitivityException requires at least one of label/shape/target")
+
+    def applies(self, *, matches: list[SensitivityMatch], command: str) -> bool:
+        """Return True when every supplied matcher applies to this hit."""
+        if not matches:
+            return False
+        if self.label is not None and not all(m.label == self.label for m in matches):
+            return False
+        if self.shape is not None and not self.shape.search(command):
+            return False
+        if self.target is not None and not self.target.search(command):
+            return False
+        return True
+
+
+def resolve_exception_effect(
+    *,
+    matches: list[SensitivityMatch],
+    command: str,
+    exceptions: list[SensitivityException],
+) -> ExceptionEffect | None:
+    """Return the effect of the first applicable catalog entry, or None.
+
+    First-match-wins by catalog order — the user controls precedence by
+    ordering entries. ``None`` means no entry blessed this command, so
+    the caller keeps DX014's default ``ask`` elevation.
+    """
+    for exc in exceptions:
+        if exc.applies(matches=matches, command=command):
+            return exc.effect
+    return None
+
+
+# ---------------------------------------------------------------------------
 # Identifier sensitivity — the NAME axis (GH-607)
 #
 # This module is the single source of the sensitivity vocabulary for every
@@ -373,10 +458,13 @@ def name_is_sensitive(name: str, *, tokens: frozenset[str] = SENSITIVE_NAME_TOKE
 
 __all__ = [
     "SENSITIVE_NAME_TOKENS",
+    "ExceptionEffect",
     "SensitivityClassifier",
+    "SensitivityException",
     "SensitivityLabel",
     "SensitivityMatch",
     "SensitivityPattern",
     "name_is_sensitive",
+    "resolve_exception_effect",
     "tokenize_identifier",
 ]

--- a/src/dev10x/hooks/hook_transport.py
+++ b/src/dev10x/hooks/hook_transport.py
@@ -18,7 +18,7 @@ import sys
 from typing import NoReturn
 
 from dev10x.domain.events.hook_event import HookEventName
-from dev10x.domain.events.hook_input import HookAllow, HookInput, HookResult, HookRetry
+from dev10x.domain.events.hook_input import HookAllow, HookAsk, HookInput, HookResult, HookRetry
 from dev10x.subprocess_utils import effective_cwd
 
 
@@ -37,11 +37,15 @@ def read_hook_input() -> HookInput:
     return HookInput.from_dict(data=data, cwd=effective_cwd() or os.getcwd())
 
 
-def emit(result: HookResult | HookAllow | HookRetry) -> NoReturn:
+def emit(result: HookResult | HookAllow | HookAsk | HookRetry) -> NoReturn:
     """Write the Claude Code hook envelope for ``result`` and exit.
 
-    ``HookResult`` denies the tool call (exit 2); ``HookAllow`` and
-    ``HookRetry`` both exit 0 with their decision-specific envelope.
+    ``HookResult`` denies the tool call (exit 2); ``HookAllow``,
+    ``HookAsk``, and ``HookRetry`` all exit 0 with their
+    decision-specific envelope. ``HookAsk`` returns
+    ``permissionDecision: "ask"`` so Claude Code shows the in-session
+    approval dialog (GH-604) — exit 0, not 2, since the decision is
+    carried in the JSON rather than the exit code.
     """
     if isinstance(result, HookResult):
         payload: dict[str, object] = {
@@ -53,6 +57,19 @@ def emit(result: HookResult | HookAllow | HookRetry) -> NoReturn:
 
     if isinstance(result, HookAllow):
         payload = {"hookSpecificOutput": {"permissionDecision": "allow"}}
+        if result.message:
+            payload["systemMessage"] = result.message
+        print(json.dumps(payload), file=sys.stderr)
+        sys.exit(0)
+
+    if isinstance(result, HookAsk):
+        payload = {
+            "hookSpecificOutput": {
+                "hookEventName": HookEventName.PRE_TOOL_USE,
+                "permissionDecision": "ask",
+                "permissionDecisionReason": result.reason or result.message,
+            },
+        }
         if result.message:
             payload["systemMessage"] = result.message
         print(json.dumps(payload), file=sys.stderr)

--- a/src/dev10x/validators/base.py
+++ b/src/dev10x/validators/base.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 from typing import ClassVar, Protocol, runtime_checkable
 
-from dev10x.domain import HookAllow, HookInput, HookResult, HookRetry
+from dev10x.domain import HookAllow, HookAsk, HookInput, HookResult, HookRetry
 from dev10x.domain.profile_tier import ProfileTier
 
 
@@ -38,7 +38,7 @@ class Validator(Protocol):
         """Fast predicate — return False to skip this validator entirely."""
         ...
 
-    def validate(self, inp: HookInput) -> HookResult | HookAllow | None:
+    def validate(self, inp: HookInput) -> HookResult | HookAllow | HookAsk | None:
         """Return HookResult to block, HookAllow to auto-approve, None for no opinion."""
         ...
 
@@ -79,6 +79,6 @@ class ValidatorBase:
         """Fast skip predicate — overridden by concrete validators."""
         raise NotImplementedError  # pragma: no cover
 
-    def validate(self, inp: HookInput) -> HookResult | HookAllow | None:
+    def validate(self, inp: HookInput) -> HookResult | HookAllow | HookAsk | None:
         """Block/allow/abstain decision — overridden by concrete validators."""
         raise NotImplementedError  # pragma: no cover

--- a/src/dev10x/validators/registry.py
+++ b/src/dev10x/validators/registry.py
@@ -27,7 +27,7 @@ from dev10x.domain.common.rule_id import RuleId
 from dev10x.domain.profile_tier import ProfileTier
 
 if TYPE_CHECKING:
-    from dev10x.domain import HookAllow, HookInput, HookResult, HookRetry
+    from dev10x.domain import HookAllow, HookAsk, HookInput, HookResult, HookRetry
     from dev10x.validators.base import Validator
 
 log = logging.getLogger(__name__)
@@ -234,14 +234,14 @@ class ValidatorChain:
 
     registry: ValidatorRegistry
 
-    def run(self, inp: HookInput) -> list[HookResult | HookAllow]:
+    def run(self, inp: HookInput) -> list[HookResult | HookAllow | HookAsk]:
         """Invoke ``validate()`` on every applicable validator.
 
         Returns the list of non-None results in registration order;
         callers emit each in turn. When a safety-critical validator
         raises, a fail-closed block is appended in its place (GH-494).
         """
-        results: list[HookResult | HookAllow] = []
+        results: list[HookResult | HookAllow | HookAsk] = []
         for validator in self.registry.active():
             try:
                 if not validator.should_run(inp=inp):

--- a/src/dev10x/validators/sensitivity_exceptions.py
+++ b/src/dev10x/validators/sensitivity_exceptions.py
@@ -1,0 +1,92 @@
+"""Loader for the user-owned sensitivity-exception catalog (GH-604).
+
+Reads ``~/.config/Dev10x/sensitivity-exceptions.yaml`` (Tier 2, synced
+across worktrees) into domain :class:`SensitivityException` value
+objects. The matching logic itself is pure domain code
+(:func:`dev10x.domain.sensitivity.resolve_exception_effect`); this
+module owns only the file I/O and YAML→value-object translation, per
+``.claude/rules/script-domain-boundaries.md``.
+
+The loader is defensive: a missing file, malformed YAML, or an invalid
+entry yields an empty/partial list with a logged warning rather than
+raising — a broken catalog must never break the bash hook (fail open to
+DX014's default ``ask`` elevation).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+import yaml
+
+from dev10x.domain.dev10x_paths import Dev10xConfigDir
+from dev10x.domain.sensitivity import ExceptionEffect, SensitivityException, SensitivityLabel
+
+log = logging.getLogger(__name__)
+
+
+def load_sensitivity_exceptions() -> list[SensitivityException]:
+    """Return catalog entries from the user config, or ``[]`` when absent."""
+    path = Dev10xConfigDir.sensitivity_exceptions_yaml()
+    if not path.exists():
+        return []
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        log.warning("Could not read sensitivity-exception catalog %s: %s", path, exc)
+        return []
+    return _parse_entries(raw=raw, source=str(path))
+
+
+def _parse_entries(*, raw: object, source: str) -> list[SensitivityException]:
+    if not isinstance(raw, dict):
+        log.warning("Sensitivity-exception catalog %s is not a mapping; ignoring", source)
+        return []
+    entries = raw.get("exceptions")
+    if entries is None:
+        return []
+    if not isinstance(entries, list):
+        log.warning("'exceptions' in %s must be a list; ignoring", source)
+        return []
+    parsed: list[SensitivityException] = []
+    for index, entry in enumerate(entries):
+        exception = _parse_entry(entry=entry, source=source, index=index)
+        if exception is not None:
+            parsed.append(exception)
+    return parsed
+
+
+def _parse_entry(*, entry: object, source: str, index: int) -> SensitivityException | None:
+    if not isinstance(entry, dict):
+        log.warning("Entry %d in %s is not a mapping; skipping", index, source)
+        return None
+    try:
+        return SensitivityException(
+            effect=_parse_effect(entry.get("effect")),
+            label=_parse_label(entry.get("label")),
+            shape=_compile(entry.get("shape")),
+            target=_compile(entry.get("target")),
+            description=str(entry.get("description", "")),
+        )
+    except (ValueError, re.error) as exc:
+        log.warning("Skipping invalid sensitivity exception %d in %s: %s", index, source, exc)
+        return None
+
+
+def _parse_effect(value: object) -> ExceptionEffect:
+    if value is None:
+        return ExceptionEffect.ALLOW
+    return ExceptionEffect(str(value).strip().lower())
+
+
+def _parse_label(value: object) -> SensitivityLabel | None:
+    if value is None:
+        return None
+    return SensitivityLabel(str(value).strip().lower())
+
+
+def _compile(value: object) -> re.Pattern[str] | None:
+    if value is None:
+        return None
+    return re.compile(str(value), re.IGNORECASE)

--- a/src/dev10x/validators/sensitivity_target.py
+++ b/src/dev10x/validators/sensitivity_target.py
@@ -36,10 +36,18 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import ClassVar
 
-from dev10x.domain import HookInput, HookResult
+from dev10x.domain import HookAllow, HookAsk, HookInput
 from dev10x.domain.profile_tier import ProfileTier
-from dev10x.domain.sensitivity import SensitivityClassifier, SensitivityMatch, SensitivityPattern
+from dev10x.domain.sensitivity import (
+    ExceptionEffect,
+    SensitivityClassifier,
+    SensitivityException,
+    SensitivityMatch,
+    SensitivityPattern,
+    resolve_exception_effect,
+)
 from dev10x.validators.base import ValidatorBase
+from dev10x.validators.sensitivity_exceptions import load_sensitivity_exceptions
 
 _ASK_MSG_TEMPLATE = """\
 ⚠️  Sensitive target detected — command requires review before execution.
@@ -65,18 +73,33 @@ def _format_matches(matches: list[SensitivityMatch]) -> str:
     return "\n".join(lines)
 
 
+def _ask_reason(matches: list[SensitivityMatch]) -> str:
+    """One-line ``permissionDecisionReason`` for the approval dialog."""
+    labels = ", ".join(sorted({m.label.value.upper() for m in matches}))
+    return f"DX014 sensitivity axis: {labels} target — approve only if intentional and safe."
+
+
 @dataclass
 class SensitivityTargetValidator(ValidatorBase):
-    """Block commands that match the PAP sensitivity wordlist.
+    """Elevate commands matching the PAP sensitivity wordlist to ``ask``.
 
     Uses ``SensitivityClassifier`` to check the full command string
-    against the default wordlist.  Returns a ``HookResult`` (deny with
-    message) when *any* sensitivity pattern fires, implementing the
-    deny-overrides rule: a sensitivity hit on the third axis elevates
-    the effective effect regardless of tier and reversibility scores.
+    against the default wordlist. When *any* sensitivity pattern fires,
+    the sensitivity axis elevates the effective effect to ``ask``
+    (``HookAsk``) — a prompt the user can approve in-session — rather
+    than a hard ``deny`` that drops them to a manual ``!`` shell (GH-604,
+    evidence #3). Genuine destructive writes are still hard-denied by the
+    safety-tier validators (DX001–DX005/DX012), which run *before* DX014
+    in the chain and short-circuit on a ``deny``.
+
+    A user-owned, synced exception catalog (Tier 2,
+    ``~/.config/Dev10x/sensitivity-exceptions.yaml``) can downgrade a
+    blessed read-only probe from ``ask`` to ``allow`` — see
+    ``with_exceptions`` and :func:`resolve_exception_effect`.
 
     The wordlist can be customised per test by injecting a ``classifier``
-    instance; production code always uses the default wordlist.
+    instance; the exception catalog can be injected via ``exceptions``
+    (``None`` = lazy-load from the user config; production default).
     """
 
     name: ClassVar[str] = "sensitivity-target"
@@ -86,6 +109,13 @@ class SensitivityTargetValidator(ValidatorBase):
     classifier: SensitivityClassifier = field(
         default_factory=SensitivityClassifier,
         repr=False,
+    )
+    exceptions: list[SensitivityException] | None = field(default=None, repr=False)
+    _loaded_exceptions: list[SensitivityException] | None = field(
+        default=None,
+        init=False,
+        repr=False,
+        compare=False,
     )
 
     def should_run(self, inp: HookInput) -> bool:
@@ -97,26 +127,60 @@ class SensitivityTargetValidator(ValidatorBase):
         """
         return bool(inp.command.strip())
 
-    def validate(self, inp: HookInput) -> HookResult | None:
-        """Return a HookResult if the command matches the sensitivity wordlist.
+    def validate(self, inp: HookInput) -> HookAsk | HookAllow | None:
+        """Elevate a sensitive command to ``ask``, or ``allow`` if blessed.
 
-        Deny-overrides: any sensitivity match wins over tier/reversibility.
+        Any sensitivity match wins over tier/reversibility (deny-overrides
+        on the sensitivity axis). A matching exception-catalog entry with
+        effect ``allow`` downgrades the hit to a silent ``HookAllow``; an
+        explicit ``ask`` entry — or no matching entry — keeps the ``ask``
+        prompt. The catalog is consulted only after a match, so benign
+        commands never touch the filesystem.
         """
         matches = self.classifier.classify(command=inp.command)
         if not matches:
             return None
-        matches_detail = _format_matches(matches=matches)
+        effect = resolve_exception_effect(
+            matches=matches,
+            command=inp.command,
+            exceptions=self._resolved_exceptions(),
+        )
+        if effect is ExceptionEffect.ALLOW:
+            return HookAllow()
         message = _ASK_MSG_TEMPLATE.format(
             count=len(matches),
-            matches_detail=matches_detail,
+            matches_detail=_format_matches(matches=matches),
         )
-        return HookResult(message=message)
+        return HookAsk(message=message, reason=_ask_reason(matches=matches))
+
+    def _resolved_exceptions(self) -> list[SensitivityException]:
+        """Return injected exceptions, else lazily load (and cache) the catalog."""
+        if self.exceptions is not None:
+            return self.exceptions
+        if self._loaded_exceptions is None:
+            self._loaded_exceptions = load_sensitivity_exceptions()
+        return self._loaded_exceptions
 
     def with_patterns(self, patterns: list[SensitivityPattern]) -> SensitivityTargetValidator:
         """Return a new validator instance using the supplied wordlist.
 
         Useful for tests and for project-local sensitivity overrides.
+        Preserves any injected exception catalog.
         """
         return SensitivityTargetValidator(
             classifier=SensitivityClassifier(patterns=patterns),
+            exceptions=self.exceptions,
+        )
+
+    def with_exceptions(
+        self, exceptions: list[SensitivityException]
+    ) -> SensitivityTargetValidator:
+        """Return a new validator using the supplied exception catalog.
+
+        Mirrors ``with_patterns`` — the seam GH-604 uses to inject the
+        user-owned, synced sensitivity-exception catalog.
+        """
+        return SensitivityTargetValidator(
+            classifier=self.classifier,
+            exceptions=exceptions,
         )

--- a/tests/domain/test_sensitivity.py
+++ b/tests/domain/test_sensitivity.py
@@ -8,15 +8,20 @@ tier=safe-read and reversibility=trivial, yet plainly sensitive.
 
 from __future__ import annotations
 
+import re
+
 import pytest
 
 from dev10x.domain.sensitivity import (
     SENSITIVE_NAME_TOKENS,
+    ExceptionEffect,
     SensitivityClassifier,
+    SensitivityException,
     SensitivityLabel,
     SensitivityMatch,
     SensitivityPattern,
     name_is_sensitive,
+    resolve_exception_effect,
     tokenize_identifier,
 )
 
@@ -335,7 +340,6 @@ class TestCustomPatterns:
         assert classifier.classify(command="gh secret list") == []
 
     def test_single_custom_pattern(self) -> None:
-        import re
 
         custom = SensitivityPattern(
             label=SensitivityLabel.INFRA,
@@ -349,7 +353,6 @@ class TestCustomPatterns:
         assert matches[0].pattern == "custom prod db"
 
     def test_custom_pattern_no_match(self) -> None:
-        import re
 
         custom = SensitivityPattern(
             label=SensitivityLabel.SECRET,
@@ -495,3 +498,121 @@ class TestNameIsSensitive:
     def test_custom_token_set_overrides_default(self) -> None:
         assert name_is_sensitive("get_token", tokens=frozenset({"token"}))
         assert not name_is_sensitive("get_token")
+
+
+# ---------------------------------------------------------------------------
+# Sensitivity-exception catalog — value objects + resolver (GH-604)
+# ---------------------------------------------------------------------------
+
+
+def _match(label: SensitivityLabel, text: str = "x") -> SensitivityMatch:
+    return SensitivityMatch(label=label, pattern="p", matched_text=text)
+
+
+class TestExceptionEffect:
+    def test_values(self) -> None:
+        assert {e.value for e in ExceptionEffect} == {"allow", "ask"}
+
+    def test_repr_includes_name(self) -> None:
+        assert "ALLOW" in repr(ExceptionEffect.ALLOW)
+
+
+class TestSensitivityExceptionConstruction:
+    def test_default_effect_is_allow(self) -> None:
+        exc = SensitivityException(label=SensitivityLabel.INFRA)
+        assert exc.effect is ExceptionEffect.ALLOW
+
+    def test_requires_at_least_one_matcher(self) -> None:
+        with pytest.raises(ValueError, match="at least one of label/shape/target"):
+            SensitivityException()
+
+    def test_label_only_matcher_is_valid(self) -> None:
+        assert SensitivityException(label=SensitivityLabel.SECRET).label is SensitivityLabel.SECRET
+
+    def test_shape_only_matcher_is_valid(self) -> None:
+        assert SensitivityException(shape=re.compile(r"\bnc\b")) is not None
+
+
+class TestSensitivityExceptionApplies:
+    def test_label_matches_when_all_matches_share_label(self) -> None:
+        exc = SensitivityException(label=SensitivityLabel.INFRA)
+        matches = [_match(SensitivityLabel.INFRA), _match(SensitivityLabel.INFRA)]
+        assert exc.applies(matches=matches, command="nc -zv host 5432") is True
+
+    def test_label_does_not_match_when_a_second_label_present(self) -> None:
+        # A blessed INFRA entry must not downgrade a command that also
+        # trips an un-blessed CREDENTIAL match (all(...) guard).
+        exc = SensitivityException(label=SensitivityLabel.INFRA)
+        matches = [_match(SensitivityLabel.INFRA), _match(SensitivityLabel.CREDENTIAL)]
+        assert exc.applies(matches=matches, command="rg DB_PASSWORD 10.0.0.5") is False
+
+    def test_shape_matches_command(self) -> None:
+        exc = SensitivityException(shape=re.compile(r"\bnc\b.*-[zv]+"))
+        assert exc.applies(matches=[_match(SensitivityLabel.INFRA)], command="nc -zv h 5432")
+
+    def test_shape_mismatch_does_not_apply(self) -> None:
+        exc = SensitivityException(shape=re.compile(r"\bdig\b"))
+        assert not exc.applies(matches=[_match(SensitivityLabel.INFRA)], command="nc -zv h 5432")
+
+    def test_target_matches_command(self) -> None:
+        exc = SensitivityException(target=re.compile(r"bastion\.example\.internal"))
+        cmd = "nc -zv bastion.example.internal 22"
+        assert exc.applies(matches=[_match(SensitivityLabel.INFRA)], command=cmd)
+
+    def test_all_supplied_fields_must_match(self) -> None:
+        # Shape matches but target does not → AND semantics → no apply.
+        exc = SensitivityException(
+            shape=re.compile(r"\bnc\b"),
+            target=re.compile(r"bastion\.example\.internal"),
+        )
+        assert not exc.applies(
+            matches=[_match(SensitivityLabel.INFRA)],
+            command="nc -zv other.host 22",
+        )
+
+    def test_empty_matches_never_applies(self) -> None:
+        exc = SensitivityException(shape=re.compile(r"\bnc\b"))
+        assert exc.applies(matches=[], command="nc -zv h 5432") is False
+
+
+class TestResolveExceptionEffect:
+    def test_no_exceptions_returns_none(self) -> None:
+        result = resolve_exception_effect(
+            matches=[_match(SensitivityLabel.INFRA)], command="nc -zv h 5432", exceptions=[]
+        )
+        assert result is None
+
+    def test_first_applicable_wins(self) -> None:
+        exceptions = [
+            SensitivityException(effect=ExceptionEffect.ASK, shape=re.compile(r"\bnc\b")),
+            SensitivityException(effect=ExceptionEffect.ALLOW, shape=re.compile(r"\bnc\b")),
+        ]
+        result = resolve_exception_effect(
+            matches=[_match(SensitivityLabel.INFRA)],
+            command="nc -zv h 5432",
+            exceptions=exceptions,
+        )
+        assert result is ExceptionEffect.ASK
+
+    def test_returns_allow_when_blessed(self) -> None:
+        exceptions = [
+            SensitivityException(
+                effect=ExceptionEffect.ALLOW,
+                target=re.compile(r"bastion\.example\.internal"),
+            )
+        ]
+        result = resolve_exception_effect(
+            matches=[_match(SensitivityLabel.INFRA)],
+            command="nc -zv bastion.example.internal 22",
+            exceptions=exceptions,
+        )
+        assert result is ExceptionEffect.ALLOW
+
+    def test_non_matching_exception_returns_none(self) -> None:
+        exceptions = [SensitivityException(shape=re.compile(r"\bdig\b"))]
+        result = resolve_exception_effect(
+            matches=[_match(SensitivityLabel.INFRA)],
+            command="nc -zv h 5432",
+            exceptions=exceptions,
+        )
+        assert result is None

--- a/tests/hooks/test_hook_transport.py
+++ b/tests/hooks/test_hook_transport.py
@@ -13,7 +13,7 @@ import json
 
 import pytest
 
-from dev10x.domain.events.hook_input import HookAllow, HookResult
+from dev10x.domain.events.hook_input import HookAllow, HookAsk, HookResult
 from dev10x.hooks.hook_transport import emit, read_hook_input
 
 
@@ -47,6 +47,35 @@ class TestEmitHookAllow:
     def test_omits_system_message_when_empty(self, capsys: pytest.CaptureFixture[str]) -> None:
         with pytest.raises(SystemExit):
             emit(HookAllow())
+        output = json.loads(capsys.readouterr().err)
+        assert "systemMessage" not in output
+
+
+class TestEmitHookAsk:
+    def test_exits_with_code_0(self) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            emit(HookAsk(message="sensitive", reason="why"))
+        assert exc_info.value.code == 0
+
+    def test_writes_ask_envelope(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with pytest.raises(SystemExit):
+            emit(HookAsk(message="sensitive probe", reason="DX014 INFRA target"))
+        output = json.loads(capsys.readouterr().err)
+        hook_output = output["hookSpecificOutput"]
+        assert hook_output["hookEventName"] == "PreToolUse"
+        assert hook_output["permissionDecision"] == "ask"
+        assert hook_output["permissionDecisionReason"] == "DX014 INFRA target"
+        assert output["systemMessage"] == "sensitive probe"
+
+    def test_reason_falls_back_to_message(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with pytest.raises(SystemExit):
+            emit(HookAsk(message="only a message"))
+        output = json.loads(capsys.readouterr().err)
+        assert output["hookSpecificOutput"]["permissionDecisionReason"] == "only a message"
+
+    def test_omits_system_message_when_empty(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with pytest.raises(SystemExit):
+            emit(HookAsk(reason="reason only"))
         output = json.loads(capsys.readouterr().err)
         assert "systemMessage" not in output
 

--- a/tests/validators/test_sensitivity_exceptions.py
+++ b/tests/validators/test_sensitivity_exceptions.py
@@ -1,0 +1,121 @@
+"""Tests for the sensitivity-exception catalog loader (GH-604).
+
+The loader reads ~/.config/Dev10x/sensitivity-exceptions.yaml into
+domain SensitivityException value objects and fails open (empty/partial
+list, logged warning) on a missing file, malformed YAML, or an invalid
+entry — a broken catalog must never break the bash hook.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dev10x.domain.dev10x_paths import Dev10xConfigDir
+from dev10x.domain.sensitivity import ExceptionEffect, SensitivityLabel
+from dev10x.validators.sensitivity_exceptions import load_sensitivity_exceptions
+
+
+@pytest.fixture()
+def config_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("DEV10X_CONFIG_HOME", str(tmp_path))
+    Dev10xConfigDir.reset_cache()
+    yield tmp_path
+    Dev10xConfigDir.reset_cache()
+
+
+def _write(config_home: Path, body: str) -> None:
+    (config_home / "sensitivity-exceptions.yaml").write_text(body, encoding="utf-8")
+
+
+class TestMissingOrEmpty:
+    def test_missing_file_returns_empty(self, config_home: Path) -> None:
+        assert load_sensitivity_exceptions() == []
+
+    def test_empty_exceptions_key_returns_empty(self, config_home: Path) -> None:
+        _write(config_home, "exceptions: []\n")
+        assert load_sensitivity_exceptions() == []
+
+    def test_absent_exceptions_key_returns_empty(self, config_home: Path) -> None:
+        _write(config_home, "other: 1\n")
+        assert load_sensitivity_exceptions() == []
+
+
+class TestValidEntries:
+    def test_full_entry_parsed(self, config_home: Path) -> None:
+        _write(
+            config_home,
+            """
+exceptions:
+  - description: bastion port probe
+    label: infra
+    shape: '\\bnc\\b.*-[zv]+'
+    target: 'bastion\\.example\\.internal'
+    effect: allow
+""",
+        )
+        exceptions = load_sensitivity_exceptions()
+        assert len(exceptions) == 1
+        exc = exceptions[0]
+        assert exc.description == "bastion port probe"
+        assert exc.label is SensitivityLabel.INFRA
+        assert exc.effect is ExceptionEffect.ALLOW
+        assert exc.shape is not None and exc.shape.search("nc -zv host 5432")
+        assert exc.target is not None and exc.target.search("bastion.example.internal")
+
+    def test_effect_defaults_to_allow(self, config_home: Path) -> None:
+        _write(config_home, "exceptions:\n  - shape: '\\bnc\\b'\n")
+        assert load_sensitivity_exceptions()[0].effect is ExceptionEffect.ALLOW
+
+    def test_explicit_ask_effect(self, config_home: Path) -> None:
+        _write(config_home, "exceptions:\n  - shape: '\\bnc\\b'\n    effect: ask\n")
+        assert load_sensitivity_exceptions()[0].effect is ExceptionEffect.ASK
+
+    def test_target_pattern_is_case_insensitive(self, config_home: Path) -> None:
+        _write(config_home, "exceptions:\n  - target: 'Bastion'\n")
+        exc = load_sensitivity_exceptions()[0]
+        assert exc.target is not None and exc.target.search("ssh bastion")
+
+
+class TestDefensiveParsing:
+    def test_malformed_yaml_returns_empty(self, config_home: Path) -> None:
+        _write(config_home, "exceptions: [unclosed\n")
+        assert load_sensitivity_exceptions() == []
+
+    def test_non_mapping_root_returns_empty(self, config_home: Path) -> None:
+        _write(config_home, "- just\n- a\n- list\n")
+        assert load_sensitivity_exceptions() == []
+
+    def test_exceptions_not_a_list_returns_empty(self, config_home: Path) -> None:
+        _write(config_home, "exceptions: not-a-list\n")
+        assert load_sensitivity_exceptions() == []
+
+    def test_invalid_effect_skips_entry(self, config_home: Path) -> None:
+        _write(
+            config_home,
+            "exceptions:\n  - shape: '\\bnc\\b'\n    effect: bogus\n"
+            "  - shape: '\\bdig\\b'\n    effect: allow\n",
+        )
+        exceptions = load_sensitivity_exceptions()
+        assert len(exceptions) == 1
+        assert exceptions[0].shape is not None and exceptions[0].shape.search("dig host")
+
+    def test_invalid_label_skips_entry(self, config_home: Path) -> None:
+        _write(config_home, "exceptions:\n  - label: nonsense\n")
+        assert load_sensitivity_exceptions() == []
+
+    def test_matcherless_entry_skipped(self, config_home: Path) -> None:
+        _write(
+            config_home, "exceptions:\n  - effect: allow\n    description: blesses everything\n"
+        )
+        assert load_sensitivity_exceptions() == []
+
+    def test_bad_regex_skips_entry(self, config_home: Path) -> None:
+        _write(config_home, "exceptions:\n  - shape: '([unclosed'\n")
+        assert load_sensitivity_exceptions() == []
+
+    def test_non_mapping_entry_skipped_others_kept(self, config_home: Path) -> None:
+        _write(config_home, "exceptions:\n  - just-a-string\n  - shape: '\\bnc\\b'\n")
+        exceptions = load_sensitivity_exceptions()
+        assert len(exceptions) == 1

--- a/tests/validators/test_sensitivity_target.py
+++ b/tests/validators/test_sensitivity_target.py
@@ -3,10 +3,13 @@
 Covers:
 - should_run() fast-skip predicate
 - validate() returning None for benign commands
-- validate() returning HookResult for each sensitivity label
+- validate() returning HookAsk for each sensitivity label (GH-604:
+  the sensitivity axis elevates to ``ask``, not hard ``deny``)
+- exception-catalog downgrade: HookAllow when blessed (GH-604)
 - deny-overrides semantics: multi-match accumulates all matches
 - Registry integration: DX014 appears in standard profile
 - Custom classifier injection via with_patterns()
+- Exception-catalog injection via with_exceptions()
 
 Fixtures are drawn from GH-271 evidence #267–#273 (same corpus as
 the SensitivityClassifier unit tests in tests/domain/test_sensitivity.py).
@@ -14,10 +17,20 @@ the SensitivityClassifier unit tests in tests/domain/test_sensitivity.py).
 
 from __future__ import annotations
 
+import re
+
 import pytest
 
+from dev10x.domain import HookAllow, HookAsk
+from dev10x.domain.dev10x_paths import Dev10xConfigDir
 from dev10x.domain.profile_tier import ProfileTier
-from dev10x.domain.sensitivity import SensitivityClassifier, SensitivityLabel, SensitivityPattern
+from dev10x.domain.sensitivity import (
+    ExceptionEffect,
+    SensitivityClassifier,
+    SensitivityException,
+    SensitivityLabel,
+    SensitivityPattern,
+)
 from dev10x.validators import get_validators, reset_registry
 from dev10x.validators.sensitivity_target import SensitivityTargetValidator
 from tests.fakers import BashHookInputFaker
@@ -25,6 +38,21 @@ from tests.fakers import BashHookInputFaker
 
 def _inp(command: str) -> BashHookInputFaker:
     return BashHookInputFaker.build(command=command)
+
+
+@pytest.fixture(autouse=True)
+def _empty_catalog(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the exception catalog to an empty config home (hermetic).
+
+    DX014 lazily loads ``~/.config/Dev10x/sensitivity-exceptions.yaml``
+    on the first sensitivity match. Point it at an empty tmp dir so the
+    default validator behaves as 'no exceptions' regardless of the
+    developer's real config (GH-604).
+    """
+    monkeypatch.setenv("DEV10X_CONFIG_HOME", str(tmp_path))
+    Dev10xConfigDir.reset_cache()
+    yield
+    Dev10xConfigDir.reset_cache()
 
 
 # ---------------------------------------------------------------------------
@@ -238,7 +266,6 @@ class TestDenyOverrides:
         result = validator.validate(inp=_inp(cmd))
         assert result is not None
         # The count line must show > 1.
-        import re
 
         count_match = re.search(r"matched (\d+) sensitivity pattern", result.message)
         assert count_match is not None
@@ -281,9 +308,102 @@ class TestMessageFormat:
 # ---------------------------------------------------------------------------
 
 
+class TestAskElevation:
+    """GH-604: a sensitivity hit elevates to ``ask``, not hard ``deny``."""
+
+    def test_returns_hook_ask_for_sensitive_command(
+        self, validator: SensitivityTargetValidator
+    ) -> None:
+        result = validator.validate(inp=_inp("nc -zv 10.0.0.5 5432"))
+        assert isinstance(result, HookAsk)
+
+    def test_ask_reason_names_label(self, validator: SensitivityTargetValidator) -> None:
+        result = validator.validate(inp=_inp("nc -zv 10.0.0.5 5432"))
+        assert isinstance(result, HookAsk)
+        assert "INFRA" in result.reason
+        assert "DX014" in result.reason
+
+    def test_ask_message_retains_detail(self, validator: SensitivityTargetValidator) -> None:
+        result = validator.validate(inp=_inp("gh secret list"))
+        assert isinstance(result, HookAsk)
+        assert "SECRET" in result.message
+        assert "DX014" in result.message
+
+
+class TestExceptionCatalogDowngrade:
+    """GH-604: a blessed exception downgrades ``ask`` to ``allow`` / keeps ``ask``."""
+
+    def test_allow_exception_returns_hook_allow(self) -> None:
+        exc = SensitivityException(
+            effect=ExceptionEffect.ALLOW,
+            target=re.compile(r"bastion\.example\.internal"),
+        )
+        v = SensitivityTargetValidator(exceptions=[exc])
+        result = v.validate(inp=_inp("nc -zv bastion.example.internal 22"))
+        assert isinstance(result, HookAllow)
+
+    def test_allow_exception_silent_message(self) -> None:
+        exc = SensitivityException(effect=ExceptionEffect.ALLOW, shape=re.compile(r"\bnc\b"))
+        v = SensitivityTargetValidator(exceptions=[exc])
+        result = v.validate(inp=_inp("nc -zv host 5432"))
+        assert isinstance(result, HookAllow)
+        assert result.message == ""
+
+    def test_ask_exception_keeps_ask(self) -> None:
+        exc = SensitivityException(effect=ExceptionEffect.ASK, shape=re.compile(r"\bnc\b"))
+        v = SensitivityTargetValidator(exceptions=[exc])
+        result = v.validate(inp=_inp("nc -zv host 5432"))
+        assert isinstance(result, HookAsk)
+
+    def test_non_matching_exception_keeps_ask(self) -> None:
+        exc = SensitivityException(
+            effect=ExceptionEffect.ALLOW,
+            target=re.compile(r"bastion\.example\.internal"),
+        )
+        v = SensitivityTargetValidator(exceptions=[exc])
+        # Different target → exception does not apply → still ask.
+        result = v.validate(inp=_inp("nc -zv other.host 22"))
+        assert isinstance(result, HookAsk)
+
+    def test_label_scoped_allow_does_not_downgrade_multilabel(self) -> None:
+        # An INFRA-only allow must not bless a command that also trips
+        # CREDENTIAL (the all-matches-share-label guard).
+        exc = SensitivityException(effect=ExceptionEffect.ALLOW, label=SensitivityLabel.INFRA)
+        v = SensitivityTargetValidator(exceptions=[exc])
+        result = v.validate(inp=_inp("rg DB_PASSWORD 10.0.0.5"))
+        assert isinstance(result, HookAsk)
+
+    def test_benign_command_skips_catalog(self) -> None:
+        # No sensitivity match → None, exceptions never consulted.
+        exc = SensitivityException(effect=ExceptionEffect.ALLOW, shape=re.compile(r".*"))
+        v = SensitivityTargetValidator(exceptions=[exc])
+        assert v.validate(inp=_inp("git status")) is None
+
+    def test_with_exceptions_factory(self) -> None:
+        exc = SensitivityException(effect=ExceptionEffect.ALLOW, shape=re.compile(r"\bnc\b"))
+        base = SensitivityTargetValidator()
+        blessed = base.with_exceptions(exceptions=[exc])
+        # Base still elevates to ask; blessed instance allows.
+        assert isinstance(base.validate(inp=_inp("nc -zv host 5432")), HookAsk)
+        assert isinstance(blessed.validate(inp=_inp("nc -zv host 5432")), HookAllow)
+
+    def test_with_patterns_preserves_exceptions(self) -> None:
+        exc = SensitivityException(effect=ExceptionEffect.ALLOW, shape=re.compile(r"\bzzz\b"))
+        v = SensitivityTargetValidator(exceptions=[exc]).with_patterns(
+            patterns=[
+                SensitivityPattern(
+                    label=SensitivityLabel.SECRET,
+                    regex=re.compile(r"\bzzz\b"),
+                    description="zzz",
+                )
+            ]
+        )
+        # The injected exception survives with_patterns and downgrades.
+        assert isinstance(v.validate(inp=_inp("run zzz now")), HookAllow)
+
+
 class TestCustomClassifier:
     def test_custom_wordlist_replaces_default(self) -> None:
-        import re
 
         custom_pattern = SensitivityPattern(
             label=SensitivityLabel.SECRET,
@@ -302,7 +422,6 @@ class TestCustomClassifier:
         assert "SECRET" in result.message
 
     def test_with_patterns_factory(self) -> None:
-        import re
 
         base = SensitivityTargetValidator()
         custom = base.with_patterns(

--- a/tests/validators/test_types.py
+++ b/tests/validators/test_types.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from dev10x.domain import HookAllow, HookInput, HookResult
+from dev10x.domain import HookAllow, HookAsk, HookInput, HookResult
 
 
 class TestHookInputFromDict:
@@ -56,3 +56,18 @@ class TestHookAllow:
 
     def test_to_dict_message_preserved(self) -> None:
         assert HookAllow(message="auto-approved").to_dict()["message"] == "auto-approved"
+
+
+class TestHookAsk:
+    def test_to_dict_decision_ask(self) -> None:
+        assert HookAsk().to_dict()["decision"] == "ask"
+
+    def test_to_dict_message_and_reason_default_empty(self) -> None:
+        result = HookAsk().to_dict()
+        assert result["message"] == ""
+        assert result["reason"] == ""
+
+    def test_to_dict_preserves_message_and_reason(self) -> None:
+        result = HookAsk(message="sensitive", reason="DX014 INFRA target").to_dict()
+        assert result["message"] == "sensitive"
+        assert result["reason"] == "DX014 INFRA target"


### PR DESCRIPTION
**When** a read-only-but-sensitive command (e.g. `nc -zv` to infra, `gh secret list`) hits DX014, **I want to** approve it in-session via a prompt instead of hitting a hard deny — backed by a user-owned, synced exception catalog for blessed read-only probes to known targets — **so I can** keep working instead of dropping to a manual `!` shell.

---

[`2fcf7530`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/695/commits/2fcf7530593f4dfbab09886541edcd05aa7302f2) ✨ GH-604 Enable in-session approval of sensitive read probes

Fixes: #604