### PR TITLE
✨ GH-610 Keep background subagents off hook-tripping shapes

### DIFF
--- a/.claude/rules/mcp-tools.md
+++ b/.claude/rules/mcp-tools.md
@@ -170,6 +170,7 @@ supporting each tool:
 | `rule_confidence_report` | `cli` | GH-350 | v0.80.0+ |
 | `record_rule_feedback` | `cli` | GH-350 | v0.80.0+ |
 | `request_sampling` | `cli` | GH-343 | v0.80.0+ |
+| `background_preamble` | `cli` | GH-610 | v0.80.0+ |
 | `query` | `db` | PR #126 | v0.25.0+ |
 
 When adding a new tool, update this table and note any dependencies on

--- a/references/orchestration/background-preamble.md
+++ b/references/orchestration/background-preamble.md
@@ -1,0 +1,84 @@
+# Background Friction Preamble (GH-610)
+
+Canonical friction-avoidance preamble for background-dispatched
+subagents (workflow / monitor / loop / fanout).
+
+## Why this exists
+
+Background subagents start with a **fresh system prompt** — they never
+receive the SessionStart "Session Guidance — Patterns & Anti-Patterns"
+briefing the main session gets. Without it they reproduce hook-tripping
+command shapes (`cd && …`, `$(…)`, pipe chains, worktree-pinned paths)
+and bypass MCP wrappers, then the harness offers the "switch to auto
+mode" nudge (the GH-310 footgun). Parent: **GH-488** (S13 / G13 / D11).
+
+This file is the **single source of truth**. Dispatchers MUST prepend
+the block below verbatim to every background subagent prompt, and
+pre-seed the subagent's tool surface (see § Pre-seed). Fetch the text
+programmatically via the `mcp__plugin_Dev10x_cli__background_preamble`
+tool (no Read prompt, no drift) or read this file.
+
+## Coverage and limits
+
+| Dispatch path | How the preamble lands |
+|---------------|------------------------|
+| `Dev10x:fanout` swarm children | Inlined into the per-item agent prompt template |
+| `Dev10x:gh-pr-monitor` micro-agents | Inlined into each micro-agent prompt |
+| Any Dev10x skill dispatching `Agent(...)` | Prepend per `references/orchestration/subagent-dispatch.md` |
+| Built-in `Workflow` tool agents | Inline into each `agent()` prompt the script builds |
+| Built-in `/loop` iterations | Harness-owned; the loop body's dispatched skills inline it |
+
+`/loop` and the built-in `Workflow` tool are harness-owned — Dev10x
+cannot inject into them automatically. The contract is therefore on the
+**dispatcher**: whenever a Dev10x skill or workflow script builds a
+subagent prompt, it prepends this preamble.
+
+## The preamble (prepend verbatim)
+
+<!-- BEGIN PREAMBLE -->
+You are a background subagent. You did NOT receive the session's
+friction briefing, so follow these rules to avoid tripping PreToolUse
+hooks and to stay on the pre-approved tool surface.
+
+Command shapes to avoid (each trips a hook or breaks allow-rule matching):
+- No `cmd1 && cmd2`, `cmd1; cmd2`, or `a | b` chaining — one command per
+  Bash call.
+- No `cd /path && …` and no `git -C /path …` — your CWD is already the
+  correct worktree; run commands directly.
+- No `$(…)` command substitution and no `ENV=value cmd` prefixes.
+- No heredocs or redirects (`cat <<EOF`, `cat > file`, `echo > file`) —
+  use the Write tool.
+- No inline interpreters (`python3 -c`, `sh -c`, `perl -e`, `node -e`) —
+  use jq / yq / yamllint / actionlint, or extract a `uv run --script`
+  tool.
+
+Prefer:
+- `Read` / `Grep` / `Glob` over `cat` / `grep` / `find` in Bash.
+- MCP wrappers and skills over raw CLI: commit → Skill(Dev10x:git-commit),
+  PR → Skill(Dev10x:gh-pr-create), push → Skill(Dev10x:git), temp files →
+  mcp__plugin_Dev10x_cli__mktmp.
+- Git base aliases for diffs/logs/rebases: `git develop-log`,
+  `git develop-diff`, `git develop-rebase`.
+
+Your tool surface is pre-seeded — the tools you need are already
+allowed. Use them. Do NOT ask to "switch to auto mode" or disable
+permission prompts to escape a blocked command (GH-310 footgun). If a
+command is blocked, switch to the wrapper / structured tool named above.
+<!-- END PREAMBLE -->
+
+## Pre-seed (dispatcher responsibility)
+
+The preamble tells the subagent to prefer `Read`/`Grep`/`Glob` and MCP
+wrappers — those tools must actually be available, or the subagent
+falls back to raw Bash and re-trips hooks. When constructing the
+`Agent(...)` / `agent()` call, ensure `allowed_tools` includes:
+
+- `Read`, `Grep`, `Glob`
+- `mcp__plugin_Dev10x_cli__mktmp` and the workflow's needed `cli`
+  wrappers (e.g. `push_safe`, `create_pr`, `ci_check_status`)
+- `Skill` only when the subagent is meant to delegate (monitor
+  micro-agents intentionally omit it)
+
+Recommend pre-seeding over the auto-mode nudge: a narrow, correct tool
+surface beats blanket `bypassPermissions`, which defeats the whole
+friction model.

--- a/references/orchestration/subagent-dispatch.md
+++ b/references/orchestration/subagent-dispatch.md
@@ -80,6 +80,35 @@ appears idle and may be closed prematurely.
 This pattern applies to ALL skills that launch background
 agents, not just `gh-pr-monitor`.
 
+## Background Friction Preamble (REQUIRED, GH-610)
+
+Background subagents (workflow / monitor / loop / fanout) start
+with a **fresh system prompt** — they never receive the
+SessionStart "Session Guidance — Patterns & Anti-Patterns"
+briefing. Without it they emit hook-tripping command shapes
+(`cd && …`, `$(…)`, pipe chains, `git -C`) and bypass MCP
+wrappers, then the harness offers the "switch to auto mode"
+nudge (the GH-310 footgun).
+
+**REQUIRED for every background dispatch:** prepend the canonical
+friction-avoidance preamble to the subagent prompt, and pre-seed
+its tool surface so the preferred tools are actually available.
+
+1. Fetch the preamble text via
+   `mcp__plugin_Dev10x_cli__background_preamble` (no Read prompt,
+   single source of truth). The canonical document is
+   [`background-preamble.md`](background-preamble.md).
+2. Prepend the returned text verbatim to the subagent's prompt.
+3. Ensure `allowed_tools` includes `Read`, `Grep`, `Glob`, the
+   `cli` wrappers the work needs (`mktmp`, `push_safe`,
+   `create_pr`, `ci_check_status`, …), and `Skill` only when the
+   subagent is meant to delegate.
+
+Recommend pre-seeding over disabling prompts: a narrow correct
+tool surface beats blanket `bypassPermissions`. See
+`background-preamble.md` § Pre-seed for the full contract and
+the harness-owned coverage limits (`/loop`, built-in `Workflow`).
+
 ## Wave-Based Orchestration
 
 When orchestrating multiple independent analysis phases, structure

--- a/skills/diag-friction/SKILL.md
+++ b/skills/diag-friction/SKILL.md
@@ -192,6 +192,26 @@ and safe — never the dead-on-arrival or over-granting default.
 Only Bash command rules are generalized; `mcp__*`, `WebFetch(...)`,
 and `Read(...)` rules pass through unchanged.
 
+### Step 3e: Background-dispatch pre-seed over auto-mode (GH-610)
+
+When the friction arose inside a **background subagent** (workflow /
+monitor / loop / fanout child) — or the only "fix" on offer is the
+harness's "switch to auto mode" / disable-prompts nudge (the GH-310
+footgun) — do NOT recommend blanket `bypassPermissions`. The correct
+remedy is to fix the **dispatcher**, not to silence prompts:
+
+1. Prepend the canonical friction-avoidance preamble to the subagent
+   prompt (fetch via `mcp__plugin_Dev10x_cli__background_preamble`).
+2. Pre-seed the subagent's `allowed_tools` with the wrappers it needs
+   (`Read`, `Grep`, `Glob`, `mktmp`, `push_safe`, `create_pr`, …) so
+   the preferred tool surface is actually available.
+
+Surface this as the primary recommendation whenever the offending
+command came from a background dispatch path. See
+`references/orchestration/background-preamble.md` and
+`references/orchestration/subagent-dispatch.md` § Background Friction
+Preamble.
+
 ### Step 4: Output reinforcement message
 
 Output a firm, concise reinforcement message with seven sections:

--- a/skills/fanout/instructions.md
+++ b/skills/fanout/instructions.md
@@ -456,7 +456,19 @@ decision-gate rules (wait vs bail), and producer/consumer
 contracts live in
 [`references/orchestration/fanout-bus.md`](../../references/orchestration/fanout-bus.md).
 
-**Per-item agent prompt template:**
+**Friction-avoidance preamble (REQUIRED, GH-610):** Before building
+the prompt below, fetch the canonical preamble via
+`mcp__plugin_Dev10x_cli__background_preamble` and prepend its
+`preamble` text verbatim to the top of each child's prompt. Swarm
+children run a full `Dev10x:work-on` lifecycle in a fresh subagent that
+never saw the SessionStart friction briefing — the preamble keeps them
+off hook-tripping shapes and on MCP wrappers. Pre-seed each child's
+`allowed_tools` with `Read`, `Grep`, `Glob`, `Skill`, and the `cli`
+wrappers (`mktmp`, `push_safe`, `create_pr`, …) rather than relying on
+auto-mode. See `references/orchestration/background-preamble.md`.
+
+**Per-item agent prompt template** (prepend the preamble above the
+`You are working as part of …` line):
 
 ```
 You are working as part of a Dev10x:fanout swarm.

--- a/skills/gh-pr-monitor/SKILL.md
+++ b/skills/gh-pr-monitor/SKILL.md
@@ -21,6 +21,7 @@ allowed-tools:
   - mcp__plugin_Dev10x_cli__ci_check_status
   - mcp__plugin_Dev10x_cli__check_top_level_comments
   - mcp__plugin_Dev10x_cli__milestone_close
+  - mcp__plugin_Dev10x_cli__background_preamble
   - Bash(gh:*)
   - Skill(Dev10x:qa-scope)
   - Skill(Dev10x:request-review)

--- a/skills/gh-pr-monitor/instructions.md
+++ b/skills/gh-pr-monitor/instructions.md
@@ -164,6 +164,15 @@ Two narrow haiku sub-agents replace the prior monolithic background
 agent. Each has a minimal tool allowlist, a hard turn budget, no
 ability to delegate further, and no ability to mutate state.
 
+**Friction-avoidance preamble (REQUIRED, GH-610):** Both micro-agents
+run in fresh subagents that never saw the SessionStart friction
+briefing. Before each dispatch, fetch the preamble via
+`mcp__plugin_Dev10x_cli__background_preamble` and prepend its
+`preamble` text to the micro-agent prompt below. The narrow
+`allowed_tools` lists are the pre-seeded tool surface — keep them
+explicit (do NOT widen to escape a hook block, and never recommend
+auto-mode). See `references/orchestration/background-preamble.md`.
+
 #### Micro-agent A: haiku-ci-poll
 
 Polls CI until the verdict changes from `pending`, then returns

--- a/src/dev10x/mcp/misc_tools.py
+++ b/src/dev10x/mcp/misc_tools.py
@@ -10,8 +10,33 @@ from typing import Literal, cast
 # `from __future__ import annotations`.
 from mcp.server.fastmcp import Context  # noqa: F401
 
-from dev10x.domain.common.result import to_wire
+from dev10x.domain.common.result import err, ok, to_wire
 from dev10x.mcp._app import server
+
+
+@server.tool()
+async def background_preamble() -> dict:
+    """Return the friction-avoidance preamble for background subagents (GH-610).
+
+    Background subagents (workflow / monitor / loop / fanout) start with a
+    fresh system prompt and never receive the SessionStart friction briefing.
+    Dispatchers fetch this text and prepend it verbatim to each subagent
+    prompt so the subagent avoids hook-tripping command shapes and stays on
+    the pre-approved tool surface. The canonical source is
+    ``references/orchestration/background-preamble.md``; this tool serves it
+    without a Read permission prompt and keeps the dispatch paths from
+    drifting.
+
+    Returns:
+        Dictionary with key: preamble (str) — the preamble document text.
+        Returns ``{"error": ...}`` when the canonical document is missing.
+    """
+    from dev10x.session.service import SessionService
+
+    text = SessionService().build_background_preamble_context()
+    if not text:
+        return to_wire(err("background-preamble.md not found in plugin root"))
+    return to_wire(ok({"preamble": text}))
 
 
 @server.tool()

--- a/src/dev10x/session/service.py
+++ b/src/dev10x/session/service.py
@@ -75,6 +75,21 @@ class SessionService:
         guidance_file = self._plugin_root / "hooks" / "scripts" / "session-guidance.md"
         return guidance_file.read_text() if guidance_file.exists() else ""
 
+    def build_background_preamble_context(self) -> str:
+        """Return the background-dispatch friction preamble (GH-610).
+
+        Background subagents (workflow / monitor / loop / fanout) start with
+        a fresh system prompt and never receive the SessionStart friction
+        briefing. Dispatchers prepend this text to each subagent prompt so it
+        avoids hook-tripping command shapes and stays on the pre-approved
+        tool surface. Returns the canonical preamble document contents, or an
+        empty string when the document is missing.
+        """
+        preamble_file = (
+            self._plugin_root / "references" / "orchestration" / "background-preamble.md"
+        )
+        return preamble_file.read_text() if preamble_file.exists() else ""
+
     def build_autonomy_reassurance_context(self, *, toplevel: str | None = _UNSET) -> str:  # type: ignore[assignment]
         """Return a reassurance block for adaptive + solo-maintainer sessions (GH-261).
 

--- a/tests/mcp/test_misc_tools.py
+++ b/tests/mcp/test_misc_tools.py
@@ -14,6 +14,30 @@ from dev10x.domain.common.result import err, ok
 from dev10x.mcp import server_cli as cli_server
 
 
+class TestBackgroundPreamble:
+    @pytest.mark.asyncio
+    @patch(
+        "dev10x.session.service.SessionService.build_background_preamble_context",
+        return_value="# Background Friction Preamble\nNo cd && chaining.",
+    )
+    async def test_returns_preamble_text(self, _mock_fn: MagicMock) -> None:
+        result = await cli_server.background_preamble()
+
+        assert result["preamble"].startswith("# Background Friction Preamble")
+        assert "error" not in result
+
+    @pytest.mark.asyncio
+    @patch(
+        "dev10x.session.service.SessionService.build_background_preamble_context",
+        return_value="",
+    )
+    async def test_returns_error_when_document_missing(self, _mock_fn: MagicMock) -> None:
+        result = await cli_server.background_preamble()
+
+        assert "error" in result
+        assert "preamble" not in result
+
+
 class TestMktmp:
     @pytest.mark.asyncio
     @patch("dev10x.utilities.mktmp", new_callable=AsyncMock)

--- a/tests/session/test_service.py
+++ b/tests/session/test_service.py
@@ -120,6 +120,29 @@ class TestBuildGuidanceContext:
         assert len(result) > 0
 
 
+class TestBuildBackgroundPreambleContext:
+    def test_empty_when_preamble_file_missing(self, tmp_path: Path) -> None:
+        svc = SessionService(plugin_root=tmp_path)
+        assert svc.build_background_preamble_context() == ""
+
+    def test_returns_file_contents_when_present(self, tmp_path: Path) -> None:
+        orchestration_dir = tmp_path / "references" / "orchestration"
+        orchestration_dir.mkdir(parents=True)
+        preamble = orchestration_dir / "background-preamble.md"
+        preamble.write_text("# Background Friction Preamble\nNo cd && chaining.")
+
+        svc = SessionService(plugin_root=tmp_path)
+        result = svc.build_background_preamble_context()
+
+        assert "Background Friction Preamble" in result
+        assert "No cd && chaining" in result
+
+    def test_real_plugin_root_has_preamble_file(self) -> None:
+        svc = SessionService()
+        result = svc.build_background_preamble_context()
+        assert len(result) > 0
+
+
 class TestBuildInstallCheckContext:
     def test_empty_when_install_current(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path


### PR DESCRIPTION
**When** a background/non-interactive context (workflow, monitor, loop) dispatches a subagent, **I want** it to carry a friction-avoidance preamble and have its tool surface pre-seeded, **so** subagents stop emitting hook-tripping shapes and bypassing wrappers — without resorting to blanket auto-mode.

---

[`28eec879`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/696/commits/28eec879aad821bbe8d4a87c3209a287f1dfc3ac) ✨ GH-610 Keep background subagents off hook-tripping shapes

---

Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/610
