### PR TITLE
♻️ GH-538 Standardize logging, path, and timestamp conventions

### DIFF
--- a/src/dev10x/audit/permissions_model.py
+++ b/src/dev10x/audit/permissions_model.py
@@ -231,7 +231,7 @@ def detect_known_friction(
     findings: list[Finding] = []
     idx = 0
     project_prefix = (project_root or effective_cwd() or os.getcwd()).rstrip("/") + "/"
-    home_prefix = os.path.expanduser("~/").rstrip("/") + "/"
+    home_prefix = str(Path.home()).rstrip("/") + "/"
 
     for tc in calls:
         if tc.tool == "Bash":
@@ -451,9 +451,9 @@ def audit_script_hygiene(skills_dir: str, tools_dir: str) -> list[HygieneFinding
     idx = 0
     dirs_to_scan = []
 
-    if os.path.isdir(skills_dir):
+    if Path(skills_dir).is_dir():
         dirs_to_scan.append(Path(skills_dir))
-    if os.path.isdir(tools_dir):
+    if Path(tools_dir).is_dir():
         dirs_to_scan.append(Path(tools_dir))
 
     for scan_dir in dirs_to_scan:
@@ -516,10 +516,10 @@ def audit_script_hygiene(skills_dir: str, tools_dir: str) -> list[HygieneFinding
 
             for m in re.finditer(r"uv run --script\s+(\S+\.py)", content):
                 script_path = m.group(1)
-                expanded = os.path.expanduser(script_path)
-                if os.path.isfile(expanded):
+                expanded = Path(script_path).expanduser()
+                if expanded.is_file():
                     try:
-                        script_content = Path(expanded).read_text()
+                        script_content = expanded.read_text()
                         if "uv run" in script_content.split("\n", 1)[0]:
                             idx += 1
                             findings.append(

--- a/src/dev10x/domain/dev10x_paths.py
+++ b/src/dev10x/domain/dev10x_paths.py
@@ -33,7 +33,7 @@ from dev10x.domain.file_locks import file_lock
 CONFIG_HOME_ENV_VAR = "DEV10X_CONFIG_HOME"
 XDG_CONFIG_HOME_ENV_VAR = "XDG_CONFIG_HOME"
 
-_log = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 def _platform_default_root() -> Path:
@@ -78,7 +78,7 @@ def migrate_path(*, legacy: Path, current: Path) -> bool:
     with file_lock(current):
         if current.exists() or not legacy.exists():
             return False
-        _log.info("Migrating Dev10x config: %s -> %s", legacy, current)
+        log.info("Migrating Dev10x config: %s -> %s", legacy, current)
         _copy(source=legacy, destination=current)
     return True
 

--- a/src/dev10x/github/__init__.py
+++ b/src/dev10x/github/__init__.py
@@ -34,7 +34,7 @@ from dev10x.subprocess_utils import (
     parse_key_value_output,
 )
 
-logger = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 async def _detect_repo() -> str | None:
@@ -115,7 +115,7 @@ async def _bot_env(*, repo: str) -> dict[str, str] | None:
     token = await get_bot_token(repo=canonical_repo)
     if token is None:
         if AppConfig.load() is not None:
-            logger.warning(
+            log.warning(
                 "GitHub App auth configured but bot token exchange failed for %s — "
                 "falling back to engineer credentials. Verify the App is installed "
                 "on the repo and the private key matches the app_id.",

--- a/src/dev10x/github/app_auth.py
+++ b/src/dev10x/github/app_auth.py
@@ -32,7 +32,7 @@ try:  # PyJWT is an optional dependency; its absence surfaces as ImportError
 except ImportError:  # pragma: no cover - exercised only without PyJWT installed
     _PyJWTError = ()  # type: ignore[assignment, misc]
 
-logger = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 DEFAULT_CONFIG_PATH = Dev10xConfigDir.github_app_yaml()
 
@@ -88,7 +88,7 @@ def _parse_expires_at(raw: str | None) -> float:
     if not raw:
         return time.time() + 3600
     try:
-        return datetime.fromisoformat(raw.replace("Z", "+00:00")).timestamp()
+        return datetime.fromisoformat(raw).timestamp()
     except ValueError:
         return time.time() + 3600
 
@@ -186,7 +186,7 @@ async def get_bot_token(
     try:
         private_key = cfg.private_key_path.read_text()
     except OSError as exc:
-        logger.warning(
+        log.warning(
             "GitHub App private key unreadable at %s: %s",
             cfg.private_key_path,
             exc,
@@ -196,7 +196,7 @@ async def get_bot_token(
     try:
         app_jwt = _create_app_jwt(app_id=cfg.app_id, private_key=private_key)
     except (_PyJWTError, ImportError, ValueError, TypeError) as exc:
-        logger.warning(
+        log.warning(
             "GitHub App JWT creation failed for app_id=%s: %s",
             cfg.app_id,
             exc,
@@ -208,7 +208,7 @@ async def get_bot_token(
         app_jwt=app_jwt,
     )
     if installation_id is None:
-        logger.warning(
+        log.warning(
             "GitHub App installation-id resolution failed for repo=%s app_id=%s",
             repo,
             cfg.app_id,
@@ -220,7 +220,7 @@ async def get_bot_token(
         app_jwt=app_jwt,
     )
     if exchanged is None:
-        logger.warning(
+        log.warning(
             "GitHub App token exchange failed for repo=%s installation_id=%s",
             repo,
             installation_id,

--- a/src/dev10x/github/learn_loop.py
+++ b/src/dev10x/github/learn_loop.py
@@ -30,7 +30,7 @@ from dev10x.github import rule_authoring
 from dev10x.github.rule_authoring import RuleDoc
 from dev10x.subprocess_utils import async_run
 
-logger = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 # Stable branch the bot reuses for its rules-update PR. Reusing one branch
 # (force-pushed each run) keeps a single open proposal per repo rather than

--- a/src/dev10x/github/pattern_validation.py
+++ b/src/dev10x/github/pattern_validation.py
@@ -34,7 +34,7 @@ from dev10x.domain.common.result import Result, SuccessResult, err, ok
 from dev10x.github import review_patterns
 from dev10x.subprocess_utils import async_run
 
-logger = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 # A pattern fires on a diff when at least this fraction of its signature
 # tokens appear among the diff's added-line tokens. Kept below 1.0 so a
@@ -198,7 +198,7 @@ async def _pr_diff(*, repo: str, pr_number: int) -> str | None:
         timeout=60,
     )
     if result.returncode != 0:
-        logger.warning(
+        log.warning(
             "skipping PR diff",
             extra={"repo": repo, "pr_number": pr_number, "stderr": result.stderr.strip()},
         )
@@ -209,7 +209,7 @@ async def _pr_diff(*, repo: str, pr_number: int) -> str | None:
 async def _recent_diffs(*, repo: str, limit: int) -> list[str]:
     numbers_result = await _merged_pr_numbers(repo=repo, limit=limit)
     if not isinstance(numbers_result, SuccessResult):
-        logger.warning("skipping repo diffs", extra={"repo": repo, "error": numbers_result.error})
+        log.warning("skipping repo diffs", extra={"repo": repo, "error": numbers_result.error})
         return []
     diffs: list[str] = []
     for pr_number in numbers_result.value:

--- a/src/dev10x/github/review_patterns.py
+++ b/src/dev10x/github/review_patterns.py
@@ -26,7 +26,7 @@ from typing import Any
 from dev10x.domain.common.result import Result, SuccessResult, err, ok
 from dev10x.subprocess_utils import async_run
 
-logger = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 # Words that carry no signal for clustering review feedback. Kept small
 # and review-specific rather than a full NLP stop-list.
@@ -223,7 +223,7 @@ async def _pr_review_comments(*, repo: str, pr_number: int) -> list[ReviewCommen
         timeout=60,
     )
     if result.returncode != 0:
-        logger.warning(
+        log.warning(
             "skipping PR review comments",
             extra={"repo": repo, "pr_number": pr_number, "stderr": result.stderr.strip()},
         )
@@ -231,7 +231,7 @@ async def _pr_review_comments(*, repo: str, pr_number: int) -> list[ReviewCommen
     try:
         payload = json.loads(result.stdout or "[]")
     except json.JSONDecodeError:
-        logger.warning("unparseable review comments", extra={"repo": repo, "pr_number": pr_number})
+        log.warning("unparseable review comments", extra={"repo": repo, "pr_number": pr_number})
         return []
     return [
         ReviewComment(
@@ -294,7 +294,7 @@ async def cluster_review_comments(
     for repo in targets:
         result = await get_review_comments(repo=repo, limit=limit)
         if not isinstance(result, SuccessResult):
-            logger.warning("skipping repo", extra={"repo": repo, "error": result.error})
+            log.warning("skipping repo", extra={"repo": repo, "error": result.error})
             continue
         all_comments.extend(result.value)
         scanned.append(repo)

--- a/src/dev10x/hooks/session_dispatch.py
+++ b/src/dev10x/hooks/session_dispatch.py
@@ -204,7 +204,7 @@ def session_persist(data: dict | None = None) -> None:
         session_id=session_id,
         toplevel=toplevel,
         run_git=lambda *args: _run_git_safe(git, *args),
-        timestamp=datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        timestamp=datetime.now(UTC).isoformat(),
     ).to_dict()
     state["working_directory"] = toplevel
     state["has_plan"] = plan_path_for_toplevel(toplevel=toplevel).exists()

--- a/src/dev10x/hooks/skill.py
+++ b/src/dev10x/hooks/skill.py
@@ -66,7 +66,7 @@ class SkillMetricsHook(AbstractHook):
         project_hash = hashlib.md5(toplevel.encode()).hexdigest()
 
         now = datetime.now(UTC)
-        timestamp = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+        timestamp = now.isoformat()
         date_tag = now.strftime("%Y-%m-%d")
 
         metrics_dir = ClaudeDir.metrics_dir()

--- a/src/dev10x/skills/audit/extract_session.py
+++ b/src/dev10x/skills/audit/extract_session.py
@@ -147,7 +147,7 @@ def check_correction(text: str) -> bool:
 
 def format_timestamp(ts: str) -> str:
     try:
-        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        dt = datetime.fromisoformat(ts)
         return dt.strftime("%H:%M:%S")
     except (ValueError, AttributeError):
         return ts or "?"

--- a/src/dev10x/skills/monitor/pr_notify.py
+++ b/src/dev10x/skills/monitor/pr_notify.py
@@ -220,8 +220,8 @@ def format_ci_table(checks: list[dict[str, Any]]) -> str:
         started = c.get("startedAt") or ""
         completed = c.get("completedAt") or ""
         if started and completed:
-            t0 = datetime.fromisoformat(started.replace("Z", "+00:00"))
-            t1 = datetime.fromisoformat(completed.replace("Z", "+00:00"))
+            t0 = datetime.fromisoformat(started)
+            t1 = datetime.fromisoformat(completed)
             secs = int((t1 - t0).total_seconds())
             duration = f"{secs // 60}m {secs % 60}s" if secs >= 60 else f"{secs}s"
         elif state == "IN_PROGRESS":

--- a/src/dev10x/validators/execution_safety.py
+++ b/src/dev10x/validators/execution_safety.py
@@ -22,6 +22,7 @@ import os
 import re
 import shlex
 from dataclasses import dataclass
+from pathlib import Path
 from typing import ClassVar
 
 from dev10x.domain import HookInput, HookResult
@@ -292,7 +293,7 @@ class ExecutionSafetyValidator(ValidatorBase):
             None,
         )
 
-        if script is None or not os.path.isabs(os.path.expanduser(script)):
+        if script is None or not Path(script).expanduser().is_absolute():
             return None
 
         if _is_approved_path(script, approved):

--- a/src/dev10x/validators/sql_safety.py
+++ b/src/dev10x/validators/sql_safety.py
@@ -12,6 +12,7 @@ import os
 import re
 import shlex
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, ClassVar
 
 from dev10x.domain import HookInput, HookResult
@@ -39,11 +40,13 @@ SAFE_PREFIXES = re.compile(
     re.IGNORECASE,
 )
 
-_PLUGIN_ROOT = os.environ.get(
-    "CLAUDE_PLUGIN_ROOT",
-    os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))),
+_PLUGIN_ROOT = Path(
+    os.environ.get(
+        "CLAUDE_PLUGIN_ROOT",
+        str(Path(__file__).resolve().parents[3]),
+    )
 )
-DB_SH_PATH = os.path.join(_PLUGIN_ROOT, "skills", "db-psql", "scripts", "db.sh")
+DB_SH_PATH = _PLUGIN_ROOT / "skills" / "db-psql" / "scripts" / "db.sh"
 
 DIRECT_CONN_MSG = (
     "BLOCKED: Direct database connection via psycopg2 or postgres:// URL "
@@ -75,7 +78,7 @@ def _is_exempt_psql_wrapper(parts: list[str]) -> bool:
     """
     if not parts:
         return False
-    command = os.path.basename(parts[0])
+    command = Path(parts[0]).name
     if command == "docker" and "exec" in parts[1:]:
         return True
     if command == "op" and "run" in parts[1:]:


### PR DESCRIPTION
**When** auditing or grepping the Dev10x codebase, **I want to** find one logger variable name, one path-handling idiom, and one timestamp format, **so I can** reason about cross-module behavior without juggling three parallel conventions.

---

[`2f74cb0a`](https://github.com/Dev10x-Guru/Dev10x-Claude/pull/697/commits/2f74cb0aa06af425def9e3d09411aa70b20ad3ab) ♻️ GH-538 Standardize logging, path, and timestamp conventions
Closes #542
Closes #549
Fixes: https://github.com/Dev10x-Guru/Dev10x-Claude/issues/538

---